### PR TITLE
Multiphase fit correctness: vcov() extraction + CoE left-truncation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,17 @@
 
 ## Bug fixes
 
+* **Conservation of Events ignored left-truncation (counting-process entry
+  times).** For multiphase fits on `Surv(start, stop, event)` data, the CoE
+  reparameterization conserved `Sum H(stop)` while the likelihood scores the
+  intercepts on the entry-time scale, `Sum E = Sum [H(stop) - H(start)]`. The
+  conserved phase therefore absorbed the spurious `Sum H(start)`, biasing its
+  intercept and lowering the attained log-likelihood (the `hz.te123.OMC` fit-1
+  parity offset, gap-list P1 #6). `.hzr_conserve_events()` and
+  `.hzr_select_fixmu_phase()` now subtract the per-phase entry-time cumulative
+  hazard, matching the likelihood and C HAZARD `setcoe` under `LCENSOR`/
+  `STARTTME`. Plain right-censored fits (no `start` time) are unaffected.
+
 * **`vcov()` was unusable for multiphase fits and returned an unnamed matrix.**
   `vcov.hazard()` collapsed the entire matrix to a scalar `NA` whenever any cell
   was `NA`. Multiphase fits legitimately have `NA` variance rows -- for

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,18 @@
 
 ## Bug fixes
 
+* **`vcov()` was unusable for multiphase fits and returned an unnamed matrix.**
+  `vcov.hazard()` collapsed the entire matrix to a scalar `NA` whenever any cell
+  was `NA`. Multiphase fits legitimately have `NA` variance rows -- for
+  parameters held fixed (e.g. early shapes) and for the
+  Conservation-of-Events-conserved phase `log_mu` -- so the finite
+  free-parameter block was discarded for almost every multiphase model. The
+  method now returns the full matrix with `NA` rows preserved and labels rows
+  and columns with the coefficient names (phase-prefixed for multiphase, e.g.
+  `early.x` vs `constant.x`), so a covariate shared across phases resolves to
+  distinct, name-addressable slots. A scalar `NA` is returned only when no
+  covariance matrix is available.
+
 * **Weibull analytic gradient produced `NaN` for right-censored `time = 0` rows.**
   `.hzr_gradient_weibull()` used an unguarded `log(time)` in the shape (`nu`)
   score; a legal right-censored row at `time = 0` made `0 * -Inf = NaN`, which

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1277,14 +1277,37 @@ coef.hazard <- function(object, ...) {
 #'               theta = c(0.3, 1.0), dist = "weibull", fit = TRUE)
 #' vcov(fit)
 #' @return A numeric matrix containing the estimated variance-covariance matrix
-#'   of the fitted coefficients, or \code{NA} if the model has not been fitted
-#'   or the covariance matrix is unavailable.
+#'   of the fitted coefficients, with rows and columns named by the coefficient
+#'   labels (phase-prefixed for multiphase models, e.g. \code{early.x}). Rows
+#'   and columns for parameters held fixed, or for the
+#'   Conservation-of-Events-conserved phase \code{log_mu}, are \code{NA} because
+#'   those parameters carry no Hessian-based variance; the finite free-parameter
+#'   block is still usable. Returns a scalar \code{NA} only when the model has
+#'   not been fitted or no covariance matrix is available.
 #' @export
 vcov.hazard <- function(object, ...) {
-  if (is.null(object$fit$vcov) || anyNA(object$fit$vcov)) {
+  v <- object$fit$vcov
+  if (is.null(v) || !is.matrix(v)) {
     return(NA)
   }
-  object$fit$vcov
+  # Label rows/cols with the coefficient names so callers can align the matrix
+  # by name. This matters for multiphase models where the same covariate can
+  # enter more than one phase (e.g. early.x vs constant.x): without names the
+  # two coefficients are indistinguishable. NA variance rows are retained
+  # rather than collapsing the whole matrix to a scalar NA -- a multiphase fit
+  # legitimately has NA rows for parameters held fixed (e.g. early shapes) and
+  # for the Conservation-of-Events-conserved phase log_mu, neither of which has
+  # a Hessian-based variance. The finite free-parameter block is still usable.
+  theta <- object$fit$theta
+  nm <- names(theta)
+  if (is.null(nm) || !all(nzchar(nm))) {
+    p <- if (is.null(object$data$x)) 0L else ncol(object$data$x)
+    nm <- .hzr_parameter_names(theta = theta, dist = object$spec$dist, p = p)
+  }
+  if (!is.null(nm) && length(nm) == nrow(v)) {
+    dimnames(v) <- list(nm, nm)
+  }
+  v
 }
 
 .hzr_parameter_names <- function(theta, dist, p) {

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -296,6 +296,10 @@
 #' @param weights Optional numeric vector of row weights (length n). Defaults to
 #'   unit weights. Applied when summing per-phase cumhaz so that selection
 #'   happens on the same scale as the (weighted) observed event count.
+#' @param time_lower Optional numeric vector of counting-process entry (start)
+#'   times. When supplied, phases are ranked by entry-time cumulative hazard
+#'   `H(stop) - H(start)`, the scale on which events are conserved. `NULL` (the
+#'   default) means no truncation, i.e. `H(start) = 0`.
 #' @return Character: name of the phase to fix.
 #' @keywords internal
 .hzr_select_fixmu_phase <- function(theta, time, status,
@@ -1366,12 +1370,15 @@
     theta_full[free_idx] <- best_result$par
     best_result$par <- theta_full
 
-    # Final CoE adjustment: solve fixmu log_mu at the optimum
+    # Final CoE adjustment: solve fixmu log_mu at the optimum. Must pass
+    # time_lower so the conserved log_mu in the returned coefficients is solved
+    # on the same entry-time scale the objective was optimized on; otherwise a
+    # left-truncated fit returns a conserved mu inconsistent with its objective.
     if (use_conserve && !is.null(fixmu_pos)) {
       best_result$par <- .hzr_conserve_events(
         best_result$par, fixmu_phase, fixmu_pos,
         time, status, phases, covariate_counts, x_list, total_events,
-        weights = weights
+        weights = weights, time_lower = time_lower
       )
     }
 

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -300,10 +300,21 @@
 #' @keywords internal
 .hzr_select_fixmu_phase <- function(theta, time, status,
                                      phases, covariate_counts, x_list,
-                                     weights = NULL) {
+                                     weights = NULL, time_lower = NULL) {
   decomp <- .hzr_multiphase_cumhaz(time, theta, phases,
                                      covariate_counts, x_list,
                                      per_phase = TRUE)
+  # Left truncation (counting-process entry times): rank phases by the cumulative
+  # hazard accrued over follow-up, H(stop) - H(start), the same scale on which
+  # events are conserved. See `.hzr_conserve_events`.
+  if (!is.null(time_lower)) {
+    decomp_start <- .hzr_multiphase_cumhaz(time_lower, theta, phases,
+                                            covariate_counts, x_list,
+                                            per_phase = TRUE)
+    for (nm in names(phases)) {
+      decomp[[nm]] <- decomp[[nm]] - decomp_start[[nm]]
+    }
+  }
   if (is.null(weights)) weights <- rep(1, length(time))
   phase_sums <- vapply(names(phases), function(nm) {
     sum(weights * decomp[[nm]])
@@ -352,16 +363,35 @@
 #' @param weights Optional numeric vector of row weights (length n). Defaults to
 #'   unit weights. Applied when summing per-phase cumhaz so Turner's adjustment
 #'   is computed on the same scale as `total_events`.
+#' @param time_lower Optional numeric vector of counting-process entry (start)
+#'   times. When supplied, conservation is enforced on the entry-time scale --
+#'   `Sum E = Sum [H(stop) - H(start)]` -- by subtracting the entry-time
+#'   cumulative hazard, matching the multiphase likelihood (and C HAZARD
+#'   `setcoe` under `LCENSOR`/`STARTTME`). `NULL` (the default) means no
+#'   truncation, i.e. `H(start) = 0`.
 #' @return Updated theta vector with fixmu phase's log_mu adjusted.
 #' @keywords internal
 .hzr_conserve_events <- function(theta, fixmu_phase, fixmu_pos,
                                   time, status,
                                   phases, covariate_counts, x_list,
-                                  total_events, weights = NULL) {
+                                  total_events, weights = NULL,
+                                  time_lower = NULL) {
   # Compute per-phase cumulative hazard contributions
   decomp <- .hzr_multiphase_cumhaz(time, theta, phases,
                                      covariate_counts, x_list,
                                      per_phase = TRUE)
+
+  # Left truncation: subtract the per-phase entry-time cumulative hazard so the
+  # conserved quantity is H(stop) - H(start), the same constraint the score
+  # equation for mu satisfies. Without this, CoE conserves Sum H(stop) and the
+  # fixmu phase absorbs the spurious Sum H(start), biasing its intercept.
+  if (!is.null(time_lower)) {
+    decomp_start <- .hzr_multiphase_cumhaz(time_lower, theta, phases,
+                                            covariate_counts, x_list,
+                                            per_phase = TRUE)
+    decomp$total <- decomp$total - decomp_start$total
+    decomp[[fixmu_phase]] <- decomp[[fixmu_phase]] - decomp_start[[fixmu_phase]]
+  }
 
   if (is.null(weights)) weights <- rep(1, length(time))
 
@@ -1141,7 +1171,16 @@
         time, theta_start, phases, covariate_counts, x_list,
         per_phase = TRUE
       )
-      sumcz_init <- sum(weights * decomp_init$total)
+      # Entry-time scale under left truncation: conserve H(stop) - H(start).
+      init_total <- decomp_init$total
+      if (!is.null(time_lower)) {
+        decomp_init_start <- .hzr_multiphase_cumhaz(
+          time_lower, theta_start, phases, covariate_counts, x_list,
+          per_phase = TRUE
+        )
+        init_total <- init_total - decomp_init_start$total
+      }
+      sumcz_init <- sum(weights * init_total)
       if (sumcz_init > 0 && is.finite(sumcz_init)) {
         init_factor <- log(total_events / sumcz_init)
         if (is.finite(init_factor)) {
@@ -1155,7 +1194,7 @@
       # Select fixmu phase (largest weighted cumhaz contributor after scaling)
       fixmu_phase <- .hzr_select_fixmu_phase(
         theta_start, time, status, phases, covariate_counts, x_list,
-        weights = weights
+        weights = weights, time_lower = time_lower
       )
       fixmu_pos <- log_mu_positions[[fixmu_phase]]
 
@@ -1163,7 +1202,7 @@
       theta_start <- .hzr_conserve_events(
         theta_start, fixmu_phase, fixmu_pos,
         time, status, phases, covariate_counts, x_list, total_events,
-        weights = weights
+        weights = weights, time_lower = time_lower
       )
 
       # Wrap logl and gradient: apply CoE before each evaluation
@@ -1173,7 +1212,7 @@
         theta <- .hzr_conserve_events(
           theta, fixmu_phase, fixmu_pos,
           time, status, phases, covariate_counts, x_list, total_events,
-          weights = weights
+          weights = weights, time_lower = time_lower
         )
         logl_fn_pre_coe(theta, time, status, time_lower,
                         time_upper, x, weights = weights, ...)
@@ -1185,7 +1224,7 @@
         theta <- .hzr_conserve_events(
           theta, fixmu_phase, fixmu_pos,
           time, status, phases, covariate_counts, x_list, total_events,
-          weights = weights
+          weights = weights, time_lower = time_lower
         )
         gradient_fn_pre_coe(theta, time, status, time_lower,
                             time_upper, x, weights = weights, ...)

--- a/man/dot-hzr_conserve_events.Rd
+++ b/man/dot-hzr_conserve_events.Rd
@@ -14,7 +14,8 @@
   covariate_counts,
   x_list,
   total_events,
-  weights = NULL
+  weights = NULL,
+  time_lower = NULL
 )
 }
 \arguments{
@@ -40,6 +41,13 @@ when \code{weights} is supplied).}
 \item{weights}{Optional numeric vector of row weights (length n). Defaults to
 unit weights. Applied when summing per-phase cumhaz so Turner's adjustment
 is computed on the same scale as \code{total_events}.}
+
+\item{time_lower}{Optional numeric vector of counting-process entry (start)
+times. When supplied, conservation is enforced on the entry-time scale --
+\verb{Sum E = Sum [H(stop) - H(start)]} -- by subtracting the entry-time
+cumulative hazard, matching the multiphase likelihood (and C HAZARD
+\code{setcoe} under \code{LCENSOR}/\code{STARTTME}). \code{NULL} (the default) means no
+truncation, i.e. \code{H(start) = 0}.}
 }
 \value{
 Updated theta vector with fixmu phase's log_mu adjusted.

--- a/man/dot-hzr_select_fixmu_phase.Rd
+++ b/man/dot-hzr_select_fixmu_phase.Rd
@@ -31,6 +31,11 @@
 \item{weights}{Optional numeric vector of row weights (length n). Defaults to
 unit weights. Applied when summing per-phase cumhaz so that selection
 happens on the same scale as the (weighted) observed event count.}
+
+\item{time_lower}{Optional numeric vector of counting-process entry (start)
+times. When supplied, phases are ranked by entry-time cumulative hazard
+\code{H(stop) - H(start)}, the scale on which events are conserved. \code{NULL} (the
+default) means no truncation, i.e. \code{H(start) = 0}.}
 }
 \value{
 Character: name of the phase to fix.

--- a/man/dot-hzr_select_fixmu_phase.Rd
+++ b/man/dot-hzr_select_fixmu_phase.Rd
@@ -11,7 +11,8 @@
   phases,
   covariate_counts,
   x_list,
-  weights = NULL
+  weights = NULL,
+  time_lower = NULL
 )
 }
 \arguments{

--- a/man/vcov.hazard.Rd
+++ b/man/vcov.hazard.Rd
@@ -13,8 +13,13 @@
 }
 \value{
 A numeric matrix containing the estimated variance-covariance matrix
-of the fitted coefficients, or \code{NA} if the model has not been fitted
-or the covariance matrix is unavailable.
+of the fitted coefficients, with rows and columns named by the coefficient
+labels (phase-prefixed for multiphase models, e.g. \code{early.x}). Rows
+and columns for parameters held fixed, or for the
+Conservation-of-Events-conserved phase \code{log_mu}, are \code{NA} because
+those parameters carry no Hessian-based variance; the finite free-parameter
+block is still usable. Returns a scalar \code{NA} only when the model has
+not been fitted or no covariance matrix is available.
 }
 \description{
 Returns the estimated variance-covariance matrix of the fitted coefficients.

--- a/tests/testthat/test-coe-left-truncation.R
+++ b/tests/testthat/test-coe-left-truncation.R
@@ -1,0 +1,80 @@
+# ---------------------------------------------------------------------------
+# Conservation of Events under left truncation (counting-process entry times).
+#
+# The multiphase log-likelihood scores mu via Sum E = Sum [H(stop) - H(start)]
+# for left-truncated rows (Surv(start, stop, event)). The Conservation-of-Events
+# reparameterization must solve the SAME constraint, i.e. it must subtract the
+# entry-time cumulative hazard H(start). If CoE instead conserves Sum H(stop)
+# (ignoring the truncation term), it constrains the fit to the wrong manifold
+# and the attained maximum log-likelihood drops below the unconstrained fit.
+#
+# Invariant exploited here: CoE only removes a redundant parameter direction, so
+# objective(conserve = TRUE) must equal objective(conserve = FALSE). This holds
+# trivially for untruncated data (start = 0) and is the discriminating check for
+# truncated data. This is the synthetic analogue of the hz.te123.OMC fit-1 gap
+# (gap-list P1 #6).
+# ---------------------------------------------------------------------------
+
+# Simulate a fittable two-phase data set with optional left truncation. The
+# exact data-generating process is unimportant; what matters is that (a) both
+# the CoE and free fits converge and (b) entry times are a non-negligible
+# fraction of follow-up so the omitted H(start) term is material.
+.sim_coe_lt <- function(n = 600, seed = 101, truncate = TRUE) {
+  set.seed(seed)
+  u <- runif(n)
+  # Early burst of events plus a long constant-ish tail -> two phases.
+  t_event <- ifelse(u < 0.5, rexp(n, rate = 3), rexp(n, rate = 0.4))
+  cens    <- runif(n, 0.2, 6)
+  stop    <- pmin(t_event, cens)
+  event   <- as.integer(t_event <= cens)
+  start   <- if (truncate) pmin(runif(n, 0, 1.0), 0.8 * stop) else rep(0, n)
+  data.frame(start = start, stop = stop, event = event)
+}
+
+.coe_phases <- function() {
+  list(
+    early    = hzr_phase("cdf", t_half = 0.3, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+}
+
+.coe_fit <- function(d, conserve) {
+  hazard(
+    survival::Surv(start, stop, event) ~ 1,
+    data    = d,
+    dist    = "multiphase",
+    phases  = .coe_phases(),
+    fit     = TRUE,
+    control = list(n_starts = 5, maxit = 1500, reltol = 1e-9, conserve = conserve)
+  )
+}
+
+test_that("CoE conserves events on the entry-time scale (left-truncated)", {
+  skip_on_cran()
+  skip_if_not_installed("survival")
+
+  d <- .sim_coe_lt(truncate = TRUE)
+  fit_coe  <- .coe_fit(d, conserve = TRUE)
+  fit_free <- .coe_fit(d, conserve = FALSE)
+
+  expect_true(isTRUE(fit_coe$fit$converged))
+  expect_true(isTRUE(fit_free$fit$converged))
+
+  # A correct CoE cannot lower the attainable maximum log-likelihood.
+  expect_equal(fit_coe$fit$objective, fit_free$fit$objective,
+               tolerance = 1e-3,
+               label = "objective(conserve=TRUE) vs conserve=FALSE, left-truncated")
+})
+
+test_that("CoE matches the free fit for untruncated data (control)", {
+  skip_on_cran()
+  skip_if_not_installed("survival")
+
+  d <- .sim_coe_lt(truncate = FALSE)
+  fit_coe  <- .coe_fit(d, conserve = TRUE)
+  fit_free <- .coe_fit(d, conserve = FALSE)
+
+  expect_equal(fit_coe$fit$objective, fit_free$fit$objective,
+               tolerance = 1e-3,
+               label = "objective(conserve=TRUE) vs conserve=FALSE, untruncated")
+})

--- a/tests/testthat/test-coe-left-truncation.R
+++ b/tests/testthat/test-coe-left-truncation.R
@@ -38,7 +38,12 @@
   )
 }
 
-.coe_fit <- function(d, conserve) {
+.coe_fit <- function(d, conserve, seed = 202) {
+  # Reset the RNG before fitting so the multi-start perturbations are
+  # deterministic: the CoE and free fits must not drift into different local
+  # optima from back-to-back RNG draws (which would make the objective
+  # comparison flaky across platforms/R versions).
+  set.seed(seed)
   hazard(
     survival::Surv(start, stop, event) ~ 1,
     data    = d,
@@ -46,6 +51,17 @@
     phases  = .coe_phases(),
     fit     = TRUE,
     control = list(n_starts = 5, maxit = 1500, reltol = 1e-9, conserve = conserve)
+  )
+}
+
+# Recompute the multiphase log-likelihood at a fitted object's returned
+# coefficients (no further CoE applied). A self-consistent fit must reproduce
+# its own reported objective here.
+.coe_ll_at_par <- function(fit, d) {
+  TemporalHazard:::.hzr_logl_multiphase(
+    theta = fit$fit$theta, time = d$stop, status = d$event,
+    time_lower = d$start, phases = fit$fit$phases,
+    covariate_counts = fit$fit$covariate_counts, x_list = fit$fit$x_list
   )
 }
 
@@ -64,6 +80,13 @@ test_that("CoE conserves events on the entry-time scale (left-truncated)", {
   expect_equal(fit_coe$fit$objective, fit_free$fit$objective,
                tolerance = 1e-3,
                label = "objective(conserve=TRUE) vs conserve=FALSE, left-truncated")
+
+  # The returned coefficients must be self-consistent with the objective: the
+  # final post-optimization CoE adjustment has to solve the conserved log_mu on
+  # the same entry-time scale, else the returned mu drifts off the optimum.
+  expect_equal(.coe_ll_at_par(fit_coe, d), fit_coe$fit$objective,
+               tolerance = 1e-6,
+               label = "LL at returned coefficients vs reported objective")
 })
 
 test_that("CoE matches the free fit for untruncated data (control)", {

--- a/tests/testthat/test-hazard-api.R
+++ b/tests/testthat/test-hazard-api.R
@@ -133,6 +133,70 @@ test_that("optimizer produces valid vcov and SEs for all distributions", {
   expect_true(all(is.finite(fit_ln$fit$se)))
 })
 
+test_that("vcov.hazard returns a named matrix and preserves NA rows", {
+  # A multiphase fit legitimately has NA variance rows: parameters held fixed
+  # (e.g. early shapes) and the Conservation-of-Events-conserved phase log_mu
+  # carry no Hessian-based variance. The old contract returned a scalar NA for
+  # the whole matrix whenever any cell was NA, making vcov() unusable for
+  # multiphase models and discarding the finite free-parameter block.
+  theta <- c(early.log_mu = -1.5, early.log_t_half = log(0.5),
+             early.nu = 1, early.m = 1, early.x = 0.8,
+             constant.log_mu = -3.0, constant.x = -0.4)
+  V <- matrix(NA_real_, 7, 7)
+  free <- c(1L, 5L, 7L)               # early.log_mu, early.x, constant.x
+  V[free, free] <- matrix(c(0.0101, -0.0065, 0.0002,
+                            -0.0065, 0.0072, -0.0004,
+                            0.0002, -0.0004, 0.0012), 3, 3)
+  fit <- structure(list(fit = list(theta = theta, vcov = V)), class = "hazard")
+
+  Vout <- vcov(fit)
+  expect_true(is.matrix(Vout))                       # not scalar NA
+  expect_equal(dim(Vout), c(7L, 7L))
+  expect_equal(rownames(Vout), names(theta))         # named for alignment
+  expect_equal(colnames(Vout), names(theta))
+  expect_true(anyNA(Vout))                           # NA rows preserved
+  expect_true(all(is.na(diag(Vout)[c(2, 3, 4, 6)]))) # fixed/conserved -> NA
+  expect_true(all(is.finite(diag(Vout)[free])))      # free block intact
+})
+
+test_that("vcov.hazard distinguishes a covariate shared across phases by name", {
+  theta <- c(early.log_mu = -1.5, early.x = 0.8,
+             constant.log_mu = -3.0, constant.x = -0.4)
+  V <- diag(c(0.01, 0.02, NA_real_, 0.03))
+  fit <- structure(list(fit = list(theta = theta, vcov = V)), class = "hazard")
+
+  Vout <- vcov(fit)
+  expect_setequal(rownames(Vout), c("early.log_mu", "early.x",
+                                    "constant.log_mu", "constant.x"))
+  # The two phase-specific x coefficients must resolve to distinct slots.
+  expect_equal(Vout["early.x", "early.x"], 0.02)
+  expect_equal(Vout["constant.x", "constant.x"], 0.03)
+})
+
+test_that("vcov.hazard returns scalar NA only when the matrix is truly absent", {
+  fit_null <- structure(list(fit = list(theta = c(a = 1), vcov = NULL)),
+                        class = "hazard")
+  expect_true(is.na(vcov(fit_null)) && !is.matrix(vcov(fit_null)))
+
+  fit_scalar <- structure(list(fit = list(theta = c(a = 1), vcov = NA)),
+                          class = "hazard")
+  expect_true(is.na(vcov(fit_scalar)) && !is.matrix(vcov(fit_scalar)))
+})
+
+test_that("vcov.hazard names single-phase (weibull) coefficients", {
+  skip_if_not_installed("numDeriv")
+  set.seed(7)
+  n <- 200
+  time <- rexp(n, 0.5)
+  status <- rep(1L, n)
+  fit <- hazard(time = time, status = status,
+                theta = c(0.3, 1.0), dist = "weibull", fit = TRUE)
+  Vout <- vcov(fit)
+  expect_true(is.matrix(Vout))
+  expect_false(is.null(rownames(Vout)))
+  expect_equal(rownames(Vout), colnames(Vout))
+})
+
 test_that("summary shows finite z-stats and p-values from fitted model", {
   skip_if_not_installed("numDeriv")
 

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -201,6 +201,108 @@ test_that("hm.deadp.VALVES: null model nu=0 m<0 LL matches SAS initial (Case 2L 
 })
 
 # ---------------------------------------------------------------------------
+# hm.death.patient: 2-phase Early(CDF, free THALF/NU, M fixed) + Constant,
+# multivariable in BOTH phases with a covariate (AGE_COP) shared across phases.
+# Primary VALVES cohort, per-patient death. CONSERVE on, no truncation.
+# ---------------------------------------------------------------------------
+# This exercises the case the gap list flagged as P1 #1 (a covariate name
+# appearing in both Early and Constant). The `.lst` parser routes the duplicate
+# AGE_COP labels to distinct slots, and `vcov()` now returns a named matrix, so
+# parity can be checked by name.
+#
+# The fit is warm-started from the SAS estimates. Blind multi-start lands in a
+# different (shrunk-beta) basin here -- a 12-parameter CoE model with widely
+# scaled covariates is hard for BFGS to optimize from beta = 0 -- so this test
+# validates likelihood/model-spec parity (R agrees the SAS point is the MLE and
+# reports the same log-likelihood there), not blind optimizer convergence.
+test_that("hm.death.patient: 2-phase both-phase covariate model matches SAS", {
+  testthat::skip_on_cran()
+  dir <- skip_if_no_sas_fixtures()
+
+  ref <- .hzr_parse_sas_lst(file.path(dir, "hm.death.patient.lst"))$fits[[1]]
+  expect_equal(ref$loglik,   -1792.07, tolerance = 1e-2)
+  expect_equal(ref$n_obs,    1533L)
+  expect_equal(ref$n_events, 338L)
+
+  # Reference estimates, pulled from the parsed fixture (no hard-coded numbers).
+  nat <- ref$natural
+  mue <- nat$estimate[nat$name == "MUE"]
+  muc <- nat$estimate[nat$name == "MUC"]
+  thalf <- nat$estimate[nat$name == "THALF" & nat$phase == "Early"]
+  nu    <- nat$estimate[nat$name == "NU"    & nat$phase == "Early"]
+  par_beta <- function(phase, name) {
+    ref$params$estimate[ref$params$phase == phase & ref$params$name == name]
+  }
+  # SAS covariate labels paired with the R `valves` column names (DOUBLE maps
+  # to `double_` because `double` is a reserved word in R).
+  early_cov <- c(AGE_COP = "age_cop", NYHA = "nyha", MV_NYHA = "mv_nyha",
+                 DOUBLE = "double_", AO_PINC = "ao_pinc")
+  const_cov <- c(AGE_COP = "age_cop", BLACK = "black", I_PATH = "i_path")
+  beta_early <- vapply(names(early_cov), par_beta, numeric(1), phase = "Early")
+  beta_const <- vapply(names(const_cov), par_beta, numeric(1), phase = "Constant")
+
+  data(valves, package = "TemporalHazard")
+  d <- valves
+  # SAS PROC STANDARD ... REPLACE fills missing NYHA with the variable mean.
+  d$nyha[is.na(d$nyha)] <- mean(d$nyha, na.rm = TRUE)
+  d$mv_nyha <- d$mitral * d$nyha
+
+  # Internal-scale warm start: log_mu, log_t_half, nu, m (fixed), early betas,
+  # then constant log_mu, constant betas -- in phase/formula order.
+  theta0 <- c(log(mue), log(thalf), nu, 1, unname(beta_early),
+              log(muc), unname(beta_const))
+
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = thalf, nu = nu, m = 1, fixed = "m",
+                           formula = ~ age_cop + nyha + mv_nyha + double_ + ao_pinc),
+      constant = hzr_phase("constant", formula = ~ age_cop + black + i_path)
+    ),
+    theta   = theta0,
+    fit     = TRUE,
+    control = list(n_starts = 1, maxit = 2000, conserve = TRUE)
+  )
+
+  expect_true(isTRUE(fit$fit$converged))
+  # R agrees the SAS estimates are the MLE: log-likelihood matches to print
+  # precision and the fit does not drift away from the seed.
+  expect_equal(fit$fit$objective, ref$loglik, tolerance = 1e-2,
+               label = "R log-likelihood vs SAS reference")
+
+  th <- fit$fit$theta
+  expect_equal(unname(exp(th[["early.log_mu"]])),      mue,   tolerance = 1e-4,
+               label = "MUE (Early) natural-scale")
+  expect_equal(unname(exp(th[["early.log_t_half"]])),  thalf, tolerance = 5e-3,
+               label = "THALF (Early) natural-scale")
+  expect_equal(unname(th[["early.nu"]]),               nu,    tolerance = 5e-3,
+               label = "NU (Early) natural-scale")
+  expect_equal(unname(exp(th[["constant.log_mu"]])),   muc,   tolerance = 1e-4,
+               label = "MUC (Constant) natural-scale")
+
+  # Covariate coefficients (same scale in R and SAS), including AGE_COP which
+  # enters both phases and must resolve to distinct, name-addressable slots.
+  for (nm in names(early_cov)) {
+    expect_equal(unname(th[[paste0("early.", early_cov[[nm]])]]),
+                 unname(beta_early[[nm]]), tolerance = 5e-3,
+                 label = paste0("early.", nm, " coefficient"))
+  }
+  for (nm in names(const_cov)) {
+    expect_equal(unname(th[[paste0("constant.", const_cov[[nm]])]]),
+                 unname(beta_const[[nm]]), tolerance = 5e-3,
+                 label = paste0("constant.", nm, " coefficient"))
+  }
+
+  # vcov() is name-addressable for the shared covariate (P1 #1 fix): the two
+  # AGE_COP coefficients occupy distinct, finite-variance slots.
+  V <- vcov(fit)
+  expect_true(is.matrix(V))
+  expect_true(all(c("early.age_cop", "constant.age_cop") %in% rownames(V)))
+})
+
+# ---------------------------------------------------------------------------
 # hz.te123.OMC: 2-phase (Early CDF + Late Weibull) repeated TE events
 # ---------------------------------------------------------------------------
 # Two fits:


### PR DESCRIPTION
Two multiphase fit-correctness fixes from the v1.1 fixture-parity workstream (gap-list P1 #1 and P1 #6). Both verified against the full test suite (**0 failures / 1460 passed**).

## P1 #1 — `vcov()` usable and named for multiphase fits
`vcov.hazard()` returned a scalar `NA` whenever **any** cell was `NA`, and carried no dimnames otherwise. Multiphase fits legitimately have `NA` variance rows (fixed shapes; the Conservation-of-Events-conserved phase `log_mu`), so `vcov()` was effectively unusable for almost every multiphase model, and callers could not distinguish `early.x` from `constant.x`.

Now returns the full matrix with `NA` rows preserved and rows/cols named by coefficient (phase-prefixed for multiphase). Scalar `NA` only when no covariance matrix exists.

**Note:** the gap-list framed this as a SAS `.lst` "wide-vcov asymmetry / fix cursor-based routing" bug. That was stale — the parser has handled duplicate cross-phase labels correctly since v0.9.8 (`hm.death.patient`, `hm.death.AVC.deciles` both parse symmetric). The real blocker was R-side extraction.

## P1 #6 — Conservation of Events honors left-truncation
For counting-process data (`Surv(start, stop, event)`), CoE conserved `Σ H(stop)` while the likelihood scores intercepts on the entry-time scale `Σ E = Σ [H(stop) − H(start)]`. The conserved phase absorbed the spurious `Σ H(start)`, biasing its intercept and lowering the log-likelihood — the documented `hz.te123.OMC` fit-1 parity offset.

Verified against the C HAZARD source: `consrv.c` fixes one mu per iteration exactly as R does (the gap-doc's "apply to all phases" prescription was a misread of `setcoe_calc_scaling.c`, the one-time initial scaling). The real divergence is the omitted `CF(ST)` term, which the C `setcoe` derivation requires under `LCENSOR`/`STARTTME`.

Fix threads `time_lower` into `.hzr_conserve_events()` / `.hzr_select_fixmu_phase()`, subtracting the per-phase entry-time cumulative hazard. Plain right-censored fits are unaffected. Adds a synthetic left-truncated invariant test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)