### PR TITLE
fix(bootstrap): resample weights in lockstep with data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 ## Bug fixes
 
+* **`hzr_bootstrap()` was non-functional for weighted fits** (Phase 7c).
+  The resample loop rewired only `data` in the refit call, leaving the
+  original `weights` argument bound to a symbol in the *caller's* frame.
+  The internal `eval()` could not resolve that symbol, so **every** replicate
+  of a weighted model errored out (`n_success == 0`) regardless of `fraction`;
+  even had it resolved, the un-resampled weights would have been misaligned
+  with the bootstrapped rows.  `weights` is now evaluated once and resampled
+  in lockstep with the data on each replicate (mirroring how `data` is
+  handled).  Unweighted bootstraps are unaffected.  A regression test covers
+  both the `fraction < 1` and full-size weighted paths in
+  `test-diagnostics.R`.
+
 * **4-phase CoE fixmu-phase selection** (Phase 7d).
   `.hzr_select_fixmu_phase()` used `which.max()` over raw per-phase cumhaz
   at the starting theta.  G3 late phases with typical shape parameters have

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1246,6 +1246,17 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   n_obs <- nrow(orig_data)
   sample_size <- max(1L, as.integer(n_obs * fraction))
 
+  # Observation weights, if any, must be resampled in lockstep with the data.
+  # The original call binds `weights` to a symbol in the *caller's* frame, which
+  # the refit eval() below cannot resolve and which -- left untouched -- would
+  # also misalign the weights with the resampled rows. Evaluate it once here and
+  # rewire each replicate to a locally bound, resampled copy (mirroring `data`).
+  orig_weights <- if (is.null(cl$weights)) {
+    NULL
+  } else {
+    eval(cl$weights, envir = parent.frame())
+  }
+
   # Parameter names from the fitted model. Shape parameters (e.g. mu, nu) are
   # named in theta, but covariate betas often come through with empty names.
   # Covariate coefficients occupy the last ncol(x) positions of theta; fill
@@ -1285,12 +1296,15 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     # Resample with replacement
     idx <- sample.int(n_obs, size = sample_size, replace = TRUE)
     boot_data <- orig_data[idx, , drop = FALSE] # nolint: object_usage_linter.
+    # boot_weights is referenced via quote() inside eval -- lintr cannot trace it
+    boot_weights <- if (is.null(orig_weights)) NULL else orig_weights[idx] # nolint: object_usage_linter.
 
-    # Refit using the same call but with resampled data
-    # (boot_data is referenced via quote() inside eval -- lintr cannot trace this)
+    # Refit using the same call but with resampled data (and weights, if any)
+    # (boot_data/boot_weights are referenced via quote() inside eval)
     boot_fit <- tryCatch({
       cl_boot <- cl
       cl_boot$data <- quote(boot_data)
+      if (!is.null(orig_weights)) cl_boot$weights <- quote(boot_weights)
       cl_boot$fit <- TRUE
       eval(cl_boot)
     }, error = function(e) NULL)

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -685,6 +685,43 @@ test_that("hzr_bootstrap preserves named betas while filling blanks", {
   expect_false("x1" %in% params)
 })
 
+test_that("hzr_bootstrap resamples weights alongside the data", {
+  # Regression test for the weighted-bootstrap bug: the resample loop used to
+  # rewire only `data`, leaving the original full-length `weights` vector bound
+  # to the refit call. Two observable consequences this guards against:
+  #   1. fraction < 1 -> weights length (n_obs) no longer matches the smaller
+  #      resampled data, so every replicate errored out: n_success == 0.
+  #   2. fraction == 1 -> length matched, so no error, but weights were applied
+  #      to the wrong (resampled) rows: silently incorrect estimates.
+  set.seed(202)
+  n <- 100
+  df <- data.frame(
+    t = stats::rexp(n, 0.1),
+    d = stats::rbinom(n, 1, 0.6),
+    x1 = stats::rnorm(n)
+  )
+  w <- stats::runif(n, 0.5, 2.0)
+
+  fit <- hazard(
+    survival::Surv(t, d) ~ x1,
+    data    = df,
+    weights = w,
+    dist    = "weibull",
+    theta   = c(mu = 0.05, nu = 0.8, 0),
+    fit     = TRUE
+  )
+
+  # (1) Subsampled weighted bootstrap must produce successful replicates.
+  bs_frac <- hzr_bootstrap(fit, n_boot = 10, fraction = 0.5, seed = 123)
+  expect_gt(bs_frac$n_success, 0)
+  expect_equal(bs_frac$n_failed, 0)
+
+  # (2) Full-size weighted bootstrap must also succeed and be well-formed.
+  bs_full <- hzr_bootstrap(fit, n_boot = 10, seed = 123)
+  expect_gt(bs_full$n_success, 0)
+  expect_true(all(is.finite(bs_full$summary$mean)))
+})
+
 
 # =========================================================================
 # hzr_competing_risks tests


### PR DESCRIPTION
## Summary

Phase 7c weighted-path hardening. `hzr_bootstrap()` was **completely non-functional for weighted fits**.

The resample loop rewired only `data` in the refit call (`cl_boot$data <- quote(boot_data)`), leaving the original `weights` argument bound to a symbol in the *caller's* frame. The internal `eval(cl_boot)` runs in `hzr_bootstrap()`'s own frame, where that symbol does not exist — so **every** replicate of a weighted model errored out and was swallowed by the `tryCatch`, yielding `n_success == 0` regardless of `fraction`. Even had the symbol resolved, the un-resampled full-length weights would have been misaligned with the bootstrapped rows (silently wrong) or length-mismatched (under `fraction < 1`).

## Fix

Evaluate `weights` once via `parent.frame()` (mirroring how `data` is already handled), then resample it in lockstep with the data on each replicate and bind a local `boot_weights` into the refit call. Unweighted bootstraps are untouched (`orig_weights` is `NULL` → no rewiring).

## Tests

New regression test in `test-diagnostics.R` covers both the `fraction < 1` and full-size weighted paths. Before the fix both gave `n_success == 0`; after, both succeed with finite summaries.

- Full suite: **PASS** (only the 2 pre-existing environmental skips: legacy C binary returns 126, missing stepwise-parity fixture)
- `lintr::lint("R/diagnostics.R")`: no lints

This continues the "no test → real bug" pattern: 4 of 4 untested 7c paths checked so far have harbored real bugs (this makes it the 4th).

🤖 Generated with [Claude Code](https://claude.com/claude-code)