### PR TITLE
Wire H(stop) - H(start) into Weibull and multiphase (Phase 4f)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling in R
-Version: 0.9.6
+Version: 0.9.7
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre"))
 Author: John Ehrlinger [aut, cre]
 Maintainer: John Ehrlinger <john.ehrlinger@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# TemporalHazard 0.9.7
+
+## New features
+
+* **Counting-process / repeating-events likelihood wired up** — Phase 4f
+  of the development plan lands. `Surv(start, stop, event)` with any
+  `start > 0` is now accepted. The Weibull and multiphase log-likelihoods
+  apply `H(stop) - H(start)` to event and right-censored terms; the
+  trivial `start = 0` case degenerates to `H(stop)` and recovers the
+  plain-Surv fit exactly. Splitting each row into contiguous epochs
+  preserves both the log-likelihood and the MLE to optimizer tolerance
+  (split-invariance).
+* **Weibull + multiphase analytic gradients handle H(start).** The
+  closed-form Weibull score adds a `-d H(start)/d theta` term per row
+  (guarded at `start = 0`). The multiphase analytic gradient computes
+  per-phase `Phi_j(start)` and its shape derivatives, then adds
+  `+w_H_start * mu_j * dPhi_j(start)` to each parameter's score; G3
+  phase derivatives at `start` use the same finite-difference machinery
+  as at `stop`.
+* **0.9.5 narrowing removed.** The `hazard()` guard that rejected
+  counting-process `Surv(start, stop, event)` with any `start > 0` is
+  gone.
+
 # TemporalHazard 0.9.6
 
 ## New features

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -256,29 +256,6 @@ hazard <- function(formula = NULL,
     time_upper <- parsed$time_upper
     x <- parsed$x
 
-    # Counting-process (start-stop) notation: the parser maps `start` to
-    # `time_lower` and `stop` to `time`, but the downstream likelihoods
-    # currently only honour `time_lower` for interval-censored rows
-    # (`status == 2`).  For counting-process rows (`status` in {0, 1})
-    # with a nonzero entry time the contribution should be
-    # `H(stop) - H(start)`; at present it is just `H(stop)`, producing a
-    # silently wrong fit.  Block the unsupported sub-case up front --
-    # `Surv(0, t, d)` is equivalent to `Surv(t, d)` and is allowed to
-    # pass through.  Full wire-up is tracked in
-    # `inst/dev/DEVELOPMENT-PLAN.md` Phase 4f.
-    if (!is.null(parsed$surv_type) && parsed$surv_type == "counting" &&
-          any(time_lower > 0)) {
-      stop(
-        "Counting-process (start-stop) notation `Surv(start, stop, event)` ",
-        "with nonzero start times is not yet supported: the likelihood ",
-        "currently computes H(stop) rather than H(stop) - H(start), which ",
-        "would produce a silently wrong fit. Workarounds: (1) use ",
-        "`Surv(time, status)` on right-censored data; (2) for ",
-        "interval-censored data use `Surv(time1, time2, type = \"interval2\")`. ",
-        "Full wire-up is tracked in `inst/dev/DEVELOPMENT-PLAN.md` Phase 4f.",
-        call. = FALSE
-      )
-    }
   }
 
   # After formula dispatch, require time and status

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -420,23 +420,37 @@
   cumhaz <- .hzr_multiphase_cumhaz(time, theta, phases, covariate_counts, x_list)
   if (any(!is.finite(cumhaz))) return(-Inf)
 
+  # Counting-process entry-time cumulative hazard; H(start) = 0 when no
+  # `time_lower` supplied (plain right-censored data).  For status in
+  # {0, 1}, the contribution becomes H(stop) - H(start); for status == 2,
+  # this value is unused (interval-censoring handled separately below).
+  if (is.null(time_lower)) {
+    cumhaz_start <- rep(0, n)
+  } else {
+    cumhaz_start <- .hzr_multiphase_cumhaz(time_lower, theta, phases,
+                                             covariate_counts, x_list)
+    if (any(!is.finite(cumhaz_start))) return(-Inf)
+  }
+
   # Instantaneous hazard at event times (only needed for exact events)
   idx_event <- status == 1
 
   logl <- 0
 
