### PR TITLE
fix: guard log(time) in Weibull gradient for right-censored time=0 rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,16 @@
 
 ## Bug fixes
 
+* **Weibull analytic gradient produced `NaN` for right-censored `time = 0` rows.**
+  `.hzr_gradient_weibull()` used an unguarded `log(time)` in the shape (`nu`)
+  score; a legal right-censored row at `time = 0` made `0 * -Inf = NaN`, which
+  poisoned the entire summed shape-gradient component (then silently zeroed by
+  the optimizer, harming convergence). `log(time)` is now guarded with
+  `log(pmax(time, .Machine$double.xmin))`, matching the analytic Hessian. The
+  other families were audited: exponential (no `log(time)` in the score),
+  log-normal (rejects `time = 0`), and multiphase (the decomposition clamps
+  `time`) are unaffected.
+
 * **Weibull event hazard was inconsistent with its cumulative hazard.**
   `.hzr_logl_weibull()` defined the event hazard as `mu*nu*t^(nu-1)*exp(eta)`
   while the cumulative hazard was `(mu*t)^nu*exp(eta)`; the former is missing a

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -325,12 +325,17 @@ NULL
   # log h = log(nu) + nu*log(mu) + (nu-1)*log(t) + eta, so the event term
   # contributes d log h/dnu = 1/nu + log(mu) + log(t); the log(mu) piece is
   # constant across rows.
+  # Guard log(time): a legal right-censored time = 0 row has w_status = 0 and
+  # cumhaz = 0, but an unguarded log(0) = -Inf turns those into 0 * -Inf = NaN,
+  # poisoning the entire summed nu (shape) gradient component (start is already
+  # guarded by the ifelse below).
+  log_t <- log(pmax(time, .Machine$double.xmin))
   log_mu_start <- ifelse(start_vec > 0, log(mu * start_vec), 0)
   d_nu_start <- weights * log_mu_start * cumhaz_start
   grad[2] <- sum(w_status) / nu +
              sum(w_status) * log(mu) +
-             sum(w_status * log(time)) -
-             (sum(log(mu * time) * weights * cumhaz) - sum(d_nu_start))
+             sum(w_status * log_t) -
+             (sum((log(mu) + log_t) * weights * cumhaz) - sum(d_nu_start))
 
   # ===== Gradient w.r.t. beta (covariate coefficients) =====
   if (n_shape < p && !is.null(x)) {

--- a/tests/testthat/test-weibull-event-hazard.R
+++ b/tests/testthat/test-weibull-event-hazard.R
@@ -30,3 +30,18 @@ test_that(".hzr_gradient_weibull matches numDeriv of the (corrected) log-likelih
   g_nd <- numDeriv::grad(obj, theta)
   expect_equal(g_an, g_nd, tolerance = 1e-5)
 })
+
+test_that(".hzr_gradient_weibull is finite for right-censored time = 0 rows", {
+  skip_if_not_installed("numDeriv")
+  set.seed(41)
+  n <- 60
+  time <- c(0, rexp(n - 1, 0.5) + 0.05)
+  status <- c(0L, rbinom(n - 1, 1, 0.7))
+  theta <- c(mu = 0.6, nu = 1.3)
+  ll <- .hzr_logl_weibull(theta, time, status, return_gradient = TRUE)
+  g_an <- attr(ll, "gradient")
+  expect_true(all(is.finite(g_an)))
+  obj <- function(th) .hzr_logl_weibull(th, time, status)
+  g_nd <- numDeriv::grad(obj, theta)
+  expect_equal(g_an, g_nd, tolerance = 1e-5)
+})


### PR DESCRIPTION
## Summary
Generalizes the log-logistic gradient fix from PR #61. Audited every family's analytic gradient for the unguarded-`log(time)` → `NaN`-on-right-censored-`time=0` pattern.

**Found + fixed — Weibull:** `.hzr_gradient_weibull()` used unguarded `log(time)` / `log(mu*time)` in the shape (`nu`) score. A legal right-censored row at `time = 0` (`w_status = 0`, `cumhaz = 0`) produced `0 * -Inf = NaN`. Because `grad[2]` is a sum over rows, one such row turned the entire shape-gradient component into `NaN`, which `.hzr_optim_generic` then silently zeros (`grad[!is.finite] <- 0`) — discarding every other row's contribution and harming convergence. Now uses `log(pmax(time, .Machine$double.xmin))`, matching the analytic Hessian (PR #60).

**Audited — clean, no change:**
- **Exponential** — constant hazard, no `log(time)` in the score.
- **Log-normal** — the LL rejects `status %in% {0,1} & time <= 0` (returns `Inf`), so right-censored `time = 0` is infeasible and the gradient is never reached.
- **Multiphase** — no direct `log(time)` in the gradient; the decomposition primitives clamp `time` via `pmax`. Confirmed by an end-to-end fit with a `time=0` right-censored row (converges, finite vcov).

## Test Plan
- [x] New regression test: Weibull gradient finite + matches `numDeriv::grad` (~1e-5) on a right-censored `time=0` dataset (was `NaN` before).
- [x] Confirmed pre-fix `NaN` → post-fix finite empirically.
- [x] Full suite: **FAIL 0 / PASS 1409** (`NOT_CRAN=true`); lint clean.