### PR TITLE
docs(phase6d): interval and left censoring section in fitting vignette

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,8 @@
   section covering: status coding reference (`-1`/`0`/`1`/`2`), a cardiac
   clinic-visit simulation with right- and interval-censored observations,
   the direct `time_lower`/`time_upper` API, and a comparison showing the
-  interval-censored fit recovering `nu = 1.0` while the naive exact-at-upper
-  fit incurs a shape bias of ~+0.45.  Includes a callout note on the correct
+  interval-censored fit recovering `nu` close to 1.0 (true value) while the
+  naive exact-at-upper fit incurs a shape bias of ~+0.45.  Includes a callout note on the correct
   use of `time_lower = 0` for right-censored rows.
 * `vignette("fitting-hazard-models")` gains a **Convergence troubleshooting**
   section covering: reading the KM cumulative hazard for Weibull starting

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## New features
 
+* `vignette("fitting-hazard-models")` gains an **Interval and left censoring**
+  section covering: status coding reference (`-1`/`0`/`1`/`2`), a cardiac
+  clinic-visit simulation with right- and interval-censored observations,
+  the direct `time_lower`/`time_upper` API, and a comparison showing the
+  interval-censored fit recovering `nu = 1.0` while the naive exact-at-upper
+  fit incurs a shape bias of ~+0.45.  Includes a callout note on the correct
+  use of `time_lower = 0` for right-censored rows.
 * `vignette("fitting-hazard-models")` gains a **Convergence troubleshooting**
   section covering: reading the KM cumulative hazard for Weibull starting
   values (log-log plot), when to fix shape parameters vs. estimate freely,

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -391,8 +391,8 @@ for (i in seq_len(n)) {
 
   if (brk > length(visits)) {
     # Event after last visit: right-censored.
-    # time_lower = 0 (no epoch start; the right-censored contribution is
-    # -H(time) computed from time, not time_lower).
+    # time_lower = 0: with H(time_lower) = H(0) = 0, the right-censored
+    # contribution reduces to -(H(time) - H(0)) = -H(time), which is correct.
     status[i]     <- 0L
     time[i]       <- max(visits)
     time_lower[i] <- 0
@@ -413,11 +413,13 @@ table(status)
 
 ::: {.callout-note}
 **`time_lower` for right-censored rows should be `0`**, not the censoring
-time.  The `time_lower` argument doubles as the counting-process *entry*
-time for right-censored and exact-event rows; setting it to `time` for
-right-censored observations would compute H(stop) − H(start) = 0 and
-silently discard those rows from the likelihood.  Pass `time_lower = 0`
-(or omit `time_lower` entirely) for right-censored rows.
+time.  In the Weibull and multiphase likelihoods, `time_lower` doubles as
+the counting-process *entry time* for right-censored and exact-event rows
+(`status %in% c(0, 1)`); setting it to `time` computes
+H(stop) − H(start) = 0 and silently discards those rows.  Pass
+`time_lower = 0` (or omit `time_lower` entirely) for right-censored rows.
+The exponential, log-logistic, and log-normal likelihoods do not use
+`time_lower` as an entry time and are unaffected.
 :::
 
 Fit a Weibull model using both censoring types:

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -326,6 +326,151 @@ the same package — there's no risk of subtle differences in censoring
 handling or estimator choice between endpoints.
 
 
+## Interval and left censoring
+
+Right censoring is by far the most common censoring type in clinical
+survival data — a patient is still alive at last follow-up, so all we
+know is that their event time exceeds the observed window. Two other
+types arise frequently enough to warrant explicit handling.
+
+**Interval censoring** occurs when the event is known to have happened
+*between* two observation times, but not at a specific time.  The
+canonical example is clinic-visit data: a patient is confirmed alive at
+month 12 and found dead at month 24, so the event occurred somewhere in
+$(12, 24)$.  A naive analysis treats the event as right-censored at 12
+or exactly observed at 24; both introduce bias.
+
+**Left censoring** is the mirror: the event occurred *before* the first
+observation time (time_upper), so it was already established at the
+moment of first contact — $T \leq t_{\text{upper}}$.
+
+### Status codes
+
+The package encodes censoring type in the `status` vector:
+
+| Status | Type | Interpretation |
+|-------:|------|----------------|
+| `1` | Exact event | Observed at `time` |
+| `0` | Right-censored | Event did not occur by `time` |
+| `2` | Interval-censored | Event occurred in `(time_lower, time_upper)` |
+| `-1` | Left-censored | Event occurred before `time` (upper bound) |
+
+For interval-censored rows, supply both `time_lower` and `time_upper`
+directly to `hazard()`.  The formula interface handles `Surv(time, status)`
+for right-censored data and `Surv(start, stop, event)` for counting-process
+(repeating-event) data; interval censoring is passed via the direct arguments.
+
+### Mixed censoring example
+
+We simulate 400 cardiac surgery patients observed at semi-annual clinic
+visits (every 6 months, 4--8 scheduled visits per patient).  If the
+event falls between two consecutive visits the observation is
+interval-censored; if it falls after the last visit the patient is
+right-censored.
+
+```{r}
+#| label: interval-simulate
+set.seed(101)
+n         <- 400
+visit_gap <- 6   # months between visits
+
+# True event times: Weibull mu = 0.025, nu = 1.0 (median ~28 months)
+true_time <- rexp(n, rate = 0.025)  # nu=1 → exponential
+
+n_visits  <- sample(4:8, n, replace = TRUE)
+
+status     <- integer(n)
+time       <- numeric(n)
+time_lower <- numeric(n)
+time_upper <- numeric(n)
+
+for (i in seq_len(n)) {
+  visits <- seq(visit_gap, n_visits[i] * visit_gap, by = visit_gap)
+  t_ev   <- true_time[i]
+  brk    <- findInterval(t_ev, c(0, visits))  # which interval contains t_ev
+
+  if (brk > length(visits)) {
+    # Event after last visit: right-censored.
+    # time_lower = 0 (no epoch start; the right-censored contribution is
+    # -H(time) computed from time, not time_lower).
+    status[i]     <- 0L
+    time[i]       <- max(visits)
+    time_lower[i] <- 0
+    time_upper[i] <- max(visits)
+  } else {
+    # Event within the visit window: interval-censored in (lower, upper)
+    lower_bound   <- if (brk == 1L) 0 else visits[brk - 1L]
+    upper_bound   <- visits[brk]
+    status[i]     <- 2L
+    time[i]       <- lower_bound
+    time_lower[i] <- lower_bound
+    time_upper[i] <- upper_bound
+  }
+}
+
+table(status)
+```
+
+::: {.callout-note}
+**`time_lower` for right-censored rows should be `0`**, not the censoring
+time.  The `time_lower` argument doubles as the counting-process *entry*
+time for right-censored and exact-event rows; setting it to `time` for
+right-censored observations would compute H(stop) − H(start) = 0 and
+silently discard those rows from the likelihood.  Pass `time_lower = 0`
+(or omit `time_lower` entirely) for right-censored rows.
+:::
+
+Fit a Weibull model using both censoring types:
+
+```{r}
+#| label: interval-fit
+fit_ic <- hazard(
+  time       = time,
+  status     = status,
+  time_lower = time_lower,
+  time_upper = time_upper,
+  dist  = "weibull",
+  theta = c(mu = 0.025, nu = 1.0),
+  fit   = TRUE
+)
+
+fit_ic
+```
+
+### Interval-censored vs naive right-censored
+
+A naive analyst who doesn't have visit-bracket data would record the death
+at the *discovery* visit (`time_upper`) rather than as an interval.
+This overstates the event time — the patient appears to have survived
+longer than they did — biasing the estimated hazard shape.
+
+```{r}
+#| label: interval-vs-naive
+# Naive: treat each interval-censored row as an exact event at time_upper
+# (the visit when the death was first recorded)
+fit_naive <- hazard(
+  time   = ifelse(status == 2L, time_upper, time),
+  status = ifelse(status == 2L, 1L,         status),
+  dist  = "weibull",
+  theta = c(mu = 0.025, nu = 1.0),
+  fit   = TRUE
+)
+
+# Compare MLEs; true parameters are mu = 0.025, nu = 1.0
+rbind(
+  interval_censored = round(coef(fit_ic)[1:2],   4),
+  naive_exact_upper = round(coef(fit_naive)[1:2], 4),
+  truth             = c(mu = 0.025, nu = 1.0)
+)
+```
+
+The interval-censored fit recovers both parameters accurately.  The naive
+fit estimates $\mu$ comparably but introduces a substantial positive bias
+in $\nu$ — it sees events consistently appearing at visit times (every 6
+months) and infers a sharper, more periodic hazard shape that doesn't
+match the underlying exponential structure.
+
+
 ## Convergence troubleshooting
 
 Multiphase models have more parameters than single-distribution fits, and the


### PR DESCRIPTION
## Summary

Adds an **Interval and left censoring** section to `vignettes/fitting-hazard-models.qmd` (Phase 6d from `inst/dev/DEVELOPMENT-PLAN.md`).

### Content

- **Status coding table** — the four codes (-1/0/1/2) with type and interpretation in one reference block
- **API explanation** — direct `time_lower`/`time_upper` for interval-censored data; notes that the formula interface handles right-censored (`Surv(time, status)`) and counting-process (`Surv(start, stop, event)`) but interval-type Surv objects map to a different encoding
- **Clinic-visit simulation** — 400 cardiac surgery patients, semi-annual visits, 168 right-censored + 232 interval-censored observations
- **`time_lower = 0` callout** — documents the correct API usage for mixed IC + RC datasets (see bug note below)
- **IC vs naive comparison** — interval-censored fit recovers mu=0.025, nu=1.03 (truth: 0.025, 1.0); naive exact-at-upper gives mu=0.026 but nu=1.46 (+0.46 shape bias from visit-schedule artifact)

### Bug discovered during development

While building this section I found that `time_lower` doubles as both (1) the interval lower bound for status=2 rows and (2) the counting-process entry time for status=0/1 rows. Setting `time_lower=time` for right-censored rows silently computes H(stop) - H(start) = 0 and discards those rows from the likelihood. The vignette documents the correct workaround (`time_lower=0` for RC rows). A separate chip has been spawned to fix the underlying code across all 5 distribution LL files.

## PR targets `dev` (v1.1.0 cycle)

## Test plan

- [ ] All code chunks run (smoke-tested — see commit, IC fit gives mu=0.0251, nu=1.035)
- [ ] Vignette renders with `devtools::build_vignettes()`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)