### PR TITLE
fix: time_lower dual-use bug silently zeroes right-censored likelihood contribution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # TemporalHazard 1.1.0 (development version)
 
+## Bug fixes
+
+* **`time_lower` dual-use bug in Weibull and multiphase likelihoods.**
+  When `time_lower` was supplied for a mixed interval-censored + right-censored
+  dataset, the Weibull LL interpreted `time_lower` as the counting-process
+  *entry time* for right-censored rows, computing H(stop) − H(start) = 0 and
+  silently zeroing those rows' likelihood contribution.  Fixed in
+  `likelihood-weibull.R` (4 sites: LL, gradient, L-BFGS-B internal LL/gradient)
+  and `likelihood-multiphase.R`: `start_vec` is now set from `time_lower` only
+  for genuine epoch rows (`status %in% c(0L, 1L)` and `time_lower < time`).
+  Two regression tests added to `test-interval-censoring-weibull.R`.
+
 ## New features
 
 * `vignette("fitting-hazard-models")` gains a **Convergence troubleshooting**

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -555,9 +555,19 @@
   # Whether to actually compute start-time quantities for the gradient.
   # Without any counting-process rows (time_lower = NULL or all zeros with
   # status in {0, 1}) these additions are identically zero and we can skip.
+  # Only genuine epoch rows (status 0/1 with time_lower < time) get a
+  # non-zero start.  Interval-censored rows (status 2) are handled through
+  # their own lower/upper cumhaz terms and must not contribute to H(start).
   need_start <- !is.null(time_lower) &&
-                any(time_lower > 0 & status %in% c(0L, 1L))
-  start_vec <- if (need_start) time_lower else NULL
+                any(time_lower > 0 & time_lower < time & status %in% c(0L, 1L))
+  start_vec <- if (need_start) {
+    sv <- rep(0, n)
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    sv[epoch_idx] <- time_lower[epoch_idx]
+    sv
+  } else {
+    NULL
+  }
 
   for (j in seq_along(phases)) {
     nm <- names(phases)[j]

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -148,9 +148,17 @@ NULL
   cumhaz_upper <- (mu * upper) ^ nu * exp(eta)
 
   # Counting-process entry-time cumulative hazard (H(start)) for
-  # event/right-censored rows.  When `time_lower` is NULL the entry time is
-  # implicitly 0 and H(start) = 0, recovering the plain-Surv likelihood.
-  start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+  # event/right-censored rows.  Only rows where time_lower < time and
+  # status is 0 or 1 (genuine epoch entries) get a non-zero start.
+  # Interval-censored rows (status == 2) always use start = 0 because
+  # their contribution goes through cumhaz_lower/cumhaz_upper, not H(start).
+  # This prevents time_lower being mistakenly interpreted as an epoch start
+  # when it was supplied as the interval lower bound for status-2 rows.
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
   cumhaz_start <- (mu * start_vec) ^ nu * exp(eta)
 
   idx_event <- status == 1
@@ -280,9 +288,13 @@ NULL
     cumhaz <- (mu * time) ^ nu * exp(eta)
   }
 
-  # Counting-process entry-time cumulative hazard; H(start) = 0 when no
-  # `time_lower` supplied (plain right-censored data).
-  start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+  # Counting-process entry-time cumulative hazard; H(start) = 0 except
+  # for genuine epoch rows (status 0/1 with time_lower < time).
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
   cumhaz_start <- (mu * start_vec) ^ nu * exp(eta)
 
   # Weighted building blocks: each per-row contribution below is the
@@ -383,8 +395,12 @@ NULL
     log_t <- log(pmax(time, .Machine$double.xmin))
     H     <- exp(alpha + eta) * (time ^ g)
 
-    # Counting-process entry-time H(start); zero when no `time_lower` given.
-    start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+    # Counting-process entry-time H(start); zero except for genuine epochs.
+    start_vec <- rep(0, n)
+    if (!is.null(time_lower)) {
+      epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+      start_vec[epoch_idx] <- time_lower[epoch_idx]
+    }
     H_start   <- exp(alpha + eta) * (start_vec ^ g)
 
     idx_event <- status == 1
@@ -446,10 +462,13 @@ NULL
     log_t <- log(pmax(time, .Machine$double.xmin))
     H     <- exp(alpha + eta) * (time ^ g)
 
