### PR TITLE
fix: theta/x conformance guards in exp/Weibull/log-logistic analytic Hessians

### DIFF
--- a/R/likelihood-exponential.R
+++ b/R/likelihood-exponential.R
@@ -294,7 +294,7 @@ NULL
   # Fail loud on inconsistent theta/x: a mismatch would otherwise yield a wrong
   # or non-conformant Hessian used for vcov without a clear error.
   p_cov <- length(theta) - 1L
-  n_x <- if (is.null(x)) 0L else ncol(x)
+  n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_exponential(): ncol(x) (", n_x, ") must equal the number ",
          "of covariate parameters in theta (", p_cov, ").", call. = FALSE)

--- a/R/likelihood-exponential.R
+++ b/R/likelihood-exponential.R
@@ -291,7 +291,15 @@ NULL
 
   log_lambda <- theta[1]
   lambda <- exp(log_lambda)
-  if (!is.null(x)) {
+  # Fail loud on inconsistent theta/x: a mismatch would otherwise yield a wrong
+  # or non-conformant Hessian used for vcov without a clear error.
+  p_cov <- length(theta) - 1L
+  n_x <- if (is.null(x)) 0L else ncol(x)
+  if (n_x != p_cov) {
+    stop(".hzr_hessian_exponential(): ncol(x) (", n_x, ") must equal the number ",
+         "of covariate parameters in theta (", p_cov, ").", call. = FALSE)
+  }
+  if (p_cov > 0L) {
     beta <- theta[2:length(theta)]
     eta <- as.numeric(x %*% beta)
   } else {

--- a/R/likelihood-exponential.R
+++ b/R/likelihood-exponential.R
@@ -294,6 +294,7 @@ NULL
   # Fail loud on inconsistent theta/x: a mismatch would otherwise yield a wrong
   # or non-conformant Hessian used for vcov without a clear error.
   p_cov <- length(theta) - 1L
+  if (!is.null(x)) x <- as.matrix(x)
   n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_exponential(): ncol(x) (", n_x, ") must equal the number ",

--- a/R/likelihood-loglogistic.R
+++ b/R/likelihood-loglogistic.R
@@ -363,6 +363,7 @@ NULL
   p_cov <- p - 2L
   # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
   # covariate rows/cols and yield a conformant-but-wrong vcov.
+  if (!is.null(x)) x <- as.matrix(x)
   n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_loglogistic(): ncol(x) (", n_x, ") must equal the number ",

--- a/R/likelihood-loglogistic.R
+++ b/R/likelihood-loglogistic.R
@@ -361,7 +361,14 @@ NULL
   beta <- exp(log_beta)
   p <- length(theta)
   p_cov <- p - 2L
-  has_cov <- p_cov > 0L && !is.null(x)
+  # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
+  # covariate rows/cols and yield a conformant-but-wrong vcov.
+  n_x <- if (is.null(x)) 0L else ncol(x)
+  if (n_x != p_cov) {
+    stop(".hzr_hessian_loglogistic(): ncol(x) (", n_x, ") must equal the number ",
+         "of covariate parameters in theta (", p_cov, ").", call. = FALSE)
+  }
+  has_cov <- p_cov > 0L
   beta_coef <- if (has_cov) theta[3:p] else numeric(0)
   eta <- if (has_cov) as.numeric(x %*% beta_coef) else rep(0, n)
 

--- a/R/likelihood-loglogistic.R
+++ b/R/likelihood-loglogistic.R
@@ -363,7 +363,7 @@ NULL
   p_cov <- p - 2L
   # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
   # covariate rows/cols and yield a conformant-but-wrong vcov.
-  n_x <- if (is.null(x)) 0L else ncol(x)
+  n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_loglogistic(): ncol(x) (", n_x, ") must equal the number ",
          "of covariate parameters in theta (", p_cov, ").", call. = FALSE)

--- a/R/likelihood-lognormal.R
+++ b/R/likelihood-lognormal.R
@@ -339,7 +339,7 @@ NULL
   # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
   # covariate rows/cols and yield a conformant-but-wrong vcov the optimizer's
   # dimension check cannot catch.
-  n_x <- if (is.null(x)) 0L else ncol(x)
+  n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_lognormal(): ncol(x) (", n_x, ") must equal the number ",
          "of covariate parameters in theta (", p_cov, ").", call. = FALSE)

