### PR TITLE
fix: address Copilot review follow-ups (NEWS version, time_lower vignette, bootstrap weights)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TemporalHazard 1.1.0 (development version)
+# TemporalHazard 1.1.0.9000 (development version)
 
 ## Bug fixes
 
@@ -12,7 +12,12 @@
   in lockstep with the data on each replicate (mirroring how `data` is
   handled).  Unweighted bootstraps are unaffected.  A regression test covers
   both the `fraction < 1` and full-size weighted paths in
-  `test-diagnostics.R`.
+  `test-diagnostics.R`.  Follow-up: `hzr_bootstrap()` now resamples the
+  weights already stored on the fitted object (`object$data$weights`) rather
+  than re-evaluating the call's `weights` expression in `parent.frame()`,
+  which fails when the original symbol is no longer in scope (e.g. the fit
+  was built inside a helper that has returned).  Caller-frame evaluation
+  remains a fallback for objects fitted before weights were stored.
 
 * **4-phase CoE fixmu-phase selection** (Phase 7d).
   `.hzr_select_fixmu_phase()` used `which.max()` over raw per-phase cumhaz

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1247,14 +1247,19 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   sample_size <- max(1L, as.integer(n_obs * fraction))
 
   # Observation weights, if any, must be resampled in lockstep with the data.
-  # The original call binds `weights` to a symbol in the *caller's* frame, which
-  # the refit eval() below cannot resolve and which -- left untouched -- would
-  # also misalign the weights with the resampled rows. Evaluate it once here and
-  # rewire each replicate to a locally bound, resampled copy (mirroring `data`).
-  orig_weights <- if (is.null(cl$weights)) {
-    NULL
-  } else {
+  # Prefer the weights already evaluated and stored on the fitted object: they
+  # are guaranteed aligned with the original rows and need no caller-frame
+  # lookup. Re-evaluating `cl$weights` in `parent.frame()` is fragile -- the
+  # original symbol/expression may no longer be in scope, or may now resolve to
+  # a different value -- so fall back to it only for objects fitted before
+  # weights were stored on `object$data`. Each replicate is then rewired to a
+  # locally bound, resampled copy (mirroring `data`).
+  orig_weights <- if (!is.null(object$data$weights)) {
+    object$data$weights
+  } else if (!is.null(cl$weights)) {
     eval(cl$weights, envir = parent.frame())
+  } else {
+    NULL
   }
 
   # Parameter names from the fitted model. Shape parameters (e.g. mu, nu) are

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -722,6 +722,38 @@ test_that("hzr_bootstrap resamples weights alongside the data", {
   expect_true(all(is.finite(bs_full$summary$mean)))
 })
 
+test_that("hzr_bootstrap uses stored weights when the original symbol is out of scope", {
+  # Robustness regression: the resample setup previously re-evaluated the call's
+  # `weights` expression in parent.frame(). If the original weights symbol is no
+  # longer in scope at bootstrap time -- e.g. the fit was built inside a helper
+  # that has since returned -- that eval() raised "object not found". The fit now
+  # carries its evaluated weights on object$data$weights, so bootstrap no longer
+  # depends on a caller-frame lookup.
+  set.seed(77)
+  n <- 80
+  # `df` stays in the test frame so the call's `data` symbol still resolves;
+  # only the `weights` symbol is confined to the local() scope and gone by the
+  # time we bootstrap, isolating the weights lookup.
+  df <- data.frame(
+    t  = stats::rexp(n, 0.1),
+    d  = stats::rbinom(n, 1, 0.6),
+    x1 = stats::rnorm(n)
+  )
+  fit <- local({
+    local_w <- stats::runif(n, 0.5, 2.0)
+    hazard(
+      survival::Surv(t, d) ~ x1,
+      data = df, weights = local_w, dist = "weibull",
+      theta = c(mu = 0.05, nu = 0.8, 0), fit = TRUE
+    )
+  })
+  # `local_w` is now out of scope; bootstrap must still resample weights via the
+  # stored copy and produce successful replicates.
+  bs <- hzr_bootstrap(fit, n_boot = 10, fraction = 0.5, seed = 5)
+  expect_gt(bs$n_success, 0)
+  expect_equal(bs$n_failed, 0)
+})
+
 
 # =========================================================================
 # hzr_competing_risks tests

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -412,14 +412,17 @@ table(status)
 ```
 
 ::: {.callout-note}
-**`time_lower` for right-censored rows should be `0`**, not the censoring
-time.  In the Weibull and multiphase likelihoods, `time_lower` doubles as
-the counting-process *entry time* for right-censored and exact-event rows
-(`status %in% c(0, 1)`); setting it to `time` computes
-H(stop) − H(start) = 0 and silently discards those rows.  Pass
-`time_lower = 0` (or omit `time_lower` entirely) for right-censored rows.
-The exponential, log-logistic, and log-normal likelihoods do not use
-`time_lower` as an entry time and are unaffected.
+**`time_lower` as a counting-process entry time.**  In the Weibull and
+multiphase likelihoods, `time_lower` doubles as the *entry* (left-truncation)
+time for right-censored and exact-event rows (`status %in% c(0, 1)`): when
+`0 < time_lower < time`, the row contributes H(stop) − H(start), the
+counting-process form used for epoch-decomposed repeated events.  For an
+ordinary right-censored or event row with no entry time, leave `time_lower`
+at `0` or omit it.  Setting `time_lower = time` is treated as *no entry* —
+`time_lower` acts as an entry time only when strictly less than `time`, so
+it no longer zeroes the row's contribution.  The exponential, log-logistic,
+and log-normal likelihoods do not use `time_lower` as an entry time and are
+unaffected.
 :::
 
 Fit a Weibull model using both censoring types:


### PR DESCRIPTION
Resolves the three legitimate items Copilot raised on #48. Those items were about
**dev-baseline** code, not #48's test additions — they only appeared because #48
had mistakenly diffed against `main`. #48 is now retargeted to `dev` (test+docs
only); this PR addresses the baseline items separately.

### Items

1. **NEWS version header** — top dev entry was `1.1.0`; bumped to `1.1.0.9000`
   to match `DESCRIPTION`.
2. **`time_lower` vignette callout** (`fitting-hazard-models.qmd`) — was stale after
   the dual-use fix (PR #36). `time_lower` is treated as a counting-process entry
   time only when `0 < time_lower < time`; setting `time_lower = time` is now a
   no-op (no longer silently zeroes the row). Callout rewritten to match.
3. **`hzr_bootstrap()` weights robustness** (`R/diagnostics.R`) — re-evaluated
   `cl$weights` in `parent.frame()`, which errors when the original weights symbol
   is out of scope (e.g. fit built inside a helper that returned). Now prefers the
   stored, already-evaluated `object$data$weights`; caller-frame eval kept as a
   fallback for older objects. Adds an out-of-scope regression test (verified to
   fail against the old path with "object not found").

**Verification:** full suite 0 failures, 1295 passing, 2 pre-existing skips; lintr clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)