### PR TITLE
Refresh vignettes for v0.9.8 (Phase 6a + audit follow-ups)

### DIFF
--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -81,8 +81,9 @@ head(km)
 
 The returned data frame is the life table: one row per event time with
 `n_risk`, `n_event`, `survival`, logit-transformed 95% CLs
-(`cl_lower` / `cl_upper`), and the Nelson-Aalen cumulative hazard.
-Plotting just requires the survival column:
+(`cl_lower` / `cl_upper`), and a KM-based cumulative hazard
+(`-log(survival)` --- use `hzr_nelson()` if you need the Nelson-Aalen
+estimator instead).  Plotting just requires the survival column:
 
 ```{r}
 #| label: fig-km-baseline

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -68,17 +68,31 @@ Before fitting any parametric model, establish the empirical survival curve
 using the Kaplan-Meier estimator.  This is the benchmark against which all
 parametric fits will be compared.
 
+`hzr_kaplan()` wraps `survival::survfit()` and adds logit-transformed exact
+confidence limits that respect the `[0, 1]` boundary --- more accurate in
+the tails than the default Greenwood intervals.  This matches the SAS
+`kaplan.sas` macro output structure.
+
+```{r}
+#| label: km-life-table
+km <- hzr_kaplan(time = avc$int_dead, status = avc$dead)
+head(km)
+```
+
+The returned data frame is the life table: one row per event time with
+`n_risk`, `n_event`, `survival`, logit-transformed 95% CLs
+(`cl_lower` / `cl_upper`), and the Nelson-Aalen cumulative hazard.
+Plotting just requires the survival column:
+
 ```{r}
 #| label: fig-km-baseline
 #| fig-cap: "Kaplan-Meier survival estimate for AVC patients (n = 310)"
 #| eval: !expr has_pkg && has_ggplot2
-km <- survival::survfit(survival::Surv(int_dead, dead) ~ 1, data = avc)
-
 km_df <- data.frame(
   time     = km$time,
-  survival = km$surv * 100,
-  lower    = km$lower * 100,
-  upper    = km$upper * 100
+  survival = km$survival * 100,
+  lower    = km$cl_lower * 100,
+  upper    = km$cl_upper * 100
 )
 
 ggplot(km_df, aes(time, survival)) +
@@ -257,24 +271,40 @@ screen_results
 ### 3b. Functional form assessment
 
 For continuous covariates that appear significant, examine whether the
-relationship with outcome is linear on the logit scale using LOESS
-smoothing.  Non-linear patterns suggest a transformation may be needed.
+relationship with outcome is monotone on the logit scale.  `hzr_calibrate()`
+implements the SAS `logit.sas` / `logitgr.sas` macros: bin the continuous
+covariate into quantile groups, compute the observed event rate per bin,
+and transform it to the logit scale.
 
 ```{r}
-#| label: fig-loess-age
-#| fig-cap: "LOESS smooth: age vs. mortality probability"
+#| label: age-calibrate
+cal_age <- hzr_calibrate(x = avc$age, event = avc$dead,
+                          groups = 10, link = "logit")
+cal_age
+```
+
+Plot the logit-transformed event rate against the bin centre (`mean`
+column).  A straight line means the covariate can enter the model
+untransformed; monotone-but-curved shapes suggest a log or square-root
+transform; U-shapes call for a quadratic term.
+
+```{r}
+#| label: fig-calibrate-age
+#| fig-cap: "Decile calibration: age vs. logit(P(death))"
 #| eval: !expr has_pkg && has_ggplot2
-ggplot(avc, aes(age, dead)) +
-  geom_point(alpha = 0.2, size = 1) +
-  geom_smooth(method = "loess", formula = y ~ x, se = TRUE,
-              colour = "#0072B2", fill = "#0072B2", alpha = 0.2) +
-  labs(x = "Age at repair (months)", y = "P(death)") +
+ggplot(cal_age, aes(mean, link_value)) +
+  geom_point(size = 3, colour = "#0072B2") +
+  geom_line(colour = "#0072B2", alpha = 0.4) +
+  geom_smooth(method = "lm", formula = y ~ x, se = FALSE,
+              colour = "#D55E00", linetype = "dashed") +
+  labs(x = "Age at repair (months, decile midpoint)",
+       y = "logit(P(death))") +
   theme_minimal()
 ```
 
