### PR TITLE
docs(competing-risks): document unweighted limitation + scope weighted feature (8a)

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1407,6 +1407,13 @@ print.hzr_bootstrap <- function(x, digits = 4, ...) {
 #' competing risks exist), this provides the correct marginal cumulative
 #' incidence for each event type.
 #'
+#' @note This estimator is **unweighted**: every observation contributes a
+#'   unit count to the at-risk and event tallies. There is no `weights`
+#'   argument, so case or inverse-probability weights are not yet supported
+#'   for competing-risks incidence (unlike [hazard()], which accepts
+#'   `weights`). Pre-expand weighted rows to individual records if an
+#'   approximate weighted estimate is needed.
+#'
 #' @param time Numeric vector of follow-up times.
 #' @param event Integer vector of event type indicators:
 #'   0 = censored, 1 = event type 1, 2 = event type 2, etc.

--- a/inst/dev/DEVELOPMENT-PLAN.md
+++ b/inst/dev/DEVELOPMENT-PLAN.md
@@ -469,7 +469,10 @@ Additional coverage needed to close confidence gaps:
   need a covariate fit with weights to confirm the weighted score/gradient is
   correct under the full CoE + covariate path
 - **Weighted competing risks** (`hzr_competing_risks()` with case weights):
-  not currently tested with non-unit weights
+  not yet *implemented* — the function takes only `(time, event)` and counts
+  raw row tallies. Building it means a weighted Aalen-Johansen recursion
+  (weighted at-risk sets and event counts) plus a weighted-Greenwood variance.
+  Feature, not a coverage gap — scope before committing
 - **Source:** Look for a CCF production model that uses fractional IPS weights
   or aggregated-cell weights (e.g. from a registry with pre-computed weights
   rather than individual patient records)
@@ -523,7 +526,7 @@ or known numerical gaps. Priority order for investigation:
 | **`predict(..., decompose=TRUE, se.fit=TRUE)`** | Currently blocked with clean error — delta-method Jacobian needs per-phase extension | Blocked |
 | **Interval censoring under multiphase** | Code path exists; no real-data or SAS parity fixture | No parity test |
 | **Hessian stability at 12+ parameters** | Numerical Hessian inversion can become ill-conditioned; `hm.death.AVC.deciles` (13 params) passes but borderline | Passing, fragile |
-| **`hzr_competing_risks()` with weights** | Greenwood variance with case weights not tested | No test |
+| **`hzr_competing_risks()` with weights** | Not a hardening item: `hzr_competing_risks(time, event)` has no `weights` argument — the Aalen-Johansen/Greenwood recursion counts raw row tallies. Weighting is an unbuilt **feature** (weighted at-risk + event counts + weighted-Greenwood variance), not a latent bug. Moved to feature backlog (7a). | Feature, not bug |
 | **Weighted multiphase + covariates** | All weighted parity tests are intercept-only; covariate + weight combination untested | No test |
 
 ---

--- a/inst/dev/DEVELOPMENT-PLAN.md
+++ b/inst/dev/DEVELOPMENT-PLAN.md
@@ -526,7 +526,7 @@ or known numerical gaps. Priority order for investigation:
 | **`predict(..., decompose=TRUE, se.fit=TRUE)`** | Currently blocked with clean error — delta-method Jacobian needs per-phase extension | Blocked |
 | **Interval censoring under multiphase** | Code path exists; no real-data or SAS parity fixture | No parity test |
 | **Hessian stability at 12+ parameters** | Numerical Hessian inversion can become ill-conditioned; `hm.death.AVC.deciles` (13 params) passes but borderline | Passing, fragile |
-| **`hzr_competing_risks()` with weights** | Not a hardening item: `hzr_competing_risks(time, event)` has no `weights` argument — the Aalen-Johansen/Greenwood recursion counts raw row tallies. Weighting is an unbuilt **feature** (weighted at-risk + event counts + weighted-Greenwood variance), not a latent bug. Moved to feature backlog (7a). | Feature, not bug |
+| **`hzr_competing_risks()` with weights** | Not a hardening item: `hzr_competing_risks(time, event)` has no `weights` argument — the Aalen-Johansen/Greenwood recursion counts raw row tallies. Weighting is an unbuilt **feature** (weighted at-risk + event counts + weighted-Greenwood variance), not a latent bug. Scoped as feature 8a. | Feature → 8a |
 | **Weighted multiphase + covariates** | All weighted parity tests are intercept-only; covariate + weight combination untested | No test |
 
 ---
@@ -594,6 +594,31 @@ Items that would improve the package beyond SAS parity.
   (distinct from the epoch-decomposition approach to repeating events)
 - **Parallel bootstrap** — leverage `future`/`furrr` for bootstrap CI
   computation
+
+### 8a. Weighted competing-risks incidence — FEATURE (scoped from 7c)
+
+`hzr_competing_risks()` is currently **unweighted** (raw row tallies; the
+Rd `@note` documents the limitation). The SAS `markov.sas` macro it mirrors
+is also unweighted, so this is a parity-plus extension, not a parity gap.
+Building it:
+
+- Add a validated `weights =` argument mirroring [hazard()]'s (non-negative,
+  finite, `length == length(time)`).
+- **Weighted Aalen-Johansen recursion** — at-risk set and per-type event
+  counts become weighted sums (`sum(w[...])`) instead of `sum(...)` row
+  counts; the transition-probability and incidence updates carry through
+  unchanged in form.
+- **Weighted-Greenwood variance** — the part needing statistical care.
+  Naïve weight substitution into the unweighted Greenwood term gives wrong
+  SEs; needs the effective-sample-size / weighted-variance formula (cf.
+  `survival::survfit` `weights` handling) and a reference to validate against.
+- **Validation target** — no SAS reference (markov.sas is unweighted);
+  anchor instead to `survival::survfit(Surv(time, event) ~ 1, weights=)`
+  CIF + SE, or a hand-computed small fixture. Integer weights must reproduce
+  the row-duplicated unweighted fit (same invariant used for `hazard()`
+  weights in 4c).
+- **Process:** `/brainstorm` the weighted-variance approach before coding;
+  this is a correctness-sensitive estimator, not a mechanical wire-up.
 
 ---
 