-  # Exact events: w * [log h(t) - H(t)]
+  # Exact events: w * [log h(stop) - (H(stop) - H(start))]
   if (any(idx_event)) {
     haz <- .hzr_multiphase_hazard(time, theta, phases, covariate_counts, x_list)
     if (any(!is.finite(haz[idx_event])) || any(haz[idx_event] <= 0)) return(-Inf)
     logl <- logl + sum(weights[idx_event] *
-                         (log(haz[idx_event]) - cumhaz[idx_event]))
+                         (log(haz[idx_event]) -
+                            (cumhaz[idx_event] - cumhaz_start[idx_event])))
   }
 
-  # Right-censored: w * [-H(t)]
+  # Right-censored: w * [-(H(stop) - H(start))]
   idx_right <- status == 0
   if (any(idx_right)) {
-    logl <- logl - sum(weights[idx_right] * cumhaz[idx_right])
+    logl <- logl - sum(weights[idx_right] *
+                         (cumhaz[idx_right] - cumhaz_start[idx_right]))
   }
 
   # Left-censored: w * [log(1 - exp(-H(u)))]
@@ -532,10 +546,18 @@
 
   # Storage for per-phase intermediate quantities
   n_phases <- length(phases)
-  phase_mu    <- vector("list", n_phases)  # mu_j(x_i) for each i
-  phase_Phi   <- vector("list", n_phases)  # Phi_j(t_i) for each i
-  phase_phi   <- vector("list", n_phases)  # phi_j(t_i) for each i
-  phase_deriv <- vector("list", n_phases)  # full derivative list from .hzr_phase_derivatives
+  phase_mu         <- vector("list", n_phases)  # mu_j(x_i) for each i
+  phase_Phi        <- vector("list", n_phases)  # Phi_j(t_i) for each i
+  phase_phi        <- vector("list", n_phases)  # phi_j(t_i) for each i
+  phase_deriv      <- vector("list", n_phases)  # derivative list at time
+  phase_Phi_start  <- vector("list", n_phases)  # Phi_j(start_i), if needed
+  phase_deriv_start <- vector("list", n_phases) # derivative list at start
+  # Whether to actually compute start-time quantities for the gradient.
+  # Without any counting-process rows (time_lower = NULL or all zeros with
+  # status in {0, 1}) these additions are identically zero and we can skip.
+  need_start <- !is.null(time_lower) &&
+                any(time_lower > 0 & status %in% c(0L, 1L))
+  start_vec <- if (need_start) time_lower else NULL
 
   for (j in seq_along(phases)) {
     nm <- names(phases)[j]
@@ -550,7 +572,7 @@
     mu_j <- exp(eta_j)
     phase_mu[[j]] <- mu_j
 
-    # Phi_j, phi_j, and shape derivatives
+    # Phi_j, phi_j, and shape derivatives at observation time
     if (phases[[nm]]$type == "constant") {
       phase_Phi[[j]] <- time
       phase_phi[[j]] <- rep(1, n)
@@ -572,6 +594,30 @@
       phase_Phi[[j]]   <- pd$Phi
       phase_phi[[j]]   <- pd$phi
       phase_deriv[[j]] <- pd
+    }
+
+    # Matching quantities at start_vec -- only Phi_j and its shape
+    # derivatives matter for the H(start) gradient contribution.
+    if (need_start) {
+      if (phases[[nm]]$type == "constant") {
+        phase_Phi_start[[j]] <- start_vec
+        phase_deriv_start[[j]] <- NULL
+      } else if (phases[[nm]]$type == "g3") {
+        tau_j <- exp(pars$log_tau)
+        d3s <- hzr_decompos_g3(start_vec, tau = tau_j, gamma = pars$gamma,
+                                 alpha = pars$alpha, eta = pars$eta)
+        phase_Phi_start[[j]] <- d3s$G3
+        phase_deriv_start[[j]] <- .hzr_g3_phase_derivatives(
+          start_vec, tau = tau_j, gamma = pars$gamma,
+          alpha = pars$alpha, eta = pars$eta)
+      } else {
+        t_half_j <- exp(pars$log_t_half)
+        pds <- .hzr_phase_derivatives(start_vec, t_half = t_half_j,
+                                        nu = pars$nu, m = pars$m,
+                                        type = phases[[nm]]$type)
+        phase_Phi_start[[j]]   <- pds$Phi
+        phase_deriv_start[[j]] <- pds
+      }
     }
 
     H_t <- H_t + mu_j * phase_Phi[[j]]
@@ -607,6 +653,16 @@
     # Left-censored uses H(upper), not H(time), so we handle below
   }
 
