### PR TITLE
fix: correct Weibull event hazard to match its cumulative hazard (Form A)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,17 @@
 
 ## Bug fixes
 
+* **Weibull event hazard was inconsistent with its cumulative hazard.**
+  `.hzr_logl_weibull()` defined the event hazard as `mu*nu*t^(nu-1)*exp(eta)`
+  while the cumulative hazard was `(mu*t)^nu*exp(eta)`; the former is missing a
+  `mu^(nu-1)` factor (the exact derivative is `nu*mu^nu*t^(nu-1)*exp(eta) =
+  (nu/t)*H`, Form A as in the C/SAS HAZARD reference). The natural-scale
+  log-likelihood and its analytic gradient (`d/dmu`, `d/dnu` event terms) are
+  corrected to match. Pure event/right-censored fits were already correct (they
+  use the self-consistent internal reparameterization); the visible effect is on
+  **mixed event + interval/left-censored Weibull fits**, which delegate to this
+  likelihood and previously optimized a slightly mis-specified event term.
+
 * **`hzr_bootstrap()` was non-functional for weighted fits** (Phase 7c).
   The resample loop rewired only `data` in the refit call, leaving the
   original `weights` argument bound to a symbol in the *caller's* frame.

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -61,9 +61,11 @@ NULL
 #' matrix is attached as \code{"hessian"}.
 #'
 #' @details
-#' The Weibull hazard model is parameterized as:
+#' The Weibull hazard model is parameterized via its cumulative hazard
+#' \eqn{H(t | x) = (\mu t)^{\nu} \exp(\eta)}, so the hazard is its exact
+#' derivative:
 #'
-#' \deqn{h(t | x) = \mu \nu t^{\nu-1} \exp(\eta)}
+#' \deqn{h(t | x) = \nu \mu^{\nu} t^{\nu-1} \exp(\eta) = (\nu / t)\, H(t | x)}
 #'
 #' where:
 #' - \eqn{\mu > 0} is scale (MU)
@@ -237,10 +239,12 @@ NULL
 #' The log-likelihood is:
 #'   L = sum(delta_i * log h(t_i)) - sum(H(t_i))
 #'
-#' where h is hazard and H is cumulative hazard. Derivatives are:
+#' where h(t) = nu * mu^nu * t^(nu-1) * exp(eta) and H(t) = (mu*t)^nu * exp(eta)
+#' (so log h = log(nu) + nu*log(mu) + (nu-1)*log(t) + eta). Derivatives are:
 #'
-#' dL/dmu  = sum(delta_i / mu) - (nu / mu) * sum(H(t_i))
-#' dL/dnu  = sum(delta_i / nu) + sum(delta_i * log(t_i)) - sum(log(mu * t_i) * H(t_i))
+#' dL/dmu  = (nu / mu) * sum(delta_i) - (nu / mu) * sum(H(t_i))
+#' dL/dnu  = sum(delta_i / nu) + sum(delta_i) * log(mu) + sum(delta_i * log(t_i))
+#'           - sum(log(mu * t_i) * H(t_i))
 #' dL/dbeta_j = sum(delta_i * x_ij) - sum(H(t_i) * x_ij)  = t(X) %*% (delta - H)
 #'
 #' @noRd

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -140,7 +140,10 @@ NULL
   }
 
   # Event-time hazard/cumulative-hazard (exact events only).
-  haz_event <- mu * nu * (time ^ (nu - 1)) * exp(eta)
+  # Hazard is the exact derivative of the cumulative hazard H = (mu t)^nu e^eta:
+  #   h = dH/dt = nu * mu^nu * t^(nu-1) * e^eta = (nu / t) * H
+  # (Form A, matching the C/SAS HAZARD reference where HF = MU * dG/dt.)
+  haz_event <- nu * mu ^ nu * (time ^ (nu - 1)) * exp(eta)
   cumhaz_event <- (mu * time) ^ nu * exp(eta)
 
   # Lower/upper cumulative hazards for censoring contributions.
@@ -284,7 +287,7 @@ NULL
       eta <- rep(0, n)
     }
 
-    haz <- mu * nu * (time ^ (nu - 1)) * exp(eta)
+    haz <- nu * mu ^ nu * (time ^ (nu - 1)) * exp(eta)
     cumhaz <- (mu * time) ^ nu * exp(eta)
   }
 
@@ -305,17 +308,22 @@ NULL
   w_cumhaz_net <- weights * (cumhaz - cumhaz_start)
 
   # ===== Gradient w.r.t. mu (scale parameter) =====
-  # dH(t)/dmu = (nu / mu) * H(t), so dL/dmu picks up a matching
-  # contribution at start: -(nu/mu) * (H(stop) - H(start)).
-  grad[1] <- sum(w_status) / mu - (nu / mu) * sum(w_cumhaz_net)
+  # log h = log(nu) + nu*log(mu) + (nu-1)*log(t) + eta, so the event term
+  # contributes d log h/dmu = nu/mu.  dH(t)/dmu = (nu / mu) * H(t), so the
+  # cumulative term subtracts -(nu/mu) * (H(stop) - H(start)).
+  grad[1] <- (nu / mu) * (sum(w_status) - sum(w_cumhaz_net))
 
   # ===== Gradient w.r.t. nu (shape parameter) =====
   # dH(t)/dnu = log(mu*t) * H(t).  When start = 0, H(start) = 0 and the
   # log(mu*start) term is undefined; `ifelse` picks the well-defined 0
   # limit there.
