### PR TITLE
docs: vignette clarity pass (pilot: getting-started)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ Suggests:
 LazyData: true
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0
-RoxygenNote: 7.3.3
+RoxygenNote: 8.0.0

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -25,6 +25,27 @@ generators remain in `data-raw/` (off the CRAN surface);
 requires an explicit `output_dir`; `\value` documentation is present for
 every exported function and S3 method.
 
+## Other changes since 1.0.2
+
+Non-reviewer-driven housekeeping and documentation polish that also
+ships in 1.0.3:
+
+* **Vignette clarity expansion.** All seven vignettes (`getting-started`,
+  `fitting-hazard-models`, `prediction-visualization`,
+  `inference-diagnostics`, `clinical-analysis-walkthrough`,
+  `mf-mathematical-foundations`, `sas-to-r-migration`) received
+  audience-grounding intros and section-level prose so readers don't
+  hit naked code blocks under headers. No code chunks, function
+  signatures, math, or numeric results were touched — narrative prose
+  only. This is the bulk of the 1.0.3 diff by line count.
+* **`inst/CITATION` version templating.** Previously hardcoded the
+  version string (last updated at 0.9.4); now reads `meta$Version` so
+  `citation("TemporalHazard")` self-reports the current version going
+  forward.
+* **`RoxygenNote` synced to installed `roxygen2`.** DESCRIPTION's
+  `RoxygenNote` field bumped to 8.0.0 to match the generator that
+  produced the committed Rd files. No Rd content changes.
+
 ## Test environments
 
 * **Local:** R 4.6.0 on macOS (aarch64-apple-darwin23).

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title    = "TemporalHazard: Temporal Parametric Hazard Modeling in R",
   author   = person("John", "Ehrlinger"),
   year     = "2026",
-  note     = "R package version 0.9.4",
+  note     = paste("R package version", meta$Version),
   url      = "https://ehrlinger.github.io/temporal_hazard/"
 )
 

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -28,24 +28,52 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette demonstrates the **complete analytical workflow** for a
-temporal parametric hazard analysis, mirroring the disciplined sequence used
-in the original SAS HAZARD system:
+The previous vignettes covered each piece of the analytical workflow
+in isolation — how to fit a model, how to predict from it, how to
+validate it. This vignette runs all of those pieces together on a
+single dataset, in the order you'd actually run them in a real
+clinical analysis. The point isn't to introduce new functions; it's
+to show how the pieces chain into a disciplined sequence that turns
+raw covariates into a fitted, validated, defensible hazard model.
 
-1. **Nonparametric baseline** --- Kaplan-Meier life table
-2. **Shape fitting** --- start simple, build to multiphase
-3. **Variable screening** --- calibrate covariates, assess functional form
-4. **Multivariable model** --- covariate entry with fixed shapes
-5. **Prediction** --- patient-specific risk profiles
-6. **Validation** --- decile-of-risk calibration
+The sequence mirrors the one in the original SAS HAZARD system, which
+codified what cardiothoracic-surgery biostatisticians had been doing
+informally for decades:
 
-This corresponds to the SAS programs `ac.*` → `hz.*` → `lg.*` → `hm.*` →
-`hp.*` → `hs.*`.
+1. **Nonparametric baseline** — Kaplan-Meier life table to see what
+   the data is saying before any model intervenes.
+2. **Shape fitting** — start with a single-distribution Weibull,
+   build up to a multiphase decomposition when the KM curve
+   demands it.
+3. **Variable screening** — univariable association tests and
+   calibration plots to decide which covariates enter the model and
+   in what functional form.
+4. **Multivariable model** — covariates layered onto a hazard shape
+   you already trust.
+5. **Prediction** — patient-specific risk profiles for clinical
+   reporting and decision support.
+6. **Validation** — decile-of-risk calibration to verify the model
+   is honest across the risk spectrum, not just on average.
 
-We use the **AVC** dataset (310 patients, atrioventricular canal repair)
-which has rich covariates and two identifiable hazard phases.
+This corresponds to the SAS programs `ac.*` → `hz.*` → `lg.*` →
+`hm.*` → `hp.*` → `hs.*`. If you're familiar with the SAS workflow,
+the section structure should feel familiar; if not, treat this as
+the canonical analytical sequence to follow on any new dataset.
+
+We use the **AVC** dataset (310 patients, atrioventricular canal
+repair) which has rich covariates and two identifiable hazard
+phases — fewer phases than the 3-phase CABG example you've seen in
+other vignettes, but with the covariate complexity needed to
+exercise the screening, multivariable-fit, and validation steps.
 
 ## Data preparation
+
+Load the package and the AVC dataset, drop incomplete rows so the
+design matrix is rectangular for the multivariable fits to come, and
+inspect the resulting column types and ranges. The `na.omit()` step
+is conservative — losing rows is a real cost — but for a walkthrough
+we want every later fit to use the same patient set so the comparisons
+are apples-to-apples.
 
 ```{r}
 #| label: setup
@@ -113,7 +141,12 @@ CDF phase plus a constant phase --- no obvious late rising hazard.
 
 ### 2a. Single-phase Weibull
 
-Start with the simplest parametric model to establish a baseline fit.
+The discipline here is to start with the simplest parametric model
+and earn any added complexity. A single-distribution Weibull
+intercept-only fit gives us a smooth two-parameter curve to compare
+against the KM baseline. If the Weibull tracks the KM step function
+reasonably well, we may be done; if it can't, the gap tells us
+exactly where a richer model needs to go.
 
 ```{r}
 #| label: weibull-fit
@@ -154,8 +187,16 @@ between the early and late time frames.
 
 ### 2b. Two-phase model (early CDF + constant)
 
-Based on the KM shape, fit an early phase (resolving operative risk) plus
-a constant phase (background attrition).
+The KM curve drops steeply in the first few months — operative
+mortality — and then settles into a roughly linear decline. The
+Weibull tried to capture both with one shape and ended up
+compromising. Splitting the hazard into two phases lets each
+mechanism have its own parameterization: an `"cdf"` early phase that
+saturates as operative risk resolves, plus a `"constant"` phase that
+carries the steady background attrition. Two phases is what AVC
+actually needs; CABG with longer follow-up would need a third
+late-rising phase to handle graft deterioration, but the AVC
+follow-up window doesn't extend far enough to identify one.
 
 ```{r}
 #| label: multiphase-fit
@@ -199,7 +240,13 @@ ggplot() +
 
 ### 2c. Decomposed hazard
 
-Visualize the per-phase contributions to the cumulative hazard.
+The overlay plot shows the *total* fit tracks KM well, but it
+doesn't show whether each phase is doing the job we asked of it.
+Decomposing the cumulative hazard into per-phase contributions is
+the diagnostic that answers that question: the early phase should
+account for most of the steep early drop, the constant phase should
+carry the rest, and neither phase should be doing implausible work
+in the wrong time window.
 
 ```{r}
 #| label: fig-decomposed
@@ -238,8 +285,15 @@ in the SAS workflow.
 
 ### 3a. Univariable logistic screening
 
-Use simple logistic regression of the event indicator on each covariate to
-get a quick ranking by strength of association.
+The cheapest screening tool we have is a univariable logistic
+regression of the event indicator on each covariate. It throws away
+the time-to-event structure but it answers a binary question
+quickly: does this covariate have *any* association with mortality
+at all? Covariates whose univariable p-value is huge will not
+suddenly become significant in the multivariable hazard model
+either — those can be deprioritized. Covariates with small
+univariable p-values deserve closer functional-form inspection
+before they enter the formula.
 
 ```{r}
 #| label: screening
@@ -311,8 +365,13 @@ warranted.
 
 ### 4a. Manual specification
 
-Enter the significant covariates from screening into the two-phase
-hazard model directly.
+We've already established the two-phase shape and screened the
+covariates; the multivariable model is the synthesis. Drop the
+covariates that passed screening onto the right-hand side of the
+formula and refit. The shape parameters stay fixed (we've earned
+that decision from §2); the optimizer estimates the two phase
+scales and one coefficient per covariate, jointly. This is the
+working model you'd report from this analysis.
 
 ```{r}
 #| label: multivariable-fit
@@ -461,8 +520,17 @@ ggplot() +
 
 ### 5b. Sensitivity analysis --- risk factor comparison
 
-Compare survival curves for a low-risk vs. high-risk patient profile to
-visualize the effect of covariates on long-term outcome.
+Coefficient tables tell you about effect *direction and magnitude*
+on the log-hazard scale. They don't directly tell a clinician what
+to expect at the bedside. Sensitivity analysis closes that gap by
+scoring two clinically meaningful profiles — a low-risk patient
+drawn from the favorable end of each covariate, and a high-risk
+patient drawn from the unfavorable end — through the fitted model
+and plotting the resulting survival curves with delta-method
+confidence bands. The vertical and horizontal gaps between the two
+curves are the model's clinical-impact statement, in the units
+(survival probability and time) that the audience actually
+recognizes.
 
 ```{r}
 #| label: fig-sensitivity

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -31,10 +31,23 @@ library(survival)
 library(ggplot2)
 ```
 
