### PR TITLE
Add lazy-loaded data and improve CI workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,10 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, r: 'devel', check_roxygen: false}
-          - {os: ubuntu-latest, r: 'release', check_roxygen: true}
+          - {os: ubuntu-latest, r: 'devel',    check_roxygen: false}
+          - {os: ubuntu-latest, r: 'release',  check_roxygen: true}
           - {os: ubuntu-latest, r: 'oldrel-1', check_roxygen: false}
-          - {os: macos-latest, r: 'release', check_roxygen: false}
+          - {os: macos-latest,  r: 'release',  check_roxygen: false}
           - {os: windows-latest, r: 'release', check_roxygen: false}
 
     env:
@@ -28,6 +28,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -50,3 +51,5 @@ jobs:
           }
 
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: release
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -26,13 +27,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, any::roxygen2
+          extra-packages: any::pkgdown, any::roxygen2, any::pkgload
           needs: website
 
-      - name: Install package
+      - name: Document and install package
         shell: Rscript {0}
         run: |
-          roxygen2::roxygenise(load_code = roxygen2::load_source)
+          roxygen2::roxygenise(load_code = roxygen2::load_pkgload)
           install.packages(".", repos = NULL, type = "source")
 
       - name: Build pkgdown site
@@ -41,9 +42,8 @@ jobs:
           pkgdown::build_site(new_process = FALSE)
 
       - name: Deploy to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          cname: ehrlinger.github.io

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: release
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for R package checks, documentation site building, and test coverage. The main changes focus on improving workflow reliability, ensuring up-to-date dependencies, and enhancing artifact handling.

**Workflow improvements and dependency management:**

* All workflows now set `use-public-rspm: true` in the `setup-r` steps to use the public RStudio Package Manager, improving package installation reliability and speed. [[1]](diffhunk://#diff-9c940e8ad2b7bc4c26ec3da57b94bc00e73e2166cfed689da51a4c59bcc0a310R31) [[2]](diffhunk://#diff-eb3d51fe47cf000aab65c6172c06d12a34ae765221529a05451295d5e9149e80R22-R36) [[3]](diffhunk://#diff-3522a8c5abb070598236011d60dce0eafc7f1d70261ae9a84917dafcf04d79c8R23)
* The `pkgdown.yaml` workflow now installs `pkgload` as an extra dependency and uses `roxygen2::load_pkgload` for documentation, ensuring more robust package documentation generation.

**Artifact handling and deployment:**

* The R CMD check workflow now uploads test snapshots by setting `upload-snapshots: true` in the `check-r-package` step, aiding in tracking test changes.
* The deployment step for the documentation site has been updated to use `peaceiris/actions-gh-pages@v4` instead of v3, ensuring the use of the latest deployment action.