-If the LOESS curve is roughly linear (or monotone), the covariate can enter
-the model untransformed.  S-shaped or U-shaped curves suggest
-transformations (log, quadratic) may improve the fit.
+The blue points are the observed decile logits; the dashed red line is a
+linear reference.  Deviations from linearity flag where a transform is
+warranted.
 
 ## Step 4: Multivariable model
 
@@ -388,9 +418,15 @@ the full argument surface including `force_in`, `force_out`, and the
 Generate the survival curve for a reference patient (median age, NYHA
 class 1, no malalignment, no interventricular communication).
 
+`predict(..., se.fit = TRUE)` adds a delta-method standard error and 95%
+confidence band around every prediction (log(-log) scale for survival so
+the band is guaranteed to lie in `[0, 1]`).  This is the parametric
+analogue of the KM confidence limits from Step 1 --- a patient-specific
+uncertainty estimate the nonparametric curve cannot provide.
+
 ```{r}
 #| label: fig-prediction
-#| fig-cap: "Reference patient survival with Kaplan-Meier overlay"
+#| fig-cap: "Reference patient survival with 95% delta-method CI and KM overlay"
 #| eval: !expr has_pkg && has_ggplot2
 ref_patient <- data.frame(
   time   = t_grid,
@@ -401,13 +437,22 @@ ref_patient <- data.frame(
 )
 
 surv_ref <- predict(fit_mv, newdata = ref_patient,
-                    type = "survival") * 100
+                    type = "survival", se.fit = TRUE)
+
+ref_df <- data.frame(
+  time     = t_grid,
+  survival = surv_ref$fit * 100,
+  lower    = surv_ref$lower * 100,
+  upper    = surv_ref$upper * 100
+)
 
 ggplot() +
   geom_step(data = km_df, aes(time, survival),
             colour = "#D55E00", linewidth = 0.6, alpha = 0.7) +
-  geom_line(data = data.frame(time = t_grid, survival = surv_ref),
-            aes(time, survival), colour = "#0072B2", linewidth = 0.8) +
+  geom_ribbon(data = ref_df, aes(time, ymin = lower, ymax = upper),
+              fill = "#0072B2", alpha = 0.15) +
+  geom_line(data = ref_df, aes(time, survival),
+            colour = "#0072B2", linewidth = 0.8) +
   labs(x = "Months after AVC repair", y = "Survival (%)") +
   coord_cartesian(ylim = c(0, 100)) +
   theme_minimal()
@@ -438,25 +483,38 @@ high_risk <- data.frame(
   com_iv = 1
 )
 
-surv_lo <- predict(fit_mv, newdata = low_risk, type = "survival") * 100
-surv_hi <- predict(fit_mv, newdata = high_risk, type = "survival") * 100
+surv_lo <- predict(fit_mv, newdata = low_risk,
+                   type = "survival", se.fit = TRUE)
+surv_hi <- predict(fit_mv, newdata = high_risk,
+                   type = "survival", se.fit = TRUE)
 
 sens_df <- data.frame(
-  time = rep(t_grid, 2),
-  survival = c(surv_lo, surv_hi),
-  profile = rep(c("Low risk", "High risk"), each = length(t_grid))
+  time     = rep(t_grid, 2),
+  survival = c(surv_lo$fit, surv_hi$fit) * 100,
+  lower    = c(surv_lo$lower, surv_hi$lower) * 100,
+  upper    = c(surv_lo$upper, surv_hi$upper) * 100,
+  profile  = rep(c("Low risk", "High risk"), each = length(t_grid))
 )
 
-ggplot(sens_df, aes(time, survival, colour = profile)) +
+ggplot(sens_df, aes(time, survival, colour = profile, fill = profile)) +
+  geom_ribbon(aes(ymin = lower, ymax = upper),
+              alpha = 0.15, colour = NA) +
   geom_line(linewidth = 0.8) +
   scale_colour_manual(values = c("Low risk" = "#0072B2",
                                   "High risk" = "#D55E00")) +
+  scale_fill_manual(values = c("Low risk" = "#0072B2",
+                                "High risk" = "#D55E00")) +
   labs(x = "Months after AVC repair", y = "Survival (%)",
-       colour = NULL) +
+       colour = NULL, fill = NULL) +
   coord_cartesian(ylim = c(0, 100)) +
   theme_minimal() +
   theme(legend.position = "bottom")
 ```
