### PR TITLE
fix(phase7d): CoE fixmu-phase selection fails for N=4 with G3 late phase

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## Bug fixes
 
+* **4-phase CoE fixmu-phase selection** (Phase 7d).
+  `.hzr_select_fixmu_phase()` used `which.max()` over raw per-phase cumhaz
+  at the starting theta.  G3 late phases with typical shape parameters have
+  unnormalized cumhaz orders of magnitude larger than other phases, causing
+  CoE to pin the G3 `log_mu` away from its true near-zero MLE.  Fixed by
+  excluding phases whose cumhaz contribution exceeds 10× the median before
+  selecting (falls back to `which.max` when all phases are outliers).  On the
+  4-phase CABGKUL fit the CoE vs no-CoE LL gap closes from 6.9 to < 0.1
+  units.  Six new tests cover the 4-phase code path in
+  `test-conservation-of-events.R`.
 * **`time_lower` dual-use bug in Weibull and multiphase likelihoods.**
   When `time_lower` was supplied for a mixed interval-censored + right-censored
   dataset, the Weibull LL interpreted `time_lower` as the counting-process

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -276,7 +276,16 @@
 #' Select the phase whose log_mu will be solved by conservation
 #'
 #' Chooses the phase contributing the largest share of total cumulative
-#' hazard, matching the C HAZARD SETCOE strategy.
+#' hazard at the current theta, matching the C HAZARD SETCOE strategy.
+#'
+#' When one phase dominates by an extreme margin (>10x the median contribution)
+#' it is typically due to poorly-scaled shape parameters at the starting theta
+#' rather than a genuine signal that the phase should absorb all events.
+#' Selecting such a phase as the fixmu phase traps the optimizer: CoE keeps
+#' rescaling that phase's log_mu upward while the optimizer tries to drive it
+#' to near-zero.  We therefore exclude extreme outliers and select among the
+#' remaining phases.  If all phases are outliers (or only one phase exists)
+#' the largest is used as a fallback.
 #'
 #' @param theta Full parameter vector (internal scale).
 #' @param time Numeric vector of follow-up times.
@@ -299,6 +308,21 @@
   phase_sums <- vapply(names(phases), function(nm) {
     sum(weights * decomp[[nm]])
   }, numeric(1))
+
+  # Exclude extreme outliers: a phase whose contribution exceeds 10x the
+  # median is likely dominated by large shape-parameter values at the starting
+  # theta rather than reflecting the true relative importance of the phase.
+  # Fixing such a phase traps the optimizer when the true MLE has that phase
+  # near zero.  Among the remaining (non-outlier) phases, pick the largest.
+  if (length(phase_sums) > 1L) {
+    med <- stats::median(phase_sums)
+    if (med > 0) {
+      non_outlier <- phase_sums[phase_sums <= 10 * med]
+      if (length(non_outlier) >= 1L) {
+        return(names(which.max(non_outlier)))
+      }
+    }
+  }
 
   names(which.max(phase_sums))
 }

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -315,11 +315,14 @@
   # Fixing such a phase traps the optimizer when the true MLE has that phase
   # near zero.  Among the remaining (non-outlier) phases, pick the largest.
   if (length(phase_sums) > 1L) {
-    med <- stats::median(phase_sums)
-    if (med > 0) {
-      non_outlier <- phase_sums[phase_sums <= 10 * med]
-      if (length(non_outlier) >= 1L) {
-        return(names(which.max(non_outlier)))
+    finite_sums <- phase_sums[is.finite(phase_sums)]
+    if (length(finite_sums) >= 1L) {
+      med <- stats::median(finite_sums, na.rm = TRUE)
+      if (is.finite(med) && med > 0) {
+        non_outlier <- phase_sums[is.finite(phase_sums) & phase_sums <= 10 * med]
+        if (length(non_outlier) >= 1L) {
+          return(names(which.max(non_outlier)))
+        }
       }
     }
   }

--- a/man/dot-hzr_select_fixmu_phase.Rd
+++ b/man/dot-hzr_select_fixmu_phase.Rd
@@ -36,6 +36,16 @@ Character: name of the phase to fix.
 }
 \description{
 Chooses the phase contributing the largest share of total cumulative
-hazard, matching the C HAZARD SETCOE strategy.
+hazard at the current theta, matching the C HAZARD SETCOE strategy.
+}
+\details{
+When one phase dominates by an extreme margin (>10x the median contribution)
+it is typically due to poorly-scaled shape parameters at the starting theta
+rather than a genuine signal that the phase should absorb all events.
+Selecting such a phase as the fixmu phase traps the optimizer: CoE keeps
+rescaling that phase's log_mu upward while the optimizer tries to drive it
+to near-zero.  We therefore exclude extreme outliers and select among the
+remaining phases.  If all phases are outliers (or only one phase exists)
+the largest is used as a fallback.
 }
 \keyword{internal}

--- a/tests/testthat/test-conservation-of-events.R
+++ b/tests/testthat/test-conservation-of-events.R
@@ -345,3 +345,193 @@ test_that("CoE default (conserve=TRUE) with weights reaches the same optimum as 
   expect_equal(fit_default$fit$objective, fit_explicit_off$fit$objective,
                tolerance = 1e-3)
 })
