### PR TITLE
Complete weights wire-up for exp/log-logistic/log-normal + CoE (Phase 4e)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling in R
-Version: 0.9.5
+Version: 0.9.6
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre"))
 Author: John Ehrlinger [aut, cre]
 Maintainer: John Ehrlinger <john.ehrlinger@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+# TemporalHazard 0.9.6
+
+## New features
+
+* **`weights` now supported for all distributions** — Phase 4e of the
+  development plan lands. The exponential, log-logistic, and
+  log-normal likelihoods and their analytic gradients now apply row
+  weights to every censoring term (event, right-censored,
+  left-censored, interval-censored). The 0.9.5 guard in `hazard()`
+  that rejected `weights` for `dist %in% c("exponential",
+  "loglogistic", "lognormal")` has been removed. Fits with integer
+  weights reproduce the row-duplicated fit to optimizer tolerance
+  across all five distributions.
+* **Conservation of Events now honours weights.**
+  `.hzr_conserve_events()` and `.hzr_select_fixmu_phase()` take an
+  optional `weights` argument; the multiphase optimizer threads it
+  through so per-phase cumulative hazards are summed on the same
+  scale as the (weighted) observed event count. CoE no longer
+  auto-disables when weights are non-uniform — the dimension
+  reduction stays on and the MLE matches the full-dim path.
+
 # TemporalHazard 0.9.5
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,21 @@
   auto-disables when weights are non-uniform — the dimension
   reduction stays on and the MLE matches the full-dim path.
 
+## Bug fixes
+
+* **Multiphase analytic gradient now applies `weights`.**
+  `.hzr_gradient_multiphase()` accepted neither `weights` nor its
+  downstream equivalents: the per-row score weights `w_H` / `inv_h`
+  were set to ±1 and the interval-censored finite-difference
+  correction summed an unweighted LL. Weighted multiphase fits
+  therefore optimised a weighted objective with an unweighted score;
+  BFGS line search still converged near the correct MLE but the
+  final gradient norm did not go to zero. All three paths now honour
+  row weights, and the optimizer's `gradient_fn` wrapper (including
+  the all-zero numeric fallback and the CoE wrapper) forwards
+  `weights` consistently. Regression test covers weighted analytic
+  vs numerical gradient parity. Surfaced by Copilot review on PR #18.
+
 # TemporalHazard 0.9.5
 
 ## New features

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -370,19 +370,6 @@ hazard <- function(formula = NULL,
     stop("'dist' must be a non-empty character scalar.", call. = FALSE)
   }
 
-  # Fisher weighting is currently only wired into the Weibull and multiphase
-  # likelihoods (and their gradients).  The exponential / log-logistic /
-  # log-normal single-distribution paths accept `weights` as a formal but do
-  # not apply it, so accepting the argument silently would return an
-  # unweighted fit -- worse than rejecting up front.  Tracked in
-  # inst/dev/DEVELOPMENT-PLAN.md Phase 8.
-  if (!is.null(weights) && !(dist %in% c("weibull", "multiphase"))) {
-    stop("'weights' is currently only supported for dist = 'weibull' or ",
-         "dist = 'multiphase'. Support for dist = '", dist, "' is deferred ",
-         "to a later release; see `NEWS.md`.",
-         call. = FALSE)
-  }
-
   if (!is.list(control)) {
     stop("'control' must be a list.", call. = FALSE)
   }

--- a/R/likelihood-exponential.R
+++ b/R/likelihood-exponential.R
@@ -96,6 +96,9 @@ NULL
 
   n <- length(time)
 
+  # Default unit weights
+  if (is.null(weights)) weights <- rep(1, n)
+
   # Extract parameters
   log_lambda <- theta[1]
   lambda <- exp(log_lambda)  # Always positive
@@ -134,31 +137,33 @@ NULL
   idx_left <- status == -1
   idx_interval <- status == 2
 
-  # Event: log h(t) + log S(t) = [log(lambda)+eta] - H(t)
+  # Event: w * [log h(t) + log S(t)] = w * [log(lambda)+eta - H(t)]
   ll_event <- if (any(idx_event)) {
-    sum((log_lambda + eta[idx_event]) - cumhaz_event[idx_event])
+    sum(weights[idx_event] *
+          ((log_lambda + eta[idx_event]) - cumhaz_event[idx_event]))
   } else {
     0
   }
 
-  # Right-censored: log S(t) = -H(t)
+  # Right-censored: w * log S(t) = -w * H(t)
   ll_right <- if (any(idx_right)) {
-    -sum(cumhaz_event[idx_right])
+    -sum(weights[idx_right] * cumhaz_event[idx_right])
   } else {
     0
   }
 
-  # Left-censored: log F(u) = log(1 - exp(-H(u)))
+  # Left-censored: w * log(1 - exp(-H(u)))
   ll_left <- if (any(idx_left)) {
-    sum(hzr_log1mexp(cumhaz_upper[idx_left]))
+    sum(weights[idx_left] * hzr_log1mexp(cumhaz_upper[idx_left]))
   } else {
     0
   }
 
-  # Interval-censored: log(S(l)-S(u))
+  # Interval-censored: w * [log(S(l)-S(u))]
   ll_interval <- if (any(idx_interval)) {
     delta_h <- cumhaz_upper[idx_interval] - cumhaz_lower[idx_interval]
-    sum(-cumhaz_lower[idx_interval] + hzr_log1mexp(delta_h))
+    sum(weights[idx_interval] *
+          (-cumhaz_lower[idx_interval] + hzr_log1mexp(delta_h)))
   } else {
     0
   }
@@ -174,6 +179,7 @@ NULL
     grad <- .hzr_gradient_exponential(
       theta = theta, time = time, status = status,
       time_lower = time_lower, time_upper = time_upper, x = x,
+      weights = weights,
       eta = eta, cumhaz = cumhaz_event,
       lambda = lambda, log_lambda = log_lambda
     )
@@ -212,10 +218,15 @@ NULL
   p <- length(theta)
   grad <- numeric(p)
 
+  # Default unit weights -- keep gradient consistent with the LL when weights
+  # are omitted.
+  if (is.null(weights)) weights <- rep(1, n)
+
   # Numerical fallback for left/interval censoring contributions.
   # Right-censored/event-only rows still use the closed-form score below.
   if (any(status %in% c(-1, 2))) {
-    return(.hzr_numeric_grad_exponential(theta, time, status, time_lower, time_upper, x))
+    return(.hzr_numeric_grad_exponential(theta, time, status, time_lower,
+                                          time_upper, x, weights = weights))
   }
 
   # Recompute if not provided
@@ -233,14 +244,19 @@ NULL
     cumhaz <- lambda * time * exp(eta)
   }
 
+  # Weighted building blocks: every term below is the unweighted form with
+  # `status` -> `w * status` and `cumhaz` -> `w * cumhaz`.
+  w_status <- weights * status
+  w_cumhaz <- weights * cumhaz
+
   # ===== Gradient w.r.t. log(lambda) =====
-  # dL/d(log lambda) = sum(delta) - sum(H) = sum(delta) - sum(lambda * t * exp(eta))
-  grad[1] <- sum(status) - sum(cumhaz)
+  # dL/d(log lambda) = sum(w * delta) - sum(w * H)
+  grad[1] <- sum(w_status) - sum(w_cumhaz)
 
   # ===== Gradient w.r.t. beta (covariate coefficients) =====
   if (p > 1 && !is.null(x)) {
-    # dL/dbeta = t(X) %*% (delta - H)
-    residual <- status - cumhaz
+    # dL/dbeta = t(X) %*% (w * delta - w * H)
+    residual <- w_status - w_cumhaz
     grad[2:p] <- as.numeric(crossprod(x, residual))
   }
 
@@ -261,7 +277,9 @@ NULL
   )
 }
 