--- a/R/likelihood-lognormal.R
+++ b/R/likelihood-lognormal.R
@@ -339,6 +339,7 @@ NULL
   # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
   # covariate rows/cols and yield a conformant-but-wrong vcov the optimizer's
   # dimension check cannot catch.
+  if (!is.null(x)) x <- as.matrix(x)
   n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_lognormal(): ncol(x) (", n_x, ") must equal the number ",

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -379,7 +379,7 @@ NULL
   p_cov <- p - 2L
   # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
   # covariate rows/cols and yield a conformant-but-wrong vcov.
-  n_x <- if (is.null(x)) 0L else ncol(x)
+  n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_weibull_internal(): ncol(x) (", n_x, ") must equal the ",
          "number of covariate parameters in theta (", p_cov, ").", call. = FALSE)

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -379,6 +379,7 @@ NULL
   p_cov <- p - 2L
   # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
   # covariate rows/cols and yield a conformant-but-wrong vcov.
+  if (!is.null(x)) x <- as.matrix(x)
   n_x <- if (is.null(x)) 0L else NCOL(x)
   if (n_x != p_cov) {
     stop(".hzr_hessian_weibull_internal(): ncol(x) (", n_x, ") must equal the ",

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -377,7 +377,14 @@ NULL
   g <- exp(psi)
   p <- length(theta)
   p_cov <- p - 2L
-  has_cov <- p_cov > 0L && !is.null(x)
+  # Fail loud on inconsistent theta/x: a silent has_cov = FALSE would zero the
+  # covariate rows/cols and yield a conformant-but-wrong vcov.
+  n_x <- if (is.null(x)) 0L else ncol(x)
+  if (n_x != p_cov) {
+    stop(".hzr_hessian_weibull_internal(): ncol(x) (", n_x, ") must equal the ",
+         "number of covariate parameters in theta (", p_cov, ").", call. = FALSE)
+  }
+  has_cov <- p_cov > 0L
   beta <- if (has_cov) theta[3:p] else numeric(0)
   eta <- if (has_cov) as.numeric(x %*% beta) else rep(0, n)
 

--- a/tests/testthat/test-exponential-hessian.R
+++ b/tests/testthat/test-exponential-hessian.R
@@ -96,3 +96,16 @@ test_that(".hzr_hessian_exponential errors on inconsistent theta/x", {
     .hzr_hessian_exponential(c(log_rate = 0, z = 0.3), time, status, x = x2),
     "ncol")
 })
+
+test_that(".hzr_hessian_exponential guard handles vector x (NCOL robustness)", {
+  set.seed(64)
+  n <- 30
+  time <- rexp(n, 0.5) + 0.01
+  status <- rbinom(n, 1, 0.7)
+  # x as a bare vector (NCOL = 1) with a 2-covariate theta -> clean "ncol" error,
+  # not a cryptic "argument is of length zero" from ncol(vector) == NULL.
+  expect_error(
+    .hzr_hessian_exponential(c(log_rate = 0, a = 0.1, b = 0.2), time, status,
+                             x = rnorm(n)),
+    "ncol")
+})

--- a/tests/testthat/test-exponential-hessian.R
+++ b/tests/testthat/test-exponential-hessian.R
@@ -109,3 +109,17 @@ test_that(".hzr_hessian_exponential guard handles vector x (NCOL robustness)", {
                              x = rnorm(n)),
     "ncol")
 })
+
+test_that(".hzr_hessian_exponential coerces a vector x to a 1-column design", {
+  skip_if_not_installed("numDeriv")
+  set.seed(65)
+  n <- 200
+  z <- rnorm(n)
+  time <- rexp(n, rate = exp(-0.4 * z) * 0.5) + 0.01
+  status <- rbinom(n, 1, 0.8)
+  theta <- c(log_rate = log(0.5), z = -0.4)
+  h_vec <- .hzr_hessian_exponential(theta, time, status, x = z)            # bare vector
+  h_mat <- .hzr_hessian_exponential(theta, time, status, x = matrix(z, n, 1))
+  expect_equal(unname(h_vec), unname(h_mat), tolerance = 1e-10)
+  expect_equal(dim(h_vec), c(2L, 2L))
+})

--- a/tests/testthat/test-exponential-hessian.R
+++ b/tests/testthat/test-exponential-hessian.R
@@ -82,3 +82,17 @@ test_that("exponential SEs are invariant to covariate rescaling", {
   z2 <- unname(f2$fit$theta[2] / se2[2])
   expect_equal(z1, z2, tolerance = 1e-2)
 })