-This vignette walks through the core model-fitting workflow, starting from
-the simplest case (intercept-only, single distribution) and building up through
-multivariable models to multiphase additive hazard decomposition.  Every
-example uses a clinical dataset shipped with the package.
+This vignette walks the core model-fitting workflow from the inside
+out: intercept-only fits to establish the baseline hazard shape, then
+covariates on top, then the multiphase decomposition, then
+multi-endpoint analyses on the same cohort. Every example uses a
+clinical dataset shipped with the package. If you haven't seen the
+basics — what a parametric hazard model is, why we use the
+`Surv(time, status)` formula — start with `vignette("getting-started")`
+first; this vignette assumes that context.
+
+The progression matters. Single-distribution intercept-only fits tell
+you whether the baseline hazard shape is monotone (Weibull territory)
+or has structure that demands a multiphase decomposition.
+Multivariable fits add covariate effects on top of a shape you already
+trust. Multiphase fits split the baseline shape into clinically
+interpretable phases. Multi-endpoint analyses reuse all the above for
+separate clinical outcomes — death, reoperation, infection — on the
+same patient cohort.
 
 
 ## Intercept-only model: CABG survival (KU Leuven)
@@ -50,7 +63,12 @@ data(cabgkul)
 str(cabgkul)
 ```
 
-Fit an intercept-only Weibull hazard (no covariates):
+Fit an intercept-only Weibull. With no covariates on the right-hand
+side of the formula the model estimates only the baseline hazard
+shape — the scale `mu` and exponent `nu` of a Weibull curve fit to all
+5,880 patients pooled. This is the right starting point for any new
+dataset: before asking which covariates matter, ask whether a single
+monotone hazard even fits the population-level pattern.
 
 ```{r}
 #| label: kul-weibull
