### PR TITLE
feat: hardened Hessian inversion + conditioning diagnostics (Hessian stability Layer 1)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,7 +91,7 @@
   inversion layer; analytic Hessians (more accurate standard errors) follow
   in subsequent releases.
 
-## New features
+## Documentation
 
 * `vignette("fitting-hazard-models")` gains an **Interval and left censoring**
   section covering: status coding reference (`-1`/`0`/`1`/`2`), a cardiac

--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,20 @@
   `g = dG/dt` internal consistency, CDF sanity, and stability at extreme
   `t_half`.
 
+## Improvements
+
+* **Hardened Hessian inversion for standard errors (Phase 7c).**
+  Post-fit variance-covariance estimation now symmetrizes the Hessian,
+  checks its reciprocal condition number, inverts via Cholesky with a
+  `solve()` fallback for non-positive-definite Hessians, and guards
+  non-positive variances instead of silently emitting `NaN` standard
+  errors. Ill-conditioned, non-positive-definite, and non-finite Hessians
+  now raise specific, named warnings, and fits carry `rcond` / `pd`
+  diagnostics that `summary()` surfaces as a note when a fit is flagged.
+  This closes the "12+-parameter Hessian stability" hardening item for the
+  inversion layer; analytic Hessians (more accurate standard errors) follow
+  in subsequent releases.
+
 ## New features
 
 * `vignette("fitting-hazard-models")` gains an **Interval and left censoring**

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -442,6 +442,8 @@ hazard <- function(formula = NULL,
     fit_state$converged <- (optim_result$convergence == 0)
     fit_state$se <- .hzr_safe_se_from_vcov(optim_result$vcov)
     fit_state$vcov <- optim_result$vcov
+    fit_state$rcond <- optim_result$rcond
+    fit_state$pd <- optim_result$pd
     fit_state$counts <- optim_result$counts
     fit_state$message <- optim_result$message
     # Store optimizer metadata for predict/summary
@@ -472,6 +474,8 @@ hazard <- function(formula = NULL,
     fit_state$converged <- (optim_result$convergence == 0)
     fit_state$se <- .hzr_safe_se_from_vcov(optim_result$vcov)
     fit_state$vcov <- optim_result$vcov
+    fit_state$rcond <- optim_result$rcond
+    fit_state$pd <- optim_result$pd
     fit_state$counts <- optim_result$counts
     fit_state$message <- optim_result$message
   }

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1147,7 +1147,9 @@ summary.hazard <- function(object, ...) {
 #'
 #' Formatted console display of [summary.hazard()] output: distribution,
 #' phase list (for multiphase), coefficient table with standard errors,
-#' and log-likelihood.  S3 dispatch only -- users call `print(summary(fit))`
+#' and log-likelihood.  When the post-fit Hessian is ill-conditioned or not
+#' positive-definite, a note is printed warning that the standard errors may
+#' be unreliable.  S3 dispatch only -- users call `print(summary(fit))`
 #' rather than invoking this directly.
 #'
 #' @param x A `summary.hazard` object returned by [summary.hazard()].

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1134,6 +1134,8 @@ summary.hazard <- function(object, ...) {
     message = object$fit$message,
     coefficients = coef_table,
     has_vcov = !is.null(vcov_mat) && is.matrix(vcov_mat),
+    rcond = object$fit$rcond,
+    pd = object$fit$pd,
     phases = object$spec$phases
   )
 
@@ -1183,6 +1185,15 @@ print.summary.hazard <- function(x, ...) {
   }
   if (!is.null(x$log_lik) && !is.na(x$log_lik)) {
     cat("  log-lik:     ", format(x$log_lik, digits = 6), "\n")
+  }
+  if (!is.null(x$rcond) && !is.na(x$rcond) && x$rcond < .hzr_rcond_tol) {
+    cat("  Note: Hessian ill-conditioned (rcond = ",
+        format(x$rcond, digits = 3),
+        "); standard errors may be unreliable.\n", sep = "")
+  }
+  if (!is.null(x$pd) && !is.na(x$pd) && !isTRUE(x$pd)) {
+    cat("  Note: Hessian not positive-definite at the optimum; ",
+        "standard errors may be unreliable.\n", sep = "")
   }
   if (!is.null(x$counts)) {
     fn_count <- x$counts[["function"]] %||% x$counts[["fn"]] %||% NA_integer_

--- a/R/hessian-invert.R
+++ b/R/hessian-invert.R
@@ -57,6 +57,7 @@ NULL
       warning("Hessian not invertible; standard errors unavailable")
       return(list(vcov = NA, rcond = rc, pd = NA))
     }
+    warning("Hessian is not positive-definite at the optimum; standard errors may be unreliable")
   }
   dimnames(vcov) <- dimnames(H)  # chol2inv() drops names
 

--- a/R/hessian-invert.R
+++ b/R/hessian-invert.R
@@ -62,7 +62,7 @@ NULL
 
   # (5) Non-positive-variance guard
   d <- diag(vcov)
-  bad <- !is.finite(d) | d < 0
+  bad <- !is.finite(d) | d <= 0
   if (any(bad)) {
     warning("Non-positive variance estimates; the optimum may not be a proper maximum")
     vcov[bad, ] <- NA_real_

--- a/R/hessian-invert.R
+++ b/R/hessian-invert.R
@@ -1,0 +1,73 @@
+#' @keywords internal
+NULL
+
+# hessian-invert.R -- Numerically stable Hessian inversion with diagnostics.
+
+# Reciprocal-condition warning threshold (~1.5e-8). Shared by .hzr_safe_solve()
+# and the summary() diagnostic note so they never drift apart.
+.hzr_rcond_tol <- .Machine$double.eps^0.5
+
+#' Stable Hessian inversion with conditioning diagnostics
+#'
+#' Inverts a negative-log-likelihood Hessian into a variance-covariance
+#' matrix, hardening against the ill-conditioning that arises at high
+#' parameter counts.  Symmetrizes the input, checks the reciprocal condition
+#' number, inverts via Cholesky (with a \code{solve()} fallback for non-PD
+#' Hessians), and guards non-positive variances.  Emits a named warning for
+#' every degenerate path.
+#'
+#' @param H Square numeric Hessian of the negative log-likelihood.
+#' @param tol Reciprocal-condition warning threshold.
+#' @return A list with:
+#'   \code{vcov} (the variance-covariance matrix, or \code{NA} on failure;
+#'   diagonals with non-positive variance, and their rows/cols, set to
+#'   \code{NA}); \code{rcond} (reciprocal condition number of the symmetrized
+#'   Hessian, \code{NA} if unavailable); \code{pd} (\code{TRUE} if the Hessian
+#'   was positive-definite, \code{FALSE} if inverted via fallback, \code{NA}
+#'   if not invertible).
+#' @noRd
+.hzr_safe_solve <- function(H, tol = .hzr_rcond_tol) {
+  # (1) Non-finite / non-matrix guard
+  if (is.null(H) || !is.matrix(H) || anyNA(H) || any(!is.finite(H))) {
+    warning("Hessian contains non-finite entries; standard errors unavailable")
+    return(list(vcov = NA, rcond = NA_real_, pd = NA))
+  }
+
+  # (2) Symmetrize (numDeriv Hessians are only symmetric to Richardson tol)
+  H <- (H + t(H)) / 2
+
+  # (3) Conditioning check
+  rc <- tryCatch(rcond(H), error = function(e) NA_real_)
+  if (is.na(rc) || rc < tol) {
+    warning(sprintf(
+      "Hessian is ill-conditioned (rcond = %.3g); standard errors may be unreliable",
+      rc
+    ))
+  }
+
+  # (4) Stable inversion: Cholesky (PD) with solve() fallback (non-PD)
+  ch <- tryCatch(chol(H), error = function(e) NULL)
+  if (!is.null(ch)) {
+    pd <- TRUE
+    vcov <- chol2inv(ch)
+  } else {
+    pd <- FALSE
+    vcov <- tryCatch(solve(H), error = function(e) NULL)
+    if (is.null(vcov)) {
+      warning("Hessian not invertible; standard errors unavailable")
+      return(list(vcov = NA, rcond = rc, pd = NA))
+    }
+  }
+  dimnames(vcov) <- dimnames(H)  # chol2inv() drops names
+
+  # (5) Non-positive-variance guard
+  d <- diag(vcov)
+  bad <- !is.finite(d) | d < 0
+  if (any(bad)) {
+    warning("Non-positive variance estimates; the optimum may not be a proper maximum")
+    vcov[bad, ] <- NA_real_
+    vcov[, bad] <- NA_real_
+  }
+
+  list(vcov = vcov, rcond = rc, pd = pd)
+}

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -138,16 +138,11 @@ NULL
     error = function(e) NA
   )
 
-  vcov <- if (!anyNA(hess_result)) {
-    tryCatch(
-      solve(hess_result),
-      error = function(e) {
-        warning("Hessian not invertible; standard errors unavailable")
-        NA
-      }
-    )
+  # Hardened inversion + conditioning diagnostics (Layer 1).
+  inv <- if (is.matrix(hess_result)) {
+    .hzr_safe_solve(hess_result)
   } else {
-    NA
+    list(vcov = NA, rcond = NA_real_, pd = NA)
   }
 
   list(
@@ -157,6 +152,8 @@ NULL
     counts = result$counts,
     message = result$message,
     hessian = hess_result,
-    vcov = vcov
+    vcov = inv$vcov,
+    rcond = inv$rcond,
+    pd = inv$pd
   )
 }

--- a/inst/dev/HESSIAN-STABILITY-DESIGN.md
+++ b/inst/dev/HESSIAN-STABILITY-DESIGN.md
@@ -1,0 +1,195 @@
+# Hessian Stability at 12+ Parameters — Design
+
+**Status:** Approved design (2026-06-03); pending implementation plan.
+**Roadmap row:** DEVELOPMENT-PLAN.md §7c — "Hessian stability at 12+
+parameters" (was: *Passing, fragile*).
+**Branch model:** all work on `dev` → v1.1.0 (`1.1.0.9000`).
+
+## Problem
+
+Standard errors are computed by inverting a post-fit Hessian. The single
+shared chokepoint is `.hzr_optim_generic()` in `R/optimizer.R`, called by
+all five distribution families (exponential, Weibull, log-logistic,
+log-normal, multiphase). Today it does:
+
+```r
+hess <- numDeriv::hessian(objective, par)   # negative log-likelihood
+vcov <- solve(hess)                          # bare inversion
+```
+
+At 12+ free parameters (multiphase + covariates; e.g. the
+`hm.death.AVC.deciles` 13-parameter fit) this is fragile:
+
+- `numDeriv::hessian()` is only symmetric to Richardson tolerance;
+  asymmetry alone destabilizes `solve()` at high dimension.
+- A near-singular or non-positive-definite Hessian either throws (→ generic
+  "not invertible" warning, `NA` SEs) or silently returns garbage / negative
+  variances that become `NaN` SEs downstream with no signal.
+- No conditioning diagnostic is surfaced, so "passing but borderline" is
+  invisible to the user and untested.
+
+## Goals
+
+1. **Robust + loud (universal).** Never silently emit garbage SEs. Detect
+   and *name* every degenerate path (ill-conditioned, non-PD, non-finite,
+   negative-variance). Use a numerically stable inversion. No user-facing
+   API signature change.
+2. **More accurate SEs (per family).** Replace the numerical Hessian with an
+   analytic Hessian as the production inversion input for all five families,
+   validated against numDeriv and against parameterization scale-invariance.
+
+The SAS `.lst` reference for the 13-parameter fit is pursued on a **parallel,
+externally-gated track** (PV1 / CCF `hazard` 4.4.6). This design does not
+depend on it; validation here is in-package and CRAN-safe.
+
+## Non-goals (adjacent rows, explicitly excluded)
+
+- **P1 #5** — `vcov.hazard()` "invalid 'nrow' value" on fixed-shape fits.
+  Separate parser/S3 bug (PRE-CRAN-PARITY-INVENTORY.md).
+- **P2 #11** — CoE-projected vcov SE mismatch vs SAS (R returns raw
+  inverse-Hessian on the free-parameter submatrix; SAS projects onto the
+  conservation manifold). Different row; not conditioning.
+
+These are noted only so the work stays scoped; touching them is out of band.
+
+## Architecture — two layers at the chokepoint
+
+```
+.hzr_optim_generic(objective, gradient, theta_start, hessian_fn = NULL, ...)
+   │
+   ├─ optim() → MLE                              (unchanged)
+   ├─ H = hessian_fn(par)        if supplied     ← LAYER 2 (per-family, opt-in)
+   │     else numDeriv::hessian(objective, par)  (existing fallback)
+   │
+   └─ {vcov, rcond, pd} = .hzr_safe_solve(H)     ← LAYER 1 (universal)
+```
+
+Both layers operate on the **internal** parameterization, upstream of:
+- each family's delta-method `J` transform to natural scale
+  (e.g. `R/likelihood-weibull.R` ~L528), and
+- the multiphase free→full NA-expansion (`R/likelihood-multiphase.R` ~L1338).
+
+None of that downstream code changes. Approach A (approved): Layer 1 ships
+first and universally; Layer 2 rolls out per family, each gated by tests.
+
+## Layer 1 — `.hzr_safe_solve(H)`
+
+New internal helper (in `R/optimizer.R` or a small `R/hessian-invert.R`).
+Input: raw Hessian of the negative log-likelihood. Output:
+`list(vcov, rcond, pd)`. Steps, in order:
+
+1. **Symmetrize.** `H <- (H + t(H)) / 2`. Always safe; removes
+   Richardson-tolerance asymmetry.
+2. **Finiteness guard.** If `anyNA(H) || any(!is.finite(H))` →
+   `vcov = NA`, warn `"Hessian contains non-finite entries; standard
+   errors unavailable"`. Preserves today's NA contract.
+3. **Conditioning check.** `rc <- rcond(H)`. If `rc < tol`
+   (`tol = .Machine$double.eps^0.5 ≈ 1.5e-8`) → warn, naming the value:
+   `"Hessian is ill-conditioned (rcond = <rc>); standard errors may be
+   unreliable"`. **Policy: still return the numbers** (do not withhold SEs
+   when ill-conditioned) — the user is warned, not denied.
+4. **Stable inversion.** Try `chol2inv(chol(H))` (valid + stable iff `H` is
+   positive-definite, the expected case at an interior minimum of the NLL;
+   `pd <- TRUE`). On `chol()` failure (non-PD) → `pd <- FALSE`, fall back to
+   `tryCatch(solve(H), ...)`; if that throws → `vcov = NA` + warning.
+5. **Negative-variance guard.** If `any(diag(vcov) < 0)` → warn
+   `"Non-positive variance estimates; the optimum may not be a proper
+   maximum"`; set offending diagonals and their rows/cols to `NA` (no
+   silent `NaN` SEs downstream).
+6. **Return** `list(vcov, rcond = rc, pd)`. The chokepoint attaches `rcond`
+   and `pd` to the fit result.
+
+**Thresholds (confirmed):** `rcond` warn threshold `1.5e-8`;
+warn-but-still-return policy when ill-conditioned.
+
+## Layer 2 — analytic Hessians (production input, per family)
+
+**Plumbing.** `.hzr_optim_generic` gains `hessian_fn = NULL`. When non-NULL,
+`H <- hessian_fn(par)` on the internal scale; else numDeriv as today. Each
+`.hzr_optim_*` wrapper builds a closure over its data/masks and passes it —
+mirroring how `gradient` is already threaded. For multiphase, `hessian_fn`
+returns the **free×free** block (respecting `free_mask`, derived on free
+params directly to avoid wasted hypergeometric evaluations); the existing
+NA-expansion is untouched.
+
+**Coverage contract (fail-loud).** A family's analytic Hessian ships as
+production input **only** for the censoring/counting-process/weights
+branches where *both* the gradient and the Hessian are analytic. numDeriv
+remains the input for any branch not yet converted. Completing remaining
+**analytic-gradient** gaps is in-scope as a forcing function; the end-state
+target is full analytic coverage, reached incrementally, never half-shipped.
+
+**Rollout order (one PR each, each gated by the §Validation cross-check
+before becoming prod input):**
+
+1. **Exponential** — 1 shape param + covariates. Pattern-setter; validates
+   the `hessian_fn` plumbing end to end.
+2. **Weibull** — 2 params (`alpha`, `psi` internal) + covariates; existing
+   delta-method `J` maps to natural scale unchanged.
+3. **Log-logistic** — 2 params + covariates; all censoring types +
+   counting-process `H(stop) − H(start)` + weights.
+4. **Log-normal** — as log-logistic.
+5. **Multiphase** — the payload. Second derivatives of the additive
+   multiphase NLL w.r.t. `{t_half, ν, m/η, μ}` per phase + covariates,
+   including **G3 hypergeometric** second-order shape terms, reusing the
+   per-phase machinery the analytic gradient already builds. CoE-constrained
+   and fixed-shape fits invert the free-parameter block only.
+
+## Validation (CRAN-safe; no external `.lst`)
+
+Added per family as each analytic Hessian lands:
+
+**(a) Analytic-vs-numDeriv cross-check — the gate.** On a representative
+fit, assert `analytic_H ≈ numDeriv::hessian(objective)` elementwise on the
+internal scale, relative tolerance `1e-4` (tight Richardson settings on the
+numDeriv reference). An analytic Hessian does not become prod input until
+this passes. Mirrors the existing analytic-gradient-vs-`numDeriv::grad`
+regression pattern.
+
+**(b) Scale-invariance / self-consistency.** Refit with a covariate linearly
+rescaled (`x → x/100`), push through the delta-method `J`, assert
+natural-scale SEs match the unscaled fit within tolerance. Exercises the
+property that is fragile at high dimension.
+
+**(c) 13-parameter anchor.** Dedicated regression on the
+`hm.death.AVC.deciles`-style 13-param multiphase fit: converges,
+`pd == TRUE`, `rcond` above the warn threshold, all SEs finite and positive,
+analytic-vs-numDeriv agree. This flips the §7c row from "passing, fragile"
+to "covered."
+
+**(d) Layer-1 unit tests.** Hand-constructed matrices: near-singular
+(ill-conditioned warning + still returns), non-PD (Cholesky fallback +
+negative-variance NA-guard + warning), non-finite (NA + warning). Pin
+Layer 1 independently of any fit.
+
+## Diagnostics surface (additive, minimal)
+
+- `fit$fit$rcond`, `fit$fit$pd` stored from Layer 1.
+- `summary.hazard()` prints one line **only when flagged**, e.g.
+  `Note: Hessian ill-conditioned (rcond = 3.2e-11); standard errors may be
+  unreliable.` Clean fits print nothing new.
+- No change to `vcov.hazard()` / `coef()` / `predict()` signatures.
+
+## PR sequencing (all on `dev` → v1.1.0)
+
+1. **PR-1** — Layer 1 + diagnostics + Layer-1 unit tests + 13-param anchor
+   (using today's numDeriv Hessian). Closes the actual fragility; may justify
+   flipping the row status on its own.
+2. **PR-2** — `hessian_fn` plumbing + Exponential analytic Hessian + cross-
+   check & invariance tests.
+3. **PR-3** — Weibull.
+4. **PR-4** — Log-logistic.
+5. **PR-5** — Log-normal.
+6. **PR-6** — Multiphase analytic Hessian (G3 second-derivative payload) +
+   full 13-param cross-check.
+
+Each PR (2–6): close any in-scope analytic-gradient gap, add the analytic
+Hessian, gate on the cross-check, add a NEWS entry under the existing
+`# TemporalHazard 1.1.0.9000` heading.
+
+## Parity-tolerance handling
+
+When a family's analytic Hessian becomes prod input, re-run the SAS parity
+SE asserts (`tolerance = 5e-3`). A shift *toward* the SAS value is expected
+(analytic should be more accurate than numDeriv). A shift *away* is a bug
+signal. Document per-PR; never silently re-tolerance.

--- a/inst/dev/PLAN-hessian-stability-layer1.md
+++ b/inst/dev/PLAN-hessian-stability-layer1.md
@@ -1,0 +1,598 @@
+# Hessian Stability — Layer 1 (PR-1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the bare `solve()` Hessian inversion with a hardened,
+diagnostic-emitting helper so no fit silently returns garbage standard
+errors, and surface `rcond`/`pd` diagnostics on the fit and in `summary()`.
+
+**Architecture:** Add `.hzr_safe_solve()` (symmetrize → rcond check →
+Cholesky-with-`solve()`-fallback → negative-variance guard, with named
+warnings) in a new focused file `R/hessian-invert.R`. Call it from the single
+shared chokepoint `.hzr_optim_generic()` in `R/optimizer.R`; thread the
+returned `rcond`/`pd` into `fit_state` in `R/hazard_api.R`; print a flagged
+note in `print.summary.hazard()`.
+
+**Tech Stack:** R, testthat (edition 3), roxygen2, devtools. Base-R numerics
+only (`rcond`, `chol`, `chol2inv`, `solve`); no new dependencies.
+
+**Scope:** This is PR-1 of the 6-PR sequence in
+`inst/dev/HESSIAN-STABILITY-DESIGN.md`. It covers **Layer 1 only** (universal
+inversion hardening + diagnostics). The analytic Hessians (PRs 2–6) are out
+of scope here and get their own plans. Branch: `dev` → v1.1.0.
+
+---
+
+## File Structure
+
+- **Create** `R/hessian-invert.R` — `.hzr_safe_solve()` + the shared
+  `.hzr_rcond_tol` threshold constant. Single responsibility: turn a raw
+  Hessian into a vcov + diagnostics.
+- **Create** `tests/testthat/test-hessian-invert.R` — unit tests for
+  `.hzr_safe_solve()` against hand-built matrices.
+- **Modify** `R/optimizer.R` (~L129–162) — call `.hzr_safe_solve()` instead
+  of `solve()`; add `rcond`/`pd` to the returned list.
+- **Modify** `R/hazard_api.R` (~L444 and ~L474) — copy `rcond`/`pd` into
+  `fit_state` in both fit branches.
+- **Modify** `R/hazard_api.R` (`summary.hazard` ~L1121, `print.summary.hazard`
+  ~L1180) — store and print the flagged diagnostic note.
+- **Create** `tests/testthat/test-hessian-stability.R` — the 13-parameter
+  multiphase anchor regression.
+- **Modify** `NEWS.md` — Layer-1 entry under `# TemporalHazard 1.1.0.9000`.
+
+**Design note (surfacing policy):** Layer 1 warnings for the *new* degenerate
+paths (ill-conditioned, non-positive variance, non-finite) are NOT added to
+the muffle list in `.hzr_run_fit_safely()` (`R/hazard_api.R` ~L404–415), so
+they surface at fit time — this is the "loud" goal. The pre-existing
+`"Hessian not invertible; standard errors unavailable"` string is reused on
+the non-invertible fallback path and stays muffled by the existing handler.
+`summary()` additionally shows a note for users who fit elsewhere.
+
+---
+
+## Task 1: `.hzr_safe_solve()` helper
+
+**Files:**
+- Create: `R/hessian-invert.R`
+- Test: `tests/testthat/test-hessian-invert.R`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/testthat/test-hessian-invert.R`:
+
+```r
+test_that("well-conditioned PD Hessian inverts cleanly with diagnostics", {
+  H <- matrix(c(4, 1, 1, 3), 2, 2)
+  res <- expect_silent(.hzr_safe_solve(H))
+  expect_equal(res$vcov, solve(H), tolerance = 1e-10)
+  expect_true(res$pd)
+  expect_true(is.finite(res$rcond) && res$rcond > 1e-3)
+})
+
+test_that("asymmetric input is symmetrized before inversion", {
+  H_sym  <- matrix(c(4, 1, 1, 3), 2, 2)
+  H_asym <- matrix(c(4, 0, 2, 3), 2, 2)  # (H+t(H))/2 == H_sym
+  expect_equal(.hzr_safe_solve(H_asym)$vcov, solve(H_sym), tolerance = 1e-10)
+})
+
+test_that("ill-conditioned Hessian warns by name but still returns numbers", {
+  H <- matrix(c(1, 1, 1, 1 + 1e-12), 2, 2)
+  expect_warning(res <- .hzr_safe_solve(H), "ill-conditioned")
+  expect_true(is.matrix(res$vcov))
+  expect_true(is.finite(res$rcond))
+})
+
+test_that("non-PD Hessian falls back to solve and reports pd = FALSE", {
+  # Indefinite (eigenvalues +/-): chol() fails, solve() succeeds.
+  H <- matrix(c(1, 2, 2, 1), 2, 2)
+  res <- suppressWarnings(.hzr_safe_solve(H))
+  expect_false(res$pd)
+  expect_true(is.matrix(res$vcov))
+})
+
+test_that("non-positive variance diagonals are NA'd with a warning", {
+  # Indefinite matrix whose inverse has a negative diagonal entry.
+  H <- matrix(c(1, 2, 2, 1), 2, 2)
+  expect_warning(res <- .hzr_safe_solve(H), "[Nn]on-positive variance")
+  expect_true(any(is.na(diag(res$vcov))))
+})
+
+test_that("non-finite Hessian returns NA vcov with a warning", {
+  H <- matrix(c(1, NA, NA, 1), 2, 2)
+  expect_warning(res <- .hzr_safe_solve(H), "non-finite")
+  expect_true(all(is.na(res$vcov)))
+  expect_true(is.na(res$pd))
+})
+
+test_that("scalar / non-matrix input is handled as non-finite", {
+  expect_warning(res <- .hzr_safe_solve(NA), "non-finite")
+  expect_true(all(is.na(res$vcov)))
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-invert.R")'`
+Expected: FAIL — `could not find function ".hzr_safe_solve"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `R/hessian-invert.R`:
+
+```r
+#' @keywords internal
+NULL
+
+# hessian-invert.R -- Numerically stable Hessian inversion with diagnostics.
+
+# Reciprocal-condition warning threshold (~1.5e-8). Shared by .hzr_safe_solve()
+# and the summary() diagnostic note so they never drift apart.
+.hzr_rcond_tol <- .Machine$double.eps^0.5
+
+#' Stable Hessian inversion with conditioning diagnostics
+#'
+#' Inverts a negative-log-likelihood Hessian into a variance-covariance
+#' matrix, hardening against the ill-conditioning that arises at high
+#' parameter counts.  Symmetrizes the input, checks the reciprocal condition
+#' number, inverts via Cholesky (with a \code{solve()} fallback for non-PD
+#' Hessians), and guards non-positive variances.  Emits a named warning for
+#' every degenerate path.
+#'
+#' @param H Square numeric Hessian of the negative log-likelihood.
+#' @param tol Reciprocal-condition warning threshold.
+#' @return A list with:
+#'   \code{vcov} (the variance-covariance matrix, or \code{NA} on failure;
+#'   diagonals with non-positive variance, and their rows/cols, set to
+#'   \code{NA}); \code{rcond} (reciprocal condition number of the symmetrized
+#'   Hessian, \code{NA} if unavailable); \code{pd} (\code{TRUE} if the Hessian
+#'   was positive-definite, \code{FALSE} if inverted via fallback, \code{NA}
+#'   if not invertible).
+#' @noRd
+.hzr_safe_solve <- function(H, tol = .hzr_rcond_tol) {
+  # (1) Non-finite / non-matrix guard
+  if (is.null(H) || !is.matrix(H) || anyNA(H) || any(!is.finite(H))) {
+    warning("Hessian contains non-finite entries; standard errors unavailable")
+    return(list(vcov = NA, rcond = NA_real_, pd = NA))
+  }
+
+  # (2) Symmetrize (numDeriv Hessians are only symmetric to Richardson tol)
+  H <- (H + t(H)) / 2
+
+  # (3) Conditioning check
+  rc <- tryCatch(rcond(H), error = function(e) NA_real_)
+  if (is.na(rc) || rc < tol) {
+    warning(sprintf(
+      "Hessian is ill-conditioned (rcond = %.3g); standard errors may be unreliable",
+      rc
+    ))
+  }
+
+  # (4) Stable inversion: Cholesky (PD) with solve() fallback (non-PD)
+  ch <- tryCatch(chol(H), error = function(e) NULL)
+  if (!is.null(ch)) {
+    pd <- TRUE
+    vcov <- chol2inv(ch)
+  } else {
+    pd <- FALSE
+    vcov <- tryCatch(solve(H), error = function(e) NULL)
+    if (is.null(vcov)) {
+      warning("Hessian not invertible; standard errors unavailable")
+      return(list(vcov = NA, rcond = rc, pd = NA))
+    }
+  }
+  dimnames(vcov) <- dimnames(H)  # chol2inv() drops names
+
+  # (5) Non-positive-variance guard
+  d <- diag(vcov)
+  bad <- !is.finite(d) | d < 0
+  if (any(bad)) {
+    warning("Non-positive variance estimates; the optimum may not be a proper maximum")
+    vcov[bad, ] <- NA_real_
+    vcov[, bad] <- NA_real_
+  }
+
+  list(vcov = vcov, rcond = rc, pd = pd)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-invert.R")'`
+Expected: PASS — all expectations pass, 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/hessian-invert.R tests/testthat/test-hessian-invert.R
+git commit -m "feat: add .hzr_safe_solve() hardened Hessian inversion (Layer 1)"
+```
+
+---
+
+## Task 2: Wire `.hzr_safe_solve()` into the chokepoint
+
+**Files:**
+- Modify: `R/optimizer.R` (~L129–162)
+- Test: `tests/testthat/test-hessian-invert.R` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/testthat/test-hessian-invert.R`:
+
+```r
+test_that(".hzr_optim_generic returns rcond and pd diagnostics", {
+  set.seed(1)
+  n <- 200L
+  time <- rexp(n, rate = 0.5)
+  status <- rep(1L, n)
+  res <- .hzr_optim_generic(
+    logl_fn = .hzr_logl_exponential,
+    gradient_fn = .hzr_gradient_exponential,
+    time = time, status = status,
+    x = NULL, theta_start = c(log_rate = 0),
+    control = list(maxit = 200, reltol = 1e-8, abstol = 1e-8),
+    use_bounds = FALSE
+  )
+  expect_true(is.finite(res$rcond))
+  expect_true(isTRUE(res$pd))
+  expect_true(is.matrix(res$vcov) && all(is.finite(diag(res$vcov))))
+})
+```
+
+(Note: `theta_start` name/length follows the exponential parameterization;
+adjust the name only if `.hzr_logl_exponential` expects a different label —
+the value `0` and length 1 are correct for a covariate-free exponential fit.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-invert.R")'`
+Expected: FAIL — `res$rcond` is `NULL` (not yet returned by the chokepoint).
+
+- [ ] **Step 3: Replace the inversion block in `.hzr_optim_generic()`**
+
+In `R/optimizer.R`, replace the existing post-fit Hessian + vcov block
+(currently lines ~129–162, from the `# Post-fit Hessian for standard errors`
+comment through the final `list(...)` return) with:
+
+```r
+  # Post-fit Hessian for standard errors
+  hess_result <- tryCatch(
+    {
+      if (requireNamespace("numDeriv", quietly = TRUE)) {
+        numDeriv::hessian(objective, result$par)
+      } else {
+        NA
+      }
+    },
+    error = function(e) NA
+  )
+
+  # Hardened inversion + conditioning diagnostics (Layer 1).
+  inv <- if (is.matrix(hess_result)) {
+    .hzr_safe_solve(hess_result)
+  } else {
+    list(vcov = NA, rcond = NA_real_, pd = NA)
+  }
+
+  list(
+    par = result$par,
+    value = -result$value,
+    convergence = result$convergence,
+    counts = result$counts,
+    message = result$message,
+    hessian = hess_result,
+    vcov = inv$vcov,
+    rcond = inv$rcond,
+    pd = inv$pd
+  )
+}
+```
+
+(The guard `if (is.matrix(hess_result))` avoids a spurious "non-finite"
+warning when `numDeriv` is unavailable and `hess_result` is scalar `NA`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-invert.R")'`
+Expected: PASS — all expectations including the new diagnostics test.
+
+- [ ] **Step 5: Run the full optimizer-touching suites for regression**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_dir("tests/testthat", filter = "weibull|exponential|loglogistic|lognormal|multiphase|wald")'`
+Expected: 0 failures (vcov values unchanged for well-conditioned fits —
+`chol2inv` and `solve` agree to numerical tolerance).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add R/optimizer.R tests/testthat/test-hessian-invert.R
+git commit -m "feat: route .hzr_optim_generic vcov through .hzr_safe_solve; emit rcond/pd"
+```
+
+---
+
+## Task 3: Thread `rcond`/`pd` onto the fit object
+
+**Files:**
+- Modify: `R/hazard_api.R` (~L444 multiphase branch, ~L474 single-dist branch)
+- Test: `tests/testthat/test-hessian-stability.R` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-hessian-stability.R`:
+
+```r
+test_that("fit object carries rcond and pd diagnostics (weibull)", {
+  set.seed(2)
+  n <- 250L
+  dat <- data.frame(t = rweibull(n, shape = 1.4, scale = 3),
+                    d = rep(1L, n))
+  fit <- hazard(survival::Surv(t, d) ~ 1, data = dat, dist = "weibull",
+                fit = TRUE)
+  expect_true(is.finite(fit$fit$rcond))
+  expect_true(isTRUE(fit$fit$pd))
+})
+
+test_that("fit object carries rcond and pd diagnostics (multiphase)", {
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+    phases = list(early = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                                    fixed = "m"),
+                  constant = hzr_phase("constant")),
+    fit = TRUE, control = list(n_starts = 3, maxit = 500, conserve = TRUE)
+  )
+  expect_true(is.finite(fit$fit$rcond))
+  expect_false(is.null(fit$fit$pd))
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-stability.R")'`
+Expected: FAIL — `fit$fit$rcond` is `NULL`.
+
+- [ ] **Step 3: Copy diagnostics into `fit_state` (both branches)**
+
+In `R/hazard_api.R`, in the **multiphase** branch, immediately after the line
+`fit_state$vcov <- optim_result$vcov` (~L444), add:
+
+```r
+    fit_state$rcond <- optim_result$rcond
+    fit_state$pd <- optim_result$pd
+```
+
+In the **single-distribution** branch, immediately after the line
+`fit_state$vcov <- optim_result$vcov` (~L474), add the identical two lines:
+
+```r
+    fit_state$rcond <- optim_result$rcond
+    fit_state$pd <- optim_result$pd
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-stability.R")'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/hazard_api.R tests/testthat/test-hessian-stability.R
+git commit -m "feat: thread rcond/pd diagnostics onto the fit object"
+```
+
+---
+
+## Task 4: Flagged diagnostic note in `summary()`
+
+**Files:**
+- Modify: `R/hazard_api.R` (`summary.hazard` out-list ~L1121; `print.summary.hazard` ~L1180)
+- Test: `tests/testthat/test-hessian-stability.R` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/testthat/test-hessian-stability.R`:
+
+```r
+test_that("summary prints no Hessian note for a clean fit", {
+  set.seed(3)
+  dat <- data.frame(t = rweibull(250, 1.4, 3), d = rep(1L, 250))
+  fit <- hazard(survival::Surv(t, d) ~ 1, data = dat, dist = "weibull",
+                fit = TRUE)
+  out <- capture.output(print(summary(fit)))
+  expect_false(any(grepl("ill-conditioned|not positive-definite", out)))
+})
+
+test_that("summary prints a note when the fit is flagged ill-conditioned", {
+  s <- summary(structure(
+    list(spec = list(dist = "weibull", phases = NULL),
+         engine = "test",
+         fit = list(theta = c(a = 1), vcov = matrix(1, 1, 1),
+                    converged = TRUE, objective = -1,
+                    rcond = 1e-12, pd = TRUE),
+         data = list(time = 1:5, x = NULL),
+         call = quote(hazard())),
+    class = "hazard"))
+  out <- capture.output(print(s))
+  expect_true(any(grepl("ill-conditioned", out)))
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-stability.R")'`
+Expected: FAIL — the flagged-fit test finds no "ill-conditioned" line.
+
+- [ ] **Step 3: Store diagnostics in the summary object**
+
+In `R/hazard_api.R`, in `summary.hazard()`, add two fields to the `out <-
+list(...)` (after `has_vcov = ...`, ~L1132):
+
+```r
+    rcond = object$fit$rcond,
+    pd = object$fit$pd,
+```
+
+- [ ] **Step 4: Print the flagged note**
+
+In `print.summary.hazard()`, immediately after the log-lik block (the
+`if (!is.null(x$log_lik) ...)` block ending ~L1182), add:
+
+```r
+  if (!is.null(x$rcond) && !is.na(x$rcond) && x$rcond < .hzr_rcond_tol) {
+    cat("  Note: Hessian ill-conditioned (rcond = ",
+        format(x$rcond, digits = 3),
+        "); standard errors may be unreliable.\n", sep = "")
+  }
+  if (!is.null(x$pd) && !is.na(x$pd) && !isTRUE(x$pd)) {
+    cat("  Note: Hessian not positive-definite at the optimum; ",
+        "standard errors may be unreliable.\n", sep = "")
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-stability.R")'`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add R/hazard_api.R tests/testthat/test-hessian-stability.R
+git commit -m "feat: summary() prints a note when the Hessian is flagged"
+```
+
+---
+
+## Task 5: 13-parameter multiphase anchor regression
+
+**Files:**
+- Test: `tests/testthat/test-hessian-stability.R` (append)
+
+This is the row's named borderline case. It pins the post-Layer-1 behavior:
+the high-dimensional fit converges and produces finite, positive SEs with a
+recoverable conditioning diagnostic.
+
+- [ ] **Step 1: Write the anchor test**
+
+Append to `tests/testthat/test-hessian-stability.R`:
+
+```r
+test_that("13-parameter multiphase deciles fit is stable (anchor)", {
+  skip_on_cran()
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+
+  # A high-dimensional multiphase fit with covariates in both phases,
+  # exercising the 12+-parameter inversion path named in DEVELOPMENT-PLAN
+  # §7c ("hm.death.AVC.deciles").
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", formula = ~ age + female + inc_surg,
+                           t_half = 0.15, nu = 1.4, m = 1, fixed = "m"),
+      constant = hzr_phase("constant", formula = ~ age + female + inc_surg)
+    ),
+    fit = TRUE, control = list(n_starts = 3, maxit = 800, conserve = TRUE)
+  )
+
+  expect_true(fit$fit$converged)
+
+  free <- which(is.finite(diag(fit$fit$vcov)))
+  expect_gte(length(free), 12L)               # genuinely high-dimensional
+  se <- sqrt(diag(fit$fit$vcov)[free])
+  expect_true(all(is.finite(se)))             # no NaN/NA SEs on free params
+  expect_true(all(se > 0))                    # positive variances
+  expect_true(is.finite(fit$fit$rcond))       # conditioning was measured
+})
+```
+
+(Note: the exact covariate names `age`, `female`, `inc_surg` are columns of
+the shipped `avc` dataset used elsewhere in the suite, e.g.
+`test-phase-specific-covariates.R`. Verify column names with
+`names(avc)` during Step 2; substitute the dataset's actual covariate
+columns if any differ, keeping the free-parameter count ≥ 12.)
+
+- [ ] **Step 2: Run the anchor test**
+
+Run: `Rscript -e 'devtools::load_all("."); testthat::test_file("tests/testthat/test-hessian-stability.R")'`
+Expected: PASS. If it FAILS on `expect_gte(length(free), 12L)`, the chosen
+covariates yielded < 12 free params — add covariate columns until ≥ 12. If
+it FAILS on `pd`/`rcond`, that is a genuine finding: the fit is legitimately
+ill-conditioned (not a numDeriv artifact); per the design's open question,
+soften the anchor to `expect_warning(..., "ill-conditioned")` / assert the
+summary note instead of asserting cleanliness, and record the finding in the
+PR description.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/testthat/test-hessian-stability.R
+git commit -m "test: 13-parameter multiphase Hessian-stability anchor"
+```
+
+---
+
+## Task 6: NEWS entry + full check
+
+**Files:**
+- Modify: `NEWS.md`
+
+- [ ] **Step 1: Add the NEWS entry**
+
+In `NEWS.md`, under the existing `# TemporalHazard 1.1.0.9000 (development
+version)` heading, in the `## Bug fixes` (or a new `## Improvements`)
+subsection, add:
+
+```markdown
+* **Hardened Hessian inversion for standard errors (Phase 7c).**
+  Post-fit variance-covariance estimation now symmetrizes the Hessian,
+  checks its reciprocal condition number, inverts via Cholesky with a
+  `solve()` fallback for non-positive-definite Hessians, and guards
+  non-positive variances instead of silently emitting `NaN` standard
+  errors. Ill-conditioned, non-positive-definite, and non-finite Hessians
+  now raise specific, named warnings, and fits carry `rcond` / `pd`
+  diagnostics that `summary()` surfaces as a note when a fit is flagged.
+  This closes the "12+-parameter Hessian stability" hardening item for the
+  inversion layer; analytic Hessians (more accurate standard errors) follow
+  in subsequent releases.
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `Rscript -e 'devtools::test()'`
+Expected: 0 failures across the whole suite.
+
+- [ ] **Step 3: Run R CMD check (lint/Rd/usage sanity)**
+
+Run: `Rscript -e 'devtools::check(args = c("--no-manual"), quiet = TRUE)'`
+Expected: 0 errors / 0 warnings; the pre-existing single NOTE only. (Confirm
+no new `object_usage_linter` notes from the new internal `.hzr_safe_solve` /
+`.hzr_rcond_tol` symbols.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add NEWS.md
+git commit -m "docs: NEWS entry for hardened Hessian inversion (Layer 1)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage (Layer 1 portion of HESSIAN-STABILITY-DESIGN.md):**
+  symmetrize (T1 §2), finiteness guard (T1 §1), rcond check + warn-but-return
+  policy (T1 §3), Cholesky-with-fallback (T1 §4), negative-variance guard
+  (T1 §5), `rcond`/`pd` on fit (T3), summary note (T4), Layer-1 unit tests
+  (T1), 13-param anchor (T5). Analytic-Hessian items (cross-check / scale-
+  invariance / `hessian_fn` plumbing) are deferred to PRs 2–6 by design and
+  intentionally absent here.
+- **Threshold DRY:** `.hzr_rcond_tol` is defined once in `R/hessian-invert.R`
+  and reused by both `.hzr_safe_solve()` and `print.summary.hazard()`.
+- **No production regression:** for well-conditioned fits, `chol2inv(chol(H))`
+  equals `solve(H)` to numerical tolerance, so existing vcov/SE-asserting
+  tests (e.g. `test-wald.R`, `test-sas-parity.R`) should not move; Task 2
+  Step 5 verifies this before the change propagates further.

--- a/man/print.summary.hazard.Rd
+++ b/man/print.summary.hazard.Rd
@@ -17,7 +17,9 @@
 \description{
 Formatted console display of \code{\link[=summary.hazard]{summary.hazard()}} output: distribution,
 phase list (for multiphase), coefficient table with standard errors,
-and log-likelihood.  S3 dispatch only -- users call \code{print(summary(fit))}
+and log-likelihood.  When the post-fit Hessian is ill-conditioned or not
+positive-definite, a note is printed warning that the standard errors may
+be unreliable.  S3 dispatch only -- users call \code{print(summary(fit))}
 rather than invoking this directly.
 }
 \keyword{internal}

--- a/tests/testthat/test-hessian-invert.R
+++ b/tests/testthat/test-hessian-invert.R
@@ -1,0 +1,47 @@
+test_that("well-conditioned PD Hessian inverts cleanly with diagnostics", {
+  H <- matrix(c(4, 1, 1, 3), 2, 2)
+  res <- expect_silent(.hzr_safe_solve(H))
+  expect_equal(res$vcov, solve(H), tolerance = 1e-10)
+  expect_true(res$pd)
+  expect_true(is.finite(res$rcond) && res$rcond > 1e-3)
+})
+
+test_that("asymmetric input is symmetrized before inversion", {
+  H_sym  <- matrix(c(4, 1, 1, 3), 2, 2)
+  H_asym <- matrix(c(4, 0, 2, 3), 2, 2)  # (H+t(H))/2 == H_sym
+  expect_equal(.hzr_safe_solve(H_asym)$vcov, solve(H_sym), tolerance = 1e-10)
+})
+
+test_that("ill-conditioned Hessian warns by name but still returns numbers", {
+  H <- matrix(c(1, 1, 1, 1 + 1e-12), 2, 2)
+  expect_warning(res <- .hzr_safe_solve(H), "ill-conditioned")
+  expect_true(is.matrix(res$vcov))
+  expect_true(is.finite(res$rcond))
+})
+
+test_that("non-PD Hessian falls back to solve and reports pd = FALSE", {
+  # Indefinite (eigenvalues +/-): chol() fails, solve() succeeds.
+  H <- matrix(c(1, 2, 2, 1), 2, 2)
+  res <- suppressWarnings(.hzr_safe_solve(H))
+  expect_false(res$pd)
+  expect_true(is.matrix(res$vcov))
+})
+
+test_that("non-positive variance diagonals are NA'd with a warning", {
+  # Indefinite matrix whose inverse has a negative diagonal entry.
+  H <- matrix(c(1, 2, 2, 1), 2, 2)
+  expect_warning(res <- .hzr_safe_solve(H), "[Nn]on-positive variance")
+  expect_true(any(is.na(diag(res$vcov))))
+})
+
+test_that("non-finite Hessian returns NA vcov with a warning", {
+  H <- matrix(c(1, NA, NA, 1), 2, 2)
+  expect_warning(res <- .hzr_safe_solve(H), "non-finite")
+  expect_true(all(is.na(res$vcov)))
+  expect_true(is.na(res$pd))
+})
+
+test_that("scalar / non-matrix input is handled as non-finite", {
+  expect_warning(res <- .hzr_safe_solve(NA), "non-finite")
+  expect_true(all(is.na(res$vcov)))
+})

--- a/tests/testthat/test-hessian-invert.R
+++ b/tests/testthat/test-hessian-invert.R
@@ -45,3 +45,9 @@ test_that("scalar / non-matrix input is handled as non-finite", {
   expect_warning(res <- .hzr_safe_solve(NA), "non-finite")
   expect_true(all(is.na(res$vcov)))
 })
+
+test_that("explicit tol drives the ill-conditioned threshold", {
+  H <- matrix(c(4, 1, 1, 3), 2, 2)        # well-conditioned (rcond ~ 0.4)
+  expect_silent(.hzr_safe_solve(H, tol = 1e-8))      # below rcond: no warning
+  expect_warning(.hzr_safe_solve(H, tol = 0.5), "ill-conditioned")  # above rcond: warns
+})

--- a/tests/testthat/test-hessian-invert.R
+++ b/tests/testthat/test-hessian-invert.R
@@ -53,6 +53,7 @@ test_that("explicit tol drives the ill-conditioned threshold", {
 })
 
 test_that(".hzr_optim_generic returns rcond and pd diagnostics", {
+  skip_if_not_installed("numDeriv")
   set.seed(1)
   n <- 200L
   time <- rexp(n, rate = 0.5)

--- a/tests/testthat/test-hessian-invert.R
+++ b/tests/testthat/test-hessian-invert.R
@@ -51,3 +51,21 @@ test_that("explicit tol drives the ill-conditioned threshold", {
   expect_silent(.hzr_safe_solve(H, tol = 1e-8))      # below rcond: no warning
   expect_warning(.hzr_safe_solve(H, tol = 0.5), "ill-conditioned")  # above rcond: warns
 })
+
+test_that(".hzr_optim_generic returns rcond and pd diagnostics", {
+  set.seed(1)
+  n <- 200L
+  time <- rexp(n, rate = 0.5)
+  status <- rep(1L, n)
+  res <- .hzr_optim_generic(
+    logl_fn = .hzr_logl_exponential,
+    gradient_fn = .hzr_gradient_exponential,
+    time = time, status = status,
+    x = NULL, theta_start = c(log_rate = 0),
+    control = list(maxit = 200, reltol = 1e-8, abstol = 1e-8),
+    use_bounds = FALSE
+  )
+  expect_true(is.finite(res$rcond))
+  expect_true(isTRUE(res$pd))
+  expect_true(is.matrix(res$vcov) && all(is.finite(diag(res$vcov))))
+})

--- a/tests/testthat/test-hessian-invert.R
+++ b/tests/testthat/test-hessian-invert.R
@@ -28,10 +28,23 @@ test_that("non-PD Hessian falls back to solve and reports pd = FALSE", {
 })
 
 test_that("non-positive variance diagonals are NA'd with a warning", {
-  # Indefinite matrix whose inverse has a negative diagonal entry.
+  # Indefinite matrix whose inverse has a negative diagonal entry. A non-PD
+  # Hessian emits both the positive-definiteness and the non-positive-variance
+  # warning, so capture all warnings rather than matching a single one.
   H <- matrix(c(1, 2, 2, 1), 2, 2)
-  expect_warning(res <- .hzr_safe_solve(H), "[Nn]on-positive variance")
+  w <- testthat::capture_warnings(res <- .hzr_safe_solve(H))
+  expect_true(any(grepl("[Nn]on-positive variance", w)))
   expect_true(any(is.na(diag(res$vcov))))
+})
+
+test_that("non-PD Hessian with positive inverse-variances warns about positive-definiteness", {
+  # Indefinite (eigenvalues +1, -3) but the inverse diagonal is +1/3 on both
+  # entries, so the non-positive-variance guard does NOT fire -- this isolates
+  # the positive-definiteness warning on its own.
+  H <- matrix(c(-1, 2, 2, -1), 2, 2)
+  expect_warning(res <- .hzr_safe_solve(H), "positive-definite")
+  expect_false(res$pd)
+  expect_true(all(diag(res$vcov) > 0))
 })
 
 test_that("non-finite Hessian returns NA vcov with a warning", {

--- a/tests/testthat/test-hessian-stability.R
+++ b/tests/testthat/test-hessian-stability.R
@@ -45,3 +45,18 @@ test_that("summary prints a note when the fit is flagged ill-conditioned", {
   out <- capture.output(print(s))
   expect_true(any(grepl("ill-conditioned", out)))
 })
+
+test_that("summary prints a note when the fit is not positive-definite", {
+  s <- summary(structure(
+    list(spec = list(dist = "weibull", phases = NULL),
+         engine = "test",
+         fit = list(theta = c(a = 1), vcov = matrix(1, 1, 1),
+                    converged = TRUE, objective = -1,
+                    rcond = 0.5, pd = FALSE),
+         data = list(time = 1:5, x = NULL),
+         call = quote(hazard())),
+    class = "hazard"))
+  out <- capture.output(print(s))
+  expect_true(any(grepl("not positive-definite", out)))
+  expect_false(any(grepl("ill-conditioned", out)))  # rcond=0.5 is healthy
+})

--- a/tests/testthat/test-hessian-stability.R
+++ b/tests/testthat/test-hessian-stability.R
@@ -22,3 +22,26 @@ test_that("fit object carries rcond and pd diagnostics (multiphase)", {
   expect_true(is.finite(fit$fit$rcond))
   expect_false(is.null(fit$fit$pd))
 })
+
+test_that("summary prints no Hessian note for a clean fit", {
+  set.seed(3)
+  dat <- data.frame(t = rweibull(250, 1.4, 3), d = rep(1L, 250))
+  fit <- hazard(survival::Surv(t, d) ~ 1, data = dat, dist = "weibull",
+                fit = TRUE, theta = c(mu = 1, nu = 1))
+  out <- capture.output(print(summary(fit)))
+  expect_false(any(grepl("ill-conditioned|not positive-definite", out)))
+})
+
+test_that("summary prints a note when the fit is flagged ill-conditioned", {
+  s <- summary(structure(
+    list(spec = list(dist = "weibull", phases = NULL),
+         engine = "test",
+         fit = list(theta = c(a = 1), vcov = matrix(1, 1, 1),
+                    converged = TRUE, objective = -1,
+                    rcond = 1e-12, pd = TRUE),
+         data = list(time = 1:5, x = NULL),
+         call = quote(hazard())),
+    class = "hazard"))
+  out <- capture.output(print(s))
+  expect_true(any(grepl("ill-conditioned", out)))
+})

--- a/tests/testthat/test-hessian-stability.R
+++ b/tests/testthat/test-hessian-stability.R
@@ -1,0 +1,24 @@
+test_that("fit object carries rcond and pd diagnostics (weibull)", {
+  set.seed(2)
+  n <- 250L
+  dat <- data.frame(t = rweibull(n, shape = 1.4, scale = 3),
+                    d = rep(1L, n))
+  fit <- hazard(survival::Surv(t, d) ~ 1, data = dat, dist = "weibull",
+                theta = c(mu = 1, nu = 1), fit = TRUE)
+  expect_true(is.finite(fit$fit$rcond))
+  expect_true(isTRUE(fit$fit$pd))
+})
+
+test_that("fit object carries rcond and pd diagnostics (multiphase)", {
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+    phases = list(early = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                                    fixed = "m"),
+                  constant = hzr_phase("constant")),
+    fit = TRUE, control = list(n_starts = 3, maxit = 500, conserve = TRUE)
+  )
+  expect_true(is.finite(fit$fit$rcond))
+  expect_false(is.null(fit$fit$pd))
+})

--- a/tests/testthat/test-hessian-stability.R
+++ b/tests/testthat/test-hessian-stability.R
@@ -10,6 +10,7 @@ test_that("fit object carries rcond and pd diagnostics (weibull)", {
 })
 
 test_that("fit object carries rcond and pd diagnostics (multiphase)", {
+  set.seed(101)
   data(avc, package = "TemporalHazard")
   avc <- na.omit(avc)
   fit <- hazard(
@@ -63,6 +64,7 @@ test_that("summary prints a note when the fit is not positive-definite", {
 
 test_that("13-parameter multiphase deciles fit is stable (anchor)", {
   skip_on_cran()
+  set.seed(102)
   data(avc, package = "TemporalHazard")
   avc <- na.omit(avc)
 

--- a/tests/testthat/test-hessian-stability.R
+++ b/tests/testthat/test-hessian-stability.R
@@ -60,3 +60,45 @@ test_that("summary prints a note when the fit is not positive-definite", {
   expect_true(any(grepl("not positive-definite", out)))
   expect_false(any(grepl("ill-conditioned", out)))  # rcond=0.5 is healthy
 })
+
+test_that("13-parameter multiphase deciles fit is stable (anchor)", {
+  skip_on_cran()
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+
+  # Continuous covariates in `avc` span wildly different scales (age up to
+  # ~286, op_age into the thousands). Unscaled, the multiphase Hessian picks
+  # up non-finite entries and collapses to < 12 identifiable directions, so
+  # scale them as any analyst fitting this model would. This is what makes
+  # the high-dimensional inversion path a *meaningful* (not degenerate) test.
+  for (cl in c("age", "opmos", "op_age", "inc_surg")) {
+    avc[[cl]] <- as.numeric(scale(avc[[cl]]))
+  }
+
+  # A high-dimensional multiphase fit with covariates in both phases,
+  # exercising the 12+-parameter inversion path named in DEVELOPMENT-PLAN
+  # §7c ("hm.death.AVC.deciles"). Six covariates per phase plus the phase
+  # shape parameters drive the free-parameter count past 12.
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf",
+                           formula = ~ age + mal + inc_surg + opmos +
+                             op_age + status,
+                           t_half = 0.15, nu = 1.4, m = 1, fixed = "m"),
+      constant = hzr_phase("constant",
+                           formula = ~ age + mal + inc_surg + opmos +
+                             op_age + status)
+    ),
+    fit = TRUE, control = list(n_starts = 3, maxit = 800, conserve = TRUE)
+  )
+
+  expect_true(fit$fit$converged)
+
+  free <- which(is.finite(diag(fit$fit$vcov)))
+  expect_gte(length(free), 12L)               # genuinely high-dimensional
+  se <- sqrt(diag(fit$fit$vcov)[free])
+  expect_true(all(is.finite(se)))             # no NaN/NA SEs on free params
+  expect_true(all(se > 0))                    # positive variances
+  expect_true(is.finite(fit$fit$rcond))       # conditioning was measured
+})

--- a/tests/testthat/test-multiphase-likelihood.R
+++ b/tests/testthat/test-multiphase-likelihood.R
@@ -383,7 +383,7 @@ test_that("3-covariate phase does not emit mu_j * phi_j recycling warning", {
     "avc dataset not available"
   )
 
-  expect_no_warning(
+  w <- testthat::capture_warnings(
     fit <- hazard(
       survival::Surv(int_dead, dead) ~ 1, data = avc,
       dist = "multiphase",
@@ -397,4 +397,7 @@ test_that("3-covariate phase does not emit mu_j * phi_j recycling warning", {
       control = list(n_starts = 1L, maxit = 10L)
     )
   )
+  # The bug under test produced a vector-recycling warning; assert it is absent.
+  # (An incidental non-PD-Hessian warning at maxit = 10 is unrelated and allowed.)
+  expect_false(any(grepl("not a multiple|longer object length", w)))
 })

--- a/vignettes/inference-diagnostics.qmd
+++ b/vignettes/inference-diagnostics.qmd
@@ -176,7 +176,11 @@ The delta-method CIs `predict(se.fit = TRUE)` returns are fast and
 asymptotically correct, but they lean on the Hessian-derived
 parameter vcov — which can mislead when the likelihood surface is
 poorly behaved near the MLE (boundary fits, near-degenerate
-parameter combinations, small samples). Bootstrap resampling is the
+parameter combinations, small samples). The package flags these
+cases for you: each fit carries `rcond` and `pd` diagnostics, and
+`summary()` prints a note (with a matching warning at fit time) when
+the Hessian is ill-conditioned or not positive-definite — a strong
+signal to prefer the bootstrap. Bootstrap resampling is the
 robust alternative: refit the model on each resampled dataset,
 collect the resulting parameter and prediction values, and read the
 empirical 2.5th / 97.5th percentiles as the 95% CI. It's

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -461,9 +461,18 @@ scale, wrapped by `.hzr_optim_generic()`.  Key features:
   `control$n_starts`).  The run with the highest log-likelihood is kept.
 - **Feasibility guard**: any parameter vector where $m < 0$ **and**
   $\nu < 0$ for the same phase returns $-\infty$ immediately.
-- **Post-fit Hessian**: the numerical Hessian at the solution is inverted
-  to produce the variance-covariance matrix.  Standard errors are
-  $\sqrt{\text{diag}(\hat{V})}$.
+- **Post-fit Hessian**: the numerical Hessian of the negative
+  log-likelihood at the solution is inverted to produce the
+  variance-covariance matrix $\hat{V}$, with standard errors
+  $\sqrt{\text{diag}(\hat{V})}$.  The inversion is hardened against the
+  ill-conditioning that arises at high parameter counts: the Hessian is
+  symmetrized, its reciprocal condition number is checked, and it is
+  inverted via a Cholesky factorization, with a general `solve()` fallback
+  when the Hessian is not positive-definite.  Non-positive variance
+  estimates are flagged rather than silently returned as `NaN` standard
+  errors.  Each fit carries `rcond` (reciprocal condition number) and `pd`
+  (positive-definiteness) diagnostics; `summary()` prints a note, and a
+  warning is raised, when a fit is ill-conditioned or not positive-definite.
 
 
 # Covariates and Phase-Specific Formulas {#sec-covariates}


### PR DESCRIPTION
## Summary

Layer 1 (PR-1 of 6) of the §7c "Hessian stability at 12+ parameters" hardening effort. Closes the *inversion-layer* fragility; analytic Hessians (more accurate SEs) follow in PRs 2–6.

- **`.hzr_safe_solve()`** (`R/hessian-invert.R`): symmetrize → reciprocal-condition check → Cholesky inversion with `solve()` fallback for non-PD Hessians → non-positive-variance guard. Emits **specific, named warnings** for every degenerate path (ill-conditioned / non-PD / non-finite) instead of silently returning garbage or `NaN` SEs.
- Wired into the single shared optimizer chokepoint **`.hzr_optim_generic()`**, so all five distribution families benefit; it now returns `rcond`/`pd` alongside `vcov`.
- `rcond`/`pd` threaded onto the fit object; **`summary()`** prints a one-line note only when a fit is flagged (clean fits print nothing new).
- Tests: Layer-1 unit tests, optimizer diagnostics test, and a **13-parameter multiphase anchor** (the named borderline case). The anchor honestly captures that the `avc` 13-param model sits at the identifiability edge (`pd = FALSE`, `rcond ≈ 8.6e-9`): unidentified directions are correctly `NA`'d while the 13 identified params get valid finite, positive SEs — the hardening working as intended.

Design + plan committed under `inst/dev/` (`HESSIAN-STABILITY-DESIGN.md`, `PLAN-hessian-stability-layer1.md`).

## Test Plan
- [x] Full suite: **FAIL 0 / PASS 1370** (`NOT_CRAN=true devtools::test()`)
- [x] `devtools::check(--no-manual)`: **0 errors / 0 warnings / 0 notes**
- [x] No SE/vcov regression — Weibull delta-method `J`, multiphase free→full expansion, `predict-cl` free-vcov, and SAS-parity SE asserts all verified intact
- [ ] Reviewer to confirm the deliberately-loud non-PD warnings in deliberately-unconverged tests are acceptable (they are the intended diagnostic)