### PR TITLE
chore: add dev branch to CI workflow triggers

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,9 @@ name: R-CMD-check
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: lint
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 
 jobs:
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,9 @@ name: pkgdown
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@ name: test-coverage
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
 
 jobs:
   test-coverage:


### PR DESCRIPTION
## Problem

All four CI workflows (`R-CMD-check`, `lint`, `test-coverage`, `pkgdown`) only triggered on `main`/`master`. PRs targeting `dev` (e.g. #33) got no CI.

## Fix

Added `dev` to both `push` and `pull_request` branch lists in all four workflow files.

**pkgdown note:** The deploy step is already guarded by `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, so pushing to `dev` will build-but-not-deploy — correct behaviour.

## After merge

Existing open PR #33 will need a no-op push (or re-open/close) to trigger CI, since GitHub only evaluates the trigger list from the base branch at the time the PR was opened. Alternatively, merging this PR first and then pushing a new commit to the #33 branch will kick off CI automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)