-.hzr_numeric_grad_exponential <- function(theta, time, status, time_lower = NULL, time_upper = NULL, x = NULL) {
+.hzr_numeric_grad_exponential <- function(theta, time, status,
+                                            time_lower = NULL, time_upper = NULL,
+                                            x = NULL, weights = NULL) {
   # Reuse log-likelihood as scalar objective and differentiate numerically.
   objective <- function(par) {
     .hzr_logl_exponential(
@@ -271,6 +289,7 @@ NULL
       time_lower = time_lower,
       time_upper = time_upper,
       x = x,
+      weights = weights,
       return_gradient = FALSE
     )
   }

--- a/R/likelihood-loglogistic.R
+++ b/R/likelihood-loglogistic.R
@@ -118,6 +118,9 @@ NULL
 
   n <- length(time)
 
+  # Default unit weights
+  if (is.null(weights)) weights <- rep(1, n)
+
   # Extract parameters
   log_alpha <- theta[1]
   log_beta <- theta[2]
@@ -169,40 +172,42 @@ NULL
   idx_left <- status == -1
   idx_interval <- status == 2
 
-  # Exact event: log f = log h + log S
+  # Exact event: w * log f = w * [log h + log S]
   # f(t|x) = alpha beta t^(beta-1) exp(eta) / (1 + alpha t^beta exp(eta))^2
   # log f  = log alpha + log beta + (beta-1) log t + eta - 2 log(1 + term)
   ll_event <- if (any(idx_event)) {
     sum(
-      log_alpha + log_beta + (beta - 1) * log(time[idx_event]) +
-        eta[idx_event] - 2 * log1p(term_event[idx_event])
+      weights[idx_event] *
+        (log_alpha + log_beta + (beta - 1) * log(time[idx_event]) +
+           eta[idx_event] - 2 * log1p(term_event[idx_event]))
     )
   } else {
     0
   }
 
-  # Right-censored: log S = -log(1 + term)
+  # Right-censored: w * log S = -w * log(1 + term)
   ll_right <- if (any(idx_right)) {
-    -sum(log1p(term_event[idx_right]))
+    -sum(weights[idx_right] * log1p(term_event[idx_right]))
   } else {
     0
   }
 
-  # Left-censored: log F = log(term/(1+term))
+  # Left-censored: w * log F = w * log(term/(1+term))
   ll_left <- if (any(idx_left)) {
-    sum(log_term_u[idx_left] - log1p(term_upper[idx_left]))
+    sum(weights[idx_left] *
+          (log_term_u[idx_left] - log1p(term_upper[idx_left])))
   } else {
     0
   }
 
-  # Interval-censored: log(F(u) - F(l)).
+  # Interval-censored: w * log(F(u) - F(l)).
   # We compute on probability scale and then log, with positivity guard.
   ll_interval <- if (any(idx_interval)) {
     p_u <- term_upper[idx_interval] / (1 + term_upper[idx_interval])
     p_l <- term_lower[idx_interval] / (1 + term_lower[idx_interval])
     diff_p <- p_u - p_l
     if (any(diff_p <= 0)) return(Inf)
-    sum(log(diff_p))
+    sum(weights[idx_interval] * log(diff_p))
   } else {
     0
   }
@@ -218,6 +223,7 @@ NULL
     grad <- .hzr_gradient_loglogistic(
       theta = theta, time = time, status = status,
       time_lower = time_lower, time_upper = time_upper, x = x,
+      weights = weights,
       eta = eta, alpha = alpha, beta = beta,
       log_alpha = log_alpha, log_beta = log_beta, term = term_event
     )
@@ -271,9 +277,14 @@ NULL
   p <- length(theta)
   grad <- numeric(p)
 
+  # Default unit weights -- keep gradient consistent with the LL when weights
+  # are omitted.
+  if (is.null(weights)) weights <- rep(1, n)
+
   # Mixed censoring uses numerical gradient for robustness.
   if (any(status %in% c(-1, 2))) {
-    return(.hzr_numeric_grad_loglogistic(theta, time, status, time_lower, time_upper, x))
+    return(.hzr_numeric_grad_loglogistic(theta, time, status, time_lower,
+                                          time_upper, x, weights = weights))
   }
 
   # Recompute if not provided
@@ -293,20 +304,23 @@ NULL
     term <- alpha * (time ^ beta) * exp(eta)
   }
 
-  # pw_i = term_i / (1 + term_i), w_i = (1 + delta_i) * pw_i
+  # pw_i = term_i / (1 + term_i), wm_i = weights_i * (1 + delta_i) * pw_i
+  # (wm is the weighted Mills building block used in every derivative term.)
   pw <- term / (1 + term)
-  w <- (1 + status) * pw
+  w_status <- weights * status
+  wm <- weights * (1 + status) * pw
 
-  # dL/d(log alpha) = sum(delta) - sum(w)
-  grad[1] <- sum(status) - sum(w)
+  # dL/d(log alpha) = sum(w * delta) - sum(wm)
+  grad[1] <- sum(w_status) - sum(wm)
 
-  # dL/d(log beta) = sum(delta) + beta * [sum(delta * log t) - sum(w * log t)]
+  # dL/d(log beta) = sum(w * delta) + beta * [sum(w * delta * log t) - sum(wm * log t)]
   log_t <- log(time)
-  grad[2] <- sum(status) + beta * (sum(status * log_t) - sum(w * log_t))
+  grad[2] <- sum(w_status) +
+             beta * (sum(w_status * log_t) - sum(wm * log_t))
 
-  # dL/dbeta_j = t(X) %*% (delta - w)
+  # dL/dbeta_j = t(X) %*% (w * delta - wm)
   if (p > 2 && !is.null(x)) {
-    residual <- status - w
+    residual <- w_status - wm
     grad[3:p] <- as.numeric(crossprod(x, residual))
   }
 
@@ -327,7 +341,9 @@ NULL
   )
 }
 
