### PR TITLE
fix: correct misleading multi-start RNG comment + document n_starts

### DIFF
--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -74,6 +74,10 @@ NULL
 #' @details
 #' Control parameters:
 #' - `maxit`: Maximum iterations (default 1000)
+#' - `n_starts`: Number of optimization starts for multiphase fits (default 5).
+#'   Starts after the first perturb the initial values with random noise drawn
+#'   from the ambient RNG stream; call `set.seed()` before fitting for
+#'   reproducible results.
 #' - `reltol`: Relative parameter change tolerance (default 1e-5)
 #' - `abstol`: Absolute gradient norm tolerance (default 1e-6)
 #' - `method`: Optimization method: "bfgs" or "nm" (default "bfgs")

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -75,7 +75,7 @@ NULL
 #' Control parameters:
 #' - `maxit`: Maximum iterations (default 1000)
 #' - `n_starts`: Number of optimization starts for multiphase fits (default 5).
-#'   Starts after the first perturb the initial values with random noise drawn
+#'   Each start after the first adds random noise to the initial values, drawn
 #'   from the ambient RNG stream; call `set.seed()` before fitting for
 #'   reproducible results.
 #' - `reltol`: Relative parameter change tolerance (default 1e-5)

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1264,7 +1264,7 @@
       theta_try <- theta_start_optim
     } else {
       # Random perturbation of the starting values, drawn from the ambient RNG
-      # stream (not internally seeded).  Call set.seed() before the fit for
+      # stream (not internally seeded). Call set.seed() before fitting for
       # reproducible multi-start results.
       theta_try <- theta_start_optim +
         stats::rnorm(length(theta_start_optim), sd = 0.5)

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1263,7 +1263,9 @@
     if (start_i == 1L) {
       theta_try <- theta_start_optim
     } else {
-      # Deterministic perturbation seeded from start index for reproducibility
+      # Random perturbation of the starting values, drawn from the ambient RNG
+      # stream (not internally seeded).  Call set.seed() before the fit for
+      # reproducible multi-start results.
       theta_try <- theta_start_optim +
         stats::rnorm(length(theta_start_optim), sd = 0.5)
     }

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -89,7 +89,7 @@ Control parameters:
 \itemize{
 \item \code{maxit}: Maximum iterations (default 1000)
 \item \code{n_starts}: Number of optimization starts for multiphase fits (default 5).
-Starts after the first perturb the initial values with random noise drawn
+Each start after the first adds random noise to the initial values, drawn
 from the ambient RNG stream; call \code{set.seed()} before fitting for
 reproducible results.
 \item \code{reltol}: Relative parameter change tolerance (default 1e-5)

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -88,6 +88,10 @@ optimize to produce fitted estimates.
 Control parameters:
 \itemize{
 \item \code{maxit}: Maximum iterations (default 1000)
+\item \code{n_starts}: Number of optimization starts for multiphase fits (default 5).
+Starts after the first perturb the initial values with random noise drawn
+from the ambient RNG stream; call \code{set.seed()} before fitting for
+reproducible results.
 \item \code{reltol}: Relative parameter change tolerance (default 1e-5)
 \item \code{abstol}: Absolute gradient norm tolerance (default 1e-6)
 \item \code{method}: Optimization method: "bfgs" or "nm" (default "bfgs")


### PR DESCRIPTION
## Summary
- The multiphase multi-start loop comment claimed the perturbation was "deterministic" and "seeded from start index for reproducibility", but the code draws from the ambient RNG with no `set.seed()` — starts 2..n are random unless the caller seeds first.
- Established convention (every multi-start test already calls `set.seed()` first) is caller-side seeding, so the honest fix is to **describe the actual behavior**, not change it. Changing to `withr::with_seed(start_i)` would add a dependency and alter results in all seeded tests.
- Reworded the internal comment; documented the previously-undocumented `n_starts` control parameter (multiphase, default 5) with the `set.seed()` reproducibility contract.

Comment/docs only — **no behavior change**. Pre-existing on both `main` and `dev`.

## Test Plan
- [x] `test-wald.R` (multi-start fit) green: FAIL 0 / PASS 23
- [x] `man/hazard.Rd` regenerated cleanly (only the `n_starts` item added)