+  # H(start) contribution for counting-process rows (status in {0, 1}).
+  # Per-row contribution is `+H(start_i)` inside the log-likelihood, so
+  # the derivative w.r.t. theta picks up `+weights_i * dH(start)/dtheta`.
+  has_start <- !is.null(time_lower) && any(time_lower > 0 & status %in% c(0L, 1L))
+  w_H_start <- numeric(n)
+  if (has_start) {
+    w_H_start[idx_event] <- weights[idx_event]
+    w_H_start[idx_right] <- weights[idx_right]
+  }
+
   # Weight for the instantaneous hazard part (events only): w_i / h(t_i).
   # This multiplies dh/d(theta_j).
   inv_h <- numeric(n)
@@ -625,12 +681,20 @@
     mu_j  <- phase_mu[[j]]
     Phi_j <- phase_Phi[[j]]
     phi_j <- phase_phi[[j]]
+    Phi_j_start <- phase_Phi_start[[j]]  # NULL when need_start = FALSE
 
     # -- d(logl) / d(log_mu_j) ------------------------------------------
     # From H part: w_H_i * dH/d(log_mu) = w_H_i * mu_j * Phi_j
     # From h part (events): inv_h_i * dh/d(log_mu) = inv_h_i * mu_j * phi_j
     dlogl_dlog_mu <- sum(w_H * mu_j * Phi_j) +
                      sum(inv_h[idx_event] * mu_j[idx_event] * phi_j[idx_event])
+
+    # Counting-process entry-time contribution: +H(start) inside the LL,
+    # so its derivative picks up +w_H_start * dH(start)/d(log_mu).
+    if (need_start) {
+      dlogl_dlog_mu <- dlogl_dlog_mu +
+        sum(w_H_start * mu_j * Phi_j_start)
+    }
 
     # Left-censored: uses H(upper), need separate Phi_j evaluation there
     if (has_left) {
@@ -675,14 +739,19 @@
           type = phases[[nm]]$type)
       }
 
+      pd_start <- if (need_start) phase_deriv_start[[j]] else NULL
+
       # For each shape param s in {log_t_half, nu, m}:
       shape_derivs <- list(
         list(dPhi = pd$dPhi_dlog_thalf, dphi = pd$dphi_dlog_thalf,
-             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dlog_thalf),
+             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dlog_thalf,
+             dPhi_start = if (!is.null(pd_start)) pd_start$dPhi_dlog_thalf),
         list(dPhi = pd$dPhi_dnu,        dphi = pd$dphi_dnu,
-             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dnu),
+             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dnu,
+             dPhi_start = if (!is.null(pd_start)) pd_start$dPhi_dnu),
         list(dPhi = pd$dPhi_dm,         dphi = pd$dphi_dm,
-             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dm)
+             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dm,
+             dPhi_start = if (!is.null(pd_start)) pd_start$dPhi_dm)
       )
 
       for (s in seq_along(shape_derivs)) {
@@ -691,6 +760,12 @@
 
         dlogl_ds <- sum(w_H * mu_j * dPhi_ds) +
                     sum(inv_h[idx_event] * mu_j[idx_event] * dphi_ds[idx_event])
+
+        # Counting-process start contribution: +w_H_start * mu * dPhi(start)
+        if (need_start && !is.null(shape_derivs[[s]]$dPhi_start)) {
+          dlogl_ds <- dlogl_ds +
+            sum(w_H_start * mu_j * shape_derivs[[s]]$dPhi_start)
+        }
 
         # Left-censoring correction: swap dPhi at time for dPhi at upper
         if (has_left && !is.null(shape_derivs[[s]]$dPhi_upper)) {
@@ -714,16 +789,22 @@
           alpha = pars$alpha, eta = pars$eta)
       }
 