-    # H(start) for counting-process rows; zero when time_lower is NULL or
-    # start == 0.  `log_t_start` is only used where start > 0 (guarded below)
-    # since log(0) = -Inf would otherwise propagate NaNs through the score.
-    start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
+    # H(start) for genuine epoch rows; zero otherwise.
+    # `log_t_start` is only used where start > 0 (guarded below).
+    start_vec <- rep(0, n)
+    if (!is.null(time_lower)) {
+      epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+      start_vec[epoch_idx] <- time_lower[epoch_idx]
+    }
     H_start   <- exp(alpha + eta) * (start_vec ^ g)
     log_t_start <- ifelse(start_vec > 0, log(pmax(start_vec, .Machine$double.xmin)), 0)
 

--- a/tests/testthat/test-interval-censoring-weibull.R
+++ b/tests/testthat/test-interval-censoring-weibull.R
@@ -141,3 +141,74 @@ test_that("Right-censored legacy path unchanged when bounds are absent", {
 
   expect_equal(ll_old, ll_new, tolerance = 1e-12)
 })
+
+test_that("Mixed IC+RC: right-censored contribution not silently zeroed when time_lower supplied", {
+  # Regression test for the time_lower dual-use bug:
+  # When time_lower is provided for a mix of interval-censored (status=2)
+  # and right-censored (status=0) rows, right-censored rows must contribute
+  # -H(stop) to the log-likelihood, NOT H(stop)-H(stop)=0.
+  theta      <- c(mu = 0.4, nu = 1.2)
+  mu <- theta[1]; nu <- theta[2]
+
+  # 3 interval-censored observations in (1, 2)
+  # 2 right-censored observations at t = 5
+  time       <- c(1, 1, 1, 5, 5)
+  status     <- c(2L, 2L, 2L, 0L, 0L)
+  time_lower <- c(1, 1, 1, 0, 0)   # correct: 0 for RC rows
+  time_upper <- c(2, 2, 2, 5, 5)
+
+  # Manual LL
+  H_lo <- (mu * 1)^nu; H_hi <- (mu * 2)^nu; H_rc <- (mu * 5)^nu
+  ll_ic_manual <- 3 * (-H_lo + log(1 - exp(-(H_hi - H_lo))))
+  ll_rc_manual <- 2 * (-H_rc)
+  ll_manual <- unname(ll_ic_manual + ll_rc_manual)
+
+  ll_pkg <- .hzr_logl_weibull(theta, time, status,
+                               time_lower = time_lower,
+                               time_upper = time_upper)
+
+  expect_equal(ll_pkg, ll_manual, tolerance = 1e-10)
+
+  # Also verify the *wrong* setup (time_lower = time for RC) now gives same
+  # result after the fix — previously it zeroed the RC contribution
+  time_lower_wrong <- c(1, 1, 1, 5, 5)  # time_lower == time for RC rows
+  ll_wrong_setup <- .hzr_logl_weibull(theta, time, status,
+                                       time_lower = time_lower_wrong,
+                                       time_upper = time_upper)
+  # With the fix, time_lower == time means NOT a genuine epoch, so RC
+  # contribution is still -H(5), same result as the correct setup
+  expect_equal(ll_wrong_setup, ll_manual, tolerance = 1e-10)
+})
+
+test_that("Mixed IC+RC: fitting recovers correct parameters with time_lower=0 for RC", {
+  set.seed(42)
+  n <- 600
+  true_time <- rexp(n, rate = 0.05)
+  # Interval censoring in 6-month windows; right-censor at 48 months
+  status     <- integer(n)
+  time       <- numeric(n)
+  time_lower <- numeric(n)
+  time_upper <- numeric(n)
+  for (i in seq_len(n)) {
+    brk <- ceiling(true_time[i] / 6)
+    if (brk > 8L) {
+      status[i]     <- 0L
+      time[i]       <- 48
+      time_lower[i] <- 0   # correct: 0 for RC rows
+      time_upper[i] <- 48
+    } else {
+      status[i]     <- 2L
+      time[i]       <- (brk - 1L) * 6
+      time_lower[i] <- (brk - 1L) * 6
+      time_upper[i] <- brk * 6
+    }
+  }
+  fit <- hazard(time = time, status = status,
+                time_lower = time_lower, time_upper = time_upper,
+                dist = "weibull", theta = c(mu = 0.05, nu = 1.0), fit = TRUE)
+  expect_true(fit$fit$converged)
+  # MLE should be within 20% of truth (nu=1 for exponential, mu=0.05)
+  coefs <- coef(fit)[1:2]
+  expect_lt(abs(coefs["nu"] - 1.0), 0.2)
+  expect_lt(abs(coefs["mu"] - 0.05) / 0.05, 0.2)
+})

