### PR TITLE
docs(roadmap): split Production Validation into its own ongoing stream

### DIFF
--- a/inst/dev/DEVELOPMENT-PLAN.md
+++ b/inst/dev/DEVELOPMENT-PLAN.md
@@ -448,12 +448,14 @@ and hardening numerical edge cases. This is distinct from the **Production
 Validation Stream** (below), which validates against external production
 models on an ongoing, externally-gated basis.
 
-> **Progress (v1.1.0 dev cycle):** the highest-risk 7c items are closed —
-> 4-phase CoE fixmu selection (PR #37), `time_lower` dual-use (PR #36),
-> `hzr_decompos()` `nu=0/m>=0` fall-through (PR #40), and phase-specific
-> covariate recovery (PR #39). Two of the three previously-untested paths
-> held real bugs; the third (phase-specific covariates) was correct and is
-> now locked in.
+> **Progress (v1.1.0 dev cycle):** four hardening fixes landed — 4-phase CoE
+> fixmu selection (PR #37), `time_lower` dual-use (PR #36), `hzr_decompos()`
+> Case 3 + `nu=0/m>=0` boundary (PR #40), and phase-specific covariate
+> recovery (PR #39). Of the three coverage-gap paths exercised here for the
+> first time — 4-phase CoE, the `hzr_decompos()` sign-dispatch boundaries,
+> and phase-specific covariates — two harbored real bugs; phase-specific
+> covariates was correct and is now locked in. (`time_lower` was a separate
+> fix surfaced during the interval-censoring vignette work.)
 
 ### 7a. Weighted Events — Additional Parity Coverage
 
@@ -529,8 +531,9 @@ or known numerical gaps. Priority order for investigation:
 ## Production Validation Stream — ONGOING
 
 Not a sequential milestone but a continuous validation track: confirm the
-package is correctly implemented for CORR's hardest real-world models, run
-against the original C HAZARD binary. This is a correctness-assurance effort,
+package is correctly implemented for the hardest real-world production models
+(Rajeswaran / Blackstone's clinical analyses), run against the original C
+HAZARD binary. This is a correctness-assurance effort,
 distinct from the feature/coverage work in Phase 7 — it is **externally
 gated** (Rajeswaran's production library, the CCF `hazard` v4.4.6 install)
 and runs **in parallel** to dev, growing as production models are collected

--- a/inst/dev/DEVELOPMENT-PLAN.md
+++ b/inst/dev/DEVELOPMENT-PLAN.md
@@ -369,11 +369,16 @@ is acceptable.
 
 ---
 
-## Phase 6: Documentation Gaps — PLANNED
+## Phase 6: Documentation Gaps — COMPLETE (v1.1.0 dev cycle)
 
 The SAS HAZARD documentation walks users through a disciplined analytical
-sequence. The R vignettes cover the same pieces but have gaps relative to
+sequence. The R vignettes cover the same pieces but had gaps relative to
 what a SAS HAZARD veteran would expect.
+
+> **Status:** 6a (clinical walkthrough) and 6b (Cox comparison) shipped in
+> the `clinical-analysis-walkthrough` vignette; 6c (convergence
+> troubleshooting, PR #33) and 6d (interval/left censoring, PR #35) landed in
+> the v1.1.0 dev cycle. All four documentation gaps are closed.
 
 ### 6a. Complete Clinical Analysis Walkthrough
 
@@ -435,44 +440,22 @@ covers the theory but there are no hands-on examples.
 
 ---
 
-## Phase 7: Production Model Parity & Edge Cases — PLANNED
+## Phase 7: Edge-Case & Coverage Hardening — IN PROGRESS
 
-Post-CRAN hardening against real production models from the original C/SAS
-HAZARD system. Goal: high confidence in both codebases for the model types
-that appear in clinical production, not just the curated examples shipped
-with the C source.
+Code-driven correctness work the package team owns end-to-end: closing test
+coverage on implemented-but-unverified paths, adding public example datasets,
+and hardening numerical edge cases. This is distinct from the **Production
+Validation Stream** (below), which validates against external production
+models on an ongoing, externally-gated basis.
 
-> **Cross-codebase note:** These items are logged in both this document and
-> `docs/PRODUCTION-TEST-PLAN.md` in the `hazard` C/SAS repo. A single `.lst`
-> reference output validates both codebases simultaneously. CCF-local fixtures
-> live at `tests/production/` (gitignored) in the hazard repo.
+> **Progress (v1.1.0 dev cycle):** the highest-risk 7c items are closed —
+> 4-phase CoE fixmu selection (PR #37), `time_lower` dual-use (PR #36),
+> `hzr_decompos()` `nu=0/m>=0` fall-through (PR #40), and phase-specific
+> covariate recovery (PR #39). Two of the three previously-untested paths
+> held real bugs; the third (phase-specific covariates) was correct and is
+> now locked in.
 
-### 7a. Rajeswaran / Blackstone Production Model Parity
-
-**Contact:** Rajeswaran (Rajes) at CCF — has the "hard" production hazard
-models run against the C HAZARD binary in clinical analyses.
-
-**Goal:** Collect 3–5 production `.lst` outputs from Blackstone's
-Rajeswaran-authored models; port each to `hazard()` calls; add
-`skip_on_cran()` parity tests with tolerances matching the existing suite.
-
-Candidate model types not yet exercised:
-- 4-phase models (early + early2 + constant + late)
-- Phase-specific covariate models with multiple covariate phases
-- Models with shaping modifiers (`/S`, `/I`, `/E`) — currently deferred from
-  primary parity (see PRE-CRAN-PARITY-INVENTORY.md gap §1)
-- High-dimensional covariate fits (12+ free parameters)
-
-**Action:** Schedule meeting with Rajes; request SAS driver scripts + `.lst`
-reference outputs for 3–5 candidate models from production library.
-
-**Sequencing dependency:** Collect Rajes examples *before* installing
-`hazard` v4.4.6 at CCF. Once the CCF production install is live, run the
-new driver scripts against the installed binary to generate fresh `.lst`
-captures; add those as `skip_on_cran()` parity fixtures. The CCF install
-is blocked on this collection step.
-
-### 7b. Weighted Events — Additional Parity Coverage
+### 7a. Weighted Events — Additional Parity Coverage
 
 The OMC dataset (`hz.tm123.OMC`) exercises case weights via the PRIMISOL
 morbidity endpoint, and `4c`/`4e` verified integer-weight duplication parity.
@@ -489,7 +472,7 @@ Additional coverage needed to close confidence gaps:
   or aggregated-cell weights (e.g. from a registry with pre-computed weights
   rather than individual patient records)
 
-### 7c. New Example Datasets
+### 7b. New Example Datasets
 
 **Hsich / UNOS (post-heart-transplant mortality)**
 - 3-phase early + constant + late structure
@@ -522,16 +505,17 @@ Additional coverage needed to close confidence gaps:
 - Actionable: identify published paper with LL + MLE table, or request
   SAS driver from Blackstone/CCF production library
 
-### 7d. Code Areas Requiring Deeper Examination
+### 7c. Code Areas Requiring Deeper Examination
 
 The following components are implemented but have limited parity coverage
 or known numerical gaps. Priority order for investigation:
 
 | Area | Risk | Status |
 |---|---|---|
-| **4-phase CoE algebra** | `.hzr_select_fixmu_phase()` selects one constrained phase from N; behavior with N=4 untested | No test |
-| **`hzr_decompos()` near-boundary cases** | Sign dispatch has 6 cases; edge values (nu≈0, m≈0, t_half→0, t_half→∞) may fall between branches | Partial — Case 2L verified |
-| **Phase-specific covariates** | `hzr_phase(formula = ~)` ships but no SAS parity fixture exercises it | No parity test |
+| **4-phase CoE algebra** | `.hzr_select_fixmu_phase()` selects one constrained phase from N; fixmu-selection trapped CoE on a G3 4th phase | ✅ Fixed + tested (PR #37) |
+| **`hzr_decompos()` near-boundary cases** | Sign dispatch has 6 cases; `nu=0, m>=0` fell through all branches | ✅ Fixed + tested (PR #40); Case 3↔3L discontinuity tracked as follow-up |
+| **Phase-specific covariates** | `hzr_phase(formula = ~)` ships but was unverified | ✅ Recovery-tested (PR #39); correct, locked in |
+| **`time_lower` dual-use** | RC rows with `time_lower=time` silently zeroed their LL contribution | ✅ Fixed + tested (PR #36) |
 | **`hzr_stepwise()` on multiphase** | Phase-specific variable entry path — no parity test against SAS SELECTION | No parity test |
 | **`hzr_bootstrap()` with weights** | Non-unit weights path through bootstrap resampling untested | No test |
 | **`predict(..., decompose=TRUE, se.fit=TRUE)`** | Currently blocked with clean error — delta-method Jacobian needs per-phase extension | Blocked |
@@ -539,6 +523,51 @@ or known numerical gaps. Priority order for investigation:
 | **Hessian stability at 12+ parameters** | Numerical Hessian inversion can become ill-conditioned; `hm.death.AVC.deciles` (13 params) passes but borderline | Passing, fragile |
 | **`hzr_competing_risks()` with weights** | Greenwood variance with case weights not tested | No test |
 | **Weighted multiphase + covariates** | All weighted parity tests are intercept-only; covariate + weight combination untested | No test |
+
+---
+
+## Production Validation Stream — ONGOING
+
+Not a sequential milestone but a continuous validation track: confirm the
+package is correctly implemented for CORR's hardest real-world models, run
+against the original C HAZARD binary. This is a correctness-assurance effort,
+distinct from the feature/coverage work in Phase 7 — it is **externally
+gated** (Rajeswaran's production library, the CCF `hazard` v4.4.6 install)
+and runs **in parallel** to dev, growing as production models are collected
+rather than "completing."
+
+> **Cross-codebase note:** logged in both this document and
+> `hazard/docs/PRODUCTION-TEST-PLAN.md`. A single `.lst` reference output
+> validates both codebases simultaneously. CCF-local fixtures live at
+> `tests/production/` (gitignored) in the hazard repo.
+
+### PV1. Rajeswaran / Blackstone Production Model Parity
+
+**Contact:** Rajeswaran (Rajes) at CCF — has the "hard" production hazard
+models run against the C HAZARD binary in clinical analyses.
+
+**Goal:** Collect 3–5 production `.lst` outputs from Blackstone's
+Rajeswaran-authored models; port each to `hazard()` calls; add
+`skip_on_cran()` parity tests with tolerances matching the existing suite.
+
+Candidate model types not yet exercised:
+- 4-phase models (early + early2 + constant + late) — *the package's 4-phase
+  CoE path is now fixed + tested (PR #37); production parity is the next
+  confidence level*
+- Phase-specific covariate models with multiple covariate phases — *recovery
+  coverage landed (PR #39); production `.lst` parity remains*
+- Models with shaping modifiers (`/S`, `/I`, `/E`) — currently deferred from
+  primary parity (see PRE-CRAN-PARITY-INVENTORY.md gap §1)
+- High-dimensional covariate fits (12+ free parameters)
+
+**Action:** Schedule meeting with Rajes; request SAS driver scripts + `.lst`
+reference outputs for 3–5 candidate models from production library.
+
+**Sequencing dependency:** Collect Rajes examples *before* installing
+`hazard` v4.4.6 at CCF. Once the CCF production install is live, run the
+new driver scripts against the installed binary to generate fresh `.lst`
+captures; add those as `skip_on_cran()` parity fixtures. The CCF install
+is blocked on this collection step.
 
 ---
 


### PR DESCRIPTION
## Motivation

Phase 7 mixed two fundamentally different kinds of work:
- **Code-driven hardening** — test coverage, edge cases, new example datasets. The package team owns this end-to-end and drives it on `dev`.
- **Production-model parity validation** (old 7a) — collecting `.lst` fixtures from Rajeswaran's production library, running against the CCF `hazard` binary. This is **externally gated** (people + the CCF v4.4.6 install) and **ongoing** — it grows as production models are collected rather than "completing."

As noted in discussion, 7a is really a *validation track* confirming the package is correctly implemented for CORR's hardest real-world models — not a feature phase.

## Changes (`inst/dev/DEVELOPMENT-PLAN.md`)

- **Phase 7 → "Edge-Case & Coverage Hardening" (IN PROGRESS).** Old sub-items renumbered `7b/7c/7d → 7a/7b/7c`. The 7c status table now reflects this cycle's fixes — `time_lower` (#36), 4-phase CoE (#37), phase-specific covariates (#39), `hzr_decompos()` boundary (#40). Two of three previously-untested paths held real bugs.
- **New "Production Validation Stream" (ONGOING)** holds the old 7a as **PV1**, reframed as a continuous, externally-gated, parallel track, with the cross-codebase `PRODUCTION-TEST-PLAN.md` note.
- **Phase 6 → COMPLETE** (6a/6b shipped; 6c #33, 6d #35 landed this cycle).

No code change — documentation/roadmap only. Vault project note's roadmap reference updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)