+      pd_start <- if (need_start) phase_deriv_start[[j]] else NULL
+
       # For each shape param s in {log_tau, gamma, alpha, eta}:
       shape_derivs <- list(
         list(dPhi = pd$dPhi_dlog_tau, dphi = pd$dphi_dlog_tau,
-             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dlog_tau),
+             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dlog_tau,
+             dPhi_start = if (!is.null(pd_start)) pd_start$dPhi_dlog_tau),
         list(dPhi = pd$dPhi_dgamma,   dphi = pd$dphi_dgamma,
-             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dgamma),
+             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dgamma,
+             dPhi_start = if (!is.null(pd_start)) pd_start$dPhi_dgamma),
         list(dPhi = pd$dPhi_dalpha,   dphi = pd$dphi_dalpha,
-             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dalpha),
+             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_dalpha,
+             dPhi_start = if (!is.null(pd_start)) pd_start$dPhi_dalpha),
         list(dPhi = pd$dPhi_deta,     dphi = pd$dphi_deta,
-             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_deta)
+             dPhi_upper = if (!is.null(pd_upper)) pd_upper$dPhi_deta,
+             dPhi_start = if (!is.null(pd_start)) pd_start$dPhi_deta)
       )
 
       for (s in seq_along(shape_derivs)) {
@@ -732,6 +813,12 @@
 
         dlogl_ds <- sum(w_H * mu_j * dPhi_ds) +
                     sum(inv_h[idx_event] * mu_j[idx_event] * dphi_ds[idx_event])
+
+        # Counting-process start contribution
+        if (need_start && !is.null(shape_derivs[[s]]$dPhi_start)) {
+          dlogl_ds <- dlogl_ds +
+            sum(w_H_start * mu_j * shape_derivs[[s]]$dPhi_start)
+        }
 
         # Left-censoring correction: swap dPhi at time for dPhi at upper
         if (has_left && !is.null(shape_derivs[[s]]$dPhi_upper)) {
@@ -755,6 +842,12 @@
         dlogl_dbeta <- sum(w_H * x_k * mu_j * Phi_j) +
                        sum(inv_h[idx_event] * x_k[idx_event] *
                            mu_j[idx_event] * phi_j[idx_event])
+
+        # Counting-process start contribution: +w_H_start * x_k * mu_j * Phi_start
+        if (need_start) {
+          dlogl_dbeta <- dlogl_dbeta +
+            sum(w_H_start * x_k * mu_j * Phi_j_start)
+        }
 
         if (has_left) {
           dlogl_dbeta <- dlogl_dbeta +

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -149,22 +149,30 @@ NULL
   cumhaz_lower <- (mu * lower) ^ nu * exp(eta)
   cumhaz_upper <- (mu * upper) ^ nu * exp(eta)
 
+  # Counting-process entry-time cumulative hazard (H(start)) for
+  # event/right-censored rows.  When `time_lower` is NULL the entry time is
+  # implicitly 0 and H(start) = 0, recovering the plain-Surv likelihood.
+  start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+  cumhaz_start <- (mu * start_vec) ^ nu * exp(eta)
+
   idx_event <- status == 1
   idx_right <- status == 0
   idx_left <- status == -1
   idx_interval <- status == 2
 
-  # Exact events: w * [log h(t) - H(t)]
+  # Exact events: w * [log h(stop) - (H(stop) - H(start))]
   ll_event <- if (any(idx_event)) {
     sum(weights[idx_event] *
-          (log(haz_event[idx_event]) - cumhaz_event[idx_event]))
+          (log(haz_event[idx_event]) -
+             (cumhaz_event[idx_event] - cumhaz_start[idx_event])))
   } else {
     0
   }
 
-  # Right-censored: w * [-H(t)]
+  # Right-censored: w * [-(H(stop) - H(start))]
   ll_right <- if (any(idx_right)) {
-    -sum(weights[idx_right] * cumhaz_event[idx_right])
+    -sum(weights[idx_right] *
+           (cumhaz_event[idx_right] - cumhaz_start[idx_right]))
   } else {
     0
   }
@@ -274,27 +282,37 @@ NULL
     cumhaz <- (mu * time) ^ nu * exp(eta)
   }
 
-  # Weighted event indicator and weighted cumhaz are the building blocks:
-  # every term below is the unweighted form with `status` -> `weights*status`
-  # and `cumhaz` -> `weights*cumhaz`.
+  # Counting-process entry-time cumulative hazard; H(start) = 0 when no
+  # `time_lower` supplied (plain right-censored data).
+  start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+  cumhaz_start <- (mu * start_vec) ^ nu * exp(eta)
+
+  # Weighted building blocks: each per-row contribution below is the
+  # unweighted form scaled by `weights`, and the cumulative-hazard term is
+  # the epoch difference `H(stop) - H(start)` (degenerates to `H(stop)` when
+  # start = 0).
   w_status <- weights * status
-  w_cumhaz <- weights * cumhaz
+  w_cumhaz_net <- weights * (cumhaz - cumhaz_start)
 
   # ===== Gradient w.r.t. mu (scale parameter) =====
-  # dL/dmu = sum(w * delta / mu) - (nu / mu) * sum(w * H)
-  grad[1] <- sum(w_status) / mu - (nu / mu) * sum(w_cumhaz)
+  # dH(t)/dmu = (nu / mu) * H(t), so dL/dmu picks up a matching
+  # contribution at start: -(nu/mu) * (H(stop) - H(start)).
+  grad[1] <- sum(w_status) / mu - (nu / mu) * sum(w_cumhaz_net)
 
   # ===== Gradient w.r.t. nu (shape parameter) =====
-  # dL/dnu = sum(w * delta / nu) + sum(w * delta * log(t))
-  #          - sum(log(mu*t) * w * H)
+  # dH(t)/dnu = log(mu*t) * H(t).  When start = 0, H(start) = 0 and the
+  # log(mu*start) term is undefined; `ifelse` picks the well-defined 0
+  # limit there.
+  log_mu_start <- ifelse(start_vec > 0, log(mu * start_vec), 0)
+  d_nu_start <- weights * log_mu_start * cumhaz_start
   grad[2] <- sum(w_status) / nu +
              sum(w_status * log(time)) -
-             sum(log(mu * time) * w_cumhaz)
+             (sum(log(mu * time) * weights * cumhaz) - sum(d_nu_start))
 
   # ===== Gradient w.r.t. beta (covariate coefficients) =====
   if (n_shape < p && !is.null(x)) {
-    # dL/dbeta = t(X) %*% (w * (delta - H))
-    residual <- w_status - w_cumhaz
+    # dL/dbeta = t(X) %*% (w * (delta - (H(stop) - H(start))))
+    residual <- w_status - w_cumhaz_net
     grad[3:p] <- as.numeric(crossprod(x, residual))
   }
 
@@ -367,18 +385,23 @@ NULL
     log_t <- log(pmax(time, .Machine$double.xmin))
     H     <- exp(alpha + eta) * (time ^ g)
 
+    # Counting-process entry-time H(start); zero when no `time_lower` given.
+    start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+    H_start   <- exp(alpha + eta) * (start_vec ^ g)
+
     idx_event <- status == 1
     idx_right <- status == 0
 
     ll_event <- if (any(idx_event)) {
       sum(w_use[idx_event] * (alpha + eta[idx_event] + theta[2] +
-          (g - 1) * log_t[idx_event] - H[idx_event]))
+          (g - 1) * log_t[idx_event] -
+          (H[idx_event] - H_start[idx_event])))
     } else {
       0
     }
 
     ll_right <- if (any(idx_right)) {
-      -sum(w_use[idx_right] * H[idx_right])
+      -sum(w_use[idx_right] * (H[idx_right] - H_start[idx_right]))
     } else {
       0
     }
