### PR TITLE
fix(bootstrap): resolve data from stored frame, not caller-frame eval

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,8 @@
   was built inside a helper that has returned).  Caller-frame evaluation
   remains a fallback for objects fitted before weights were stored.  The same
   fragility applied to the call's `data` argument: `hazard()` now stores the
-  evaluated model frame on the fitted object (`object$data$frame`), and
+  evaluated `data` argument (the data frame passed to `hazard()`, not a
+  `model.frame()` result) on the fitted object (`object$data$frame`), and
   `hzr_bootstrap()` resamples that stored frame instead of re-evaluating
   `cl$data` in `parent.frame()`, so bootstrap succeeds even when the original
   `data` symbol is out of scope.  Caller-frame evaluation remains a fallback

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,13 @@
   than re-evaluating the call's `weights` expression in `parent.frame()`,
   which fails when the original symbol is no longer in scope (e.g. the fit
   was built inside a helper that has returned).  Caller-frame evaluation
-  remains a fallback for objects fitted before weights were stored.
+  remains a fallback for objects fitted before weights were stored.  The same
+  fragility applied to the call's `data` argument: `hazard()` now stores the
+  evaluated model frame on the fitted object (`object$data$frame`), and
+  `hzr_bootstrap()` resamples that stored frame instead of re-evaluating
+  `cl$data` in `parent.frame()`, so bootstrap succeeds even when the original
+  `data` symbol is out of scope.  Caller-frame evaluation remains a fallback
+  for objects fitted before the frame was stored.
 
 * **4-phase CoE fixmu-phase selection** (Phase 7d).
   `.hzr_select_fixmu_phase()` used `which.max()` over raw per-phase cumhaz

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1242,7 +1242,17 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
 
   # Reconstruct the call components
   cl <- object$call
-  orig_data <- eval(cl$data, envir = parent.frame())
+  # Prefer the evaluated model frame stored on the fitted object: it is
+  # guaranteed available and needs no caller-frame lookup. Re-evaluating
+  # `cl$data` in `parent.frame()` is fragile -- the original `data` symbol may
+  # no longer be in scope (e.g. the fit was built inside a helper that has
+  # returned) -- so fall back to it only for objects fitted before the frame
+  # was stored on `object$data`.
+  orig_data <- if (!is.null(object$data$frame)) {
+    object$data$frame
+  } else {
+    eval(cl$data, envir = parent.frame())
+  }
   n_obs <- nrow(orig_data)
   sample_size <- max(1L, as.integer(n_obs * fraction))
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1242,12 +1242,13 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
 
   # Reconstruct the call components
   cl <- object$call
-  # Prefer the evaluated model frame stored on the fitted object: it is
-  # guaranteed available and needs no caller-frame lookup. Re-evaluating
-  # `cl$data` in `parent.frame()` is fragile -- the original `data` symbol may
-  # no longer be in scope (e.g. the fit was built inside a helper that has
-  # returned) -- so fall back to it only for objects fitted before the frame
-  # was stored on `object$data`.
+  # Prefer the evaluated `data` argument stored on the fitted object
+  # (`object$data$frame` -- the data frame passed to hazard(), not a
+  # model.frame() result): it is guaranteed available and needs no caller-frame
+  # lookup. Re-evaluating `cl$data` in `parent.frame()` is fragile -- the
+  # original `data` symbol may no longer be in scope (e.g. the fit was built
+  # inside a helper that has returned) -- so fall back to it only for objects
+  # fitted before the frame was stored on `object$data`.
   orig_data <- if (!is.null(object$data$frame)) {
     object$data$frame
   } else {

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -493,7 +493,12 @@ hazard <- function(formula = NULL,
       time_upper = time_upper,
       status = as.numeric(status),
       x = x,
-      weights = weights
+      weights = weights,
+      # Evaluated model frame (formula path; NULL when called with raw vectors).
+      # Stored so refit-based tooling such as hzr_bootstrap() can re-run the
+      # original call without a caller-frame lookup of the `data` symbol, which
+      # fails when that symbol has gone out of scope.
+      frame = data
     ),
     fit = fit_state,
     legacy_args = list(...),

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -494,10 +494,12 @@ hazard <- function(formula = NULL,
       status = as.numeric(status),
       x = x,
       weights = weights,
-      # Evaluated model frame (formula path; NULL when called with raw vectors).
-      # Stored so refit-based tooling such as hzr_bootstrap() can re-run the
-      # original call without a caller-frame lookup of the `data` symbol, which
-      # fails when that symbol has gone out of scope.
+      # The evaluated `data` argument as passed to hazard() (formula path; NULL
+      # when called with raw vectors). This is the user's data frame, not a
+      # model.frame() result. Stored so refit-based tooling such as
+      # hzr_bootstrap() can re-run the original call without a caller-frame
+      # lookup of the `data` symbol, which fails when that symbol has gone out
+      # of scope.
       frame = data
     ),
     fit = fit_state,

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -754,6 +754,36 @@ test_that("hzr_bootstrap uses stored weights when the original symbol is out of 
   expect_equal(bs$n_failed, 0)
 })
 
