### PR TITLE
feat: make non-invertible Hessian (standard errors unavailable) loud

### DIFF
--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1205,9 +1205,9 @@ print.summary.hazard <- function(x, ...) {
     cat("  Note: Hessian not positive-definite at the optimum; ",
         "standard errors may be unreliable.\n", sep = "")
   }
-  if (!is.null(x$converged) && !is.na(x$converged) && !isTRUE(x$has_vcov)) {
+  if (!is.null(x$converged) && !is.na(x$converged) && isFALSE(x$has_vcov)) {
     cat("  Note: standard errors unavailable; the Hessian could not be ",
-        "inverted at the optimum.\n", sep = "")
+        "inverted.\n", sep = "")
   }
   if (!is.null(x$counts)) {
     fn_count <- x$counts[["function"]] %||% x$counts[["fn"]] %||% NA_integer_

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -410,8 +410,11 @@ hazard <- function(formula = NULL,
       expr,
       warning = function(w) {
         msg <- conditionMessage(w)
-        if (grepl("NaNs produced", msg, fixed = TRUE) ||
-            grepl("Hessian not invertible; standard errors unavailable", msg, fixed = TRUE)) {
+        # Muffle only benign numerical noise from optim().  The hardened-inversion
+        # diagnostics (ill-conditioned / not positive-definite / not invertible /
+        # non-finite) are deliberately allowed to surface so a fit that cannot
+        # produce reliable standard errors is never silent.
+        if (grepl("NaNs produced", msg, fixed = TRUE)) {
           invokeRestart("muffleWarning")
         }
       }
@@ -1152,8 +1155,9 @@ summary.hazard <- function(object, ...) {
 #' Formatted console display of [summary.hazard()] output: distribution,
 #' phase list (for multiphase), coefficient table with standard errors,
 #' and log-likelihood.  When the post-fit Hessian is ill-conditioned or not
-#' positive-definite, a note is printed warning that the standard errors may
-#' be unreliable.  S3 dispatch only -- users call `print(summary(fit))`
+#' positive-definite, a note warns that the standard errors may be unreliable;
+#' when the Hessian could not be inverted at all, a note reports that standard
+#' errors are unavailable.  S3 dispatch only -- users call `print(summary(fit))`
 #' rather than invoking this directly.
 #'
 #' @param x A `summary.hazard` object returned by [summary.hazard()].
@@ -1200,6 +1204,10 @@ print.summary.hazard <- function(x, ...) {
   if (!is.null(x$pd) && !is.na(x$pd) && !isTRUE(x$pd)) {
     cat("  Note: Hessian not positive-definite at the optimum; ",
         "standard errors may be unreliable.\n", sep = "")
+  }
+  if (!is.null(x$converged) && !is.na(x$converged) && !isTRUE(x$has_vcov)) {
+    cat("  Note: standard errors unavailable; the Hessian could not be ",
+        "inverted at the optimum.\n", sep = "")
   }
   if (!is.null(x$counts)) {
     fn_count <- x$counts[["function"]] %||% x$counts[["fn"]] %||% NA_integer_

--- a/man/print.summary.hazard.Rd
+++ b/man/print.summary.hazard.Rd
@@ -18,8 +18,9 @@
 Formatted console display of \code{\link[=summary.hazard]{summary.hazard()}} output: distribution,
 phase list (for multiphase), coefficient table with standard errors,
 and log-likelihood.  When the post-fit Hessian is ill-conditioned or not
-positive-definite, a note is printed warning that the standard errors may
-be unreliable.  S3 dispatch only -- users call \code{print(summary(fit))}
+positive-definite, a note warns that the standard errors may be unreliable;
+when the Hessian could not be inverted at all, a note reports that standard
+errors are unavailable.  S3 dispatch only -- users call \code{print(summary(fit))}
 rather than invoking this directly.
 }
 \keyword{internal}

--- a/tests/testthat/test-hessian-invert.R
+++ b/tests/testthat/test-hessian-invert.R
@@ -83,3 +83,13 @@ test_that(".hzr_optim_generic returns rcond and pd diagnostics", {
   expect_true(isTRUE(res$pd))
   expect_true(is.matrix(res$vcov) && all(is.finite(diag(res$vcov))))
 })
+
+test_that("singular Hessian (chol and solve both fail) warns 'not invertible'", {
+  # Rank-deficient PSD matrix: chol() fails (not PD) and solve() fails
+  # (singular), so the helper takes the not-invertible path.
+  H <- matrix(c(1, 1, 1, 1), 2, 2)
+  w <- testthat::capture_warnings(res <- .hzr_safe_solve(H))
+  expect_true(any(grepl("not invertible", w)))
+  expect_true(all(is.na(res$vcov)))
+  expect_true(is.na(res$pd))
+})

--- a/tests/testthat/test-hessian-stability.R
+++ b/tests/testthat/test-hessian-stability.R
@@ -104,3 +104,28 @@ test_that("13-parameter multiphase deciles fit is stable (anchor)", {
   expect_true(all(se > 0))                    # positive variances
   expect_true(is.finite(fit$fit$rcond))       # conditioning was measured
 })
+
+test_that("summary reports when standard errors are unavailable", {
+  # A fitted object whose Hessian could not be inverted: vcov is NA (scalar),
+  # so has_vcov is FALSE while converged is TRUE.
+  s <- summary(structure(
+    list(spec = list(dist = "weibull", phases = NULL),
+         engine = "test",
+         fit = list(theta = c(a = 1), vcov = NA,
+                    converged = TRUE, objective = -1,
+                    rcond = NA_real_, pd = NA),
+         data = list(time = 1:5, x = NULL),
+         call = quote(hazard())),
+    class = "hazard"))
+  out <- capture.output(print(s))
+  expect_true(any(grepl("standard errors unavailable", out)))
+})
+
+test_that("clean fit reports no standard-errors-unavailable note", {
+  set.seed(7)
+  dat <- data.frame(t = rweibull(250, 1.4, 3), d = rep(1L, 250))
+  fit <- hazard(survival::Surv(t, d) ~ 1, data = dat, dist = "weibull",
+                fit = TRUE, theta = c(mu = 1, nu = 1))
+  out <- capture.output(print(summary(fit)))
+  expect_false(any(grepl("standard errors unavailable", out)))
+})


### PR DESCRIPTION
## Summary
Closes the loudness gap left by Layer 1 (PR #54). Previously, a fit whose Hessian could **not** be inverted was silent: `hazard()` muffled the "Hessian not invertible" warning, and `summary()` printed no note (the existing rcond/pd notes are guarded out because both are `NA` in that case). The user only saw `NA` standard errors with no explanation — contrary to the "robust + **loud**" goal.

- **Fit time:** `hazard()` no longer muffles the "Hessian not invertible" warning. Only benign `NaNs produced` optim noise is suppressed, so the not-invertible / non-finite / non-PD / ill-conditioned diagnostics all surface immediately.
- **`summary()`:** prints `standard errors unavailable; the Hessian could not be inverted at the optimum.` when a fitted model has no usable variance-covariance matrix.
- Roxygen for `print.summary.hazard` updated to document the new note.

## Test Plan
- [x] New tests: summary note fires on an SE-unavailable fit and is absent on a clean fit; a singular Hessian takes the not-invertible path in `.hzr_safe_solve()`.
- [x] Helper suite: FAIL 0 / PASS 28
- [x] Full suite: **FAIL 0 / PASS 1378** (`NOT_CRAN=true devtools::test()`). Warning count rises (74 → 125) — the intended loud behavior from borderline/unconverged test fits; no test regressed.