--- a/man/hzr_competing_risks.Rd
+++ b/man/hzr_competing_risks.Rd
@@ -44,6 +44,14 @@ Unlike the naive 1 - KM estimator (which overestimates incidence when
 competing risks exist), this provides the correct marginal cumulative
 incidence for each event type.
 }
+\note{
+This estimator is \strong{unweighted}: every observation contributes a
+unit count to the at-risk and event tallies. There is no \code{weights}
+argument, so case or inverse-probability weights are not yet supported
+for competing-risks incidence (unlike \code{\link[=hazard]{hazard()}}, which accepts
+\code{weights}). Pre-expand weighted rows to individual records if an
+approximate weighted estimate is needed.
+}
 \examples{
 data(valves)
 valves_cc <- na.omit(valves)


### PR DESCRIPTION
## Summary

Scoping outcome for the last "weighted-path 7c" candidate, plus the two follow-ups you asked for (document now, queue the build).

`hzr_competing_risks(time, event)` has **no `weights` argument** — the Aalen-Johansen/Greenwood recursion counts raw row tallies. Unlike `hzr_bootstrap()` (which accepted weights and mishandled them — fixed in #46), there's no latent weighted code path to harbor a bug. So this was never a 7c hardening item; it's an unbuilt feature.

This PR:
1. **Documents the limitation now** — `@note` on `hzr_competing_risks()` stating the estimator is unweighted, with a pre-expand workaround pointer (`man/hzr_competing_risks.Rd` regenerated).
2. **Reclassifies the roadmap entries** — the 7c table row and 7a bullet no longer imply an untested existing path.
3. **Scopes the feature** — new **Phase 8a** entry: weighted Aalen-Johansen recursion + weighted-Greenwood variance (the statistically sensitive part), validated against `survival::survfit(..., weights=)` with the integer-weight = row-duplication invariant; brainstorm-first before coding.

No functional code change (doc + roadmap only). Full `test-diagnostics.R` passes (160), lint clean.

Closes out the 7c weighted-path investigation: `hzr_bootstrap()` (#46) was the only real weighted-path bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)