### PR TITLE
docs(cran): capture expected NOTE disposition for future submissions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,14 +23,34 @@ So the cycle is:
 2. `NEWS.md` top heading is `# TemporalHazard X.Y.Z` and describes the
    user-visible changes since the last CRAN release.
 3. `cran-comments.md` version heading matches `DESCRIPTION`; if a
-   resubmission, each reviewer point is itemised with how it was addressed;
-   test environments and NOTE disposition reflect reality.
+   resubmission, each reviewer point is itemised with how it was addressed.
 4. `devtools::document()` is clean and `man/` is in sync.
 5. `R CMD check --as-cran` → 0 errors, 0 warnings, 0 notes
    (`devtools::check(args = "--as-cran")`).
-6. Optional wider checks: `devtools::check_win_devel()`,
-   `rhub::rhub_check()`.
+6. `devtools::check_win_devel()` (and optionally `rhub::rhub_check()`).
+   **This is the source of truth for the NOTE disposition** — the local
+   `--as-cran` in step 5 does *not* run the CRAN incoming-feasibility /
+   aspell step, so it will under-report. Reconcile the
+   `## NOTE disposition` section of `cran-comments.md` against the
+   *win-builder* `00check.log`, not the local result, before submitting.
+   See "Known benign NOTE" below.
 7. Submit: `devtools::submit_cran()` (writes `CRAN-SUBMISSION`).
+
+### Known benign NOTE
+
+Every submission produces one expected NOTE from the CRAN incoming check
+that the local `--as-cran` does not show:
+
+- **New submission** — until the package is accepted on CRAN. Drop this
+  line from `cran-comments.md` once accepted.
+- **Possibly misspelled words in DESCRIPTION** — proper nouns (`Naftel`,
+  `Rajeswaran`), the acronym `UAB`, the `et al.` citation, and the domain
+  term `multiphase`. All intentional; not misspellings. `inst/WORDLIST`
+  feeds only the `spelling` test, **not** the CRAN aspell check, so this
+  recurs by design — document it, don't try to suppress it.
+
+The canonical wording lives in `cran-comments.md` `## NOTE disposition`;
+keep the two in agreement.
 
 ## On CRAN acceptance
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -49,12 +49,34 @@ home-filespace item was only partially fixed and is now fully resolved in
   `R CMD check --as-cran` returns 0 errors, 0 warnings, 0 notes.
 * **GitHub Actions matrix:** ubuntu-latest (R-devel / R-release / R-oldrel-1),
   macos-latest (R-release), windows-latest (R-release).
+* **win-builder:** R-devel (`devtools::check_win_devel()`) — 1 NOTE
+  (expected; see NOTE disposition below).
 * **Reverse-dependency check:** `tools::package_dependencies(reverse = TRUE)`
   returns 0.
 
 ## NOTE disposition
 
-No notes in local `R CMD check --as-cran`.
+Local `R CMD check --as-cran` is clean (0 errors, 0 warnings, 0 notes).
+CRAN's incoming-feasibility check (and win-builder) report a single
+expected NOTE — the local check does not exercise the incoming-feasibility
+/ aspell step, which is why it is surfaced only by CRAN/win-builder:
+
+* **New submission.** TemporalHazard is not yet on CRAN. *(Remove this
+  bullet once the package is accepted — subsequent releases are updates,
+  not new submissions.)*
+* **Possibly misspelled words in DESCRIPTION:** `Naftel`, `Rajeswaran`
+  (cited authors, appearing with their `<doi:...>` references), `UAB`
+  (acronym — University of Alabama at Birmingham), `et`, `al`
+  ("et al." citation), and `multiphase` (the core statistical term this
+  package implements). None are misspellings; all are intentional proper
+  nouns, an acronym, a standard citation, and a domain term. No action
+  taken.
+
+(`inst/WORDLIST` already lists these words for the `spelling` package's
+unit test, but the CRAN incoming aspell check has no package-level
+suppression mechanism, so this NOTE is informational and recurs by design
+on every submission. Keep this section in sync with the actual
+CRAN/win-builder output, not the local `--as-cran` result.)
 
 ## Background
 


### PR DESCRIPTION
## Context

The CRAN auto-check for 1.0.2 returned **1 NOTE** (Windows + Debian): the standard *New submission* + proper-noun spelling false positives (`Naftel`, `Rajeswaran`, `UAB`, `et`, `al`, `multiphase`). Benign — nothing blocks acceptance.

But `cran-comments.md` said *"No notes in local `R CMD check --as-cran`"*, which contradicts what CRAN actually saw. The 1.0.2 tarball is already submitted (locked), so this can't help that submission — but **`cran-comments.md` is the persistent file `submit_cran()` uploads every time**, so fixing it now makes every future submission correct, and prevents the mismatch recurring.

## Changes

- **`cran-comments.md`** — `## NOTE disposition` rewritten to state the real, expected CRAN/win-builder NOTE: *New submission* (with a marker to drop once accepted) + each flagged word explained as an intentional proper noun / acronym / `et al.` / domain term. Notes that `inst/WORDLIST` does **not** feed the CRAN aspell check (so the NOTE recurs by design and is documented, not suppressed). Added a win-builder line under test environments.
- **`RELEASE.md`** — pre-submission checklist now treats `check_win_devel()` as the **source of truth** for the NOTE disposition (local `--as-cran` under-reports because it skips the incoming-feasibility/aspell step), plus a "Known benign NOTE" reference block kept in sync with `cran-comments.md`.

Docs-only; both files are `.Rbuildignore`d. No effect on the in-queue 1.0.2 submission.

## Test plan

- [x] N/A — documentation-only
- [ ] Maintainer review