### PR TITLE
docs: surface planned items and decompose+se.fit limitation in README and help

### DIFF
--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -532,6 +532,13 @@ hazard <- function(formula = NULL,
 #'   Only used when `se.fit = TRUE`.
 #' @param ... Unused; included for S3 compatibility.
 #'
+#' @section Known limitations:
+#' `decompose = TRUE` and `se.fit = TRUE` cannot be used together.  The
+#' delta-method Jacobian has not yet been extended to per-phase contributions.
+#' To obtain confidence limits for a multiphase model, request point predictions
+#' first (`decompose = TRUE, se.fit = FALSE`), then separately request CLs on
+#' the total prediction (`decompose = FALSE, se.fit = TRUE`).
+#'
 #' @details
 #' For Weibull models with survival or cumulative_hazard predictions:
 #' - Cumulative hazard: H(t|x) = (mu*t)^nu * exp(eta)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ adjustment, prediction, and extrapolation.
 | Covariance and correlation matrix estimation | :white_check_mark: |
 | Delta-method confidence limits on `predict()` (`se.fit = TRUE`) | :white_check_mark: |
 | Seven `hzr_*` utility functions (Kaplan-Meier, Nelson, GOF, deciles, calibration, bootstrap, competing risks) | :white_check_mark: |
+| Per-phase confidence limits (`decompose = TRUE, se.fit = TRUE`) | :construction: |
+| 4-phase example dataset and vignette | :construction: |
 
-:white_check_mark: = implemented | :construction: = planned
+:white_check_mark: = implemented &nbsp;&nbsp; :construction: = planned
 
 ## Installation
 

--- a/man/predict.hazard.Rd
+++ b/man/predict.hazard.Rd
@@ -66,6 +66,15 @@ For models fit with \code{time_windows}, predictions for \code{type = "linear_pr
 or \code{"hazard"} also require time values (via \code{newdata$time} or fitted-time fallback)
 so window-specific coefficients can be selected.
 }
+\section{Known limitations}{
+
+\code{decompose = TRUE} and \code{se.fit = TRUE} cannot be used together.  The
+delta-method Jacobian has not yet been extended to per-phase contributions.
+To obtain confidence limits for a multiphase model, request point predictions
+first (\verb{decompose = TRUE, se.fit = FALSE}), then separately request CLs on
+the total prediction (\verb{decompose = FALSE, se.fit = TRUE}).
+}
+
 \examples{
 # -- Basic predictions ------------------------------------------------
 set.seed(1)


### PR DESCRIPTION
## Summary

- **README capability table**: Added two `:construction:` rows that were missing despite the legend advertising them:
  - Per-phase confidence limits (`decompose = TRUE, se.fit = TRUE`) — blocked since v0.9.8; delta-method Jacobian extension is deferred to a future release
  - 4-phase example dataset and vignette — Phase 7c work; no shipped example exercises the 4-phase code path end-to-end yet
- **`predict.hazard()` `@section Known limitations`**: Documents the `decompose + se.fit` restriction and the workaround (request each separately) so it appears in `?predict.hazard` rather than only in the runtime error message.

## Motivation

The README implied feature completeness by showing only checkmarks. Two functional gaps were invisible to a reader who hadn't read the source or dev plan. The `decompose=TRUE, se.fit=TRUE` case is particularly likely to surprise users who have the delta-method CLs working and then try to combine them with decomposed output.

## Test plan

- [ ] `devtools::document()` regenerates `man/predict.hazard.Rd` with the Known limitations section
- [ ] `R CMD check` clean
- [ ] README renders correctly (`:construction:` emoji visible, legend legible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)