+  # log h = log(nu) + nu*log(mu) + (nu-1)*log(t) + eta, so the event term
+  # contributes d log h/dnu = 1/nu + log(mu) + log(t); the log(mu) piece is
+  # constant across rows.
   log_mu_start <- ifelse(start_vec > 0, log(mu * start_vec), 0)
   d_nu_start <- weights * log_mu_start * cumhaz_start
   grad[2] <- sum(w_status) / nu +
+             sum(w_status) * log(mu) +
              sum(w_status * log(time)) -
              (sum(log(mu * time) * weights * cumhaz) - sum(d_nu_start))
 

--- a/tests/testthat/test-weibull-event-hazard.R
+++ b/tests/testthat/test-weibull-event-hazard.R
@@ -1,0 +1,32 @@
+# Regression tests for the Weibull event-hazard / cumulative-hazard consistency
+# bug: haz_event must equal dH/dt for H = (mu*t)^nu*exp(eta), i.e.
+# h = nu*mu^nu*t^(nu-1)*exp(eta) = (nu/t)*H  (Form A, matching C/SAS HAZARD).
+
+test_that(".hzr_logl_weibull event hazard is consistent with its cumulative hazard", {
+  set.seed(11)
+  n <- 150
+  time <- rexp(n, 0.6) + 0.01
+  status <- rbinom(n, 1, 0.7)
+  mu <- 0.7
+  nu <- 1.6
+  cumhaz <- (mu * time)^nu                  # Form A cumulative hazard
+  haz <- nu * mu^nu * time^(nu - 1)         # correct hazard = dH/dt = (nu/t)*H
+  ll_expected <- sum(status * (log(haz) - cumhaz)) - sum((1 - status) * cumhaz)
+  ll_actual <- .hzr_logl_weibull(c(mu, nu), time, status)
+  expect_equal(ll_actual, ll_expected, tolerance = 1e-8)
+})
+
+test_that(".hzr_gradient_weibull matches numDeriv of the (corrected) log-likelihood", {
+  skip_if_not_installed("numDeriv")
+  set.seed(12)
+  n <- 120
+  x <- cbind(z = rnorm(n))
+  time <- rexp(n, 0.5) + 0.01
+  status <- rbinom(n, 1, 0.75)
+  theta <- c(mu = 0.8, nu = 1.4, z = 0.3)
+  ll <- .hzr_logl_weibull(theta, time, status, x = x, return_gradient = TRUE)
+  g_an <- attr(ll, "gradient")
+  obj <- function(th) .hzr_logl_weibull(th, time, status, x = x)
+  g_nd <- numDeriv::grad(obj, theta)
+  expect_equal(g_an, g_nd, tolerance = 1e-5)
+})


### PR DESCRIPTION
## Summary

Root-caused while scoping the Weibull analytic Hessian (PR-3): `.hzr_logl_weibull()` defined the event hazard inconsistently with its own cumulative hazard.

- `cumhaz = (mu*t)^nu * exp(eta)` (correct, Form A)
- `haz_event = mu*nu*t^(nu-1) * exp(eta)` (**wrong** — missing `mu^(nu-1)`)

`d/dt[(mu*t)^nu] = nu*mu^nu*t^(nu-1)`, so the correct event hazard is `nu*mu^nu*t^(nu-1)*exp(eta) = (nu/t)*H`. **Verified against the C/SAS HAZARD source of truth** (`src/llike/setlik.c:383-384`: `HF = MU*SG`, `CF = MU*G`, `SG = dG/dt` — same `MU` factors both; Weibull reduces to `H = exp(alpha+Xbeta)*t^gamma`, i.e. Form A).

Fixed the event hazard **and** the analytic gradient's event terms, which were *buggy-consistent* (matched the numerical derivative of the wrong LL):
- `d/dmu` event term: `sum(delta)/mu` → `(nu/mu)*sum(delta)`
- `d/dnu` event term: added the missing `+ sum(delta)*log(mu)`

## Impact
- ✅ **Event/right-censored fits unaffected** — they use the self-consistent internal `(alpha, psi)` reparameterization, which never touched the buggy code.
- 🐛 **Mixed event + interval/left-censored Weibull fits** delegate the whole dataset to this likelihood and previously optimized a mis-specified event term — now corrected.
- No golden fixtures change (all event/right, fit via the internal optimizer).

## Test Plan
- [x] New `test-weibull-event-hazard.R`: `h = dH/dt` consistency (was off by `(nu-1)*log(mu)*n_events`); analytic gradient vs numDeriv of the corrected LL.
- [x] Weibull-related suites green: gradient 13/13, weights 21/21, interval 15/15, repeating 8/8.
- [x] Full suite: **FAIL 0 / PASS 1395** (`NOT_CRAN=true devtools::test()`); new test file lint-clean.