--- a/tests/testthat/test-interval-censoring-weibull.R
+++ b/tests/testthat/test-interval-censoring-weibull.R
@@ -162,7 +162,7 @@ test_that("Mixed IC+RC: right-censored contribution not silently zeroed when tim
   H_lo <- (mu * 1)^nu
   H_hi <- (mu * 2)^nu
   H_rc <- (mu * 5)^nu
-  ll_ic_manual <- 3 * (-H_lo + log(1 - exp(-(H_hi - H_lo))))
+  ll_ic_manual <- 3 * (-H_lo + hzr_log1mexp(H_hi - H_lo))
   ll_rc_manual <- 2 * (-H_rc)
   ll_manual <- unname(ll_ic_manual + ll_rc_manual)
 

--- a/tests/testthat/test-interval-censoring-weibull.R
+++ b/tests/testthat/test-interval-censoring-weibull.R
@@ -148,7 +148,8 @@ test_that("Mixed IC+RC: right-censored contribution not silently zeroed when tim
   # and right-censored (status=0) rows, right-censored rows must contribute
   # -H(stop) to the log-likelihood, NOT H(stop)-H(stop)=0.
   theta      <- c(mu = 0.4, nu = 1.2)
-  mu <- theta[1]; nu <- theta[2]
+  mu <- theta[1]
+  nu <- theta[2]
 
   # 3 interval-censored observations in (1, 2)
   # 2 right-censored observations at t = 5
@@ -158,7 +159,9 @@ test_that("Mixed IC+RC: right-censored contribution not silently zeroed when tim
   time_upper <- c(2, 2, 2, 5, 5)
 
   # Manual LL
-  H_lo <- (mu * 1)^nu; H_hi <- (mu * 2)^nu; H_rc <- (mu * 5)^nu
+  H_lo <- (mu * 1)^nu
+  H_hi <- (mu * 2)^nu
+  H_rc <- (mu * 5)^nu
   ll_ic_manual <- 3 * (-H_lo + log(1 - exp(-(H_hi - H_lo))))
   ll_rc_manual <- 2 * (-H_rc)
   ll_manual <- unname(ll_ic_manual + ll_rc_manual)


### PR DESCRIPTION
## Problem

When `time_lower` was passed for a mixed interval-censored + right-censored dataset, the Weibull (and multiphase) likelihoods used `time_lower` as the counting-process *entry time* for **all** rows. Right-censored rows where `time_lower == time` got H(stop) − H(start) = H(t) − H(t) = 0, silently dropping their contribution.

**Consequence:** the optimizer saw no resistance from right-censored rows and found degenerate parameters — e.g., mu=0.99, nu=244 for truly exponential data — because the interval-censored rows showed probability ≈ 1 at those parameters while the zeroed RC rows offered nothing.

Discovered while writing the Phase 6d interval censoring vignette section (PR #35).

## Root cause

```r
# Before (buggy) — all 4 Weibull sites + multiphase:
start_vec <- if (is.null(time_lower)) rep(0, n) else time_lower
```

`time_lower` serves two semantically different roles:
1. **Interval lower bound** — for status=2 rows, via `cumhaz_lower`
2. **Counting-process entry time** — for status=0/1 epoch rows, via `start_vec`

Setting `start_vec = time_lower` unconditionally conflated them.

## Fix

```r
# After — only genuine epochs get a non-zero start
start_vec <- rep(0, n)
if (!is.null(time_lower)) {
  epoch_idx <- status %in% c(0L, 1L) & time_lower < time
  start_vec[epoch_idx] <- time_lower[epoch_idx]
}
```

Applied to:
- `likelihood-weibull.R` — 4 sites (LL, gradient, L-BFGS-B internal LL, L-BFGS-B internal gradient)
- `likelihood-multiphase.R` — `need_start` guard + `start_vec` construction

`likelihood-exponential.R`, `likelihood-loglogistic.R`, `likelihood-lognormal.R` — **not affected** (they have no `start_vec` / counting-process epoch mechanism).

## Verification

- `time_lower=0` for RC rows (correct API): LL matches analytic manual calculation ✓
- `time_lower=time` for RC rows (previously pathological): now also gives correct LL ✓
- Fitting n=600 mixed IC+RC data recovers Weibull mu=0.05, nu=1.0 within 20% ✓
- All 15 existing interval-censoring tests pass ✓
- Counting-process (epoch) split-invariance tests pass ✓

## Test plan

- [ ] `testthat::test_file("tests/testthat/test-interval-censoring-weibull.R")` — 15/15 pass
- [ ] `testthat::test_dir(filter="interval|weibull|parity|repeating|time-varying")` — all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)