### PR TITLE
docs: bring vignette prose into author's voice

### DIFF
--- a/vignettes/ar-architecture.qmd
+++ b/vignettes/ar-architecture.qmd
@@ -176,8 +176,8 @@ mapping:
 `.hzr_optim_multiphase()` runs a multi-start strategy: the first start
 uses the assembled starting values (from `theta` or `hzr_phase` specs);
 subsequent starts perturb randomly (sd = 0.5). The best log-likelihood
-across all starts is kept. This helps escape shallow local optima common
-in multiphase models.
+across all starts is kept. This helps the optimizer escape the shallow local
+optima that are common in multiphase models.
 
 The optimizer delegates to `.hzr_optim_generic()`, which wraps
 `stats::optim()` with method `"BFGS"` (unconstrained; all scale

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -610,8 +610,8 @@ overpredicts risk; persistent negative means it underpredicts.
 
 ## Why not Cox regression?
 
-The temporal parametric approach offers several advantages over Cox
-proportional hazards for this type of analysis:
+For this kind of analysis the temporal parametric approach buys you
+several things that Cox proportional hazards does not:
 
 | Feature | Cox (`coxph`) | TemporalHazard |
 |:---|:---:|:---:|
@@ -623,10 +623,10 @@ proportional hazards for this type of analysis:
 | Conservation of events check | No | Yes (`hzr_gof()`) |
 | Interval censoring | Not standard | Supported |
 
-The key insight is that many clinical outcomes exhibit **non-proportional
+Many clinical outcomes show **non-proportional
 hazards**: the risk factors that dominate early mortality (e.g., surgical
 complexity) differ from those driving late attrition (e.g., age, comorbidity).
-The multiphase model captures this naturally through phase-specific
+The multiphase model captures this through phase-specific
 covariate effects.
 
 ## Summary

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -31,10 +31,10 @@ library(survival)
 library(ggplot2)
 ```
 
-This vignette demonstrates the core model-fitting workflow, progressing from
-the simplest case (intercept-only, single distribution) through multivariable
-models to multiphase additive hazard decomposition.  All examples use the
-clinical datasets shipped with the package.
+This vignette walks through the core model-fitting workflow, starting from
+the simplest case (intercept-only, single distribution) and building up through
+multivariable models to multiphase additive hazard decomposition.  Every
+example uses a clinical dataset shipped with the package.
 
 
 ## Intercept-only model: CABG survival (KU Leuven)
@@ -242,9 +242,9 @@ fit_pve <- hazard(
 fit_pve
 ```
 
-Each endpoint can be modeled independently with appropriate covariates.  The
-hazard model structure --- temporal shape + covariate effects --- is the same
-regardless of the clinical endpoint.
+Each endpoint gets its own model with its own covariates.  But the hazard
+model structure --- temporal shape plus covariate effects --- stays the same
+whatever the clinical endpoint.
 
 
 ## Phase types reference

--- a/vignettes/inference-diagnostics.qmd
+++ b/vignettes/inference-diagnostics.qmd
@@ -40,9 +40,9 @@ HAZARD analysis workflow.
 
 ## Exploratory covariate screening
 
-Before fitting the parametric hazard model, it is useful to screen candidate
-covariates with simple logistic models.  This identifies transformations and
-functional forms that should enter the final model.
+Before fitting the parametric hazard model, screen the candidate
+covariates with simple logistic models.  This shows you which transformations and
+functional forms should enter the final model.
 
 ```{r}
 #| label: explore-data
@@ -87,8 +87,8 @@ ggplot(avc, aes(age, dead)) +
   theme_minimal()
 ```
 
-The LOESS smooth reveals the functional form of each covariate relationship
-to mortality, guiding decisions about transformations (log, polynomial) before
+The LOESS smooth shows the shape of the covariate-mortality relationship,
+which guides the choice of transformation (log, polynomial) before you fit
 the hazard model.
 
 

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -31,12 +31,12 @@ knitr::opts_chunk$set(
 library(TemporalHazard)
 ```
 
-This vignette provides the mathematical foundation for the models implemented
-in TemporalHazard.  It covers the generalized temporal decomposition family
+This vignette lays out the mathematical foundation for the models in
+TemporalHazard.  It covers the generalized temporal decomposition family
 (Blackstone, Naftel, and Turner 1986), the additive multiphase hazard model,
 maximum likelihood estimation under mixed censoring, and extensions for
-time-varying covariates.  The decomposition framework extends naturally to
-longitudinal mixed-effects settings (Rajeswaran et al. 2018).
+time-varying covariates.  The same decomposition framework also carries over
+to longitudinal mixed-effects settings (Rajeswaran et al. 2018).
 
 For users migrating from the legacy SAS/C HAZARD program, each section notes
 how the R parameterization relates to the original parameter names.  For the
@@ -454,8 +454,8 @@ $$
 \mu_j(\mathbf{x}) = \exp\!\bigl(\alpha_j + \mathbf{x}\,\boldsymbol{\beta}_j\bigr)
 $$
 
-This means the same predictors can have different effects on early vs. late
-risk — a core feature of multiphase models.
+So the same predictors can have different effects on early vs. late risk,
+which is a core feature of multiphase models.
 
 ```{r}
 #| label: global-covariates
@@ -577,7 +577,7 @@ The decomposition engine applies several guards:
 - Left- and interval-censored contributions use `hzr_log1mexp()` to avoid
   $\log(0)$ when $H(t)$ is very small
 
-These guards ensure finite gradients throughout the optimization, even in
+Together these keep the gradients finite throughout the optimization, even in
 regions of parameter space far from the optimum.
 
 

--- a/vignettes/prediction-visualization.qmd
+++ b/vignettes/prediction-visualization.qmd
@@ -38,9 +38,9 @@ overlaying parametric fits with Kaplan-Meier estimates.
 
 ## Kaplan-Meier baseline
 
-Before any parametric modeling, the Kaplan-Meier curve establishes a
-nonparametric reference.  All subsequent parametric predictions should be
-compared against this baseline to assess goodness-of-fit.
+Before any parametric modeling, the Kaplan-Meier curve gives us a
+nonparametric reference.  Compare every parametric prediction that follows
+against this baseline to judge goodness-of-fit.
 
 ```{r}
 #| label: km-baseline
@@ -340,8 +340,8 @@ ggplot(curves, aes(time, survival, colour = Profile)) +
   theme(legend.position = "bottom")
 ```
 
-The separation between curves quantifies the prognostic discrimination of the
-model.  A wider spread indicates stronger covariate effects.
+The gap between curves is the model's prognostic discrimination: a wider
+spread means stronger covariate effects.
 
 
 ## Multi-endpoint visualization: valves

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -474,7 +474,7 @@ older SAS parity notes:
 ## Rcpp acceleration note
 
 `TemporalHazard` is currently pure R. If profiling against large real datasets
-reveals bottlenecks in the likelihood kernel or optimizer inner loop, those
+turns up bottlenecks in the likelihood kernel or the optimizer inner loop, those
 specific functions will be re-implemented with Rcpp. The public interface
 (`hazard()`, `predict.hazard()`, etc.) will not change.
 


### PR DESCRIPTION
## Summary
- Audited all package documentation against the writing-voice fingerprint to remove AI tells.
- Fixed 13 genuine tells across the 7 Quarto vignettes — authorless/flavorless phrasing, mechanical parallelism, sterile "should be compared" passive balance, a "the key insight is that" cliche.
- README, NEWS.md, and roxygen prose were audited and found already in voice — no changes needed.

## Scope
Only narrative prose was touched. No code chunks, math/LaTeX, function names, argument names, YAML keys, or numeric results were changed.

## Test plan
- [ ] Vignettes still render (`quarto render` / `devtools::build_vignettes()`)
- [ ] `devtools::check()` clean