@@ -65,7 +83,10 @@ fit_kul <- hazard(
 fit_kul
 ```
 
-Compare the parametric fit to the Kaplan-Meier estimate:
+The summary tells us where the optimizer landed; the picture tells us
+whether that landing point matches the data. Plot the fitted survival
+curve on a fine time grid and overlay the Kaplan-Meier step function
+from the raw cohort.
 
 ```{r}
 #| label: fig-kul-km
@@ -100,8 +121,13 @@ the multiphase approach below.
 
 ## Multivariable model: AVC repair
 
-The `avc` dataset has 310 patients with 9 covariates.  We can use the formula
-interface to fit a multivariable Weibull model.
+The `avc` dataset has 310 patients who underwent atrioventricular canal
+repair, with 9 candidate covariates spanning patient demographics (age,
+NYHA status), anatomical features (malalignment, orifice morphology),
+intra-operative grading (`inc_surg` = surgical grade of AV valve
+incompetence), and post-operative complications (`com_iv` = grade IV
+complications). We drop incomplete rows so the design matrix is
+rectangular, then look at the column types and ranges.
 
 ```{r}
 #| label: avc-data
@@ -109,6 +135,13 @@ data(avc)
 avc <- na.omit(avc)
 str(avc)
 ```
+
+Now we put covariates on the right-hand side of the formula and refit.
+The `theta` vector grows: two Weibull shape parameters (`mu`, `nu`) plus
+six covariate coefficients (`beta1`..`beta6`), each starting at zero.
+The optimizer estimates a log-hazard-ratio for every covariate jointly
+with the Weibull shape — so the shape and the covariate effects are
+identified from the same likelihood, not sequentially.
 
 ```{r}
 #| label: avc-mv
@@ -124,20 +157,41 @@ fit_avc <- hazard(
 fit_avc
 ```
 
-The coefficient estimates give the log-hazard-ratio for each covariate.
-Covariates with large positive coefficients (`mal`, `com_iv`) are associated
-with higher operative risk.
+Each coefficient is a log-hazard-ratio: positive means higher risk,
+negative means lower, zero means no effect. The large positive
+coefficients on `mal` (anatomical malalignment) and `com_iv`
+(grade IV post-operative complications) flag these as the dominant
+risk markers in this cohort. The standard errors and Wald
+z-statistics in the summary tell you which effects are well
+identified and which are noise — a coefficient with a z-statistic
+near zero contributes essentially nothing the data can defend.
 
 
 ## Multiphase model: additive hazard decomposition
 
-The key innovation of the Blackstone--Naftel--Turner framework is decomposing
-the hazard into additive temporal phases:
+The single-Weibull fits above gave us a curve that's mediocre
+everywhere instead of right anywhere. That's a structural limitation
+of a monotone parametric shape, not something more iterations will
+fix. The Blackstone–Naftel–Turner framework's key idea is to split
+the hazard into a *sum* of phase-specific contributions, each with its
+own temporal shape and its own scale:
 
 $$H(t \mid x) = \sum_{j=1}^{J} \mu_j(x) \cdot \Phi_j(t)$$
 
-Each phase has its own temporal shape (early peaking, constant, late rising)
-and its own intercept.  We specify phases with `hzr_phase()`:
+Each $\Phi_j(t)$ is a phase-specific unit-scaled curve (early-peaking
+saturating, flat constant, late-rising polynomial) and each $\mu_j(x)$
+is the phase-specific scale, possibly modulated by covariates. The
+phases overlap and add — no switching, no thresholds — so the total
+instantaneous hazard at any $t$ is the sum of the per-phase rates.
+See `vignette("getting-started")` for the longer-form motivation; what
+follows here is the practical workflow for *fitting* one.
+
+For AVC we'll use two phases — an early phase to absorb the
+operative-window mortality, and a constant phase for the background
+rate. AVC patients don't have a clear late-deterioration regime over
+this follow-up window, so a third (g3) phase would be unidentified.
+We fix the shape parameters and estimate only the scales, matching
+the workflow you'd run against a SAS HAZARD reference fit.
 
 ```{r}
 #| label: avc-mp
@@ -157,7 +211,10 @@ fit_mp <- hazard(
 summary(fit_mp)
 ```
 
-Comparing the single-phase Weibull to the multiphase fit:
+The diagnostic that matters is whether the multiphase fit actually
+out-performs the single Weibull against the data. Plot both parametric
+curves against the same Kaplan-Meier reference so we can see, by eye,
+where each model is honest and where each is reaching.
 
 ```{r}
 #| label: fig-avc-compare
@@ -199,9 +256,13 @@ ggplot() +
   theme(legend.position = "bottom")
 ```
 
-The multiphase model tracks the KM curve much more closely, capturing both
-the steep early decline and the gradual late attrition that a single Weibull
-cannot represent.
+The multiphase model tracks the KM curve much more closely than the
+single Weibull, especially across the steep early-mortality window —
+which is exactly where the single Weibull was forced to compromise.
+The constant phase then carries the slow post-recovery attrition. The
+point isn't that multiphase always wins; it's that *when the data has
+phase structure*, fitting that structure explicitly is strictly more
+honest than averaging it away into one monotone curve.
 
 
 ## Multi-endpoint models: heart valve replacement
@@ -210,6 +271,10 @@ The `valves` dataset (1,533 patients) has multiple time-to-event endpoints ---
 death, prosthetic valve endocarditis (PVE), and reoperation --- each with its
 own follow-up time and event indicator.  The same `hazard()` call fits each
 endpoint independently:
+
+Start with the death endpoint. We use age at operation, NYHA class,
+and mechanical-valve indicator as covariates — the clinically
+canonical set for survival after valve replacement.
 
 ```{r}
 #| label: valves-death
@@ -228,6 +293,14 @@ fit_death <- hazard(
 fit_death
 ```
 
+Switch endpoints. Same data, same package, but now we model time to
+prosthetic valve endocarditis instead of death. The covariate list
+shifts to match the clinical question: `nve` (native-valve endocarditis
+history) replaces `nyha` because functional class is less informative
+for infection risk than prior endocarditis exposure. The fit returns
+its own MLE, coefficients, and standard errors completely independent
+of the death model.
+
 ```{r}
 #| label: valves-pve
 fit_pve <- hazard(
@@ -242,14 +315,23 @@ fit_pve <- hazard(
 fit_pve
 ```
 
-Each endpoint gets its own model with its own covariates.  But the hazard
-model structure --- temporal shape plus covariate effects --- stays the same
-whatever the clinical endpoint.
+Each endpoint gets its own model with its own covariates, but the
+hazard model structure — temporal shape plus covariate effects — stays
+the same whatever the clinical endpoint. Repeating the workflow for a
+third endpoint (reoperation, for example) is mechanical: swap the
+`Surv(...)` columns, swap the covariates, refit. The advantage over
+running three separate analyses in different tools is that the
+predictions, diagnostics, and uncertainty quantification all come from
+the same package — there's no risk of subtle differences in censoring
+handling or estimator choice between endpoints.
 
 
 ## Phase types reference
 
-The `hzr_phase()` constructor supports three temporal shapes:
+You've now seen each phase type in use: a `"cdf"` early phase for AVC
+operative mortality, a `"constant"` phase for AVC background rate, and
+the implicit single shape of every Weibull fit. The package supports
+three phase types in total, summarized here for quick reference:
 
 | Type | Description | Typical use |
 |------|-------------|-------------|
@@ -257,8 +339,13 @@ The `hzr_phase()` constructor supports three temporal shapes:
 | `"constant"` | Flat hazard (no temporal shape parameters) | Ongoing background risk |
 | `"g3"` | Late-phase G3 parameterization (4 parameters: `tau`, `gamma`, `alpha`, `eta`) | Late-rising risk matching C/SAS G3 output |
 
-The `"cdf"` type covers the widest range of shapes.  Setting `t_half` small
-(e.g., 0.5) creates an early-peaking phase; setting it large (e.g., 10)
-creates a late-rising phase.  The `"constant"` phase needs no shape parameters.
-See `vignette("mf-mathematical-foundations")` for the full mathematical
-treatment.
+The `"cdf"` type covers the widest range of shapes: setting `t_half`
+small (e.g., 0.5) creates an early-peaking phase; setting it large
+(e.g., 10) creates a late-rising phase. The `"constant"` phase needs no
+shape parameters. The `"g3"` shape is the explicit late-rising parameterization
+that matches the SAS HAZARD "late" library; use it when you need
+parity against a C/SAS reference fit, or when the late rise has a
+clear lag-then-accelerate pattern that a delayed `"cdf"` doesn't
+capture cleanly. See `vignette("mf-mathematical-foundations")` for the
+full mathematical treatment of each, including the parameter
+identifiability constraints.

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -127,8 +127,15 @@ new_patients
 
 ## Visualizing predicted survival
 
-Here we build a survival curve over a fine time grid for a median-profile
-patient and overlay the Kaplan-Meier nonparametric estimate from the raw data.
+The summary table and the patient-level scores tell us the fit
+*converged* and what it *predicts*, but not whether the predicted shape
+matches the data. For that we plot the model. Below we build a smooth
+survival curve over a fine time grid for a median-profile patient and
+overlay the Kaplan-Meier nonparametric estimate from the raw data on
+the same axes. If the parametric curve hugs the KM step function the
+Weibull shape is honest to the data; visible drift in either direction
+flags a model the optimizer fit happily but that doesn't actually
+describe the cohort.
 
 ```{r}
 #| label: fig-survival
@@ -426,8 +433,19 @@ mathematical treatment.
 
 ## Numerical helpers
 
-The numerical helper functions remain available directly when you need stable
-log-scale calculations for custom work or debugging.
+The package ships a small set of numerical helpers used internally to
+keep the likelihood evaluations stable across the wide range of
+arguments an optimizer encounters. They're exported so you can reach
+for them in custom code or when debugging a fit.
+
+The most common one is `hzr_log1pexp(x)`, which computes
+$\log(1 + e^x)$ in a numerically stable way. The naive `log(1 + exp(x))`
+overflows once $x$ exceeds about 700 (because `exp(x)` itself
+overflows); the helper switches to the asymptotic $x + \log(1 + e^{-x})$
+for large $x$, which is exact to floating-point precision. The package
+uses it inside every log-likelihood expression that involves a
+log-survival term, so the same evaluation can run on $x = -50$ and
+$x = 5000$ without producing `Inf` or `NaN`.
 
 ```{r}
 TemporalHazard::hzr_log1pexp(c(-2, 0, 2))

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -43,6 +43,24 @@ single-distribution Weibull fit on simulated data — fit, summary,
 predict — then move to the multiphase fit on CABGKUL, the canonical
 three-phase cardiac-surgery example.
 
+## A first Weibull fit
+
+The simulated data below has 180 patients with three plausible risk
+covariates — age, NYHA functional class, and cardiogenic shock. We fit
+a single Weibull hazard: a scale parameter (`mu`) and a shape exponent
+(`nu`) that lets the hazard accelerate when `nu > 1`, decelerate when
+`nu < 1`, or stay flat at `nu = 1`. The Weibull is the natural starting
+point for a single-distribution fit because it covers all three
+monotone shapes with just two parameters.
+
+The `hazard()` interface takes a survival formula
+(`Surv(time, status)` on the left, covariates on the right), a
+starting-value vector (`theta`), and a distribution name. Passing
+`fit = TRUE` runs the optimizer and returns a fitted model; passing
+`fit = FALSE` returns the model specification without fitting, which is
+useful for sanity-checking the formula and starting values before
+committing to the optimizer.
+
 ```{r}
 library(TemporalHazard)
 library(survival)
@@ -70,6 +88,24 @@ summary(fit)
 ```
 
 ## Prediction workflow
+
+A fitted hazard model lets you score new patients without refitting.
+The `predict()` method takes a `newdata` frame and a `type` argument
+that selects which quantity to compute:
+
+- `"linear_predictor"` — the covariate-driven log-hazard-ratio for
+  each row, $x^\top \beta$.
+- `"hazard"` — the hazard multiplier, $\exp(x^\top \beta)$.
+- `"survival"` — the probability of surviving past each row's `time`,
+  $S(t \mid x)$.
+- `"cumulative_hazard"` — the integrated hazard up to each row's
+  `time`, $H(t \mid x) = -\log S(t \mid x)$.
+
+The three rows below are made-up patients spanning the covariate range
+in the training data: a younger, low-NYHA, no-shock patient at an
+early time; a middle case at the median; and an older, high-NYHA,
+shock patient further out. We compute all four prediction types for
+each.
 
 ```{r}
 new_patients <- data.frame(

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -21,8 +21,6 @@ knitr::opts_chunk$set(
 )
 ```
 
-## What this vignette does
-
 TemporalHazard fits *parametric hazard models* to time-to-event data.
 If you've worked with `survival::coxph()` or Kaplan-Meier curves before
 you already have most of the vocabulary; this is a quick refresh of the

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -21,8 +21,27 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette shows the minimal workflow for fitting a parametric hazard model,
-summarizing the fit, and generating predictions.
+## What this vignette does
+
+TemporalHazard fits *parametric hazard models* to time-to-event data.
+If you've worked with `survival::coxph()` or Kaplan-Meier curves before
+you already have most of the vocabulary; this is a quick refresh of the
+bits that matter for what follows.
+
+A **hazard** is the instantaneous risk of the event at time $t$, given
+the subject has survived until $t$. A Kaplan-Meier curve reflects it
+implicitly: KM gives you survival probabilities, and the rate at which
+those probabilities drop is (minus) the hazard. A **parametric** hazard
+model writes the hazard as a smooth function of $t$ with a small number
+of parameters, plus covariate effects. The payoff over nonparametric
+KM is a smooth curve you can extrapolate, patient-specific risk
+predictions, and the ability to compare fitted hazard *shapes* across
+groups or models.
+
+This vignette walks the minimal workflow. We start with a
+single-distribution Weibull fit on simulated data — fit, summary,
+predict — then move to the multiphase fit on CABGKUL, the canonical
+three-phase cardiac-surgery example.
 
 ```{r}
 library(TemporalHazard)
@@ -114,18 +133,69 @@ ggplot() +
 
 ## Multiphase models
 
-Real clinical hazard patterns are rarely monotone. After cardiac surgery, the
-risk of death starts high (early post-operative risk), drops to a low background
-rate, and eventually rises again as patients age. A single Weibull curve cannot
-capture this --- but a multiphase additive hazard model can.
+The Weibull fit above describes the hazard with one smooth, monotone
+curve — it can rise, fall, or stay flat over time, but it cannot change
+direction. That's fine for some processes (light bulbs failing, parts
+wearing out). It breaks down quickly for clinical data.
 
-The total hazard is decomposed into additive phases, each with its own temporal
-shape:
+Consider CABG (coronary artery bypass graft) surgery. In the days right
+after the operation the risk of death is at its highest: the patient is
+in the ICU, exposed to operative complications, infections, bleeding.
+If they survive that window the risk drops to a low, roughly flat
+background rate: they recover, go home, live their lives. Years later
+the risk rises again as the grafts begin to deteriorate and the cohort
+ages. Three distinct regimes, each with its own clinical mechanism.
+
+No single Weibull (or log-normal, or any other monotone distribution)
+can fit all three at once. The optimizer would have to compromise:
+picking a shape that's mediocre everywhere instead of right in any one
+regime. You'd predict too few early deaths, the wrong slope in the
+middle, and too few late deaths.
+
+The **multiphase decomposition** is the workaround. Instead of asking
+one distribution to do everything, we describe the total cumulative
+hazard as a *sum* of phase-specific contributions, each with its own
+temporal shape:
 
 $$H(t \mid x) = \sum_{j=1}^{J} \mu_j(x) \cdot \Phi_j(t)$$
 
-Each phase is specified with `hzr_phase()`, which sets the temporal shape type
-and starting values for the optimizer.
+Each $\Phi_j(t)$ is a phase-specific *temporal shape*: a unit-scaled
+curve that says *how* phase $j$'s hazard accumulates over time. Each
+$\mu_j(x)$ is the phase-specific *scale*: how much cumulative hazard
+belongs to phase $j$, possibly modulated by covariates. The phases
+overlap and their hazards add. There's no switching, no thresholds, no
+piecewise joins; at any time $t$ the instantaneous hazard $h(t) = dH/dt$
+is the sum of the per-phase contributions $\mu_j \cdot \phi_j(t)$, where
+$\phi_j = d\Phi_j/dt$.
+
+### Why multiple phases?
+
+Because the number of phases is the modeling lever that lets you match
+the data's actual structure. Some processes are well-described by two
+phases (early failure + steady-state). Most cardiac-surgery cohorts
+need three: early operative risk + constant background + late
+deterioration. A small handful — acute aortic dissection is the
+classic — need four (operative + subacute + constant + late). The
+framework is general; the *count* is a modeling choice driven by
+clinical knowledge and the shape of the Kaplan-Meier cumulative hazard
+curve.
+
+For the CABGKUL fit below we use three phases. That's not a property of
+the package; it's a property of this dataset.
+
+Each phase is specified with `hzr_phase()`. The first argument picks
+the shape function: `"cdf"` for a saturating curve bounded between 0
+and 1 (the SAS "early" / G1 shape), `"constant"` for a flat hazard
+plateau (SAS "G2"), `"g3"` for the polynomial late-rising shape from
+the SAS "late" library. Remaining arguments set the shape's free
+parameters, or fix them with `fixed = "shapes"`. The Phase types
+section below has the full menu.
+
+For this fit we use the textbook three-phase decomposition: a
+saturating early peak, a constant background, and a polynomial late
+rise. We fix the shapes so we can compare the fitted scales against
+the published reference; in your own work you would usually estimate
+them.
 
 ```{r}
 #| label: multiphase-fit
@@ -173,9 +243,20 @@ absorbs the third `log_mu`.
 
 ### Decomposed hazard visualization
 
-The `decompose = TRUE` argument returns per-phase cumulative hazard
-contributions. We numerically differentiate these to visualize the
-instantaneous hazard rate for each phase.
+The MLE numbers in the summary tell us *what* the model committed to,
+but not *how* the three phases fit together over time. For that we
+need the per-phase contributions. The `decompose = TRUE` argument on
+`predict()` returns one cumulative-hazard column per phase plus the
+total; we numerically differentiate each one (a coarse first-difference
+is fine here, since we just want to look) to get an instantaneous
+hazard rate.
+
+The plot that follows is the diagnostic that matters: it shows whether
+the model carved up the timeline the way we expected. The early phase
+should dominate near $t = 0$ and die off. The constant phase should be
+a flat floor. The late phase should be near zero early and rise after
+a lag. If any of those shapes looks wrong, the fix is in the starting
+values or in the choice of shape function, not in the data.
 
 ```{r}
 #| label: fig-hazard-phases
@@ -226,6 +307,14 @@ ggplot(h_long, aes(time, hazard, colour = Phase, linetype = Phase)) +
 
 ### Multiphase survival with Kaplan-Meier overlay
 
+The decomposition plot tells us the model has the right *shape*; the
+overlay plot tells us it has the right *level*. Plotting the
+parametric survival curve against the Kaplan-Meier estimate on the
+same axis is the single most useful diagnostic for a hazard fit. KM
+is the gold-standard nonparametric reference; if the parametric curve
+drifts away from it, something is wrong with the model that more
+iterations won't fix.
+
 ```{r}
 #| label: fig-mp-survival
 #| fig-cap: "Multiphase parametric survival vs. Kaplan-Meier"
@@ -257,7 +346,33 @@ ggplot() +
 
 ### Phase types
 
-TemporalHazard supports several phase types:
+Picking the right phase shape is the single biggest modeling decision
+in a multiphase fit. The package ships the canonical shapes from the
+SAS C HAZARD library:
+
+- **`"cdf"`** — a saturating curve $\Phi(t) \in [0, 1]$, parameterized
+  by `t_half` (the time at which $G(t_{1/2}) = 0.5$), `nu` (a time
+  exponent), and `m` (a shape exponent). This is the SAS "early" or G1
+  shape. Use it for the early phase, or for any phase whose accumulated
+  hazard saturates rather than growing without bound.
+- **`"constant"`** — $\Phi(t) = t$. The phase's hazard rate is flat;
+  there are no shape parameters to estimate, only the scale $\mu$. This
+  is the SAS G2 shape. Use it for a background plateau.
+- **`"g3"`** — the SAS "late" shape, parameterized by `tau` (a
+  time-scale), `gamma` (a time exponent), `alpha` (a shape parameter;
+  $\alpha = 0$ gives an exponential limit), and `eta` (an outer
+  exponent). Use it for a late phase that is near-zero early and
+  accelerates over time — graft deterioration over years is the
+  archetype.
+
+See `?hzr_phase` for the additional `"hazard"` shape and the full
+parameterization of each.
+
+In practice you choose phase shapes by looking at the Kaplan-Meier
+cumulative hazard plot, identifying which regimes are present, and
+matching each regime to the shape family whose behavior fits. Then
+you fit, look at the decomposition plot, and adjust starting values
+or fix shapes if a phase doesn't land where you expected.
 
 ```{r}
 #| eval: false

--- a/vignettes/inference-diagnostics.qmd
+++ b/vignettes/inference-diagnostics.qmd
@@ -31,18 +31,38 @@ library(survival)
 library(ggplot2)
 ```
 
-This vignette covers the diagnostic and inferential tools surrounding hazard
-model fitting: exploratory covariate screening, bootstrap confidence intervals,
-decile-of-risk validation, and sensitivity analysis across covariate scenarios.
-These correspond to the `lg.*`, `bs.*`, and `hs.*` steps in the classic
-HAZARD analysis workflow.
+Fitting a hazard model is the middle of the workflow, not the end.
+Before you fit, you screen the covariates so you know what
+transformations the data actually supports. After you fit, you
+quantify uncertainty (bootstrap CIs, Wald intervals), check whether
+the model is honest to the data (goodness-of-fit overlays,
+decile-of-risk calibration), and probe its behavior under different
+covariate scenarios (sensitivity analysis). This vignette walks the
+diagnostic and inferential tools the package ships for each of those
+steps.
+
+These pieces correspond directly to steps in the classic SAS HAZARD
+workflow — the `lg.*` logistic-screening macros, the `bs.*` bootstrap
+macros, the `hs.*` hazard-sensitivity macros — re-implemented as
+first-class R functions (`hzr_calibrate()`, `hzr_kaplan()`,
+`hzr_nelson()`, `hzr_bootstrap()`, `hzr_gof()`, `hzr_deciles()`). If
+you've worked through a SAS HAZARD analysis you already know the
+shape of what follows; if not, treat this vignette as the standard
+diagnostic pass you'd run on any fitted hazard model before trusting
+its conclusions.
 
 
 ## Exploratory covariate screening
 
-Before fitting the parametric hazard model, screen the candidate
-covariates with simple logistic models.  This shows you which transformations and
-functional forms should enter the final model.
+Before fitting the parametric hazard model, screen each candidate
+covariate with a simple logistic regression against the event
+indicator. This is much cheaper than fitting the full hazard model
+and answers two distinct questions: which covariates carry signal at
+all (rough significance triage), and what *functional form* each
+covariate enters with — linear, log, polynomial, or something
+non-monotone that needs binning. The screening step is what stops you
+from blindly throwing every column at `hazard()` and then trying to
+debug a model that has shape mis-specification baked in.
 
 ```{r}
 #| label: explore-data
@@ -53,8 +73,12 @@ avc <- na.omit(avc)
 candidates <- c("age", "status", "mal", "com_iv", "inc_surg", "orifice")
 ```
 
-Fit a univariable logistic regression for each covariate against the death
-indicator:
+Fit a univariable logistic regression for each candidate against the
+death indicator. The p-values that come out are not the final word on
+whether a covariate matters — they ignore the joint structure of the
+hazard model and they treat the event time as a binary outcome — but
+they do tell you which covariates have no chance of mattering, and
+which deserve closer inspection.
 
 ```{r}
 #| label: explore-logit
@@ -87,9 +111,13 @@ ggplot(avc, aes(age, dead)) +
   theme_minimal()
 ```
 
-The LOESS smooth shows the shape of the covariate-mortality relationship,
-which guides the choice of transformation (log, polynomial) before you fit
-the hazard model.
+The LOESS smooth reveals the *shape* of the covariate-mortality
+relationship in a non-parametric way. A roughly linear smooth means
+the covariate enters the hazard model on its natural scale; a U or
+inverted-U shape means a polynomial or a non-monotone transform; a
+plateau-then-rise means a threshold effect that may need binning.
+This is the call you make *before* writing the formula for
+`hazard()`, not after staring at a converged-but-misspecified model.
 
 
 ### Quantile calibration with `hzr_calibrate()`
@@ -116,12 +144,18 @@ example, polynomial or log).
 
 ## Nonparametric baselines
 