+
+Non-overlapping confidence bands between the two profiles indicate the
+risk-factor combination is well-identified; overlap around the bands'
+centre-of-mass flags where the model can't distinguish the profiles with
+the available sample size.
 
 ## Step 6: Validation --- decile-of-risk calibration
 

--- a/vignettes/prediction-visualization.qmd
+++ b/vignettes/prediction-visualization.qmd
@@ -130,6 +130,71 @@ ggplot() +
   theme(legend.position = "bottom")
 ```
 
+## Confidence limits on predictions
+
+As of v0.9.8, `predict.hazard()` accepts `se.fit = TRUE` (default `FALSE`)
+and `level = 0.95` to return delta-method standard errors and
+confidence limits alongside the point estimate.  The return value
+changes shape: a plain numeric vector with `se.fit = FALSE`, a data
+frame with columns `fit`, `se.fit`, `lower`, and `upper` with
+`se.fit = TRUE`.
+
+```{r}
+#| label: pred-with-se
+# Build a clean newdata frame (the earlier chunk appended result
+# columns to `profile`, which would confuse predict()'s column count).
+profile_ci <- data.frame(
+  time   = t_grid,
+  age    = median(avc$age),
+  status = 2,
+  mal    = 0,
+  com_iv = 0
+)
+surv_ci <- predict(fit, newdata = profile_ci,
+                   type = "survival", se.fit = TRUE, level = 0.95)
+head(surv_ci)
+```
+
+Confidence limits use SAS-matched transformations: log-scale for
+`hazard` and `cumulative_hazard` (keeps the lower bound positive), and
+`log(-log(S))` for `survival` (keeps the interval in `[0, 1]`).  The
+linear predictor uses symmetric natural-scale CLs.
+
+```{r}
+#| label: fig-surv-ci
+#| fig-cap: "Parametric survival with 95% delta-method confidence band"
+#| fig-width: 7
+#| fig-height: 4.5
+ci_df <- data.frame(
+  time     = profile_ci$time,
+  survival = surv_ci$fit * 100,
+  lower    = surv_ci$lower * 100,
+  upper    = surv_ci$upper * 100
+)
+
+ggplot() +
+  geom_step(data = km_df, aes(time, survival, colour = "Kaplan-Meier"),
+            linewidth = 0.5) +
+  geom_ribbon(data = ci_df,
+              aes(time, ymin = lower, ymax = upper),
+              fill = "#0072B2", alpha = 0.15) +
+  geom_line(data = ci_df,
+            aes(time, survival, colour = "Parametric + 95% CI"),
+            linewidth = 1) +
+  scale_colour_manual(
+    values = c("Parametric + 95% CI" = "#0072B2",
+               "Kaplan-Meier"        = "#D55E00")
+  ) +
+  scale_y_continuous(limits = c(0, 100)) +
+  labs(x = "Months after repair", y = "Freedom from death (%)",
+       colour = NULL) +
+  theme_minimal() +
+  theme(legend.position = "bottom")
+```
+
+Weibull and multiphase use a closed-form Jacobian.  Exponential,
+log-logistic, and log-normal use `numDeriv::jacobian()` on a per-call
+cumulative-hazard closure --- identical results, just slightly slower.
 
 ## Decomposed multiphase hazard
 

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -416,33 +416,9 @@ for multiphase fits to get per-phase contributions.
 ## Known limitations vs. SAS HAZARD
 
 A SAS HAZARD veteran migrating to `TemporalHazard` should be aware of
-the following scope limits as of v0.9.5.  Detailed status per feature is
-tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md`.
-
-### Observation weights (`WEIGHT` statement)
-
-- **Supported:** `dist = "weibull"` and `dist = "multiphase"` (LL and
-  analytic gradient).
-- **Not yet supported:** `dist = "exponential"`, `"log-logistic"`,
-  `"log-normal"`.  `hazard()` raises an explicit error rather than
-  returning a silently unweighted fit.
-- **Caveat for multiphase:** the Conservation of Events optimiser trick
-  auto-disables when weights are not all 1.  Fits are still correct;
-  they just take the full-dimensional optimisation path.
-- Tracked: `DEVELOPMENT-PLAN.md` Phase 4e.
-
-### Repeating events / counting-process notation
-
-- **Supported:** `Surv(time, status)` (standard right-censoring),
-  `Surv(time1, time2, type = "interval2")` (interval censoring),
-  `Surv(0, t, d)` (trivial start-stop form, equivalent to right
-  censoring).
-- **Not yet supported:** `Surv(start, stop, event)` with any `start > 0`.
-  The parser accepts it, but the downstream likelihood currently scores
-  every row as `H(stop)` instead of `H(stop) - H(start)`.  `hazard()`
-  errors out to prevent a silently wrong fit.  The SAS `LCENSOR`/`STIME`
-  mechanism maps onto this notation in principle.
-- Tracked: `DEVELOPMENT-PLAN.md` Phase 4f.
+the following scope limits as of v0.9.8.  Detailed status per feature is
+tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md` and
+`inst/dev/DEVELOPMENT-PLAN.md`.
 
 ### Stepwise variable selection (`SELECTION` statement)
 
@@ -450,23 +426,48 @@ tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md`.
   two-way stepwise with SAS-style SLENTRY / SLSTAY thresholds,
   per-phase entry for multiphase, and a MOVE oscillation guard.
 - **Not yet supported:** FAST-screening (Lawless-Singhal approximate
-  Wald updates).  Every candidate currently gets a full refit.
+  Wald updates).  Every candidate currently gets a full refit, which
+  is slower but always correct.
 