-.hzr_numeric_grad_loglogistic <- function(theta, time, status, time_lower = NULL, time_upper = NULL, x = NULL) {
+.hzr_numeric_grad_loglogistic <- function(theta, time, status,
+                                            time_lower = NULL, time_upper = NULL,
+                                            x = NULL, weights = NULL) {
   # Reuse log-likelihood as scalar objective and differentiate numerically.
   objective <- function(par) {
     .hzr_logl_loglogistic(
@@ -337,6 +353,7 @@ NULL
       time_lower = time_lower,
       time_upper = time_upper,
       x = x,
+      weights = weights,
       return_gradient = FALSE
     )
   }

--- a/R/likelihood-lognormal.R
+++ b/R/likelihood-lognormal.R
@@ -117,6 +117,9 @@ NULL
 
   n <- length(time)
 
+  # Default unit weights
+  if (is.null(weights)) weights <- rep(1, n)
+
   # Extract parameters
   mu <- theta[1]          # Location (unrestricted)
   log_sigma <- theta[2]   # Log-scale (unrestricted)
@@ -153,29 +156,30 @@ NULL
   idx_left <- status == -1
   idx_interval <- status == 2
 
-  # Event: log f(t)
+  # Event: w * log f(t)
   ll_event <- if (any(idx_event)) {
-    sum(log_phi_z[idx_event] - log_sigma - log_t[idx_event])
+    sum(weights[idx_event] *
+          (log_phi_z[idx_event] - log_sigma - log_t[idx_event]))
   } else {
     0
   }
 
-  # Right-censored: log S(t)
+  # Right-censored: w * log S(t)
   ll_right <- if (any(idx_right)) {
-    sum(log_surv[idx_right])
+    sum(weights[idx_right] * log_surv[idx_right])
   } else {
     0
   }
 
-  # Left-censored: log F(u)
+  # Left-censored: w * log F(u)
   ll_left <- if (any(idx_left)) {
     z_u <- (log(upper[idx_left]) - eta[idx_left]) / sigma
-    sum(pnorm(z_u, log.p = TRUE))
+    sum(weights[idx_left] * pnorm(z_u, log.p = TRUE))
   } else {
     0
   }
 
-  # Interval-censored: log(F(u) - F(l)) with positivity guard.
+  # Interval-censored: w * log(F(u) - F(l)) with positivity guard.
   ll_interval <- if (any(idx_interval)) {
     z_l <- (log(lower[idx_interval]) - eta[idx_interval]) / sigma
     z_u <- (log(upper[idx_interval]) - eta[idx_interval]) / sigma
@@ -183,7 +187,7 @@ NULL
     f_u <- pnorm(z_u)
     diff_f <- f_u - f_l
     if (any(diff_f <= 0)) return(Inf)
-    sum(log(diff_f))
+    sum(weights[idx_interval] * log(diff_f))
   } else {
     0
   }
@@ -198,6 +202,7 @@ NULL
     grad <- .hzr_gradient_lognormal(
       theta = theta, time = time, status = status,
       time_lower = time_lower, time_upper = time_upper, x = x,
+      weights = weights,
       eta = eta, sigma = sigma, log_sigma = log_sigma,
       z = z, log_phi_z = log_phi_z, log_surv = log_surv
     )
@@ -239,9 +244,14 @@ NULL
   p <- length(theta)
   grad <- numeric(p)
 
+  # Default unit weights -- keep gradient consistent with the LL when weights
+  # are omitted.
+  if (is.null(weights)) weights <- rep(1, n)
+
   # Mixed-censoring score uses numerical differentiation for robustness.
   if (any(status %in% c(-1, 2))) {
-    return(.hzr_numeric_grad_lognormal(theta, time, status, time_lower, time_upper, x))
+    return(.hzr_numeric_grad_lognormal(theta, time, status, time_lower,
+                                        time_upper, x, weights = weights))
   }
 
   # Recompute if not provided
@@ -263,29 +273,32 @@ NULL
     log_surv <- pnorm(-z, log.p = TRUE)
   }
 
-  # Inverse Mills ratio: w_i = phi(z_i) / Phi(-z_i)
-  # Computed in log scale for numerical stability, then exponentiating
-  log_w <- log_phi_z - log_surv
-  w <- exp(log_w)  # Safe: log_surv can be -Inf when Phi(-z) -> 0 (z -> +Inf)
-  # Handle case where log_surv = -Inf (z very large -> all censored obs have w -> Inf)
-  # But this only matters for censored obs. For events, w is not used in dL/dmu.
-  # Clamp to prevent Inf * 0 issues.
-  w <- pmin(w, 1e6)
+  # Inverse Mills ratio: mills_i = phi(z_i) / Phi(-z_i)
+  # Computed in log scale for numerical stability, then exponentiating.
+  log_mills <- log_phi_z - log_surv
+  mills <- exp(log_mills)  # Safe: log_surv can be -Inf when Phi(-z) -> 0 (z -> +Inf)
+  # Clamp to prevent Inf * 0 issues when z is very large.
+  mills <- pmin(mills, 1e6)
 
   censored <- 1 - status  # (1 - delta_i)
 
+  # Weighted per-row building blocks. Every term below is the unweighted form
+  # with `delta`, `(1-delta)*mills` etc. multiplied by `weights`.
+  w_status <- weights * status
+  w_censmills <- weights * censored * mills
+
   # ===== Gradient w.r.t. mu =====
-  # dL/dmu = (1/sigma) * [sum(delta_i * z_i) + sum((1-delta_i) * w_i)]
-  grad[1] <- (sum(status * z) + sum(censored * w)) / sigma
+  # dL/dmu = (1/sigma) * sum(w * [delta * z + (1-delta) * mills])
+  grad[1] <- (sum(w_status * z) + sum(w_censmills)) / sigma
 
   # ===== Gradient w.r.t. log(sigma) =====
-  # dL/d(log sigma) = sum(delta_i * (z_i^2 - 1)) + sum((1-delta_i) * w_i * z_i)
-  grad[2] <- sum(status * (z^2 - 1)) + sum(censored * w * z)
+  # dL/d(log sigma) = sum(w * delta * (z^2 - 1)) + sum(w * (1-delta) * mills * z)
+  grad[2] <- sum(w_status * (z^2 - 1)) + sum(w_censmills * z)
 
   # ===== Gradient w.r.t. covariate beta =====
-  # dL/dbeta_j = (1/sigma) * sum([delta_i * z_i + (1-delta_i) * w_i] * x_ij)
+  # dL/dbeta_j = (1/sigma) * sum(w * [delta * z + (1-delta) * mills] * x_ij)
   if (p > 2 && !is.null(x)) {
-    score_i <- (status * z + censored * w) / sigma
+    score_i <- (w_status * z + w_censmills) / sigma
     grad[3:p] <- as.numeric(crossprod(x, score_i))
   }
 
@@ -306,7 +319,9 @@ NULL
   )
 }
 