@@ -424,25 +447,35 @@ NULL
 
     log_t <- log(pmax(time, .Machine$double.xmin))
     H     <- exp(alpha + eta) * (time ^ g)
+
+    # H(start) for counting-process rows; zero when time_lower is NULL or
+    # start == 0.  `log_t_start` is only used where start > 0 (guarded below)
+    # since log(0) = -Inf would otherwise propagate NaNs through the score.
+    start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+    H_start   <- exp(alpha + eta) * (start_vec ^ g)
+    log_t_start <- ifelse(start_vec > 0, log(pmax(start_vec, .Machine$double.xmin)), 0)
+
     grad  <- numeric(p)
 
-    # Weighted building blocks (w * delta, w * H).  Every term below is the
-    # unweighted form with `status` -> `w * status` and `H` -> `w * H`.
-    w_status <- w_use * status
-    w_H      <- w_use * H
+    # Weighted building blocks.  Every term below is the unweighted form with
+    # `status` -> `w * status` and `H` -> `w * (H(stop) - H(start))`.
+    w_status   <- w_use * status
+    w_H_net    <- w_use * (H - H_start)
+    w_H        <- w_use * H
+    w_H_start  <- w_use * H_start
 
-    # dL/dalpha = sum(w * delta) - sum(w * H)
-    grad[1] <- sum(w_status) - sum(w_H)
+    # dL/dalpha = sum(w * delta) - sum(w * (H(stop) - H(start)))
+    grad[1] <- sum(w_status) - sum(w_H_net)
 