-### Prediction confidence limits
+### Per-phase time-varying windows
 
-- **Supported:** point predictions for every type
-  (`hazard`, `linear_predictor`, `survival`, `cumulative_hazard`,
-  plus `decompose = TRUE` for multiphase).
-- **Not yet supported:** delta-method standard errors / confidence
-  limits on prediction curves (the C reference has
-  `hzp_calc_haz_CL.c`, `hzp_calc_srv_CL.c`).  Use `hzr_bootstrap()` +
-  `predict()` for prediction-level CIs today.
+- **Supported:** `time_windows` applies one piecewise-constant cut-point
+  set across all covariates.
+- **Not yet supported:** distinct `EARLY`/`LATE` window sets per phase.
+  Workaround: expand the design matrix manually before calling
+  `hazard()`.
 
 ### Output datasets (`OUTEST=`, `OUTVCOV=`)
 
 - The R equivalents are `coef(fit)` and `vcov(fit)` in memory; there
-  is no automatic dataset-export mode.  Write them to disk yourself if
-  you need one.
+  is no automatic dataset-export mode.  `saveRDS()` them yourself if
+  you need an on-disk artefact.
+
+### Density / quantile prediction types
+
+- `predict.hazard()` covers `hazard`, `cumulative_hazard`, `survival`,
+  and `linear_predictor`.  Density and quantile (median survival)
+  types are not wired up; derive them from `cumulative_hazard` and
+  `survival` predictions if needed.
+
+### Previously listed gaps that have since been closed
+
+For users migrating from older TemporalHazard versions or reading
+older SAS parity notes:
+
+- **`weights` on all distributions** — shipped v0.9.6.  Weibull,
+  exponential, log-logistic, log-normal, and multiphase all honour
+  observation weights end-to-end (LL + analytic gradient + multiphase
+  Conservation of Events).
+- **`Surv(start, stop, event)` with `start > 0`** — shipped v0.9.7.
+  Counting-process rows contribute `H(stop) - H(start)` for Weibull
+  and multiphase.  The previous `hazard()` guard against non-zero
+  starts is gone.
+- **Delta-method prediction confidence limits** — shipped v0.9.8.
+  Use `predict(..., se.fit = TRUE, level = 0.95)` to get a data frame
+  with `fit`, `se.fit`, `lower`, and `upper` per row.  Closed-form
+  Jacobian for Weibull and multiphase, `numDeriv::jacobian` fallback
+  for exponential / log-logistic / log-normal.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the vignette-refresh half of Phase 6a (the other half — a full new walkthrough — was already shipped in v0.9.3 and just needed updating for v0.9.8 features). Also addresses documentation staleness flagged by a full vignette audit.