+
+test_that(".hzr_hessian_exponential errors on inconsistent theta/x", {
+  set.seed(61)
+  n <- 30
+  time <- rexp(n, 0.5) + 0.01
+  status <- rbinom(n, 1, 0.7)
+  expect_error(
+    .hzr_hessian_exponential(c(log_rate = 0, z = 0.3), time, status, x = NULL),
+    "ncol")
+  x2 <- cbind(a = rnorm(n), b = rnorm(n))
+  expect_error(
+    .hzr_hessian_exponential(c(log_rate = 0, z = 0.3), time, status, x = x2),
+    "ncol")
+})

--- a/tests/testthat/test-loglogistic-hessian.R
+++ b/tests/testthat/test-loglogistic-hessian.R
@@ -109,3 +109,17 @@ test_that(".hzr_logl_loglogistic gradient is finite for right-censored time = 0 
   g_nd <- numDeriv::grad(obj, theta)
   expect_equal(g_an, g_nd, tolerance = 1e-5)
 })
+
+test_that(".hzr_hessian_loglogistic errors on inconsistent theta/x", {
+  set.seed(63)
+  n <- 30
+  time <- rexp(n, 0.5) + 0.01
+  status <- rbinom(n, 1, 0.7)
+  expect_error(
+    .hzr_hessian_loglogistic(c(log_alpha = 0, log_beta = 0, z = 0.3), time, status, x = NULL),
+    "ncol")
+  x2 <- cbind(a = rnorm(n), b = rnorm(n))
+  expect_error(
+    .hzr_hessian_loglogistic(c(log_alpha = 0, log_beta = 0, z = 0.3), time, status, x = x2),
+    "ncol")
+})

--- a/tests/testthat/test-weibull-hessian.R
+++ b/tests/testthat/test-weibull-hessian.R
@@ -137,3 +137,17 @@ test_that("weibull SEs are invariant to covariate rescaling", {
   expect_equal(unname(se1[1]), unname(se2[1]), tolerance = 1e-2)
   expect_equal(unname(se1[2]), unname(se2[2]), tolerance = 1e-2)
 })
+
+test_that(".hzr_hessian_weibull_internal errors on inconsistent theta/x", {
+  set.seed(62)
+  n <- 30
+  time <- rexp(n, 0.5) + 0.01
+  status <- rbinom(n, 1, 0.7)
+  expect_error(
+    .hzr_hessian_weibull_internal(c(alpha = 0, psi = 0, z = 0.3), time, status, x = NULL),
+    "ncol")
+  x2 <- cbind(a = rnorm(n), b = rnorm(n))
+  expect_error(
+    .hzr_hessian_weibull_internal(c(alpha = 0, psi = 0, z = 0.3), time, status, x = x2),
+    "ncol")
+})


### PR DESCRIPTION
## Summary
Generalizes the conformance guard added to `.hzr_hessian_lognormal` in PR #63 to the other three analytic Hessians. Each now errors when `ncol(x)` (0 if `NULL`) does not equal the covariate-parameter count `p_cov`, instead of silently letting `has_cov` degrade to `FALSE`.

**Why it matters (per family):**
- **Weibull** (`.hzr_hessian_weibull_internal`) — genuinely at risk: like lognormal, it pre-allocates a full `p × p` matrix, so an inconsistent `theta`/`x` produced a **conformant-but-wrong** vcov that `.hzr_optim_generic`'s dimension check could not catch.
- **Exponential** / **log-logistic** — previously returned a *non-conformant* matrix (caught by the dimension check → numDeriv fallback). Now they fail loud earlier with a clear message, for consistency.

All cases are unreachable via the public API (the `hessian_fn` closure always passes a consistent `theta`/`x` from the same fitted model) — this is defensive, fail-loud hardening aligned with the project's "accepts the formal but never applies it" → fail-fast policy.

## Test Plan
- [x] Per-family `expect_error(..., "ncol")` regression tests (theta-with-covariate + `x=NULL`, and `x` with wrong column count) — exp/Weibull/log-logistic.
- [x] Hessian suites green: exp 10, Weibull 13, log-logistic 14.
- [x] Full suite: **FAIL 0 / PASS 1427** (`NOT_CRAN=true`); all three test files lint-clean.

Internal `@noRd` guards only — no user-visible behavior change, no NEWS entry.