-    # dL/dpsi = sum(w * delta) + g * sum(w * delta * log(t))
-    #          - g * sum(w * H * log(t))
+    # dL/dpsi = sum(w * delta) + g * sum(w * delta * log(stop))
+    #          - g * [sum(w * H(stop) * log(stop)) - sum(w * H(start) * log(start))]
     grad[2] <- sum(w_status) +
                g * sum(w_status * log_t) -
-               g * sum(w_H * log_t)
+               g * (sum(w_H * log_t) - sum(w_H_start * log_t_start))
 
-    # dL/dbeta_j = X_j' (w * (delta - H))
+    # dL/dbeta_j = X_j' (w * (delta - (H(stop) - H(start))))
     if (p > n_shape && !is.null(x)) {
-      grad[(n_shape + 1):p] <- as.numeric(crossprod(x, w_status - w_H))
+      grad[(n_shape + 1):p] <- as.numeric(crossprod(x, w_status - w_H_net))
     }
 
     grad

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TemporalHazard
 
 <!-- badges: start -->
-[![version](https://img.shields.io/badge/version-0.9.6-blue.svg)](https://github.com/ehrlinger/temporal_hazard)
+[![version](https://img.shields.io/badge/version-0.9.7-blue.svg)](https://github.com/ehrlinger/temporal_hazard)
 [![R-CMD-check](https://github.com/ehrlinger/temporal_hazard/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ehrlinger/temporal_hazard/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/ehrlinger/temporal_hazard/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ehrlinger/temporal_hazard?branch=main)
 [![lint](https://github.com/ehrlinger/temporal_hazard/actions/workflows/lint.yaml/badge.svg)](https://github.com/ehrlinger/temporal_hazard/actions/workflows/lint.yaml)

--- a/inst/dev/DEVELOPMENT-PLAN.md
+++ b/inst/dev/DEVELOPMENT-PLAN.md
@@ -158,15 +158,13 @@ the weighted event count), and the numerical-gradient fallbacks for
 mixed censoring. Integer weights reproduce the row-duplicated fit to
 optimizer tolerance for every distribution.
 
-### 4d. Repeating Events (Epoch Decomposition) -- PARTIAL (narrowed in v0.9.5)
+### 4d. Repeating Events (Epoch Decomposition) -- COMPLETE (v0.9.7)
 
 `Surv(start, stop, event)` is parsed (start -> time_lower, stop -> time,
-event -> status). The trivial case `Surv(0, t, d)` fits identically to
-`Surv(t, d)` on all distributions. Counting-process data with any
-`start > 0` is rejected by `hazard()` in v0.9.5: the downstream
-likelihoods only honour `time_lower` for interval-censored
-(`status == 2`) rows, so a nonzero-start epoch would be silently
-scored with `H(stop)` alone rather than `H(stop) - H(start)`.
+event -> status) and scored as `H(stop) - H(start)` per epoch in the
+Weibull and multiphase likelihoods. The trivial `Surv(0, t, d)` case
+degenerates to `H(stop)` and recovers the plain-Surv fit exactly. Full
+wire-up is tracked under 4f below.
 
 ### 4e. Complete `weights` wire-up (exp / log-logistic / log-normal + CoE) -- COMPLETE (v0.9.6)
 
@@ -186,39 +184,28 @@ gone. Duplication-parity tests for each distribution are in
 `test-weights.R`; weighted-CoE parity (CoE on and off) lives in
 `test-conservation-of-events.R`.
 
-### 4f. Complete repeating-events wire-up (counting-process LL)
+### 4f. Complete repeating-events wire-up (counting-process LL) -- COMPLETE (v0.9.7)
 
-**Priority:** Medium
-**Effort:** Small--Medium
-**Gate:** Remove the counting-process-with-start>0 guard in
-`hazard()`, re-enable the split-invariance tests in
-`test-repeating-events.R`.
+`.hzr_logl_weibull()` and `.hzr_logl_multiphase()` apply
+`H(stop) - H(start)` to event and right-censored terms via a
+`cumhaz_start` term that is zero when no `time_lower` is supplied
+(plain-Surv path). Analytic gradients for both distributions add the
+matching `-d H(start)/d theta` contributions (Weibull closed-form;
+multiphase per-phase `Phi_j(start)` and shape derivatives, reusing
+the existing G3 finite-difference machinery). The `hazard()` guard on
+`start > 0` is removed; the three split-invariance tests in
+`test-repeating-events.R` are live.
 
-Tasks:
-
-1. `R/likelihood-weibull.R` (`.hzr_logl_weibull`) -- in the event and
-   right-censored terms, replace `cumhaz_event[idx]` with
-   `cumhaz_event[idx] - cumhaz_lower[idx]` so the contribution is
-   `H(stop) - H(start)` per SAS. The existing `cumhaz_lower` is already
-   computed for interval-censored rows and just needs to flow into the
-   other paths.
-2. Same for `R/likelihood-multiphase.R` (`.hzr_logl_multiphase`).
-3. Analytic gradient updates: the derivatives of the event and
-   right-censored terms pick up an extra `-d/dtheta cumhaz_lower`
-   contribution; implementation mirrors the `cumhaz` derivative code
-   already in place.
-4. Remove the `hazard()` guard on counting-process data.
-5. Re-enable (remove `skip()` from) the split-invariance tests in
-   `test-repeating-events.R`.
-6. Add a vignette section on epoch-decomposed longitudinal data.
-7. SAS parity test against a repeating-events reference fit.
+Remaining follow-ups (low priority): vignette section on
+epoch-decomposed longitudinal data, and a SAS-parity fixture for a
+counting-process reference fit.
 
 ### 4b scheduling note
 
-With 4a, 4b, 4c, and 4e complete and 4d narrowed, the remaining
-SAS-parity gaps are: repeating-events wire-up (4f), prediction
-confidence limits (4g), and the stepwise enhancements (FAST screening,
-multi-step MOVE trace) tracked separately.
+With 4a, 4b, 4c, 4d, 4e, and 4f complete, the remaining SAS-parity
+gaps are: prediction confidence limits (4g) and the stepwise
+enhancements (FAST screening, multi-step MOVE trace) tracked
+separately.
 
 ---
 

--- a/tests/testthat/test-repeating-events.R
+++ b/tests/testthat/test-repeating-events.R
@@ -70,13 +70,9 @@ split_epochs <- function(df, split_frac = 0.5) {
 
 # The two split-invariance tests below are the canonical check that
 # `H(stop) - H(start)` is actually applied to counting-process rows.
-# They are deferred: v0.9.5 narrowed the feature to `start = 0` only
-# (see NEWS "Repeating-events narrowed" and
-# `inst/dev/DEVELOPMENT-PLAN.md` Phase 4f). When the wire-up lands,
-# remove the skip() calls and re-enable the expectations.
+# Wired up in v0.9.6 (Phase 4f).
 
 test_that("splitting each row into two epochs preserves Weibull log-lik", {
-  skip("deferred: requires Phase 4f wire-up of H(stop) - H(start) in counting-process LL")
   df <- make_toy_rc()
   df_split <- split_epochs(df, split_frac = 0.3)
 
@@ -98,7 +94,6 @@ test_that("splitting each row into two epochs preserves Weibull log-lik", {
 })
 
 test_that("splitting each row into two epochs preserves multiphase log-lik", {
-  skip("deferred: requires Phase 4f wire-up of H(stop) - H(start) in counting-process LL")
   df <- make_toy_rc()
   df_split <- split_epochs(df, split_frac = 0.4)
 
@@ -106,7 +101,10 @@ test_that("splitting each row into two epochs preserves multiphase log-lik", {
     early    = hzr_phase("cdf", t_half = 0.3, nu = 1, m = 1, fixed = "shapes"),
     constant = hzr_phase("constant")
   )
-  theta <- c(-4, log(0.3), 0, 0, -3, 0.1, 0.05)
+  # Theta layout: [log_mu_e, log_thalf, nu, m, beta_e, log_mu_c, beta_c].
+  # Match the phase spec's nu = m = 1 so the decomposition case dispatch
+  # hits Case 1 (m > 0, nu > 0); otherwise nu = m = 0 lands in a gap.
+  theta <- c(-4, log(0.3), 1, 1, -3, 0.1, 0.05)
 
   ll_orig <- TemporalHazard:::.hzr_logl_multiphase(
     theta = theta, time = df$time, status = df$status,
@@ -154,7 +152,6 @@ test_that("Surv(start, stop, event) routes start -> time_lower in formula parser
 # ---------------------------------------------------------------------------
 
 test_that("Weibull fit on split-epoch data matches unsplit fit", {
-  skip("deferred: requires Phase 4f wire-up of H(stop) - H(start) in counting-process LL")
   df <- make_toy_rc()
   df_split <- split_epochs(df, split_frac = 0.35)
 
@@ -172,25 +169,11 @@ test_that("Weibull fit on split-epoch data matches unsplit fit", {
 })
 
 # ---------------------------------------------------------------------------
-# Guard: counting-process with nonzero start times is rejected
+# Counting-process data with nonzero starts is now accepted (v0.9.6)
 # ---------------------------------------------------------------------------
-# This is the user-visible contract for v0.9.5: rather than silently
-# returning a mis-scored fit, hazard() errors out. When Phase 4f lands,
-# remove this test along with the guard in hazard_api.R.
-
-test_that("hazard() rejects counting-process Surv with any start > 0", {
-  df <- data.frame(
-    start = c(0.0, 0.5, 0.0, 1.2),
-    stop  = c(1.5, 2.0, 3.0, 3.5),
-    event = c(1, 0, 1, 0),
-    x     = c(0.1, 0.2, 0.3, 0.4)
-  )
-  expect_error(
-    hazard(survival::Surv(start, stop, event) ~ x,
-           data = df, dist = "weibull"),
-    "Counting-process"
-  )
-})
+# The v0.9.5 narrowing rejected `Surv(start, stop, event)` with any
+# `start > 0`; v0.9.6 wires `H(stop) - H(start)` into the Weibull and
+# multiphase likelihoods, so the guard is gone.
 
 test_that("hazard() accepts counting-process Surv when every start is 0", {
   df <- data.frame(


### PR DESCRIPTION
## Summary

Closes Phase 4f of the DEVELOPMENT-PLAN. `Surv(start, stop, event)` with `start > 0` now scores correctly across Weibull and multiphase; the v0.9.5 `hazard()` guard that rejected non-zero entry times is gone.

- **Likelihoods:** `.hzr_logl_weibull()` and `.hzr_logl_multiphase()` apply `H(stop) - H(start)` to event and right-censored terms via a `cumhaz_start` term that is zero when no `time_lower` is supplied (plain-Surv path is byte-identical to v0.9.6).
- **Weibull analytic gradient:** the closed-form score and the `alpha`/`psi` reparam inside `.hzr_optim_weibull()` both subtract the `-dH(start)/dtheta` contribution; the `log(mu*start) * H(start)` term in the `nu` derivative is guarded at `start = 0` so the 0 * -Inf limit resolves to 0.
- **Multiphase analytic gradient:** per-phase `Phi_j(start)` and shape derivatives computed alongside the existing `Phi_j(stop)` pipeline; each parameter's score picks up `+w_H_start * mu_j * dPhi_j(start)`. G3 derivatives at `start` reuse the existing finite-difference machinery.

## Test plan

- [x] Three deferred split-invariance tests in `test-repeating-events.R` re-enabled: Weibull LL, multiphase LL, end-to-end Weibull fit
- [x] Weibull gradient matches `numDeriv::grad` of the weighted LL with `start > 0` to 1e-9
- [x] Multiphase split-invariance: `ll([0, T]) == ll([0, t1], 0) + ll([t1, T], d)` to 1e-8
- [x] `Surv(0, t, d)` path produces a byte-identical fit to `Surv(t, d)` (plain-Surv regression)
- [x] Full suite: 1111 PASS / 0 FAIL / 0 lints
- [x] `R CMD check --no-build-vignettes`: 0 errors, 0 notes

## Side-fix

The pre-existing multiphase split-invariance test had `nu = m = 0` in theta while the phase spec declared `nu = m = 1 fixed = "shapes"`; raw `.hzr_logl_multiphase()` calls ignore `fixed`, so 0/0 landed in an unhandled branch of `hzr_decompos()`. Corrected theta to match the phase spec. The underlying `hzr_decompos()` case-dispatch gap (no branch for `m = nu = 0`) is noted in the project note's gotchas list but not patched here.

## Follow-ups (deferred, low-priority)

- Vignette section on epoch-decomposed longitudinal data
- SAS-parity fixture for a counting-process reference fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)