-Before fitting the parametric model, run a Kaplan-Meier or Nelson
-baseline.  `hzr_kaplan()` returns KM with logit-transformed confidence
-limits (more accurate in the tails than Greenwood), along with interval
-hazard rate, density, and restricted mean survival time.  `hzr_nelson()`
-returns the Wayne Nelson cumulative hazard estimator with lognormal
-confidence limits.
+A parametric fit has to be compared against *something*. The natural
+something is the nonparametric estimate of the same quantity from the
+same data — Kaplan-Meier for survival, Nelson-Aalen for cumulative
+hazard. The package's `hzr_kaplan()` and `hzr_nelson()` are
+convenience wrappers that return richer output than `survival::survfit()`:
+`hzr_kaplan()` ships KM with logit-transformed confidence limits
+(more accurate in the tails than the standard Greenwood limits, which
+can stray outside $[0, 1]$), interval hazard rates, density estimates,
+and a restricted-mean-survival-time scalar. `hzr_nelson()` returns the
+Wayne Nelson cumulative hazard estimator with log-normal confidence
+limits — the right reference when you care about the integrated
+intensity rather than the survival probability.
 
 ```{r}
 #| label: km-baseline
@@ -138,9 +172,22 @@ print(nel)
 
 ## Bootstrap confidence intervals
 
-Bootstrap resampling is the primary uncertainty quantification method in the
-HAZARD workflow.  Each replicate refits the model on a resampled dataset and
-accumulates prediction curves; the CI is summarized across replicates.
+The delta-method CIs `predict(se.fit = TRUE)` returns are fast and
+asymptotically correct, but they lean on the Hessian-derived
+parameter vcov — which can mislead when the likelihood surface is
+poorly behaved near the MLE (boundary fits, near-degenerate
+parameter combinations, small samples). Bootstrap resampling is the
+robust alternative: refit the model on each resampled dataset,
+collect the resulting parameter and prediction values, and read the
+empirical 2.5th / 97.5th percentiles as the 95% CI. It's
+computationally heavier but it doesn't assume the likelihood is
+locally quadratic, and it picks up the right tail behavior even
+when delta-method theory creaks.
+
+`hzr_bootstrap()` wraps the resample-and-refit loop and corresponds to
+the SAS `bootstrap.hazard.sas` and `bootstrap.summary.sas` macros. We
+fit a base model first; bootstrap replicates will resample from the
+same data and refit using these starting values.
 
 ```{r}
 #| label: fit-base