### Clinical walkthrough (`clinical-analysis-walkthrough.qmd`)

- **Step 1 (nonparametric baseline)** — swapped `survival::survfit()` for `hzr_kaplan()`. Shows the life-table output and logit-transformed exact CLs.
- **Step 3b (functional form)** — swapped LOESS for `hzr_calibrate()`. Matches the §6a plan's call for \"manual screening with `hzr_calibrate()`\" and the SAS `logit.sas` / `logitgr.sas` macros.
- **Steps 5a and 5b (prediction)** — now use `predict(..., se.fit = TRUE)` with `geom_ribbon()` 95% delta-method CI bands. First vignette demonstration of the v0.9.8 marquee feature.

### Prediction-visualization (`prediction-visualization.qmd`)

- New **\"Confidence limits on predictions\"** subsection. Shows the data-frame return shape of `se.fit = TRUE` and plots a 95% CI band on the reference-patient Weibull survival curve. Notes the log / log(-log S) / natural scale choices that mirror SAS `hzp_calc_haz_CL.c` / `hzp_calc_srv_CL.c`.

### SAS-to-R migration (`sas-to-r-migration.qmd`)

The \"Known limitations vs. SAS HAZARD\" section was a v0.9.5 snapshot listing three shipped features as unimplemented:

- Weights on exponential / log-logistic / log-normal (actually shipped v0.9.6)
- `Surv(start, stop, event)` with `start > 0` (actually shipped v0.9.7)
- Delta-method prediction CLs (actually shipped v0.9.8)

Rewrote the section for v0.9.8 reality plus added a \"Previously listed gaps that have since been closed\" block for anyone reading older notes. Remaining limits now cover only: FAST-screening stepwise, per-phase time windows, `OUTEST` / `OUTVCOV` dataset export, and density / quantile prediction types.

## Test plan

- [x] `knitr::purl(...) |> source()` executes end-to-end on all three modified vignettes
- [x] Full test suite: 1164 PASS / 0 FAIL
- [x] `lintr::lint_package()`: no new lints introduced (the 4 pre-existing `object_usage_linter` false positives on `.hzr_predict_with_se` remain; CI exit code 0)
- [x] Roxygen `@examples` spot-check clean (audit found no stale API usage in `R/`)

After this and #21 (README refresh) merge, the only remaining item before CRAN submission is the Phase 3 housekeeping pass: `devtools::spell_check()`, regenerate README figures, `submit_cran()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)