### PR TITLE
Enhance hazard model documentation and update examples with phases

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -33,14 +33,13 @@
 #'      main = "AVC: Kaplan-Meier survival estimate")
 #'
 #' \donttest{
-#' # Multiphase hazard fit
+#' # Two-phase hazard fit (early CDF + constant — what AVC supports)
 #' fit <- hazard(
 #'   survival::Surv(int_dead, dead) ~ 1, data = avc,
 #'   dist = "multiphase",
 #'   phases = list(
 #'     early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1),
-#'     constant = hzr_phase("constant"),
-#'     late     = hzr_phase("cdf", t_half = 10, nu = 1, m = 1)
+#'     constant = hzr_phase("constant")
 #'   ),
 #'   fit = TRUE, control = list(n_starts = 5, maxit = 1000)
 #' )

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -988,8 +988,10 @@ print.summary.hazard <- function(x, ...) {
       nm <- names(x$phases)[i]
       ph <- x$phases[[i]]
       label <- switch(ph$type,
-        cdf = "cdf (early risk)", hazard = "hazard (late risk)",
-        constant = "constant (flat rate)")
+        cdf      = paste0("cdf (", nm, " risk)"),
+        hazard   = "hazard (late risk)",
+        constant = "constant (flat rate)",
+        g3       = "g3 (late risk)")
       cat("  phase ", i, ":      ", nm, " - ", label, "\n", sep = "")
     }
   }

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -936,8 +936,9 @@ summary.hazard <- function(object, ...) {
     z_stat <- rep(NA_real_, length(theta))
     p_value <- rep(NA_real_, length(theta))
 
-    if (!is.null(vcov_mat) && is.matrix(vcov_mat) && !anyNA(vcov_mat)) {
-      std_error <- sqrt(diag(vcov_mat))
+    if (!is.null(vcov_mat) && is.matrix(vcov_mat)) {
+      d <- diag(vcov_mat)
+      std_error <- sqrt(d)            # NA for fixed params, finite for free
       valid <- is.finite(std_error) & std_error > 0
       z_stat[valid] <- theta[valid] / std_error[valid]
       p_value[valid] <- 2 * pnorm(-abs(z_stat[valid]))
@@ -964,7 +965,7 @@ summary.hazard <- function(object, ...) {
     counts = object$fit$counts,
     message = object$fit$message,
     coefficients = coef_table,
-    has_vcov = !is.null(vcov_mat) && is.matrix(vcov_mat) && !anyNA(vcov_mat),
+    has_vcov = !is.null(vcov_mat) && is.matrix(vcov_mat),
     phases = object$spec$phases
   )
 
@@ -1025,7 +1026,8 @@ print.summary.hazard <- function(x, ...) {
         if (length(rows) > 0) {
           ph <- x$phases[[nm]]
           label <- switch(ph$type,
-            cdf = "cdf", hazard = "hazard", constant = "constant")
+            cdf = "cdf", hazard = "hazard", constant = "constant",
+            g3 = "g3")
           cat("\n  Phase: ", nm, " (", label, ")\n", sep = "")
           sub_table <- x$coefficients[rows, , drop = FALSE]
           # Strip phase prefix from row names for cleaner display

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ fit_mp <- hazard(
   data   = cabgkul,
   dist   = "multiphase",
   phases = list(
-    early    = hzr_phase("cdf",      t_half = 0.5, nu = 1, m = 1),
+    early    = hzr_phase("cdf", t_half = 0.2, nu = 1, m = 1,
+                          fixed = "shapes"),
     constant = hzr_phase("constant"),
-    late     = hzr_phase("cdf",      t_half = 10,  nu = 1, m = 1)
+    late     = hzr_phase("g3",  tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
   ),
   fit = TRUE
 )

--- a/inst/dev/generate-readme-figures.R
+++ b/inst/dev/generate-readme-figures.R
@@ -15,9 +15,11 @@ fit <- hazard(
   data   = cabgkul,
   dist   = "multiphase",
   phases = list(
-    early    = hzr_phase("cdf",      t_half = 0.5, nu = 1, m = 1),
+    early    = hzr_phase("cdf", t_half = 0.2, nu = 1, m = 1,
+                          fixed = "shapes"),
     constant = hzr_phase("constant"),
-    late     = hzr_phase("cdf",      t_half = 10,  nu = 1, m = 1)
+    late     = hzr_phase("g3",  tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
   ),
   fit     = TRUE,
   control = list(n_starts = 10, maxit = 2000, reltol = 1e-10)

--- a/man/avc.Rd
+++ b/man/avc.Rd
@@ -43,14 +43,13 @@ plot(km, xlab = "Months after AVC repair", ylab = "Survival",
      main = "AVC: Kaplan-Meier survival estimate")
 
 \donttest{
-# Multiphase hazard fit
+# Two-phase hazard fit (early CDF + constant — what AVC supports)
 fit <- hazard(
   survival::Surv(int_dead, dead) ~ 1, data = avc,
   dist = "multiphase",
   phases = list(
     early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1),
-    constant = hzr_phase("constant"),
-    late     = hzr_phase("cdf", t_half = 10, nu = 1, m = 1)
+    constant = hzr_phase("constant")
   ),
   fit = TRUE, control = list(n_starts = 5, maxit = 1000)
 )

--- a/vignettes/ar-architecture.qmd
+++ b/vignettes/ar-architecture.qmd
@@ -285,7 +285,7 @@ tiers <- data.frame(
   ),
   Files = c(
     "test-math-primitives, test-decomposition, test-phase-spec, test-argument-mapping",
-    "test-gradient-weibull, test-exponential-dist, test-loglogistic-dist, test-lognormal-dist",
+    "test-gradient-weibull, test-exponential-dist, test-loglogistic-dist, test-lognormal-dist, test-multiphase-gradient",
     "test-hazard-api, test-predict-types, test-interval-censoring-*, test-time-varying-*, test-multiphase-likelihood, test-multiphase-api",
     "test-parity-core, test-parity-edge-cases, test-parity-c-binary, test-multiphase-parity"
   ),
@@ -489,9 +489,12 @@ during active development:
 - **v0.1.0** ---Single-phase engine: Weibull, exponential, log-logistic,
   log-normal distributions with formula interface, predict, and golden
   fixture testing.
-- **v0.9.0** (current) ---Multiphase engine: N-phase additive cumulative
-  hazard, `hzr_phase()` specification, decomposition engine, C binary
-  parity tests, dataset catalog.
+- **v0.9.0** ---Multiphase engine: N-phase additive cumulative hazard,
+  `hzr_phase()` specification, decomposition engine, C binary parity
+  tests, dataset catalog.
+- **v0.9.1** (current) ---Vignette suite, roxygen multiphase examples,
+  CI workflow fixes (load_pkgload), SAS missing-value handling
+  (`na.strings`), print.hazard phase labels, and README refresh.
 
 
 # References {.unnumbered}

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -149,8 +149,7 @@ fit_mp <- hazard(
   dist   = "multiphase",
   phases = list(
     early    = hzr_phase("cdf",      t_half = 0.5, nu = 1, m = 1),
-    constant = hzr_phase("constant"),
-    late     = hzr_phase("cdf",      t_half = 10,  nu = 1, m = 1)
+    constant = hzr_phase("constant")
   ),
   fit     = TRUE,
   control = list(n_starts = 5, maxit = 1000)
@@ -182,7 +181,7 @@ surv_mp <- predict(fit_mp, newdata = nd, type = "survival") * 100
 
 plot_df <- rbind(
   data.frame(time = t_grid, survival = surv_wb, Model = "Single Weibull"),
-  data.frame(time = t_grid, survival = surv_mp, Model = "Multiphase (3-phase)")
+  data.frame(time = t_grid, survival = surv_mp, Model = "Multiphase (2-phase)")
 )
 
 ggplot() +
@@ -191,7 +190,7 @@ ggplot() +
   geom_line(data = plot_df, aes(time, survival, colour = Model),
             linewidth = 1) +
   scale_colour_manual(values = c("Single Weibull" = "#E69F00",
-                                 "Multiphase (3-phase)" = "#0072B2")) +
+                                 "Multiphase (2-phase)" = "#0072B2")) +
   scale_y_continuous(limits = c(0, 100)) +
   annotate("text", x = max(t_grid) * 0.6, y = 95, label = "KM (grey)",
            size = 3, colour = "grey50") +

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -15,7 +15,6 @@ format:
 ```{r}
 #| include: false
 has_pkg <- requireNamespace("TemporalHazard", quietly = TRUE)
-has_avc <- has_pkg && "avc" %in% utils::data(package = "TemporalHazard")$results[, "Item"]
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
@@ -87,9 +86,9 @@ library(ggplot2)
 # Parametric curve on a fine grid
 t_grid <- seq(0.05, max(dat$time), length.out = 80)
 curve_df <- data.frame(
-  time = t_grid,
-  AGE = median(dat$age),
-  nyha = 2,
+  time  = t_grid,
+  age   = median(dat$age),
+  nyha  = 2,
   shock = 0
 )
 curve_df$survival <- predict(fit, newdata = curve_df, type = "survival") * 100
@@ -130,13 +129,12 @@ and starting values for the optimizer.
 
 ```{r}
 #| label: multiphase-fit
-#| eval: !expr has_avc
-# AVC dataset is lazy-loaded with the package
-data(avc)
+# CABGKUL is the benchmark dataset for 3-phase decomposition (n = 5,880)
+data(cabgkul)
 
 fit_mp <- hazard(
   Surv(int_dead, dead) ~ 1,
-  data   = avc,
+  data   = cabgkul,
   dist   = "multiphase",
   phases = list(
     early    = hzr_phase("cdf",      t_half = 0.5, nu = 1, m = 1),
@@ -158,11 +156,10 @@ instantaneous hazard rate for each phase.
 
 ```{r}
 #| label: fig-hazard-phases
-#| eval: !expr has_avc
 #| fig-cap: "Additive phase decomposition: the total hazard (solid) is the sum of early, constant, and late components (dashed)"
 #| fig-width: 7
 #| fig-height: 4.5
-t_grid <- seq(0.01, max(avc$int_dead) * 0.95, length.out = 200)
+t_grid <- seq(0.01, max(cabgkul$int_dead) * 0.95, length.out = 200)
 nd     <- data.frame(time = t_grid)
 
 # decompose = TRUE returns per-phase cumulative hazard columns
@@ -197,7 +194,7 @@ ggplot(h_long, aes(time, hazard, colour = Phase, linetype = Phase)) +
                                    Constant = "dashed", Late = "dashed")) +
   scale_linewidth_manual(values = c(Total = 1.3, Early = 0.7,
                                     Constant = 0.7, Late = 0.7)) +
-  labs(x = "Months after surgery", y = "Hazard rate",
+  labs(x = "Months after CABG", y = "Hazard rate",
        colour = "Phase", linetype = "Phase", linewidth = "Phase") +
   theme_minimal() +
   theme(legend.position = "bottom")
@@ -207,7 +204,6 @@ ggplot(h_long, aes(time, hazard, colour = Phase, linetype = Phase)) +
 
 ```{r}
 #| label: fig-mp-survival
-#| eval: !expr has_avc
 #| fig-cap: "Multiphase parametric survival vs. Kaplan-Meier"
 #| fig-width: 7
 #| fig-height: 4.5
@@ -216,7 +212,7 @@ surv_df <- data.frame(
   survival = predict(fit_mp, newdata = nd, type = "survival") * 100
 )
 
-km    <- survfit(Surv(int_dead, dead) ~ 1, data = avc)
+km    <- survfit(Surv(int_dead, dead) ~ 1, data = cabgkul)
 km_df <- data.frame(time = km$time, survival = km$surv * 100)
 
 ggplot() +
@@ -228,7 +224,7 @@ ggplot() +
     values = c("Multiphase model" = "#0072B2", "Kaplan-Meier" = "#D55E00")
   ) +
   scale_y_continuous(limits = c(0, 100)) +
-  labs(x = "Months after surgery", y = "Freedom from death (%)",
+  labs(x = "Months after CABG", y = "Freedom from death (%)",
        colour = NULL) +
   theme_minimal() +
   theme(legend.position = "bottom")

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -137,9 +137,11 @@ fit_mp <- hazard(
   data   = cabgkul,
   dist   = "multiphase",
   phases = list(
-    early    = hzr_phase("cdf",      t_half = 0.5, nu = 1, m = 1),
+    early    = hzr_phase("cdf", t_half = 0.2, nu = 1, m = 1,
+                          fixed = "shapes"),
     constant = hzr_phase("constant"),
-    late     = hzr_phase("cdf",      t_half = 10,  nu = 1, m = 1)
+    late     = hzr_phase("g3",  tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
   ),
   fit     = TRUE,
   control = list(n_starts = 5, maxit = 1000)

--- a/vignettes/prediction-visualization.qmd
+++ b/vignettes/prediction-visualization.qmd
@@ -141,14 +141,18 @@ returns a data frame with columns for each phase.
 
 ```{r}
 #| label: fit-mp
+data(cabgkul)
+
 fit_mp <- hazard(
   Surv(int_dead, dead) ~ 1,
-  data   = avc,
+  data   = cabgkul,
   dist   = "multiphase",
   phases = list(
-    early    = hzr_phase("cdf",      t_half = 0.5, nu = 1, m = 1),
+    early    = hzr_phase("cdf", t_half = 0.2, nu = 1, m = 1,
+                          fixed = "shapes"),
     constant = hzr_phase("constant"),
-    late     = hzr_phase("cdf",      t_half = 10,  nu = 1, m = 1)
+    late     = hzr_phase("g3",  tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
   ),
   fit     = TRUE,
   control = list(n_starts = 5, maxit = 1000)
@@ -160,7 +164,8 @@ fit_mp <- hazard(
 #| fig-cap: "Additive phase decomposition: total hazard rate (solid) = early + constant + late (dashed)"
 #| fig-width: 7
 #| fig-height: 4.5
-nd <- data.frame(time = t_grid)
+t_mp <- seq(0.01, max(cabgkul$int_dead) * 0.95, length.out = 200)
+nd   <- data.frame(time = t_mp)
 
 decomp <- predict(fit_mp, newdata = nd, type = "cumulative_hazard",
                   decompose = TRUE)
@@ -173,13 +178,13 @@ num_hazard <- function(cumhaz, time) {
 }
 
 h_long <- rbind(
-  data.frame(time = t_grid, hazard = num_hazard(decomp$early, t_grid),
+  data.frame(time = t_mp, hazard = num_hazard(decomp$early, t_mp),
              Phase = "Early"),
-  data.frame(time = t_grid, hazard = num_hazard(decomp$constant, t_grid),
+  data.frame(time = t_mp, hazard = num_hazard(decomp$constant, t_mp),
              Phase = "Constant"),
-  data.frame(time = t_grid, hazard = num_hazard(decomp$late, t_grid),
+  data.frame(time = t_mp, hazard = num_hazard(decomp$late, t_mp),
              Phase = "Late"),
-  data.frame(time = t_grid, hazard = num_hazard(decomp$total, t_grid),
+  data.frame(time = t_mp, hazard = num_hazard(decomp$total, t_mp),
              Phase = "Total")
 )
 h_long$Phase <- factor(h_long$Phase,
@@ -193,7 +198,7 @@ ggplot(h_long, aes(time, hazard, colour = Phase, linetype = Phase)) +
                                    Constant = "dashed", Late = "dashed")) +
   scale_linewidth_manual(values = c(Total = 1.3, Early = 0.7,
                                     Constant = 0.7, Late = 0.7)) +
-  labs(x = "Months after surgery", y = "Hazard rate",
+  labs(x = "Months after CABG", y = "Hazard rate",
        colour = "Phase", linetype = "Phase", linewidth = "Phase") +
   theme_minimal() +
   theme(legend.position = "bottom")


### PR DESCRIPTION
This pull request updates documentation, vignettes, and summary/print methods to improve clarity, modernize examples, and add support for new phase types in the multiphase hazard model. The most important changes are grouped below.

**Documentation and Example Updates:**

* Updated all multiphase model examples in the documentation and vignettes to use the `cabgkul` dataset (benchmark for 3-phase decomposition) instead of `avc`, and revised phase specifications to include a `g3` (generalized gamma) late phase with fixed shape parameters. Example descriptions and plot labels now consistently refer to "CABG" and clarify the number of phases used. [[1]](diffhunk://#diff-4aa3b824448137b5b0dd8fc5a665f35db7852a06c68a3132ad6f9d1a572abbc8L133-R144) [[2]](diffhunk://#diff-4aa3b824448137b5b0dd8fc5a665f35db7852a06c68a3132ad6f9d1a572abbc8L161-R164) [[3]](diffhunk://#diff-4aa3b824448137b5b0dd8fc5a665f35db7852a06c68a3132ad6f9d1a572abbc8L200-R199) [[4]](diffhunk://#diff-4aa3b824448137b5b0dd8fc5a665f35db7852a06c68a3132ad6f9d1a572abbc8L219-R217) [[5]](diffhunk://#diff-4aa3b824448137b5b0dd8fc5a665f35db7852a06c68a3132ad6f9d1a572abbc8L231-R229) [[6]](diffhunk://#diff-22d8535e41640a9cfaa22cd8b2bb3d284dcdbb712f2173ccd9d69c05d17cedb6R144-R155) [[7]](diffhunk://#diff-22d8535e41640a9cfaa22cd8b2bb3d284dcdbb712f2173ccd9d69c05d17cedb6L163-R168) [[8]](diffhunk://#diff-22d8535e41640a9cfaa22cd8b2bb3d284dcdbb712f2173ccd9d69c05d17cedb6L176-R187) [[9]](diffhunk://#diff-22d8535e41640a9cfaa22cd8b2bb3d284dcdbb712f2173ccd9d69c05d17cedb6L196-R201) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R79) [[11]](diffhunk://#diff-e356f20d85fb55d524aa82e7f81d8d180ea191b886aa8adef585335537649fc3L18-R22) [[12]](diffhunk://#diff-662b849c82afa7fc234688d3844e3006848ead9f8aebfe1fea2be3976a7cc921L152-R152) [[13]](diffhunk://#diff-662b849c82afa7fc234688d3844e3006848ead9f8aebfe1fea2be3976a7cc921L185-R184) [[14]](diffhunk://#diff-662b849c82afa7fc234688d3844e3006848ead9f8aebfe1fea2be3976a7cc921L194-R193) [[15]](diffhunk://#diff-1aa706d06e32cbc095fff924f0bd6a4c65e58f37a9be55b00c4d6a238cdc9abfL46-R52) [[16]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171L36-R42)

* Updated the vignette and README to clarify model descriptions (e.g., "Multiphase (2-phase)" instead of "Multiphase (3-phase)") and ensure all code and plots match the new example structure. [[1]](diffhunk://#diff-662b849c82afa7fc234688d3844e3006848ead9f8aebfe1fea2be3976a7cc921L185-R184) [[2]](diffhunk://#diff-662b849c82afa7fc234688d3844e3006848ead9f8aebfe1fea2be3976a7cc921L194-R193) [[3]](diffhunk://#diff-1aa706d06e32cbc095fff924f0bd6a4c65e58f37a9be55b00c4d6a238cdc9abfL46-R52)

**Enhancements to Summary and Print Methods:**

* Improved the `print.summary.hazard` method to support and label the new `g3` phase type, and made phase labeling more descriptive and dynamic based on the phase name and type. [[1]](diffhunk://#diff-b6d34825fe06e55815195c1d59311fdb27d475ce96129569f3da25b5718f50c3L991-R995) [[2]](diffhunk://#diff-b6d34825fe06e55815195c1d59311fdb27d475ce96129569f3da25b5718f50c3L1026-R1030)

**Statistical Output and Robustness:**

* In `summary.hazard`, improved the calculation of standard errors and the `has_vcov` flag to handle models with fixed parameters more robustly, ensuring statistical summaries are accurate even when some parameters are fixed. [[1]](diffhunk://#diff-b6d34825fe06e55815195c1d59311fdb27d475ce96129569f3da25b5718f50c3L939-R941) [[2]](diffhunk://#diff-b6d34825fe06e55815195c1d59311fdb27d475ce96129569f3da25b5718f50c3L967-R968)

**Testing and Maintenance:**

* Added `test-multiphase-gradient` to the vignette's test tier documentation and updated the changelog to reflect new features and maintenance improvements. [[1]](diffhunk://#diff-bd8608746cbf31cede89118822711ebe0c6d9b701fc48f846d200a4acc55a4ecL288-R288) [[2]](diffhunk://#diff-bd8608746cbf31cede89118822711ebe0c6d9b701fc48f846d200a4acc55a4ecL492-R497)

**Minor Fixes:**

* Fixed a typo in a vignette data frame (`AGE` → `age`).

These changes modernize and clarify the package's documentation and outputs, add support for new phase types, and improve robustness in statistical summaries.