### PR TITLE
Label bootstrap covariate rows with design-matrix names

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1186,10 +1186,24 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   n_obs <- nrow(orig_data)
   sample_size <- max(1L, as.integer(n_obs * fraction))
 
-  # Parameter names from the fitted model
+  # Parameter names from the fitted model. Shape parameters (e.g. mu, nu) are
+  # named in theta, but covariate betas often come through with empty names.
+  # Fill those from the design matrix column names so downstream pivots
+  # (e.g. reshape(wide)) get a distinct column per covariate.
   param_names <- names(object$fit$theta)
   if (is.null(param_names)) {
-    param_names <- paste0("param_", seq_along(object$fit$theta))
+    param_names <- character(length(object$fit$theta))
+  }
+  blank <- !nzchar(param_names)
+  if (any(blank) && !is.null(object$data$x)) {
+    x_names <- colnames(object$data$x)
+    if (!is.null(x_names) && length(x_names) == sum(blank)) {
+      param_names[blank] <- x_names
+    }
+  }
+  still_blank <- !nzchar(param_names)
+  if (any(still_blank)) {
+    param_names[still_blank] <- paste0("param_", which(still_blank))
   }
 
   # Accumulate results

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1188,17 +1188,23 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
 
   # Parameter names from the fitted model. Shape parameters (e.g. mu, nu) are
   # named in theta, but covariate betas often come through with empty names.
-  # Fill those from the design matrix column names so downstream pivots
-  # (e.g. reshape(wide)) get a distinct column per covariate.
+  # Covariate coefficients occupy the last ncol(x) positions of theta; fill
+  # any blanks within that block from the design matrix column names by
+  # relative index, so downstream pivots (e.g. reshape(wide)) get a distinct
+  # column per covariate -- even when some betas are already named and
+  # others are not.
   param_names <- names(object$fit$theta)
   if (is.null(param_names)) {
     param_names <- character(length(object$fit$theta))
   }
-  blank <- !nzchar(param_names)
-  if (any(blank) && !is.null(object$data$x)) {
+  if (!is.null(object$data$x)) {
     x_names <- colnames(object$data$x)
-    if (!is.null(x_names) && length(x_names) == sum(blank)) {
-      param_names[blank] <- x_names
+    p <- ncol(object$data$x)
+    n_theta <- length(param_names)
+    if (!is.null(x_names) && p > 0L && n_theta >= p) {
+      cov_idx <- seq.int(n_theta - p + 1L, n_theta)
+      blank_in_block <- !nzchar(param_names[cov_idx])
+      param_names[cov_idx[blank_in_block]] <- x_names[blank_in_block]
     }
   }
   still_blank <- !nzchar(param_names)

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -655,6 +655,36 @@ test_that("hzr_bootstrap labels covariate rows with design-matrix names", {
   expect_true(all(c("x1", "x2") %in% bs$summary$parameter))
 })
 
+test_that("hzr_bootstrap preserves named betas while filling blanks", {
+  # Mixed-naming case: one beta is explicitly named in the starting theta
+  # and the other is left blank. The named slot must be preserved; the
+  # blank slot should pick up its design-matrix column name.
+  set.seed(11)
+  n <- 80
+  df <- data.frame(
+    t = stats::rexp(n, 0.1),
+    d = stats::rbinom(n, 1, 0.6),
+    x1 = stats::rnorm(n),
+    x2 = stats::rnorm(n)
+  )
+  fit <- hazard(
+    survival::Surv(t, d) ~ x1 + x2,
+    data  = df,
+    dist  = "weibull",
+    theta = c(mu = 0.05, nu = 0.8, b_custom = 0, 0),
+    fit   = TRUE
+  )
+
+  bs <- hzr_bootstrap(fit, n_boot = 5, seed = 321)
+  params <- bs$replicates$parameter
+
+  expect_false(any(!nzchar(params)))
+  # Named beta retained; blank beta filled from colnames(x) -> "x2".
+  expect_true("b_custom" %in% params)
+  expect_true("x2" %in% params)
+  expect_false("x1" %in% params)
+})
+
 
 # =========================================================================
 # hzr_competing_risks tests

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -623,6 +623,38 @@ test_that("print.hzr_bootstrap runs without error", {
   expect_output(print(bs), "Bootstrap")
 })
 
+test_that("hzr_bootstrap labels covariate rows with design-matrix names", {
+  # Regression test: covariate parameter rows used to be emitted with empty
+  # strings, which broke wide pivots of $replicates. They should now carry
+  # the design-matrix column names (e.g. "x1", "x2").
+  set.seed(7)
+  n <- 80
+  df <- data.frame(
+    t = stats::rexp(n, 0.1),
+    d = stats::rbinom(n, 1, 0.6),
+    x1 = stats::rnorm(n),
+    x2 = stats::rnorm(n)
+  )
+  fit <- hazard(
+    survival::Surv(t, d) ~ x1 + x2,
+    data  = df,
+    dist  = "weibull",
+    theta = c(mu = 0.05, nu = 0.8, 0, 0),
+    fit   = TRUE
+  )
+
+  bs <- hzr_bootstrap(fit, n_boot = 5, seed = 123)
+  params <- bs$replicates$parameter
+
+  expect_false(any(!nzchar(params)))
+  expect_true(all(c("x1", "x2") %in% params))
+  # Each successful replicate should contribute one row per covariate.
+  expect_equal(sum(params == "x1"), bs$n_success)
+  expect_equal(sum(params == "x2"), bs$n_success)
+  # Summary table should also carry the covariate labels.
+  expect_true(all(c("x1", "x2") %in% bs$summary$parameter))
+})
+
 
 # =========================================================================
 # hzr_competing_risks tests


### PR DESCRIPTION
## Summary

- `hzr_bootstrap()` used to emit empty strings in `$replicates$parameter` for covariate betas, because `names(fit$theta)` only populates the shape parameters (`mu`, `nu`) for Weibull fits. That broke wide pivots of the replicates frame — every covariate column collided on the empty key.
- Fill blank slots with `colnames(object$data$x)` so covariates surface under their model-formula names (e.g. `age`, `mal`); the summary table and `print.hzr_bootstrap` inherit the fix because both derive from the `parameter` column via `split()`.
- Add a regression test in `test-diagnostics.R` against a synthetic 2-covariate Weibull fit.

## Why

Downstream users calling `reshape(bs$replicates, direction = "wide", ...)` couldn't produce a per-replicate row with one column per parameter: every covariate landed in a single collapsed column keyed on `""`. Multiphase fits weren't affected (those already ship phase-prefixed names), so this only changes output for single-phase fits with covariates.

## Behavior

Before — for `Surv(int_dead, dead) ~ age + mal`:
```
replicate parameter  estimate
        1        mu  4.36e-08
        1        nu  2.29e-01
        1            -2.62e-03   <- empty (age)
        1             5.28e-01   <- empty (mal)
```

After:
```
replicate parameter  estimate
        1        mu  4.36e-08
        1        nu  2.29e-01
        1       age -2.62e-03
        1       mal  5.28e-01
```

Fallback: if `colnames(object$data$x)` is missing or length-mismatched, remaining blanks become `param_<i>` rather than empty strings.

## Test plan

- [x] `devtools::load_all()` + `testthat::test_file("tests/testthat/test-diagnostics.R")` — 156 tests pass, including the new `hzr_bootstrap labels covariate rows with design-matrix names` case.
- [x] `lintr::lint_package()` clean.
- [ ] CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)