-.hzr_numeric_grad_lognormal <- function(theta, time, status, time_lower = NULL, time_upper = NULL, x = NULL) {
+.hzr_numeric_grad_lognormal <- function(theta, time, status,
+                                          time_lower = NULL, time_upper = NULL,
+                                          x = NULL, weights = NULL) {
   # Reuse log-likelihood as scalar objective and differentiate numerically.
   objective <- function(par) {
     .hzr_logl_lognormal(
@@ -316,6 +331,7 @@ NULL
       time_lower = time_lower,
       time_upper = time_upper,
       x = x,
+      weights = weights,
       return_gradient = FALSE
     )
   }

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -484,12 +484,13 @@
 #' @keywords internal
 .hzr_gradient_multiphase <- function(theta, time, status,
                                       time_lower = NULL, time_upper = NULL,
-                                      x = NULL,
+                                      x = NULL, weights = NULL,
                                       phases, covariate_counts, x_list,
                                       ...) {
   n <- length(time)
   p <- length(theta)
   grad <- numeric(p)
+  if (is.null(weights)) weights <- rep(1, n)
 
   # Feasibility check
   theta_split <- .hzr_split_theta(theta, phases, covariate_counts)
@@ -590,10 +591,11 @@
   # For events, there's also the d/d[theta] of log h(t):
   #   d(log h) / d(theta_j) = (1/h) * dh/d(theta_j)
 
-  # Weight for the cumulative hazard part: w_H_i = dLogl / dH(t_i)
+  # Weight for the cumulative hazard part at `time[i]`: w_H_i = dLogl/dH(t_i),
+  # scaled by Fisher weights so the score matches the weighted log-likelihood.
   w_H <- numeric(n)
-  w_H[idx_event] <- -1
-  w_H[idx_right] <- -1
+  w_H[idx_event] <- -weights[idx_event]
+  w_H[idx_right] <- -weights[idx_right]
 
   if (has_left) {
     H_upper <- .hzr_multiphase_cumhaz(upper, theta, phases, covariate_counts,
@@ -601,17 +603,17 @@
     # d/dH log(1 - exp(-H)) = exp(-H) / (1 - exp(-H))
     exp_neg_H_u <- exp(-H_upper[idx_left])
     one_minus   <- pmax(1 - exp_neg_H_u, .Machine$double.xmin)
-    w_H[idx_left] <- exp_neg_H_u / one_minus
+    w_H[idx_left] <- weights[idx_left] * (exp_neg_H_u / one_minus)
     # Left-censored uses H(upper), not H(time), so we handle below
   }
 
-  # Weight for the instantaneous hazard part (events only): 1/h(t_i)
-  # This multiplies dh/d(theta_j)
+  # Weight for the instantaneous hazard part (events only): w_i / h(t_i).
+  # This multiplies dh/d(theta_j).
   inv_h <- numeric(n)
   if (length(idx_event) > 0) {
     h_event <- h_t[idx_event]
     h_event <- pmax(h_event, .Machine$double.xmin)
-    inv_h[idx_event] <- 1 / h_event
+    inv_h[idx_event] <- weights[idx_event] / h_event
   }
 
   # -- Assemble gradient per phase -------------------------------------------
@@ -772,16 +774,18 @@
 
   # -- Interval-censored fallback: add correction via finite difference ---
   # Interval-censored observations are uncommon; their gradient contribution
-  # is added via one-sided numerical difference on the log-likelihood of
-  # just those observations.
+  # is added via one-sided numerical difference on the weighted
+  # log-likelihood of just those observations.
   if (has_interval) {
+    w_iv <- weights[idx_interval]
     logl_iv <- function(th) {
       cumhaz_l <- .hzr_multiphase_cumhaz(lower, th, phases, covariate_counts,
                                           x_list)
       cumhaz_u <- .hzr_multiphase_cumhaz(upper, th, phases, covariate_counts,
                                           x_list)
       delta <- cumhaz_u[idx_interval] - cumhaz_l[idx_interval]
-      sum(-cumhaz_l[idx_interval] + hzr_log1mexp(delta))
+      sum(w_iv *
+            (-cumhaz_l[idx_interval] + hzr_log1mexp(delta)))
     }
     eps_rel <- sqrt(.Machine$double.eps)
     ll0_iv <- logl_iv(theta)
@@ -960,22 +964,24 @@
     grad <- .hzr_gradient_multiphase(
       theta = theta, time = time, status = status,
       time_lower = time_lower, time_upper = time_upper, x = x,
+      weights = weights,
       phases = phases, covariate_counts = covariate_counts, x_list = x_list
     )
 
     # Fallback: if gradient is all zero (e.g. at infeasible point), try
-    # numerical gradient to keep optimizer moving
+    # numerical gradient of the *weighted* LL to keep optimizer moving.
     if (all(grad == 0)) {
       eps_rel <- sqrt(.Machine$double.eps)
       p <- length(theta)
       ll0 <- logl_fn_unwrapped(theta, time, status, time_lower,
-                                time_upper, x, ...)
+                                time_upper, x, weights = weights, ...)
       for (i in seq_len(p)) {
         h_i <- eps_rel * max(abs(theta[i]), 1)
         theta_plus <- theta
         theta_plus[i] <- theta_plus[i] + h_i
         ll_plus <- logl_fn_unwrapped(theta_plus, time, status,
-                                      time_lower, time_upper, x, ...)
+                                      time_lower, time_upper, x,
+                                      weights = weights, ...)
         grad[i] <- (ll_plus - ll0) / h_i
       }
     }

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -284,15 +284,20 @@
 #' @param phases Named list of validated `hzr_phase` objects.
 #' @param covariate_counts Named integer vector.
 #' @param x_list Named list of per-phase design matrices.
+#' @param weights Optional numeric vector of row weights (length n). Defaults to
+#'   unit weights. Applied when summing per-phase cumhaz so that selection
+#'   happens on the same scale as the (weighted) observed event count.
 #' @return Character: name of the phase to fix.
 #' @keywords internal
 .hzr_select_fixmu_phase <- function(theta, time, status,
-                                     phases, covariate_counts, x_list) {
+                                     phases, covariate_counts, x_list,
+                                     weights = NULL) {
   decomp <- .hzr_multiphase_cumhaz(time, theta, phases,
                                      covariate_counts, x_list,
                                      per_phase = TRUE)
+  if (is.null(weights)) weights <- rep(1, length(time))
   phase_sums <- vapply(names(phases), function(nm) {
-    sum(decomp[[nm]])
+    sum(weights * decomp[[nm]])
   }, numeric(1))
 
   names(which.max(phase_sums))
@@ -315,23 +320,29 @@
 #' @param phases Named list of validated `hzr_phase` objects.
 #' @param covariate_counts Named integer vector.
 #' @param x_list Named list of per-phase design matrices.
-#' @param total_events Numeric: sum of observed events (precomputed).
+#' @param total_events Numeric: sum of observed events (precomputed, weighted
+#'   when `weights` is supplied).
+#' @param weights Optional numeric vector of row weights (length n). Defaults to
+#'   unit weights. Applied when summing per-phase cumhaz so Turner's adjustment
+#'   is computed on the same scale as `total_events`.
 #' @return Updated theta vector with fixmu phase's log_mu adjusted.
 #' @keywords internal
 .hzr_conserve_events <- function(theta, fixmu_phase, fixmu_pos,
                                   time, status,
                                   phases, covariate_counts, x_list,
-                                  total_events) {
+                                  total_events, weights = NULL) {
   # Compute per-phase cumulative hazard contributions
   decomp <- .hzr_multiphase_cumhaz(time, theta, phases,
                                      covariate_counts, x_list,
                                      per_phase = TRUE)
 
-  # Total predicted events (sum of cumhaz across all observations)
-  sumcz <- sum(decomp$total)
+  if (is.null(weights)) weights <- rep(1, length(time))
 
-  # Contribution from the fixmu phase alone
-  sumcj <- sum(decomp[[fixmu_phase]])
+  # Total predicted events (weighted sum of cumhaz across all observations)
+  sumcz <- sum(weights * decomp$total)
+
+  # Weighted contribution from the fixmu phase alone
+  sumcj <- sum(weights * decomp[[fixmu_phase]])
 
   if (sumcj <= 0 || !is.finite(sumcj)) return(theta)
 
@@ -985,25 +996,16 @@
   # left censoring require a different event-counting formulation.
   coe_supported_data <- all(status %in% c(0, 1))
 
-  # CoE with non-uniform weights is not yet wired up: `.hzr_conserve_events()`
-  # receives the weighted event count as `total_events` but sums the per-phase
-  # cumhaz across rows *without* applying weights, so Turner's adjustment is
-  # computed on a mismatched scale.  Auto-disable CoE when weights are not
-  # all 1 and let the optimizer fall through to the (correctly weighted)
-  # full-dimensional path.  Tracked in
-  # `inst/dev/DEVELOPMENT-PLAN.md` Phase 4e.
-  coe_supported_weights <- all(weights == 1)
-
-  if (use_conserve && coe_supported_data && coe_supported_weights &&
-        length(phases) >= 2L) {
+  if (use_conserve && coe_supported_data && length(phases) >= 2L) {
     total_events <- sum(weights[status == 1])
     if (total_events > 0) {
-      # Initial CoE scaling: adjust all log_mu proportionally
+      # Initial CoE scaling: adjust all log_mu proportionally (weighted sums
+      # so the scaling is consistent with total_events).
       decomp_init <- .hzr_multiphase_cumhaz(
         time, theta_start, phases, covariate_counts, x_list,
         per_phase = TRUE
       )
-      sumcz_init <- sum(decomp_init$total)
+      sumcz_init <- sum(weights * decomp_init$total)
       if (sumcz_init > 0 && is.finite(sumcz_init)) {
         init_factor <- log(total_events / sumcz_init)
         if (is.finite(init_factor)) {
@@ -1014,16 +1016,18 @@
         }
       }
 
-      # Select fixmu phase (largest cumhaz contributor after scaling)
+      # Select fixmu phase (largest weighted cumhaz contributor after scaling)
       fixmu_phase <- .hzr_select_fixmu_phase(
-        theta_start, time, status, phases, covariate_counts, x_list
+        theta_start, time, status, phases, covariate_counts, x_list,
+        weights = weights
       )
       fixmu_pos <- log_mu_positions[[fixmu_phase]]
 
       # Apply precise CoE adjustment to the fixmu phase
       theta_start <- .hzr_conserve_events(
         theta_start, fixmu_phase, fixmu_pos,
-        time, status, phases, covariate_counts, x_list, total_events
+        time, status, phases, covariate_counts, x_list, total_events,
+        weights = weights
       )
 
       # Wrap logl and gradient: apply CoE before each evaluation
@@ -1032,7 +1036,8 @@
                           time_upper, x, weights = NULL, ...) {
         theta <- .hzr_conserve_events(
           theta, fixmu_phase, fixmu_pos,
-          time, status, phases, covariate_counts, x_list, total_events
+          time, status, phases, covariate_counts, x_list, total_events,
+          weights = weights
         )
         logl_fn_pre_coe(theta, time, status, time_lower,
                         time_upper, x, weights = weights, ...)
@@ -1043,7 +1048,8 @@
                               time_upper, x, weights = NULL, ...) {
         theta <- .hzr_conserve_events(
           theta, fixmu_phase, fixmu_pos,
-          time, status, phases, covariate_counts, x_list, total_events
+          time, status, phases, covariate_counts, x_list, total_events,
+          weights = weights
         )
         gradient_fn_pre_coe(theta, time, status, time_lower,
                             time_upper, x, weights = weights, ...)
@@ -1187,7 +1193,8 @@
     if (use_conserve && !is.null(fixmu_pos)) {
       best_result$par <- .hzr_conserve_events(
         best_result$par, fixmu_phase, fixmu_pos,
-        time, status, phases, covariate_counts, x_list, total_events
+        time, status, phases, covariate_counts, x_list, total_events,
+        weights = weights
       )
     }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TemporalHazard
 
 <!-- badges: start -->
-[![version](https://img.shields.io/badge/version-0.9.5-blue.svg)](https://github.com/ehrlinger/temporal_hazard)
+[![version](https://img.shields.io/badge/version-0.9.6-blue.svg)](https://github.com/ehrlinger/temporal_hazard)
 [![R-CMD-check](https://github.com/ehrlinger/temporal_hazard/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ehrlinger/temporal_hazard/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/ehrlinger/temporal_hazard/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ehrlinger/temporal_hazard?branch=main)
 [![lint](https://github.com/ehrlinger/temporal_hazard/actions/workflows/lint.yaml/badge.svg)](https://github.com/ehrlinger/temporal_hazard/actions/workflows/lint.yaml)

--- a/inst/dev/DEVELOPMENT-PLAN.md
+++ b/inst/dev/DEVELOPMENT-PLAN.md
@@ -146,14 +146,17 @@ Tasks:
 7. User-facing API: `hzr_stepwise()` or `step.hazard()` method
 8. Selection trace printing/reporting
 
-### 4c. Observation Weights -- PARTIAL (v0.9.4 + v0.9.5 Weibull gradient fix)
+### 4c. Observation Weights -- COMPLETE (v0.9.6)
 
 `weights` argument on `hazard()` applies Fisher weighting to the
-log-likelihood for `dist = "weibull"` and `dist = "multiphase"`.
-Threaded through both likelihoods, the multiphase Conservation-of-Events
-adjustment, and (as of 0.9.5) the Weibull analytic gradient.
-`hazard()` raises an explicit error when `weights` is supplied with
-`dist` in `{"exponential", "log-logistic", "log-normal"}`.
+log-likelihood across all five distributions (Weibull, exponential,
+log-logistic, log-normal, multiphase). Threaded through every
+distribution's likelihood and analytic gradient, the multiphase
+Conservation-of-Events adjustment (`.hzr_conserve_events()` weights
+per-phase cumhaz sums so Turner's adjustment is on the same scale as
+the weighted event count), and the numerical-gradient fallbacks for
+mixed censoring. Integer weights reproduce the row-duplicated fit to
+optimizer tolerance for every distribution.
 
 ### 4d. Repeating Events (Epoch Decomposition) -- PARTIAL (narrowed in v0.9.5)
 
@@ -165,33 +168,23 @@ likelihoods only honour `time_lower` for interval-censored
 (`status == 2`) rows, so a nonzero-start epoch would be silently
 scored with `H(stop)` alone rather than `H(stop) - H(start)`.
 
-### 4e. Complete `weights` wire-up (exp / log-logistic / log-normal + CoE)
+### 4e. Complete `weights` wire-up (exp / log-logistic / log-normal + CoE) -- COMPLETE (v0.9.6)
 
-**Priority:** Medium
-**Effort:** Small--Medium
-**Gate:** Remove the `dist %in% c("weibull", "multiphase")` guard
-in `hazard()` *and* the `all(weights == 1)` guard on CoE in
-`R/likelihood-multiphase.R`. Add parity tests in `test-weights.R`
-covering each distribution against the row-duplicated reference fit,
-and re-enable weighted-CoE tests in `test-conservation-of-events.R`.
+Every LL term in `R/likelihood-exponential.R`,
+`R/likelihood-loglogistic.R`, and `R/likelihood-lognormal.R` now
+multiplies by `weights[idx_*]`; analytic gradients use weighted
+building blocks (`w * status`, `w * cumhaz`, `w * (1+delta) * pw`
+for log-logistic, `w * (1-delta) * mills` for log-normal). Numerical
+gradient fallbacks forward `weights` through. The
+`dist %in% c("weibull", "multiphase")` guard in `hazard()` has been
+removed.
 
-Tasks:
-
-1. `R/likelihood-exponential.R` -- multiply every LL term by
-   `weights[idx_*]`; update analytic gradient to use weighted building
-   blocks (`w * status`, `w * cumhaz`).
-2. Same for `R/likelihood-loglogistic.R` and `R/likelihood-lognormal.R`.
-3. Thread `weights` from `.hzr_optim_*` into each distribution's
-   `grad_internal` closure (mirroring the Weibull fix from 0.9.5).
-4. Remove the error guard in `hazard()`.
-5. Extend `test-weights.R` with per-distribution duplication-parity
-   tests.
-6. `.hzr_conserve_events()` -- add a `weights` argument and apply it
-   when summing per-phase cumhaz (`sumcz`, `sumcj`) so the Turner
-   target and predicted-event target are on the same scale.
-7. Remove the `all(weights == 1)` check in the CoE guard at
-   `R/likelihood-multiphase.R:944` and re-enable weighted-CoE parity
-   tests in `test-conservation-of-events.R`.
+`.hzr_conserve_events()` and `.hzr_select_fixmu_phase()` take an
+optional `weights` argument applied to per-phase cumhaz sums; the
+`all(weights == 1)` guard on CoE in `R/likelihood-multiphase.R` is
+gone. Duplication-parity tests for each distribution are in
+`test-weights.R`; weighted-CoE parity (CoE on and off) lives in
+`test-conservation-of-events.R`.
 
 ### 4f. Complete repeating-events wire-up (counting-process LL)
 
@@ -222,10 +215,10 @@ Tasks:
 
 ### 4b scheduling note
 
-With 4a, 4b, and 4c/4d narrowed, the remaining SAS-parity gaps are:
-`weights` completion (4e), repeating-events wire-up (4f), and the
-stepwise enhancements (FAST screening, multi-step MOVE trace) tracked
-separately.
+With 4a, 4b, 4c, and 4e complete and 4d narrowed, the remaining
+SAS-parity gaps are: repeating-events wire-up (4f), prediction
+confidence limits (4g), and the stepwise enhancements (FAST screening,
+multi-step MOVE trace) tracked separately.
 
 ---
 

--- a/man/dot-hzr_conserve_events.Rd
+++ b/man/dot-hzr_conserve_events.Rd
@@ -13,7 +13,8 @@
   phases,
   covariate_counts,
   x_list,
-  total_events
+  total_events,
+  weights = NULL
 )
 }
 \arguments{
@@ -33,7 +34,12 @@
 
 \item{x_list}{Named list of per-phase design matrices.}
 
-\item{total_events}{Numeric: sum of observed events (precomputed).}
+\item{total_events}{Numeric: sum of observed events (precomputed, weighted
+when \code{weights} is supplied).}
+
+\item{weights}{Optional numeric vector of row weights (length n). Defaults to
+unit weights. Applied when summing per-phase cumhaz so Turner's adjustment
+is computed on the same scale as \code{total_events}.}
 }
 \value{
 Updated theta vector with fixmu phase's log_mu adjusted.

--- a/man/dot-hzr_gradient_multiphase.Rd
+++ b/man/dot-hzr_gradient_multiphase.Rd
@@ -11,6 +11,7 @@
   time_lower = NULL,
   time_upper = NULL,
   x = NULL,
+  weights = NULL,
   phases,
   covariate_counts,
   x_list,

--- a/man/dot-hzr_select_fixmu_phase.Rd
+++ b/man/dot-hzr_select_fixmu_phase.Rd
@@ -4,7 +4,15 @@
 \alias{.hzr_select_fixmu_phase}
 \title{Select the phase whose log_mu will be solved by conservation}
 \usage{
-.hzr_select_fixmu_phase(theta, time, status, phases, covariate_counts, x_list)
+.hzr_select_fixmu_phase(
+  theta,
+  time,
+  status,
+  phases,
+  covariate_counts,
+  x_list,
+  weights = NULL
+)
 }
 \arguments{
 \item{theta}{Full parameter vector (internal scale).}
@@ -18,6 +26,10 @@
 \item{covariate_counts}{Named integer vector.}
 
 \item{x_list}{Named list of per-phase design matrices.}
+
+\item{weights}{Optional numeric vector of row weights (length n). Defaults to
+unit weights. Applied when summing per-phase cumhaz so that selection
+happens on the same scale as the (weighted) observed event count.}
 }
 \value{
 Character: name of the phase to fix.

--- a/tests/testthat/test-conservation-of-events.R
+++ b/tests/testthat/test-conservation-of-events.R
@@ -234,22 +234,17 @@ test_that("CoE auto-disables (no error) when any observation is interval-censore
 })
 
 # ===========================================================================
-# CoE auto-disables for non-unit weights
+# CoE with non-unit weights (wired up in v0.9.6, Phase 4e)
 # ===========================================================================
 #
-# `.hzr_conserve_events()` takes the weighted event count as `total_events`
-# but computes the per-phase cumhaz sums *without* applying row weights, so
-# Turner's adjustment comes out on a mismatched scale when weights aren't
-# all 1. The optimizer was narrowed in v0.9.5 to auto-disable CoE in that
-# regime and fall through to the (correctly weighted) full-dim path.
-#
-# Under that narrowing, a weighted fit on D must match the unweighted fit
-# on the row-duplicated dataset expand(D, w) -- the same invariant as
-# test-weights.R, repeated here with a multiphase model to prove that
-# (a) CoE is indeed disabled with w != 1, and (b) the weighted LL path
-# is consistent end-to-end with duplication.
+# Prior to 0.9.6, `.hzr_conserve_events()` summed per-phase cumhaz without
+# applying row weights, so Turner's adjustment was on a mismatched scale
+# vs the (weighted) observed event count.  CoE therefore auto-disabled
+# when any weight != 1.  As of 0.9.6, weights are threaded into
+# `.hzr_conserve_events()` / `.hzr_select_fixmu_phase()` and CoE stays on
+# for weighted fits.  Duplication parity is the acceptance criterion.
 
-test_that("weighted multiphase fit matches the row-duplicated fit (CoE auto-off for w != 1)", {
+test_that("weighted multiphase fit matches the row-duplicated fit (CoE off)", {
   skip_on_cran()
   set.seed(42)
   data(cabgkul, package = "TemporalHazard")
@@ -283,11 +278,45 @@ test_that("weighted multiphase fit matches the row-duplicated fit (CoE auto-off 
   expect_equal(unname(coef(fit_w)), unname(coef(fit_dup)), tolerance = 1e-2)
 })
 
-test_that("CoE auto-disabled when default conserve=TRUE meets non-unit weights", {
-  # With weights != 1 the optimizer should behave identically to an
-  # explicit `conserve = FALSE` run.  We check by comparing
-  # log-likelihoods (coefficients may differ by trivially small amounts
-  # due to multi-start RNG), not by inspecting optimizer internals.
+test_that("weighted multiphase fit matches the row-duplicated fit (CoE on)", {
+  skip_on_cran()
+  set.seed(42)
+  data(cabgkul, package = "TemporalHazard")
+  small <- cabgkul[1:40, ]
+  w <- sample(1:2, nrow(small), replace = TRUE)
+  idx <- rep(seq_len(nrow(small)), times = w)
+  dup <- small[idx, ]
+
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.2, nu = 1, m = 1,
+                           fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+
+  # CoE enabled on both sides: the weighted fit reduces the dimension on
+  # D, the unweighted fit reduces it on expand(D, w).  The optimum (MLE
+  # and log-likelihood) must match because CoE is a reparameterisation
+  # of the same surface.
+  fit_w <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data = small, dist = "multiphase", phases = phases,
+    weights = w, fit = TRUE,
+    control = list(n_starts = 2, maxit = 300, conserve = TRUE)
+  )
+  fit_dup <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data = dup, dist = "multiphase", phases = phases,
+    fit = TRUE,
+    control = list(n_starts = 2, maxit = 300, conserve = TRUE)
+  )
+
+  expect_equal(fit_w$fit$objective, fit_dup$fit$objective, tolerance = 1e-3)
+  expect_equal(unname(coef(fit_w)), unname(coef(fit_dup)), tolerance = 1e-2)
+})
+
+test_that("CoE default (conserve=TRUE) with weights reaches the same optimum as conserve=FALSE", {
+  # CoE reduces dimension; it does not change the log-likelihood surface.
+  # Both paths must land at the same MLE log-likelihood.
   skip_on_cran()
   set.seed(77)
   data(cabgkul, package = "TemporalHazard")

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -546,6 +546,48 @@ test_that("weighted LL matches duplicated-row LL under mixed censoring (log-norm
   expect_equal(ll_w, ll_dup, tolerance = 1e-10)
 })
 
+test_that("weighted multiphase analytic gradient matches numerical gradient", {
+  # `.hzr_gradient_multiphase()` must apply `weights` to the per-row score
+  # (w_H, inv_h, and the interval-censored finite-difference correction).
+  # Prior to 0.9.6 it ignored the argument, so weighted multiphase fits
+  # optimized a weighted objective with an unweighted gradient -- the fit
+  # still converged near the right MLE via line search but the final
+  # gradient norm did not go to zero.  This test would have caught it.
+  skip_if_not_installed("numDeriv")
+
+  set.seed(31)
+  n <- 40
+  t <- runif(n, 0.1, 3)
+  status <- rbinom(n, 1, 0.45)
+  w <- sample(1:3, n, replace = TRUE)
+
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.3, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  cov_counts <- c(early = 0L, constant = 0L)
+  x_list <- list(early = NULL, constant = NULL)
+  # [log_mu_e, log_thalf, nu, m, log_mu_c]
+  theta <- c(-4, log(0.3), 1, 1, -3)
+
+  num_g <- numDeriv::grad(
+    function(th) {
+      TemporalHazard:::.hzr_logl_multiphase(
+        theta = th, time = t, status = status,
+        phases = phases, covariate_counts = cov_counts,
+        x_list = x_list, weights = w
+      )
+    },
+    theta
+  )
+  ana_g <- TemporalHazard:::.hzr_gradient_multiphase(
+    theta = theta, time = t, status = status,
+    weights = w,
+    phases = phases, covariate_counts = cov_counts, x_list = x_list
+  )
+  expect_equal(as.numeric(ana_g), num_g, tolerance = 1e-4)
+})
+
 test_that("zero weight drops the row's contribution across mixed censoring (log-normal)", {
   # Targeted sanity check of the per-term weighting: zeroing one row of each
   # censoring flavour must equal dropping those rows entirely.

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -452,3 +452,122 @@ test_that("fit with integer weights matches the duplicated-row fit (log-normal)"
   expect_equal(coef(fit_w), coef(fit_dup), tolerance = 1e-3)
   expect_equal(fit_w$fit$objective, fit_dup$fit$objective, tolerance = 1e-4)
 })
+
+# ---------------------------------------------------------------------------
+# Mixed-censoring (status == -1 and status == 2) duplication-parity for
+# exp / log-logistic / log-normal.  The weighted LL now applies row
+# weights to the left-censored term `log(1 - exp(-H(u)))` and the
+# interval-censored term `log(F(u) - F(l))` as well; these tests
+# exercise those newly weighted branches.
+# ---------------------------------------------------------------------------
+
+make_mixed <- function(seed = 23) {
+  set.seed(seed)
+  n <- 24
+  x <- rnorm(n)
+  t <- runif(n, 0.1, 2.0)
+  # 10 events, 4 right-censored, 5 left-censored, 5 interval-censored
+  status <- c(rep(1L, 10), rep(0L, 4), rep(-1L, 5), rep(2L, 5))
+  # Interval bounds must be strictly positive with lower < upper.
+  # Left-censored rows set time_upper = time; non-interval rows set
+  # time_lower = time (ignored by the LL except on interval rows).
+  time_lower <- t
+  time_upper <- t
+  idx_iv <- which(status == 2)
+  time_lower[idx_iv] <- t[idx_iv]
+  time_upper[idx_iv] <- t[idx_iv] + runif(length(idx_iv), 0.05, 0.3)
+  list(time = t, status = status, x = x,
+       time_lower = time_lower, time_upper = time_upper)
+}
+
+test_that("weighted LL matches duplicated-row LL under mixed censoring (exponential)", {
+  m <- make_mixed()
+  n <- length(m$time)
+  w <- sample(1:3, n, replace = TRUE)
+  idx <- rep(seq_len(n), times = w)
+  theta <- c(log_lambda = log(0.5), beta = 0.2)
+  xm <- matrix(m$x, ncol = 1)
+
+  ll_w <- TemporalHazard:::.hzr_logl_exponential(
+    theta = theta, time = m$time, status = m$status,
+    time_lower = m$time_lower, time_upper = m$time_upper,
+    x = xm, weights = w
+  )
+  ll_dup <- TemporalHazard:::.hzr_logl_exponential(
+    theta = theta,
+    time = m$time[idx], status = m$status[idx],
+    time_lower = m$time_lower[idx], time_upper = m$time_upper[idx],
+    x = matrix(m$x[idx], ncol = 1), weights = rep(1, sum(w))
+  )
+  expect_equal(ll_w, ll_dup, tolerance = 1e-10)
+})
+
+test_that("weighted LL matches duplicated-row LL under mixed censoring (log-logistic)", {
+  m <- make_mixed()
+  n <- length(m$time)
+  w <- sample(1:3, n, replace = TRUE)
+  idx <- rep(seq_len(n), times = w)
+  theta <- c(log_alpha = log(0.5), log_beta = log(1.1), beta = 0.2)
+  xm <- matrix(m$x, ncol = 1)
+
+  ll_w <- TemporalHazard:::.hzr_logl_loglogistic(
+    theta = theta, time = m$time, status = m$status,
+    time_lower = m$time_lower, time_upper = m$time_upper,
+    x = xm, weights = w
+  )
+  ll_dup <- TemporalHazard:::.hzr_logl_loglogistic(
+    theta = theta,
+    time = m$time[idx], status = m$status[idx],
+    time_lower = m$time_lower[idx], time_upper = m$time_upper[idx],
+    x = matrix(m$x[idx], ncol = 1), weights = rep(1, sum(w))
+  )
+  expect_equal(ll_w, ll_dup, tolerance = 1e-10)
+})
+
+test_that("weighted LL matches duplicated-row LL under mixed censoring (log-normal)", {
+  m <- make_mixed()
+  n <- length(m$time)
+  w <- sample(1:3, n, replace = TRUE)
+  idx <- rep(seq_len(n), times = w)
+  theta <- c(mu = 0, log_sigma = log(1), beta = 0.2)
+  xm <- matrix(m$x, ncol = 1)
+
+  ll_w <- TemporalHazard:::.hzr_logl_lognormal(
+    theta = theta, time = m$time, status = m$status,
+    time_lower = m$time_lower, time_upper = m$time_upper,
+    x = xm, weights = w
+  )
+  ll_dup <- TemporalHazard:::.hzr_logl_lognormal(
+    theta = theta,
+    time = m$time[idx], status = m$status[idx],
+    time_lower = m$time_lower[idx], time_upper = m$time_upper[idx],
+    x = matrix(m$x[idx], ncol = 1), weights = rep(1, sum(w))
+  )
+  expect_equal(ll_w, ll_dup, tolerance = 1e-10)
+})
+
+test_that("zero weight drops the row's contribution across mixed censoring (log-normal)", {
+  # Targeted sanity check of the per-term weighting: zeroing one row of each
+  # censoring flavour must equal dropping those rows entirely.
+  m <- make_mixed()
+  n <- length(m$time)
+  w <- rep(1, n)
+  # Zero out one event, one RC, one left, one interval row.
+  w[c(1, 11, 15, 20)] <- 0
+  keep <- w > 0
+  theta <- c(mu = 0, log_sigma = log(1), beta = 0.2)
+  xm <- matrix(m$x, ncol = 1)
+
+  ll_w <- TemporalHazard:::.hzr_logl_lognormal(
+    theta = theta, time = m$time, status = m$status,
+    time_lower = m$time_lower, time_upper = m$time_upper,
+    x = xm, weights = w
+  )
+  ll_drop <- TemporalHazard:::.hzr_logl_lognormal(
+    theta = theta,
+    time = m$time[keep], status = m$status[keep],
+    time_lower = m$time_lower[keep], time_upper = m$time_upper[keep],
+    x = xm[keep, , drop = FALSE], weights = rep(1, sum(keep))
+  )
+  expect_equal(ll_w, ll_drop, tolerance = 1e-12)
+})

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -255,3 +255,200 @@ test_that("a zero weight drops the row's contribution to the likelihood", {
   )
   expect_equal(ll_w, ll_drop, tolerance = 1e-12)
 })
+
+# ---------------------------------------------------------------------------
+# Per-distribution duplication-parity for exp / log-logistic / log-normal
+# (wired up in v0.9.6 as part of Phase 4e).
+# ---------------------------------------------------------------------------
+
+test_that("integer weights match row duplication (exponential LL)", {
+  df <- make_toy()
+  n <- nrow(df)
+  w <- sample(1:3, n, replace = TRUE)
+  idx <- rep(seq_len(n), times = w)
+  theta <- c(log_lambda = log(0.6), beta = 0.25)
+  xm <- matrix(df$x, ncol = 1)
+
+  ll_w <- TemporalHazard:::.hzr_logl_exponential(
+    theta = theta, time = df$time, status = df$status,
+    x = xm, weights = w
+  )
+  ll_dup <- TemporalHazard:::.hzr_logl_exponential(
+    theta = theta, time = df$time[idx], status = df$status[idx],
+    x = matrix(df$x[idx], ncol = 1), weights = rep(1, sum(w))
+  )
+  expect_equal(ll_w, ll_dup, tolerance = 1e-10)
+})
+
+test_that("integer weights match row duplication (log-logistic LL)", {
+  df <- make_toy()
+  n <- nrow(df)
+  w <- sample(1:3, n, replace = TRUE)
+  idx <- rep(seq_len(n), times = w)
+  theta <- c(log_alpha = log(0.6), log_beta = log(1.2), beta = 0.25)
+  xm <- matrix(df$x, ncol = 1)
+
+  ll_w <- TemporalHazard:::.hzr_logl_loglogistic(
+    theta = theta, time = df$time, status = df$status,
+    x = xm, weights = w
+  )
+  ll_dup <- TemporalHazard:::.hzr_logl_loglogistic(
+    theta = theta, time = df$time[idx], status = df$status[idx],
+    x = matrix(df$x[idx], ncol = 1), weights = rep(1, sum(w))
+  )
+  expect_equal(ll_w, ll_dup, tolerance = 1e-10)
+})
+
+test_that("integer weights match row duplication (log-normal LL)", {
+  df <- make_toy()
+  n <- nrow(df)
+  w <- sample(1:3, n, replace = TRUE)
+  idx <- rep(seq_len(n), times = w)
+  theta <- c(mu = 0, log_sigma = log(1), beta = 0.25)
+  xm <- matrix(df$x, ncol = 1)
+
+  ll_w <- TemporalHazard:::.hzr_logl_lognormal(
+    theta = theta, time = df$time, status = df$status,
+    x = xm, weights = w
+  )
+  ll_dup <- TemporalHazard:::.hzr_logl_lognormal(
+    theta = theta, time = df$time[idx], status = df$status[idx],
+    x = matrix(df$x[idx], ncol = 1), weights = rep(1, sum(w))
+  )
+  expect_equal(ll_w, ll_dup, tolerance = 1e-10)
+})
+
+# Analytic gradients for exp / log-logistic / log-normal match numerical
+# gradients of the weighted LL.  Catches the "accepts formal but never
+# applies it" pattern in the analytic score path.
+
+test_that("weighted exponential gradient equals numerical gradient", {
+  skip_if_not_installed("numDeriv")
+  df <- make_toy()
+  w <- sample(1:3, nrow(df), replace = TRUE)
+  theta <- c(log_lambda = log(0.6), beta = 0.25)
+  xm <- matrix(df$x, ncol = 1)
+
+  num_g <- numDeriv::grad(
+    function(th) {
+      TemporalHazard:::.hzr_logl_exponential(
+        theta = th, time = df$time, status = df$status,
+        x = xm, weights = w
+      )
+    },
+    theta
+  )
+  ana_g <- TemporalHazard:::.hzr_gradient_exponential(
+    theta = theta, time = df$time, status = df$status,
+    x = xm, weights = w
+  )
+  expect_equal(as.numeric(ana_g), num_g, tolerance = 1e-5)
+})
+
+test_that("weighted log-logistic gradient equals numerical gradient", {
+  skip_if_not_installed("numDeriv")
+  df <- make_toy()
+  w <- sample(1:3, nrow(df), replace = TRUE)
+  theta <- c(log_alpha = log(0.6), log_beta = log(1.2), beta = 0.25)
+  xm <- matrix(df$x, ncol = 1)
+
+  num_g <- numDeriv::grad(
+    function(th) {
+      TemporalHazard:::.hzr_logl_loglogistic(
+        theta = th, time = df$time, status = df$status,
+        x = xm, weights = w
+      )
+    },
+    theta
+  )
+  ana_g <- TemporalHazard:::.hzr_gradient_loglogistic(
+    theta = theta, time = df$time, status = df$status,
+    x = xm, weights = w
+  )
+  expect_equal(as.numeric(ana_g), num_g, tolerance = 1e-5)
+})
+
+test_that("weighted log-normal gradient equals numerical gradient", {
+  skip_if_not_installed("numDeriv")
+  df <- make_toy()
+  w <- sample(1:3, nrow(df), replace = TRUE)
+  theta <- c(mu = 0, log_sigma = log(1), beta = 0.25)
+  xm <- matrix(df$x, ncol = 1)
+
+  num_g <- numDeriv::grad(
+    function(th) {
+      TemporalHazard:::.hzr_logl_lognormal(
+        theta = th, time = df$time, status = df$status,
+        x = xm, weights = w
+      )
+    },
+    theta
+  )
+  ana_g <- TemporalHazard:::.hzr_gradient_lognormal(
+    theta = theta, time = df$time, status = df$status,
+    x = xm, weights = w
+  )
+  expect_equal(as.numeric(ana_g), num_g, tolerance = 1e-5)
+})
+
+# End-to-end: weighted fit == duplicated-row fit for each distribution.
+
+test_that("fit with integer weights matches the duplicated-row fit (exponential)", {
+  skip_on_cran()
+  df <- make_toy()
+  n <- nrow(df)
+  w <- sample(1:3, n, replace = TRUE)
+  df_exp <- expand_rows(df, w)
+
+  fit_w <- hazard(
+    survival::Surv(time, status) ~ x, data = df,
+    dist = "exponential", weights = w, fit = TRUE
+  )
+  fit_dup <- hazard(
+    survival::Surv(time, status) ~ x, data = df_exp,
+    dist = "exponential", fit = TRUE
+  )
+
+  expect_equal(coef(fit_w), coef(fit_dup), tolerance = 1e-3)
+  expect_equal(fit_w$fit$objective, fit_dup$fit$objective, tolerance = 1e-4)
+})
+
+test_that("fit with integer weights matches the duplicated-row fit (log-logistic)", {
+  skip_on_cran()
+  df <- make_toy()
+  n <- nrow(df)
+  w <- sample(1:3, n, replace = TRUE)
+  df_exp <- expand_rows(df, w)
+
+  fit_w <- hazard(
+    survival::Surv(time, status) ~ x, data = df,
+    dist = "loglogistic", weights = w, fit = TRUE
+  )
+  fit_dup <- hazard(
+    survival::Surv(time, status) ~ x, data = df_exp,
+    dist = "loglogistic", fit = TRUE
+  )
+
+  expect_equal(coef(fit_w), coef(fit_dup), tolerance = 1e-3)
+  expect_equal(fit_w$fit$objective, fit_dup$fit$objective, tolerance = 1e-4)
+})
+
+test_that("fit with integer weights matches the duplicated-row fit (log-normal)", {
+  skip_on_cran()
+  df <- make_toy()
+  n <- nrow(df)
+  w <- sample(1:3, n, replace = TRUE)
+  df_exp <- expand_rows(df, w)
+
+  fit_w <- hazard(
+    survival::Surv(time, status) ~ x, data = df,
+    dist = "lognormal", weights = w, fit = TRUE
+  )
+  fit_dup <- hazard(
+    survival::Surv(time, status) ~ x, data = df_exp,
+    dist = "lognormal", fit = TRUE
+  )
+
+  expect_equal(coef(fit_w), coef(fit_dup), tolerance = 1e-3)
+  expect_equal(fit_w$fit$objective, fit_dup$fit$objective, tolerance = 1e-4)
+})


### PR DESCRIPTION
## Summary

Closes Phase 4e of the DEVELOPMENT-PLAN. `weights` now applies across all five distributions (Weibull, exponential, log-logistic, log-normal, multiphase) with duplication parity against the row-duplicated fit.

- **Likelihoods:** every censoring term in `R/likelihood-{exponential,loglogistic,lognormal}.R` multiplies by `weights[idx_*]`; LL defaults to unit weights when `weights = NULL`.
- **Analytic gradients:** each distribution's score vector uses weighted building blocks (`w*status`, `w*cumhaz`; `w*(1+delta)*pw` for log-logistic; `w*(1-delta)*mills` for log-normal). Numeric-gradient fallbacks for mixed censoring forward `weights`.
- **CoE:** `.hzr_conserve_events()` and `.hzr_select_fixmu_phase()` take an optional `weights` argument; multiphase optimizer threads it through so Turner's adjustment is on the same scale as the weighted event count. Drops the v0.9.5 `all(weights == 1)` auto-off narrowing — CoE stays on for weighted fits.
- **API:** removed the `dist %in% c("weibull", "multiphase")` guard in `hazard()` that rejected weights for the single-distribution paths.

## Scope change from v0.9.5

The v0.9.5 NEWS flagged CoE as auto-disabled for `weights != 1` and `hazard()` as rejecting weights for exp/loglog/lognorm. Both of those narrowings are now resolved, not worked around.

## Test plan

- [x] Per-distribution duplication-parity LL tests: `logl(theta; w, D) == logl(theta; 1, expand(D, w))` for exp/loglog/lognorm
- [x] Weighted analytic gradient matches `numDeriv::grad` of the weighted LL for exp/loglog/lognorm
- [x] End-to-end `hazard(..., weights = w)` MLE + log-likelihood matches `hazard(..., data = expand(D, w))` for exp/loglog/lognorm
- [x] Weighted multiphase fit matches duplicated-row fit with CoE off (regression of the v0.9.5 test)
- [x] Weighted multiphase fit matches duplicated-row fit with CoE on (new — proves CoE weight-threading is correct)
- [x] CoE default (on) and explicit-off reach the same objective with weights
- [x] Full suite: 1103 PASS / 0 FAIL
- [x] `lintr::lint_package()`: 0 lints
- [x] `R CMD check` (no vignettes): 0 errors, 0 notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)