### PR TITLE
ci(pkgdown): release/dev site split so root reflects the CRAN version

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -38,14 +40,22 @@ jobs:
           roxygen2::roxygenise(load_code = roxygen2::load_pkgload)
           install.packages(".", repos = NULL, type = "source")
 
+      # development: mode is "auto" in _pkgdown.yml, so a released DESCRIPTION
+      # version builds the site to docs/ (site root) and a development version
+      # (ending in .9000) builds to docs/dev/.
       - name: Build pkgdown site
         shell: Rscript {0}
-        run: |
-          pkgdown::build_site(new_process = FALSE)
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
 
-      - name: Deploy to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      # clean: false so a dev build (docs/dev/) does not wipe the released
+      # root, and a release build (docs/) does not wipe the /dev/ subdir.
+      - name: Deploy to gh-pages
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,12 @@ url: https://ehrlinger.github.io/temporal_hazard/
 title: TemporalHazard
 description: Pure-R implementation of the HAZARD model with transparency and parity validation
 
+# Released-version docs build to the site root; development versions
+# (DESCRIPTION Version ending in .9000) build to /dev/ with a
+# "(development version)" marker, so the public root always reflects CRAN.
+development:
+  mode: auto
+
 template:
   bootstrap: 5
 


### PR DESCRIPTION
## Problem

After the post-acceptance bump to `1.0.3.9000`, the pkgdown site root shows `1.0.3.9000` instead of the CRAN `1.0.3`. The old workflow deployed `main`'s DESCRIPTION version and wiped the whole site each build (`peaceiris` + `publish_dir: ./docs`), with no released-vs-dev split.

## Fix (standard r-lib dev-mode setup)

- **`_pkgdown.yml`**: `development: mode: auto`. Released versions build to the site **root**; development versions (`Version` ending `.9000`) build to **`/dev/`** with a "(development version)" marker. Verified locally — `as_pkgdown()` routes `1.0.3.9000` → `docs/dev/`, a `1.0.3` release → `docs/` root.
- **`pkgdown.yaml`**: build with `build_site_github_pages()` and deploy with `clean: false` (JamesIves action), so a dev build into `/dev/` no longer wipes the released root, and a release build doesn't wipe `/dev/`. Added a `release: published` trigger; deploy guarded to `main` pushes, releases, and `workflow_dispatch`.

## ⚠️ One-time follow-up after merge

Because `main`'s version is `1.0.3.9000` (dev), the workflow only ever builds `/dev/` from `main` — it won't refresh the **root** until a release-version build happens (v1.1.0). So once this is on `main`, the root needs a one-time seed with the `1.0.3` release docs:

```r
# local, on a clean main checkout with this config:
desc::desc_set_version("1.0.3")          # temporarily, do NOT commit
pkgdown::deploy_to_branch(new_process = FALSE)   # release -> gh-pages root
# then discard the DESCRIPTION change
```

After that, the root self-maintains: each future release build refreshes it, and `main`/dev pushes keep `/dev/` current. I can run this step once the PR is merged (it's a live gh-pages deploy), or you can.

This goes to `main` because the live site deploys from `main` (same as the post-acceptance badge swap). It'll reach `dev` at the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)