### PR TITLE
Refresh README feature flags to match shipped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,16 @@ adjustment, prediction, and extrapolation.
 | Feature | Status |
 |:---|:---:|
 | Multi-phase hazard modeling (early, constant, late phases) | :white_check_mark: |
-| Right censoring and interval censoring | :white_check_mark: |
-| Repeating events (epoch decomposition) | :construction: |
-| Time-varying covariates | :white_check_mark: |
-| Weighted events | :construction: |
-| Automatic stepwise covariate selection (forward, backward, stepwise) | :construction: |
+| Five parametric distributions (Weibull, exponential, log-logistic, log-normal, multiphase) | :white_check_mark: |
+| Right, left, interval, and counting-process censoring | :white_check_mark: |
+| Repeating events (epoch decomposition via `Surv(start, stop, event)`) | :white_check_mark: |
+| Time-varying covariates (piecewise windows) | :white_check_mark: |
+| Weighted events across all distributions | :white_check_mark: |
+| Automatic stepwise covariate selection (forward, backward, stepwise; Wald or AIC) | :white_check_mark: |
 | Conservation of Events theorem for numerically stable parameter estimation | :white_check_mark: |
 | Covariance and correlation matrix estimation | :white_check_mark: |
+| Delta-method confidence limits on `predict()` (`se.fit = TRUE`) | :white_check_mark: |
+| Seven `hzr_*` utility functions (Kaplan-Meier, Nelson, GOF, deciles, calibration, bootstrap, competing risks) | :white_check_mark: |
 
 :white_check_mark: = implemented | :construction: = planned
 


### PR DESCRIPTION
## Summary

Three capabilities were marked :construction: in the README despite having shipped, and delta-method prediction CLs (which just landed on main via #20) were absent from the table. All flipped / added.

| Feature | Was | Now |
|---|---|---|
| Repeating events (epoch decomposition) | 🚧 | ✅ shipped v0.9.7 (PR #19) |
| Weighted events | 🚧 | ✅ shipped v0.9.6 across all 5 distributions (PR #18) |
| Automatic stepwise covariate selection | 🚧 | ✅ shipped v0.9.5 (PR #15) |
| Delta-method confidence limits on `predict()` | (absent) | ✅ shipped v0.9.8 (PR #20) |

Also adds rows for capabilities that were missing from the table entirely:
- Five parametric distributions (Weibull, exponential, log-logistic, log-normal, multiphase)
- Counting-process censoring (now a sibling to the existing right/left/interval row)
- The seven `hzr_*` utility functions shipped in v0.9.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)