@@ -162,11 +209,12 @@ base_nd <- data.frame(time = t_grid, age = median(avc$age),
 surv_point <- predict(fit, newdata = base_nd, type = "survival")
 ```
 
-`hzr_bootstrap()` wraps the resample-and-refit loop: it returns a long
-data frame of per-replicate coefficient estimates (`$replicates`) and a
-parameter-level summary (mean, SD, 95 % percentile CI) in `$summary`.
-It corresponds to the SAS `bootstrap.hazard.sas` and
-`bootstrap.summary.sas` macros.
+`hzr_bootstrap()` returns a long data frame of per-replicate
+coefficient estimates (`$replicates`) and a parameter-level summary
+(mean, SD, 95% percentile CI) in `$summary`. We use `n_boot = 30`
+here purely so the vignette renders in reasonable time — for a real
+analysis you'd want 200 or more replicates. The `set.seed(42)` call
+before `hzr_bootstrap()` makes the resample sequence reproducible.
 
 ```{r}
 #| label: bootstrap
@@ -185,9 +233,15 @@ all in the returned object.
 
 ## Goodness-of-fit overlay
 
-`hzr_gof()` computes parametric predictions against the nonparametric
-Kaplan-Meier estimator and the Conservation-of-Events observed-vs-
-expected event counts.  It corresponds to the SAS `hazplot.sas` macro.
+The Kaplan-Meier overlay in the prediction-visualization vignette is
+the *visual* goodness-of-fit check. `hzr_gof()` is the *quantitative*
+complement: it tabulates parametric predictions side by side with the
+nonparametric KM estimate at each event time, and computes the
+Conservation-of-Events observed-vs-expected ratio across the whole
+follow-up window. The ratio compresses everything the model is doing
+into a single number, which makes it the right summary statistic to
+report alongside coefficient tables. (`hzr_gof()` corresponds to the
+SAS `hazplot.sas` macro.)
 
 ```{r}
 #| label: gof-summary
@@ -204,10 +258,19 @@ isn't really linear on the log-hazard scale.
 
 ## Decile-of-risk calibration
 
-`hzr_deciles()` partitions patients into deciles of predicted risk at a
-chosen time point and compares observed with expected event counts
-decile-by-decile, returning a chi-square goodness-of-fit test.  It
-corresponds to the SAS `deciles.hazard.sas` macro.
+The conservation-of-events ratio above tells you whether the model is
+calibrated *on average*. That's necessary but not sufficient — a
+model can hit the right total event count while systematically
+over-predicting risk for one part of the cohort and under-predicting
+for another, with the errors cancelling in aggregate.
+`hzr_deciles()` is the check that catches that failure mode: it
+partitions patients into deciles of predicted risk at a chosen time
+point and compares observed with expected event counts within each
+decile, returning a chi-square goodness-of-fit test. A
+well-calibrated model has observed-vs-expected close in every decile;
+a model that's globally calibrated but locally biased will show large
+residuals in the extreme deciles. (Corresponds to the SAS
+`deciles.hazard.sas` macro.)
 
 ```{r}
 #| label: deciles
@@ -248,8 +311,19 @@ ggplot(cal_long, aes(group, rate, fill = Series)) +
 
 ## Sensitivity analysis
 
-Sensitivity analysis compares predictions across different covariate
-configurations to assess how the model responds to risk factor changes.
+Coefficient estimates tell you the *direction and magnitude* of a
+covariate's effect on the hazard scale, but they don't directly answer
+the clinical question of *what survival difference this implies* for a
+real patient. Sensitivity analysis closes that gap. You define two
+or more covariate profiles — typically a reference profile and one or
+more high-risk profiles — score each through `predict()`, and plot
+the resulting survival curves on shared axes. The horizontal and
+vertical gaps between curves translate the model's coefficients into
+the clinically meaningful currency of survival probability differences
+and median-survival shifts. It's also a stress test: if your high-risk
+profile produces only a small survival gap, either the risk factors
+aren't doing much in this cohort, or the model is missing the
+mechanism that makes them matter.
 
 ```{r}
 #| label: sensitivity
@@ -309,7 +383,11 @@ statistically meaningful.
 
 ## Analysis workflow summary
 
-The complete HAZARD analysis sequence, now implemented in TemporalHazard:
+The pieces in this vignette aren't independent diagnostics — they
+chain together into a single analytical workflow that goes from raw
+covariates to a defensible, uncertainty-quantified, well-calibrated
+fitted model. The complete sequence, with the SAS HAZARD
+correspondences each piece descends from:
 
 1. **Exploratory screening** (`glm`, `hzr_calibrate()`) --- identify
    covariate transformations and functional forms

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -32,16 +32,27 @@ library(TemporalHazard)
 ```
 
 This vignette lays out the mathematical foundation for the models in
-TemporalHazard.  It covers the generalized temporal decomposition family
-(Blackstone, Naftel, and Turner 1986), the additive multiphase hazard model,
-maximum likelihood estimation under mixed censoring, and extensions for
-time-varying covariates.  The same decomposition framework also carries over
-to longitudinal mixed-effects settings (Rajeswaran et al. 2018).
+TemporalHazard. The other vignettes treat the package as a black box
+you call `hazard()` on; this one opens the box. If you've used the
+package and want to know *what* it's computing, *why* the
+parameterization is what it is, and *how* the multiphase
+decomposition relates to standard parametric survival families, this
+is the place.
 
-For users migrating from the legacy SAS/C HAZARD program, each section notes
-how the R parameterization relates to the original parameter names.  For the
-full translation table, see `vignette("sas-to-r-migration")` or call
-`hzr_argument_mapping()`.
+The four pieces, in order: the generalized temporal decomposition
+family (Blackstone, Naftel, and Turner 1986) that every phase is
+built from; the additive multiphase hazard model that composes
+phases into a full hazard; the maximum-likelihood objective under
+mixed censoring (right, left, interval, counting-process), which is
+what the optimizer minimizes; and extensions for phase-specific and
+time-varying covariates. The same decomposition framework carries
+over to longitudinal mixed-effects settings (Rajeswaran et al.
+2018), though this vignette stays in the survival regime.
+
+For users migrating from the legacy SAS/C HAZARD program, each
+section notes how the R parameterization relates to the original
+parameter names. For the full translation table, see
+`vignette("sas-to-r-migration")` or call `hzr_argument_mapping()`.
 
 
 # Generalized Temporal Decomposition {#sec-decomposition}
@@ -98,8 +109,12 @@ cat("Max |h - g/(1-G)| =", max(abs(d$h - h_check)), "\n")
 
 ## The six valid cases
 
-The signs of `nu` and `m` determine six distinct distributional shapes.  The
-combination $m < 0$ **and** $\nu < 0$ is undefined and raises an error.
+Different sign combinations of $\nu$ and $m$ pick out different
+asymptotic behaviors of `decompos()`, and the package treats each as
+a separate case for numerical stability. The combination $m < 0$
+**and** $\nu < 0$ produces an integrand with no finite normalization
+and is rejected at the input-validation step. The remaining six are
+the catalog every phase in the package selects from:
 
 ```{r}
 #| label: six-cases-table
@@ -252,7 +267,15 @@ The derivative $\varphi_j(t)$ depends on phase type:
 
 ## Constructing phases in R
 
-Each phase is specified with `hzr_phase()` and passed to `hazard()`:
+The math above is exposed in R through `hzr_phase()`, which builds
+one phase at a time, and `hazard()`, which composes phases into a
+full model. The same `(t_half, nu, m)` triple from `decompos()`
+parameterizes the `"cdf"` and `"hazard"` shapes; the `"g3"` shape
+exposes its own `(tau, gamma, alpha, eta)` parameters from the SAS
+"late" library; and `"constant"` has no shape parameters at all. A
+canonical three-phase model uses the `"cdf"` shape for the early
+phase, `"constant"` for the background, and either a delayed
+`"cdf"` or `"g3"` for the late phase.
 
 ```{r}
 #| label: phase-construction
@@ -476,8 +499,20 @@ hazard(
 
 ## Phase-specific covariates
 
-When different phases are driven by different risk factors, each phase can
-specify its own one-sided formula:
+The global formula above lets every covariate act on every phase
+through a shared shift $x^\top \beta$. That's the right structure
+when a covariate plausibly affects the entire hazard trajectory. But
+clinical reality often pulls the other way: surgical risk factors
+(grade IV complications, intra-operative blood loss) belong in the
+early phase but say nothing about late attrition; chronic
+comorbidities (NYHA class progression, late-onset diabetes) belong
+in the late phase but were irrelevant during the operative window.
+Phase-specific covariates let you build that structure directly.
+
+When a phase carries its own one-sided formula, the phase gets its
+own design matrix from the data, and only those covariates appear
+in that phase's $\boldsymbol{\beta}_j$. Other phases ignore them
+entirely.
 
 ```{r}
 #| label: phase-specific-covariates

--- a/vignettes/prediction-visualization.qmd
+++ b/vignettes/prediction-visualization.qmd
@@ -31,16 +31,35 @@ library(survival)
 library(ggplot2)
 ```
 
-This vignette covers prediction from fitted hazard models: generating survival
-curves, decomposing the multiphase hazard, comparing risk profiles, and
-overlaying parametric fits with Kaplan-Meier estimates.
+A fitted hazard model is only useful insofar as you can extract
+answers from it. This vignette covers the predict-and-visualize half
+of the workflow: pulling survival probabilities, cumulative hazards,
+and patient-level risk scores out of a fitted model, attaching
+delta-method uncertainty to those predictions, and plotting them in
+the formats that come up in actual clinical analyses.
+
+The structure mirrors how a real analysis unfolds. We start with the
+Kaplan-Meier baseline (the nonparametric reference every parametric
+fit gets judged against), enumerate the prediction types the model
+exposes, plot the parametric survival curve against KM as a
+goodness-of-fit check, layer on confidence bands, then move to the
+multiphase decomposition and patient-specific risk profiles where the
+covariate machinery pays off. The last section reuses the workflow
+across multiple endpoints on the same cohort. If you haven't seen the
+fitting workflow yet, `vignette("fitting-hazard-models")` is the
+prerequisite.
 
 
 ## Kaplan-Meier baseline
 
-Before any parametric modeling, the Kaplan-Meier curve gives us a
-nonparametric reference.  Compare every parametric prediction that follows
-against this baseline to judge goodness-of-fit.
+The Kaplan-Meier curve is what the data itself says about survival
+before any parametric model intervenes. It makes no assumption about
+the shape of the hazard, handles censoring honestly, and gives you a
+nonparametric step function that's the gold-standard reference for any
+follow-up fit. Every parametric prediction that follows gets compared
+back to this curve — if a model's smooth prediction can't track the KM
+step function, the model is missing something the data has been
+telling you all along.
 
 ```{r}
 #| label: km-baseline
@@ -66,8 +85,28 @@ ggplot(km_df, aes(time, survival)) +
 
 ## Prediction types
 
-The `predict()` method supports several output types.  For a multivariable
-Weibull model on the AVC data:
+The `predict()` method exposes four quantities through its `type=`
+argument, each useful for a different downstream question:
+
+- `"linear_predictor"` — $x^\top \beta$, the covariate-driven
+  log-hazard shift. Use it to rank patients on relative risk without
+  pinning down absolute survival probabilities.
+- `"hazard"` — $\exp(x^\top \beta)$, the multiplicative hazard ratio
+  relative to the baseline. Use it when you want hazard ratios for
+  reporting or for further calculation.
+- `"cumulative_hazard"` — $H(t \mid x)$, the integrated hazard up to
+  time $t$ for each row. Use it when you need the raw integrated
+  intensity (decomposing it by phase, for example, or computing
+  derived quantities like the expected number of events).
+- `"survival"` — $S(t \mid x) = \exp(-H(t \mid x))$, the probability
+  of surviving past time $t$. This is what clinicians and patients
+  actually want to see; it's also what we plot for diagnostics.
+
+The two predictions we extract below are `"survival"` and
+`"cumulative_hazard"` — survival for the clinical communication, and
+the cumulative hazard so we can sanity-check the relationship
+$S = \exp(-H)$ holds row-by-row. We fit a multivariable Weibull on the
+AVC death endpoint first.
 
 ```{r}
 #| label: fit-mv
@@ -81,7 +120,11 @@ fit <- hazard(
 )
 ```
 
-Generate predictions at a median-risk profile over a time grid:
+Pick a representative patient — here a median-aged, mid-status,
+no-malalignment, no-grade-IV-complication profile — and evaluate the
+prediction types over a fine time grid. The result is a data frame
+with one row per time point, ready for plotting or downstream
+analysis.
 
 ```{r}
 #| label: pred-types
@@ -106,7 +149,15 @@ head(profile[, c("time", "survival", "cumulative_hazard")])
 
 ## Parametric survival with KM overlay
 
-The fundamental diagnostic: does the parametric model track the Kaplan-Meier?
+The fundamental diagnostic for any parametric survival fit is whether
+its predictions track the Kaplan-Meier step function. Plot the
+median-profile survival curve from the previous chunk on top of the
+KM estimate from the raw cohort. Where the parametric curve hugs the
+steps, the model is faithful to the data; where it drifts, it's
+imposing a shape the data doesn't support. This isn't a hypothesis
+test, it's an eyeball check — and it's the single most informative
+thing you can do with a fitted model before trusting its
+predictions.
 
 ```{r}
 #| label: fig-surv-overlay
@@ -132,9 +183,17 @@ ggplot() +
 
 ## Confidence limits on predictions
 
-As of v0.9.8, `predict.hazard()` accepts `se.fit = TRUE` (default `FALSE`)
-and `level = 0.95` to return delta-method standard errors and
-confidence limits alongside the point estimate.  The return value
+A point estimate without an uncertainty band tells you what the model
+thinks, not how confident it is. For patient-level survival
+predictions that distinction matters: a survival probability of 0.85
+with a tight band around it is a fundamentally different number than
+a survival probability of 0.85 with a 0.4–0.97 band around it, even
+though both round to "85%". Delta-method confidence limits let you
+plot the second case honestly instead of pretending it's the first.
+
+As of v0.9.8, `predict.hazard()` accepts `se.fit = TRUE` (default
+`FALSE`) and `level = 0.95` to return delta-method standard errors
+and confidence limits alongside the point estimate. The return value
 changes shape: a plain numeric vector with `se.fit = FALSE`, a data
 frame with columns `fit`, `se.fit`, `lower`, and `upper` with
 `se.fit = TRUE`.
@@ -155,10 +214,14 @@ surv_ci <- predict(fit, newdata = profile_ci,
 head(surv_ci)
 ```
 
-Confidence limits use SAS-matched transformations: log-scale for
-`hazard` and `cumulative_hazard` (keeps the lower bound positive), and
-`log(-log(S))` for `survival` (keeps the interval in `[0, 1]`).  The
-linear predictor uses symmetric natural-scale CLs.
+Confidence limits use SAS-matched transformations chosen so the
+interval respects the natural range of each quantity: log-scale for
+`hazard` and `cumulative_hazard` (keeps the lower bound positive),
+and `log(-log(S))` for `survival` (keeps the interval inside
+$[0, 1]$). The linear predictor uses symmetric natural-scale CLs.
+The point isn't notational fussiness — it's that a symmetric CI on
+survival probability would frequently dip below 0 or rise above 1,
+giving nonsense values that the transformed form avoids by construction.
 
 ```{r}
 #| label: fig-surv-ci
@@ -192,15 +255,25 @@ ggplot() +
   theme(legend.position = "bottom")
 ```
 
-Weibull and multiphase use a closed-form Jacobian.  Exponential,
-log-logistic, and log-normal use `numDeriv::jacobian()` on a per-call
-cumulative-hazard closure --- identical results, just slightly slower.
+Implementation detail worth knowing: Weibull and multiphase use a
+closed-form Jacobian for the delta-method calculation. Exponential,
+log-logistic, and log-normal fall back to `numDeriv::jacobian()` on a
+per-call cumulative-hazard closure — identical results, just slightly
+slower because the Jacobian is computed numerically per prediction
+point. The user-facing API is the same regardless of distribution.
 
 ## Decomposed multiphase hazard
 
-The multiphase model decomposes the cumulative hazard into per-phase
-contributions.  Using `decompose = TRUE` with `type = "cumulative_hazard"`
-returns a data frame with columns for each phase.
+The multiphase model's whole point is that the total hazard is a sum
+of phase contributions. `predict()` with `decompose = TRUE` and
+`type = "cumulative_hazard"` exposes those contributions row by row,
+returning a data frame with one column per phase plus a `total`
+column. Numerically differentiating each column gives you the
+instantaneous hazard rate for each phase — which is the diagnostic
+that tells you whether the multiphase model is doing what you asked
+of it. The early phase should dominate near $t = 0$ and fall off, the
+constant phase should be a flat floor, and the late phase should sit
+near zero early and rise after a lag.
 
 ```{r}
 #| label: fit-mp
@@ -267,12 +340,29 @@ ggplot(h_long, aes(time, hazard, colour = Phase, linetype = Phase)) +
   theme(legend.position = "bottom")
 ```
 
-The early phase captures the steep post-operative risk that peaks within the
-first year.  The constant phase represents ongoing background mortality.  The
-late phase captures the gradually increasing risk of late attrition.
+Each phase is doing its job. The early (orange) phase captures the
+steep post-operative risk that peaks within the first months. The
+constant (blue) phase represents the ongoing background mortality
+that persists once patients are past the operative window. The late
+(pink) phase captures the gradually increasing risk of late
+attrition — graft failure, comorbidity progression, the aging cohort.
+Crucially, none of these shapes was specified by hand; the optimizer
+landed on them given the data and the phase-type choices we made up
+front. If a phase looked wrong here (a constant phase dominating
+where we expected an early peak, or a late phase that never rose)
+that would be a signal to revisit either the starting values, the
+shape parameters, or the data itself.
 
 
 ## Multiphase survival with KM overlay
+
+The decomposed-hazard plot above tells us the model has the right
+*shape* per phase. To check that the *total* fit also tracks the
+data, we collapse back to the overall survival curve and overlay it
+on the KM estimate — same diagnostic as the single-Weibull case
+earlier in this vignette, but now against a model that has the
+structural flexibility to follow the cohort's actual mortality
+pattern.
 
 ```{r}
 #| label: fig-mp-surv
@@ -301,8 +391,17 @@ ggplot() +
 
 ## Patient-specific risk profiles
 
-The multivariable model generates patient-specific survival curves by varying
-the covariate profile:
+This is the payoff of having covariates in the model. A
+population-level curve is fine for cohort-level reporting, but the
+question a clinician usually wants answered is: *what does the model
+predict for this particular patient, given their risk factors?*
+Holding the fitted model fixed and varying the covariate profile
+generates patient-specific survival curves you can show side by side.
+Below we score three plausible profiles drawn from the cohort's own
+quantiles — a low-risk patient (young, mild status, no malalignment,
+no grade-IV complications), a median patient, and a high-risk patient
+(older, severe status, with both adverse anatomical and
+post-operative findings).
 
 ```{r}
 #| label: fig-risk-profiles
@@ -340,13 +439,25 @@ ggplot(curves, aes(time, survival, colour = Profile)) +
   theme(legend.position = "bottom")
 ```
 
-The gap between curves is the model's prognostic discrimination: a wider
-spread means stronger covariate effects.
+The gap between the three curves is the model's *prognostic
+discrimination*: a wider spread means the covariates are doing real
+work, separating patients with different actual risk levels. A
+collapsed plot (all three curves on top of each other) means the
+covariate effects are too weak to distinguish patients meaningfully,
+even if they're statistically significant.
 
 
 ## Multi-endpoint visualization: valves
 
-The `valves` dataset has multiple endpoints that can be visualized together:
+When a cohort has multiple clinical endpoints — death, valve
+endocarditis, reoperation — putting them on the same survival axis
+gives an immediate comparative picture of which event the cohort is
+most at risk for, and over what time horizon. The `valves` dataset
+has separate event-time pairs for each endpoint, so we can plot all
+of them as Kaplan-Meier curves on shared axes without needing a
+parametric fit at all. (You'd parametrize them in the next step, one
+endpoint per `hazard()` call, as we did in
+`vignette("fitting-hazard-models")`.)
 
 ```{r}
 #| label: fig-valves-endpoints

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -24,12 +24,28 @@ library(TemporalHazard)
 
 ## Overview
 
-The legacy HAZARD program is a SAS macro (`%HAZARD(...)`) that wraps a compiled
-C executable implementing the multiphase parametric hazard model of Blackstone,
-Naftel, and Turner (1986). This vignette is the canonical reference for
-translating a SAS HAZARD analysis into native R using `TemporalHazard`.
+If you've been running multiphase hazard analyses in SAS HAZARD —
+the macro suite that wraps the C HAZARD binary written by Blackstone,
+Naftel, and Turner at UAB — this vignette is the bridge to running
+the same analyses in R. Every SAS `HAZARD` statement, every common
+macro option, and every output field maps to something in
+`TemporalHazard`; this document spells out the correspondences and
+flags the small handful of features the R port doesn't yet cover.
 
-The full formal argument mapping table is available programmatically:
+The mapping is faithful, not literal. SAS HAZARD is a step-driven
+DSL: you write a `PROC HAZARD` block with separate `TIME`, `EVENT`,
+`PARMS`, `EARLY`, `CONSTANT`, and `SELECTION` statements, and the
+macro assembles them into a binary call. R is function-driven: you
+write a single `hazard()` call with named arguments. The conceptual
+pieces are identical; the syntactic ergonomics differ. Use this
+vignette to translate an existing SAS analysis, or as a reference
+when comparing the package's output against a SAS HAZARD reference
+fit for parity testing.
+
+The full formal argument mapping table is available programmatically
+and ships with the package — handy when you want to grep for a
+specific SAS parameter name and find its R equivalent without
+scrolling through the prose below:
 
 ```{r}
 #| label: mapping-table
@@ -48,7 +64,17 @@ knitr::kable(
 
 ## Statement-by-statement mapping
 
+A SAS HAZARD analysis is a stack of statements inside a `PROC HAZARD`
+block. We walk through them in roughly the order they appear in a
+typical analysis script, showing the SAS form and the corresponding
+R call.
+
 ### `PROC HAZARD DATA=`
+
+The procedure-level statement that names the dataset and sets
+global options. The `NOCOV` / `NOCOR` flags suppress covariance and
+correlation output; `CONDITION=` is a tolerance switch for the
+convergence check.
 
 ```sas
 PROC HAZARD DATA=AVCS NOCOV NOCOR CONDITION=14;
@@ -75,6 +101,10 @@ through `...` as named arguments and stored in `fit$legacy_args`.
 
 ### `TIME`
 
+Names the follow-up time variable. In SAS HAZARD this is a separate
+statement; in R it's the first argument to `Surv()` inside the
+formula.
+
 ```sas
 TIME INT_DEAD;
 ```
@@ -97,6 +127,9 @@ fit <- hazard(
 
 ### `EVENT`
 
+Names the event-indicator variable. Like `TIME`, this is a separate
+statement in SAS HAZARD but enters the R formula through `Surv()`.
+
 ```sas
 EVENT DEAD;
 ```
@@ -117,6 +150,12 @@ fit <- hazard(
 ---
 
 ### `PARMS`
+
+Supplies starting values for the optimizer and flags which
+parameters to hold fixed (`FIXM`, `FIXMU`, etc.). The starting
+values matter — for the multiphase optimizer in particular, a poor
+starting point can park the fit at a local minimum well away from
+the global MLE.
 
 ```sas
 PARMS MUE=0.3504743 THALF=0.1905077 NU=1.437416 M=1 FIXM
@@ -145,6 +184,12 @@ fit <- hazard(
 ---
 
 ### `EARLY` and `CONSTANT` covariate blocks
+
+These statements assign covariates to specific phases. In SAS HAZARD
+each block lists the covariates that affect that phase and their
+starting coefficients. Covariates can appear in multiple blocks with
+different starting values — same column, different phase-specific
+effect.
 
 ```sas
 EARLY  AGE=-0.03205774, COM_IV=1.336675, MAL=0.6872028,
@@ -190,6 +235,12 @@ fit <- hazard(
 ---
 
 ### `SELECTION`
+
+Triggers stepwise covariate selection inside the hazard fit. `SLE`
+is the significance level for entry, `SLS` for staying. SAS HAZARD
+embedded this in the same `PROC HAZARD` call; in R the stepwise
+loop is a separate `hzr_stepwise()` function that wraps a fitted
+`hazard()` object.
 
 ```sas
 SELECTION SLE=0.2 SLS=0.1;
@@ -287,10 +338,20 @@ head(hzr_competing_risks(valves$int_dead, valves$ev), 4)
 
 ## Full worked example: AVC death after repair
 
-This mirrors the final multivariable model from
-`examples/hm.death.AVC.sas` in the reference C repository.
+Statement-by-statement mapping is fine for reference, but the full
+gestalt only lands when you see a complete SAS HAZARD analysis and
+its R translation side by side. The example below is the final
+multivariable model from `examples/hm.death.AVC.sas` in the
+reference C repository — death after atrioventricular canal repair,
+two-phase model with covariates assigned to specific phases. It's
+the canonical "this is what a real SAS HAZARD analysis looks like"
+specimen.
 
 ### SAS (original)
+
+The original SAS code, exactly as it appears in the reference
+distribution. Notice how the statements stack inside a single
+`%HAZARD()` macro call.
 
 ```sas
 %HAZARD(
@@ -306,6 +367,16 @@ PROC HAZARD DATA=AVCS P CONSERVE OUTHAZ=OUTEST CONDITION=14 QUASI;
 ```
 
 ### R equivalent (current runnable translation pattern)
+
+The same model in `TemporalHazard`. Every SAS statement above has a
+corresponding R argument here: `TIME` and `EVENT` collapse into
+`Surv(int_dead, dead)` on the left of the formula; the global
+covariate list goes on the right; the `PARMS` starting values
+become the `theta` vector; phase-specific assignments use the
+`formula` argument inside each `hzr_phase()`; `FIXM` becomes
+`fixed = "shapes"` (or a subset of shape names). The line-by-line
+correspondence is the point — once you've translated one analysis
+this way, the pattern carries to every other.
 
 ```{r}
 #| label: avc-example
@@ -395,7 +466,14 @@ fit
 
 ## Prediction
 
-`predict.hazard()` currently supports two output types:
+In SAS HAZARD the `P` (predict / print) option on the `PROC HAZARD`
+line writes predicted survival, hazard, and cumulative-hazard tables
+to the output dataset. In R the same predictions come from
+`predict.hazard()` on the fitted object, with the requested quantity
+chosen via the `type=` argument. `predict.hazard()` currently
+supports four output types — `"linear_predictor"`, `"hazard"`,
+`"survival"`, and `"cumulative_hazard"` — covering every quantity
+the SAS `P` option produces:
 
 ```{r}
 #| eval: false
@@ -407,9 +485,10 @@ eta <- predict(fit, type = "linear_predictor")
 hz  <- predict(fit, type = "hazard")
 ```
 
-`"survival"` and `"cumulative_hazard"` types are also supported, mirroring
-the `P` (predict/print) option in `PROC HAZARD`.  Pass `decompose = TRUE`
-for multiphase fits to get per-phase contributions.
+The code chunk above shows only `"linear_predictor"` and `"hazard"`;
+`"survival"` and `"cumulative_hazard"` follow the same pattern. For
+multiphase fits pass `decompose = TRUE` to get per-phase cumulative
+hazard contributions instead of just the total.
 
 ---
 


### PR DESCRIPTION
## Scope

Voice-fingerprint-calibrated clarity expansion across all seven vignettes, plus a small release-prep housekeeping bundle folded in at the end. Base is `main` (rebased after PR #29 merged). Independent of any CRAN cycle — the package builds clean with or without this PR; merging it just makes the docs better.

## What landed

### Vignette clarity pass

Calibrated pattern applied to all seven vignettes, one commit per file so per-vignette diffs are reviewable in isolation:

- [x] **`getting-started.qmd`** — unheaded preface for audience grounding (opens from `coxph` / KM), `## A first Weibull fit` section with two paragraphs before the first `hazard()` call, `## Prediction workflow` with full `type=` menu, multiphase opener backed up before assuming "monotone", `## Why multiple phases?` (concept-headed, not count-headed), diagnostic framing for the three plot subsections, expanded Phase types reference, and an explanation of the standing `NA` columns in the multiphase summary output.
- [x] **`fitting-hazard-models.qmd`** — preface names the inside-out progression (intercept-only → multivariable → multiphase → multi-endpoint); each section explains *why* the next layer of complexity is being added; multi-endpoint section explains per-endpoint covariate choice.
- [x] **`prediction-visualization.qmd`** — bulleted `predict() type=` menu with math, diagnostic framing for the KM overlays (both Weibull and multiphase), motivated confidence-limit section (uncertainty at the patient level), expanded patient-specific risk profile + multi-endpoint sections.
- [x] **`inference-diagnostics.qmd`** — preface frames diagnostics as bracketing the fit (screening before, validation after); each diagnostic motivated against its alternative (bootstrap vs delta-method; decile-of-risk vs global GOF).
- [x] **`clinical-analysis-walkthrough.qmd`** — preface reframes the doc as the synthesis of the others; each step in the 6-step sequence gets a one-line motivation alongside its SAS-program correspondence; data-preparation section (previously naked code) now grounded.
- [x] **`mf-mathematical-foundations.qmd`** — math-heavy vignette; preface opens with "opening the box" framing; six-cases section explains *why* the package treats each sign combination separately; phase-specific covariate section motivated concretely.
- [x] **`sas-to-r-migration.qmd`** — reference-style doc; brief functional sentence before each SAS code block explaining what the statement does; worked-example sections framed as the gestalt the statement-by-statement table can't deliver.

### Release-prep housekeeping (folded in after the clarity pass)

- [x] **`inst/CITATION`** — was hardcoding `R package version 0.9.4`; now templates via `meta$Version` so `citation("TemporalHazard")` self-reports the current version (now and going forward).
- [x] **`DESCRIPTION` `RoxygenNote`** — bumped 7.3.3 → 8.0.0 to match installed `roxygen2` and the existing `Config/roxygen2/version` field. `devtools::document()` produced no `man/` changes — purely a declaration sync.
- [x] **`cran-comments.md`** — added a brief `## Other changes since 1.0.2` section noting the vignette expansion + CITATION + RoxygenNote as non-reviewer-driven polish, so the reviewer browsing the 1.0.3 diff has the framing up front.

## Pattern locked in across all 7 vignettes

- Unheaded preface under the vignette title (no "What this vignette does" H2).
- No naked code blocks under headers — every section grounded before code.
- Voice-fingerprint compliance — opens from the familiar, "we"/"you", em-dashes audited, no AI tells.
- Question-headed subsections for conceptual jumps.
- Diagnostic framing for plots — what to look for, what "right" looks like.
- Math notation consistent ($H$ / $\Phi_j$ cumulative; $h$ / $\phi_j$ instantaneous derived inline).
- Cross-vignette stitching — each knows its place in the sequence.

## Verification

- `lintr::lint_package()` = **0** at every commit
- `R CMD check --as-cran` = **0 errors, 0 warnings, 0 notes** (post-merge, rebased tip)
- Net diff: ~700 lines of new prose across 7 vignettes, no code chunks / function signatures / math / numeric results changed (except the tiny CITATION and DESCRIPTION two-line housekeeping)

## Note

`main` is at the merged PR #29 tip and is independently ready for CRAN resubmission of 1.0.3 (`devtools::check_win_devel()` → `devtools::submit_cran()`). This PR can land before or after that — it improves docs, doesn't touch policy-relevant code.