+test_that("hzr_bootstrap uses stored data frame when the original symbol is out of scope", {
+  # Robustness regression (sibling of the weights case): the resample setup
+  # re-evaluated the call's `data` expression via eval(cl$data, parent.frame()).
+  # If the original data symbol is no longer in scope at bootstrap time -- e.g.
+  # the entire fit was built inside a helper that has since returned -- that
+  # eval() failed and n_obs was malformed, so bootstrap errored before the loop.
+  # The fit now carries its evaluated model frame on object$data$frame, so the
+  # resample no longer depends on a caller-frame lookup of the data symbol.
+  set.seed(91)
+  n <- 80
+  # Build EVERYTHING inside local(): both the `data` (`bdf`) and `weights`
+  # (`bw`) symbols are gone by the time we bootstrap.
+  fit <- local({
+    bdf <- data.frame(
+      t  = stats::rexp(n, 0.1),
+      d  = stats::rbinom(n, 1, 0.6),
+      x1 = stats::rnorm(n)
+    )
+    bw <- stats::runif(n, 0.5, 2.0)
+    hazard(
+      survival::Surv(t, d) ~ x1,
+      data = bdf, weights = bw, dist = "weibull",
+      theta = c(mu = 0.05, nu = 0.8, 0), fit = TRUE
+    )
+  })
+  bs <- hzr_bootstrap(fit, n_boot = 10, fraction = 0.5, seed = 7)
+  expect_gt(bs$n_success, 0)
+  expect_equal(bs$n_failed, 0)
+})
+
 
 # =========================================================================
 # hzr_competing_risks tests


### PR DESCRIPTION
Sibling of the weights fix in #50. `hzr_bootstrap()` reconstructed the original
data with `eval(cl$data, parent.frame())`, which raises "object not found" when
the original `data` symbol is no longer in scope (e.g. the fit was built inside a
helper that has since returned) — bootstrap then failed before the resample loop.

### Why not just use `object$data`
The refit re-runs the **original call** (formula / `Surv` parsing) against a
resampled data.frame, so it needs the full frame's named columns. `object$data`
only carried `time`/`status`/`x`/`weights`, so it can't drive the refit.

### Fix
- `hazard()` now stores the evaluated model frame on **`object$data$frame`**
  (formula path; `NULL` for raw-vector calls).
- `hzr_bootstrap()` resamples that stored frame; falls back to
  `eval(cl$data, parent.frame())` only for objects fitted before the frame was
  stored (backward compat).
- Regression test builds a weighted fit entirely inside `local({...})` so **both**
  the `data` and `weights` symbols are out of scope, then asserts
  `n_success > 0`, `n_failed == 0`. Verified red before the fix
  (`eval(cl$data, parent.frame())`: object 'bdf' not found).

**Verification:** full suite 0 failures, 1303 passing, 2 pre-existing skips; lintr clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)