+
+
+# ===========================================================================
+# 4-phase CoE algebra (Phase 7d)
+# ===========================================================================
+#
+# .hzr_select_fixmu_phase() and .hzr_conserve_events() must work correctly
+# for N = 4 phases.  The key regression: when a G3 phase has a large
+# unnormalized cumhaz at starting theta, the old which.max() selection
+# picked that phase, causing CoE to pin it away from its true near-zero MLE.
+
+test_that(".hzr_log_mu_positions returns correct positions for 4 phases", {
+  phases4 <- list(
+    early1   = hzr_phase("cdf", t_half = 0.1, nu = 1, m = 1),
+    early2   = hzr_phase("cdf", t_half = 2.0, nu = 1, m = 1),
+    constant = hzr_phase("constant"),
+    late     = hzr_phase("g3", tau = 1, gamma = 3, alpha = 1, eta = 1)
+  )
+  cov_counts <- c(early1 = 0L, early2 = 0L, constant = 0L, late = 0L)
+  pos <- TemporalHazard:::.hzr_log_mu_positions(phases4, cov_counts)
+
+  # early1: log_mu at 1, then 3 shapes = 4 params → early2 starts at 5
+  # early2: log_mu at 5, then 3 shapes = 4 params → constant starts at 9
+  # constant: log_mu at 9, no shapes = 1 param → late starts at 10
+  # late: log_mu at 10, then 4 G3 shapes = 5 params
+  expect_equal(pos[["early1"]],   1L)
+  expect_equal(pos[["early2"]],   5L)
+  expect_equal(pos[["constant"]], 9L)
+  expect_equal(pos[["late"]],    10L)
+})
+
+test_that(".hzr_select_fixmu_phase excludes extreme-outlier phases for N=4", {
+  # With G3 starting values tau=1, gamma=3, alpha=1, eta=1 the late phase
+  # cumhaz is orders of magnitude larger than the other phases at typical
+  # starting theta.  The fixed selection should skip it and pick among the
+  # non-outlier phases.
+  data(cabgkul, package = "TemporalHazard")
+  phases4 <- list(
+    early1   = hzr_phase("cdf", t_half = 0.1, nu = 1, m = 1, fixed = "shapes"),
+    early2   = hzr_phase("cdf", t_half = 2.0, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant"),
+    late     = hzr_phase("g3", tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
+  )
+  cov_counts <- c(early1 = 0L, early2 = 0L, constant = 0L, late = 0L)
+  x_list <- list(early1 = NULL, early2 = NULL, constant = NULL, late = NULL)
+  theta0 <- c(-3, log(0.1), 1, 1,   # early1
+               -3, log(2.0), 1, 1,   # early2
+               -5,                   # constant
+               -3, log(1), 3, 1, 1)  # late
+
+  fixmu <- TemporalHazard:::.hzr_select_fixmu_phase(
+    theta0, cabgkul$int_dead, cabgkul$dead,
+    phases4, cov_counts, x_list
+  )
+  # G3 late phase should be excluded as an outlier; constant or one of the
+  # CDF phases should be selected instead
+  expect_false(fixmu == "late",
+               label = paste("fixmu should not be 'late'; got:", fixmu))
+})
+
+test_that(".hzr_conserve_events satisfies CoE identity for 4 phases", {
+  data(cabgkul, package = "TemporalHazard")
+  # Use 4 CDF/constant phases (no G3) to avoid the shape-value scale issue:
+  # G3 with tau=1 generates enormous base cumhaz at long follow-up times even
+  # with log_mu = -20, making jevent < 0 and causing a valid guard bail-out.
+  phases4 <- list(
+    early1   = hzr_phase("cdf", t_half = 0.1, nu = 1, m = 1),
+    early2   = hzr_phase("cdf", t_half = 2.0, nu = 1, m = 1),
+    constant = hzr_phase("constant"),
+    late     = hzr_phase("cdf", t_half = 20, nu = 1, m = 1)
+  )
+  cov_counts <- c(early1 = 0L, early2 = 0L, constant = 0L, late = 0L)
+  x_list <- list(early1 = NULL, early2 = NULL, constant = NULL, late = NULL)
+  # Positions: early1=1 (4 params), early2=5 (4), constant=9 (1), late=10 (4)
+  # Use small log_mu values so total cumhaz < total_events — the CoE
+  # adjustment then has room to increase the constant phase log_mu upward.
+  # exp(-6.5) * sum(cabgkul$int_dead) ≈ 503 < 545 = total_events.
+  theta0 <- c(-10, log(0.1), 1, 1,   # early1  (negligible contribution)
+               -10, log(2.0), 1, 1,   # early2  (negligible contribution)
+               -6.5,                   # constant (log_mu at pos 9, will be adjusted)
+               -10, log(20), 1, 1)     # late    (negligible contribution)
+  total_events <- sum(cabgkul$dead)
+
+  theta_adj <- TemporalHazard:::.hzr_conserve_events(
+    theta0, fixmu_phase = "constant", fixmu_pos = 9L,
+    time = cabgkul$int_dead, status = cabgkul$dead,
+    phases = phases4, covariate_counts = cov_counts,
+    x_list = x_list, total_events = total_events
+  )
+
+  # Only the constant phase log_mu should have changed
+  expect_false(theta_adj[9] == theta0[9])
+  expect_equal(theta_adj[-9], theta0[-9])
+
+  # After adjustment, total predicted events should equal observed events
+  decomp <- TemporalHazard:::.hzr_multiphase_cumhaz(
+    cabgkul$int_dead, theta_adj, phases4, cov_counts, x_list
+  )
+  expect_equal(sum(decomp), total_events, tolerance = 1e-6)
+})
+
+test_that("4-phase CoE fit converges and conservation ratio is 1.0", {
+  data(cabgkul, package = "TemporalHazard")
+  phases4 <- list(
+    early1   = hzr_phase("cdf", t_half = 0.1, nu = 1, m = 1, fixed = "shapes"),
+    early2   = hzr_phase("cdf", t_half = 2.0, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant"),
+    late     = hzr_phase("g3", tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
+  )
+  set.seed(42)
+  fit4 <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data    = cabgkul,
+    dist    = "multiphase",
+    phases  = phases4,
+    fit     = TRUE,
+    control = list(n_starts = 3, maxit = 500)
+  )
+
+  expect_true(is.finite(fit4$fit$objective))
+  gof <- hzr_gof(fit4)
+  s   <- attr(gof, "summary")
+  ratio <- unname(s$total_expected / s$total_observed)
+  expect_equal(ratio, 1.0, tolerance = 1e-4)
+})
+
+test_that("4-phase CoE and non-CoE find the same optimum", {
+  skip_on_cran()
+  data(cabgkul, package = "TemporalHazard")
+  phases4 <- list(
+    early1   = hzr_phase("cdf", t_half = 0.1, nu = 1, m = 1, fixed = "shapes"),
+    early2   = hzr_phase("cdf", t_half = 2.0, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant"),
+    late     = hzr_phase("g3", tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
+  )
+  set.seed(42)
+  fit_coe <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data    = cabgkul,
+    dist    = "multiphase",
+    phases  = phases4,
+    fit     = TRUE,
+    control = list(n_starts = 5, maxit = 500, conserve = TRUE)
+  )
+  fit_no_coe <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data    = cabgkul,
+    dist    = "multiphase",
+    phases  = phases4,
+    fit     = TRUE,
+    control = list(n_starts = 5, maxit = 500, conserve = FALSE)
+  )
+  expect_equal(fit_coe$fit$objective, fit_no_coe$fit$objective, tolerance = 0.1)
+})
+
+test_that("4-phase predict(decompose=TRUE) returns 4 per-phase columns", {
+  data(cabgkul, package = "TemporalHazard")
+  phases4 <- list(
+    early1   = hzr_phase("cdf", t_half = 0.1, nu = 1, m = 1, fixed = "shapes"),
+    early2   = hzr_phase("cdf", t_half = 2.0, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant"),
+    late     = hzr_phase("g3", tau = 1, gamma = 3, alpha = 1, eta = 1,
+                          fixed = "shapes")
+  )
+  set.seed(42)
+  fit4 <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data    = cabgkul,
+    dist    = "multiphase",
+    phases  = phases4,
+    fit     = TRUE,
+    control = list(n_starts = 3, maxit = 500)
+  )
+  nd <- data.frame(time = c(6, 24, 60, 120))
+  d  <- predict(fit4, newdata = nd, type = "cumulative_hazard",
+                decompose = TRUE)
+
+  expect_true(is.data.frame(d) || is.matrix(d))
+  expect_true("total"   %in% colnames(d))
+  expect_true("early1"  %in% colnames(d))
+  expect_true("early2"  %in% colnames(d))
+  expect_true("constant" %in% colnames(d))
+  expect_true("late"    %in% colnames(d))
+  # Total must equal sum of per-phase contributions
+  phase_sum <- d[, "early1"] + d[, "early2"] + d[, "constant"] + d[, "late"]
+  expect_equal(unname(d[, "total"]), unname(phase_sum), tolerance = 1e-10)
+})


### PR DESCRIPTION
## Problem

`.hzr_select_fixmu_phase()` used `which.max()` over per-phase cumhaz contributions at the starting theta. G3 phases with shape parameters `tau=1, gamma=3, alpha=1, eta=1` generate unnormalized cumhaz values **4–6 orders of magnitude** larger than CDF/constant phases at typical CABGKUL follow-up times (~145M vs ~2K for constant).

CoE then pins the G3 `log_mu` to absorb all events, trapping the optimizer and preventing the phase from reaching its true near-zero MLE. On a 4-phase CABGKUL fit: **CoE LL = −3747.4 vs no-CoE LL = −3740.5** (6.9 unit gap). The existing 3-phase tests never surface this because the 3-phase model genuinely has a late-rising phase.

## Fix

After computing per-phase cumhaz contributions, exclude phases whose contribution exceeds **10× the median** before calling `which.max`. Phases in the extreme tail are dominated by starting-value shape artifacts, not genuine model importance. Falls back to `which.max` when all phases are outliers or only one phase exists.

**After fix:** CoE vs no-CoE LL diff < 0.1 units. 3-phase C reference still matches (−3740.52).

## Tests (6 new)

- `.hzr_log_mu_positions()` with 4 phases — position arithmetic
- `.hzr_select_fixmu_phase()` excludes the extreme-outlier G3 phase
- `.hzr_conserve_events()` satisfies the CoE identity for 4 phases
- Full 4-phase fit converges with conservation ratio = 1.0
- 4-phase CoE and no-CoE find the same optimum (`skip_on_cran`)
- `predict(decompose=TRUE)` returns 4 per-phase columns + additive total

All 17 tests pass (5 skip_on_cran); existing 3-phase suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)