### PR TITLE
feat: align hzr_deciles() to SAS %DECILES + hm.death.AVC.deciles parity (Group A)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,21 @@
   only that phase's parameters, so per-phase limits do not sum to the total.
   Previously this combination raised an error.
 
+## Changes
+
+* **`hzr_deciles()` now matches the SAS `deciles.hazard` macro exactly.**
+  Previously it excluded subjects censored before the horizon and defined the
+  expected count as `sum(1 - S(horizon))`. It now follows the SAS method: **all**
+  subjects are ranked into equal-sized risk groups by predicted survival at the
+  horizon, and the expected count per group is the **sum of predicted cumulative
+  hazard at each subject's own follow-up time** (so group totals sum to the total
+  observed events under conservation of events). The `time` argument now only
+  stratifies subjects into risk groups; it no longer restricts or excludes any
+  subject, and the expected/observed totals are horizon-independent. Verified to
+  reproduce the `hm.death.AVC.deciles` SAS decile table (CASES/EXPECTED/ACTUAL)
+  to print precision. The output columns are unchanged; their definitions are
+  updated in `?hzr_deciles`.
+
 ## Bug fixes
 
 * **Conservation of Events ignored left-truncation (counting-process entry

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -11,16 +11,20 @@ NULL
 #' compare observed vs. expected event counts in each group.  Good
 #' calibration means the two track each other across the risk spectrum.
 #'
-#' This implements the workflow of the SAS `deciles.hazard.sas` macro.
-#' Patients are ranked by predicted cumulative hazard at a specified time
-#' point, grouped into quantile bins, and each bin is tested with a
-#' chi-square goodness-of-fit statistic. Subjects censored before the
-#' requested horizon are excluded from the observed-vs-expected comparison.
+#' This reproduces the SAS `deciles.hazard.sas` macro. **All** subjects are
+#' ranked by predicted survival at the horizon `time` and split into equal-sized
+#' risk groups. Within each group the **expected** event count is the sum of
+#' each subject's predicted cumulative hazard at its *own* follow-up time, and
+#' the **observed** count is its number of events; under conservation of events
+#' the group totals sum to the total observed events. The horizon therefore only
+#' stratifies subjects into risk groups -- it does not restrict or exclude any
+#' subject, and the expected/observed totals are independent of it.
 #'
 #' @param object A fitted `hazard` object (with `fit = TRUE`).
-#' @param time Numeric scalar: the time point at which to evaluate
-#'   predicted survival / cumulative hazard.  For example, `time = 12`
-#'   evaluates 12-month predictions.
+#' @param time Numeric scalar: the horizon at which predicted survival is used
+#'   to **rank subjects into risk groups** (e.g. `time = 12` ranks by 12-month
+#'   predicted survival). It does not restrict the event/expected counts, which
+#'   are accumulated over each subject's full follow-up.
 #' @param groups Integer: number of risk groups (default 10 for deciles).
 #' @param status Optional numeric vector of event indicators (1 = event,
 #'   0 = censored).
@@ -30,22 +34,23 @@ NULL
 #'
 #' @return A data frame with one row per risk group and columns:
 #' \describe{
-#'   \item{group}{Integer group label (1 = lowest risk).}
+#'   \item{group}{Integer group label (1 = lowest risk, ranked by predicted
+#'     survival at \code{time}).}
 #'   \item{n}{Number of observations in the group.}
-#'   \item{events}{Observed event count by the requested horizon
-#'     (event indicator = 1 and event time <= \code{time}).}
-#'   \item{expected}{Expected event count by the requested horizon,
-#'     computed as the sum of individual event probabilities
-#'     (\eqn{1 - S(time)}).}
+#'   \item{events}{Observed event count in the group (all events over
+#'     follow-up).}
+#'   \item{expected}{Expected event count: the sum of each subject's predicted
+#'     cumulative hazard at its own follow-up time.}
 #'   \item{observed_rate}{Observed event rate (events / n).}
 #'   \item{expected_rate}{Expected event rate (expected / n).}
 #'   \item{chi_sq}{Chi-square contribution: (events - expected)^2 /
 #'     expected.}
 #'   \item{p_value}{Upper-tail p-value from the chi-square test for
 #'     this group (1 df).}
-#'   \item{mean_survival}{Mean predicted survival probability in the
+#'   \item{mean_survival}{Mean predicted survival probability at the horizon
+#'     in the group.}
+#'   \item{mean_cumhaz}{Mean predicted cumulative hazard at follow-up in the
 #'     group.}
-#'   \item{mean_cumhaz}{Mean predicted cumulative hazard in the group.}
 #' }
 #'
 #' An attribute `"overall"` is attached with the overall chi-square
@@ -113,59 +118,55 @@ hzr_deciles <- function(object, time, groups = 10L,
          n_model, ").", call. = FALSE)
   }
 
-  # --- Predicted cumulative hazard and survival at the target time ----------
-  # Compute per-observation predictions at the calibration horizon.
-  if (identical(object$spec$dist, "multiphase")) {
-    phases <- object$fit$phases
-    if (is.null(phases)) phases <- object$spec$phases
-    cov_counts <- object$fit$covariate_counts
-    x_list <- object$fit$x_list
-    cumhaz <- .hzr_multiphase_cumhaz(
-      rep(time, n_model), object$fit$theta, phases, cov_counts, x_list,
-      per_phase = FALSE
-    )
-  } else if (!is.null(object$data$x) && ncol(object$data$x) > 0) {
-    nd <- as.data.frame(object$data$x)
-    nd$time <- time
-    cumhaz <- predict(object, newdata = nd, type = "cumulative_hazard")
-  } else {
-    nd <- data.frame(time = rep(time, n_model))
-    cumhaz <- predict(object, newdata = nd, type = "cumulative_hazard")
-  }
-  survival <- exp(-cumhaz)
-
-  # Exclude subjects censored before the calibration horizon.
-  include <- (status == 1) | (event_time >= time)
-  n_excluded <- sum(!include)
-  if (!any(include)) {
-    stop("No observations are available at the requested horizon after ",
-         "excluding subjects censored before 'time'.", call. = FALSE)
+  # --- Per-observation predicted cumulative hazard --------------------------
+  # SAS %DECILES method (Blackstone/Naftel HAZARD): the "expected events" in a
+  # group are the sum of predicted cumulative hazard at each subject's OWN
+  # follow-up time, so the total expected equals the observed event count under
+  # conservation of events.  Risk grouping is by predicted survival at the
+  # calibration horizon `time`; the horizon only stratifies subjects into risk
+  # groups -- it does not restrict the event or expected counts, and all
+  # subjects are included.
+  cumhaz_at <- function(times) {
+    if (identical(object$spec$dist, "multiphase")) {
+      phases <- object$fit$phases
+      if (is.null(phases)) phases <- object$spec$phases
+      .hzr_multiphase_cumhaz(times, object$fit$theta, phases,
+                             object$fit$covariate_counts, object$fit$x_list,
+                             per_phase = FALSE)
+    } else if (!is.null(object$data$x) && ncol(object$data$x) > 0) {
+      nd <- as.data.frame(object$data$x)
+      nd$time <- times
+      predict(object, newdata = nd, type = "cumulative_hazard")
+    } else {
+      predict(object, newdata = data.frame(time = times),
+              type = "cumulative_hazard")
+    }
   }
 
-  status <- status[include]
-  event_time <- event_time[include]
-  cumhaz <- cumhaz[include]
-  survival <- survival[include]
-  observed <- as.integer(status == 1 & event_time <= time)
-  n_included <- length(observed)
+  cumhaz_fu    <- cumhaz_at(event_time)        # expected-event contribution
+  cumhaz_hor   <- cumhaz_at(rep(time, n_obs))  # risk grouping at the horizon
+  survival_hor <- exp(-cumhaz_hor)
+  observed     <- as.integer(status == 1)
+  n_included   <- n_obs
+  n_excluded   <- 0L
 
-  if (groups > n_included) {
-    stop("'groups' must be <= number of included observations at horizon (",
-         n_included, ").", call. = FALSE)
+  if (groups > n_obs) {
+    stop("'groups' must be <= number of observations (", n_obs, ").",
+         call. = FALSE)
   }
 
-  # --- Rank into groups by predicted risk (cumulative hazard) ---------------
-  # Higher cumhaz = higher risk; group 1 = lowest risk.
-  # Use ntile-style assignment that handles ties gracefully (no duplicate
-
-  # breaks).  When all predictions are identical (intercept-only model),
-  # observations are distributed as evenly as possible across groups.
-  ranks <- rank(cumhaz, ties.method = "first")
-  group <- as.integer(cut(ranks,
-                          breaks = seq(0, n_included,
-                                       length.out = groups + 1L),
-                          include.lowest = TRUE,
-                          labels = seq_len(groups)))
+  # --- Rank into equal-sized groups by predicted risk at the horizon --------
+  # Rank by cumulative hazard at the horizon, ascending, so group 1 = lowest
+  # risk (highest predicted survival).  This is the same partition SAS PROC
+  # RANK GROUPS= produces on predicted survival, with the opposite label order
+  # (SAS _DECILE_ 0 = highest risk).  Equal-count bins via PROC RANK's floor
+  # rule.  Ties are broken by order of appearance ("first") so that an
+  # intercept-only model (all predictions identical) still yields equal-sized
+  # groups rather than collapsing into one; for models with distinct
+  # predictions the tie rule is irrelevant.
+  ranks <- rank(cumhaz_hor, ties.method = "first")
+  group <- as.integer(floor(groups * (ranks - 1) / n_obs)) + 1L
+  group[group > groups] <- groups
 
   # --- Aggregate by group ---------------------------------------------------
   result <- data.frame(
@@ -185,15 +186,15 @@ hzr_deciles <- function(object, time, groups = 10L,
     idx <- which(group == g)
     ng <- length(idx)
     obs_events <- sum(observed[idx] == 1)
-    exp_events <- sum(1 - survival[idx])
+    exp_events <- sum(cumhaz_fu[idx])
 
     result$n[g] <- ng
     result$events[g] <- obs_events
     result$expected[g] <- exp_events
     result$observed_rate[g] <- if (ng > 0) obs_events / ng else NA_real_
     result$expected_rate[g] <- if (ng > 0) exp_events / ng else NA_real_
-    result$mean_survival[g] <- if (ng > 0) mean(survival[idx]) else NA_real_
-    result$mean_cumhaz[g] <- if (ng > 0) mean(cumhaz[idx]) else NA_real_
+    result$mean_survival[g] <- if (ng > 0) mean(survival_hor[idx]) else NA_real_
+    result$mean_cumhaz[g] <- if (ng > 0) mean(cumhaz_fu[idx]) else NA_real_
 
     # Per-group chi-square: (O - E)^2 / E
     if (exp_events > 0) {
@@ -224,7 +225,7 @@ hzr_deciles <- function(object, time, groups = 10L,
     time = time,
     groups = groups,
     total_events = sum(observed == 1),
-    total_expected = sum(1 - survival),
+    total_expected = sum(cumhaz_fu),
     n_included = n_included,
     n_excluded = n_excluded
   )

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -209,9 +209,12 @@ hzr_deciles <- function(object, time, groups = 10L,
   }
 
   # --- Overall chi-square ---------------------------------------------------
-  valid <- !is.na(result$chi_sq)
+  # Only groups with a positive expected count contribute (a zero-expected
+  # group has an undefined (O-E)^2/E term and NA chi_sq). Clamp df at 0 so
+  # degenerate inputs (<=1 contributing group) never yield a negative df.
+  valid <- result$expected > 0 & !is.na(result$chi_sq)
   overall_chi_sq <- sum(result$chi_sq[valid])
-  overall_df <- sum(valid) - 1L
+  overall_df <- max(0L, sum(valid) - 1L)
   overall_p <- if (overall_df > 0) {
     stats::pchisq(overall_chi_sq, df = overall_df, lower.tail = FALSE)
   } else {
@@ -256,10 +259,9 @@ hzr_deciles <- function(object, time, groups = 10L,
 #' @export
 print.hzr_deciles <- function(x, digits = 3, ...) {
   ov <- attr(x, "overall")
-  cat("Decile-of-risk calibration at time =", ov$time, "\n")
-  if (!is.null(ov$n_included) && !is.null(ov$n_excluded)) {
-    cat("Included", ov$n_included, "observations (excluded", ov$n_excluded,
-        "censored before horizon).\n")
+  cat("Decile-of-risk calibration (risk grouped at time =", ov$time, ")\n")
+  if (!is.null(ov$n_included)) {
+    cat(ov$n_included, "subjects, all included.\n")
   }
   cat(ov$groups, "groups,", ov$total_events, "observed events,",
       signif(ov$total_expected, digits), "expected\n\n")

--- a/man/hzr_deciles.Rd
+++ b/man/hzr_deciles.Rd
@@ -9,9 +9,10 @@ hzr_deciles(object, time, groups = 10L, status = NULL, event_time = NULL)
 \arguments{
 \item{object}{A fitted \code{hazard} object (with \code{fit = TRUE}).}
 
-\item{time}{Numeric scalar: the time point at which to evaluate
-predicted survival / cumulative hazard.  For example, \code{time = 12}
-evaluates 12-month predictions.}
+\item{time}{Numeric scalar: the horizon at which predicted survival is used
+to \strong{rank subjects into risk groups} (e.g. \code{time = 12} ranks by 12-month
+predicted survival). It does not restrict the event/expected counts, which
+are accumulated over each subject's full follow-up.}
 
 \item{groups}{Integer: number of risk groups (default 10 for deciles).}
 
@@ -25,22 +26,23 @@ times.  If \code{NULL} (default), extracted from the fitted object.}
 \value{
 A data frame with one row per risk group and columns:
 \describe{
-\item{group}{Integer group label (1 = lowest risk).}
+\item{group}{Integer group label (1 = lowest risk, ranked by predicted
+survival at \code{time}).}
 \item{n}{Number of observations in the group.}
-\item{events}{Observed event count by the requested horizon
-(event indicator = 1 and event time <= \code{time}).}
-\item{expected}{Expected event count by the requested horizon,
-computed as the sum of individual event probabilities
-(\eqn{1 - S(time)}).}
+\item{events}{Observed event count in the group (all events over
+follow-up).}
+\item{expected}{Expected event count: the sum of each subject's predicted
+cumulative hazard at its own follow-up time.}
 \item{observed_rate}{Observed event rate (events / n).}
 \item{expected_rate}{Expected event rate (expected / n).}
 \item{chi_sq}{Chi-square contribution: (events - expected)^2 /
 expected.}
 \item{p_value}{Upper-tail p-value from the chi-square test for
 this group (1 df).}
-\item{mean_survival}{Mean predicted survival probability in the
+\item{mean_survival}{Mean predicted survival probability at the horizon
+in the group.}
+\item{mean_cumhaz}{Mean predicted cumulative hazard at follow-up in the
 group.}
-\item{mean_cumhaz}{Mean predicted cumulative hazard in the group.}
 }
 
 An attribute \code{"overall"} is attached with the overall chi-square
@@ -52,11 +54,14 @@ compare observed vs. expected event counts in each group.  Good
 calibration means the two track each other across the risk spectrum.
 }
 \details{
-This implements the workflow of the SAS \code{deciles.hazard.sas} macro.
-Patients are ranked by predicted cumulative hazard at a specified time
-point, grouped into quantile bins, and each bin is tested with a
-chi-square goodness-of-fit statistic. Subjects censored before the
-requested horizon are excluded from the observed-vs-expected comparison.
+This reproduces the SAS \code{deciles.hazard.sas} macro. \strong{All} subjects are
+ranked by predicted survival at the horizon \code{time} and split into equal-sized
+risk groups. Within each group the \strong{expected} event count is the sum of
+each subject's predicted cumulative hazard at its \emph{own} follow-up time, and
+the \strong{observed} count is its number of events; under conservation of events
+the group totals sum to the total observed events. The horizon therefore only
+stratifies subjects into risk groups -- it does not restrict or exclude any
+subject, and the expected/observed totals are independent of it.
 }
 \examples{
 \donttest{

--- a/tests/testthat/helper-sas-parity.R
+++ b/tests/testthat/helper-sas-parity.R
@@ -408,6 +408,48 @@
   list(fits = parsed)
 }
 
+# Parse the %DECILES goodness-of-fit table printed by the SAS deciles.hazard
+# macro. The block is introduced by a spaced-out title "D E C I L E ..." and
+# has one row per group: the leading token is the _DECILE_ index ("." for the
+# overall row, then 0..groups-1), followed by numeric columns whose first four
+# are CASES, EXPECTED (sum of cumulative hazard), CUM_HAZ (mean), ACTUAL
+# (observed events). Returns a data frame with columns decile/cases/expected/
+# actual (NA decile = overall row), or NULL if no decile block is present.
+.hzr_parse_sas_deciles <- function(path) {
+  lines <- .hzr_read_lst(path)
+  start <- grep("D E C I L E   A N A L Y S I S", lines)
+  if (!length(start)) return(NULL)
+  body <- lines[start[1]:length(lines)]
+
+  rows <- list()
+  started <- FALSE
+  num_only <- "^[0-9eE+.[:space:]-]+$"
+  for (ln in body) {
+    if (!nzchar(trimws(ln))) next
+    m <- regmatches(ln, regexec("^[[:space:]]*([.]|[0-9]+)[[:space:]]+(.+)$", ln))[[1]]
+    is_row <- length(m) >= 3 && grepl(num_only, m[3])
+    if (is_row) {
+      nums <- suppressWarnings(as.numeric(strsplit(trimws(m[3]),
+                                                   "[[:space:]]+")[[1]]))
+      nums <- nums[!is.na(nums)]
+      if (length(nums) >= 4) {
+        rows[[length(rows) + 1L]] <- data.frame(
+          decile   = if (m[2] == ".") NA_integer_ else as.integer(m[2]),
+          cases    = nums[1],
+          expected = nums[2],
+          actual   = nums[4]
+        )
+        started <- TRUE
+        next
+      }
+    }
+    # A non-blank, non-data line after the table has started ends the block.
+    if (started) break
+  }
+  if (!length(rows)) return(NULL)
+  do.call(rbind, rows)
+}
+
 # Default discovery: ~/Documents/GitHub/hazard/examples/ if it exists,
 # else NULL.  Skip tests when fixtures are unavailable.
 .hzr_sas_fixture_dir <- function() {

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -40,16 +40,15 @@ test_that("hzr_deciles returns correct structure", {
   expect_equal(ov$groups, 10)
 })
 
-test_that("hzr_deciles group counts sum to evaluable n", {
+test_that("hzr_deciles includes all subjects and counts all events (SAS method)", {
   fit <- .fit_avc_weibull()
   avc <- .avc_data()
   cal <- hzr_deciles(fit, time = 120)
-  included <- with(avc, dead == 1 | int_dead >= 120)
-  events_120 <- with(avc, dead == 1 & int_dead <= 120 & included)
 
-  expect_equal(sum(cal$n), sum(included))
-  expect_equal(sum(cal$events), sum(events_120))
-  expect_equal(attr(cal, "overall")$n_excluded, sum(!included))
+  # SAS %DECILES uses every subject; the horizon only stratifies risk.
+  expect_equal(sum(cal$n), nrow(avc))
+  expect_equal(sum(cal$events), sum(avc$dead == 1))
+  expect_equal(attr(cal, "overall")$n_excluded, 0L)
 })
 
 test_that("hzr_deciles works with non-default groups", {
@@ -57,41 +56,34 @@ test_that("hzr_deciles works with non-default groups", {
   avc <- .avc_data()
   cal5 <- hzr_deciles(fit, time = 60, groups = 5)
   expect_equal(nrow(cal5), 5)
-  expect_equal(sum(cal5$n), sum(avc$dead == 1 | avc$int_dead >= 60))
+  expect_equal(sum(cal5$n), nrow(avc))
 })
 
-test_that("hzr_deciles events and expected totals increase with horizon", {
+test_that("hzr_deciles totals are horizon-invariant; only the grouping changes", {
   fit <- .fit_avc_weibull()
   avc <- .avc_data()
-  status_all <- avc$dead
-  time_all <- ifelse(avc$dead == 1, avc$int_dead, 1e9)
 
-  cal60 <- hzr_deciles(fit, time = 60, status = status_all,
-                       event_time = time_all)
-  cal120 <- hzr_deciles(fit, time = 120, status = status_all,
-                        event_time = time_all)
+  cal60  <- hzr_deciles(fit, time = 60)
+  cal120 <- hzr_deciles(fit, time = 120)
 
-  events_60 <- with(avc, sum(dead == 1 & int_dead <= 60))
-  events_120 <- with(avc, sum(dead == 1 & int_dead <= 120))
-
-  expect_equal(sum(cal60$events), events_60)
-  expect_equal(sum(cal120$events), events_120)
+  # Expected = sum of cumulative hazard at each subject's own follow-up time,
+  # and events = all observed deaths: both totals are independent of the
+  # grouping horizon. Only the assignment of subjects to risk groups changes.
   expect_equal(sum(cal60$n), nrow(avc))
   expect_equal(sum(cal120$n), nrow(avc))
-  expect_true(sum(cal120$events) >= sum(cal60$events))
-  expect_true(sum(cal120$expected) >= sum(cal60$expected))
+  expect_equal(sum(cal60$events), sum(avc$dead == 1))
+  expect_equal(sum(cal120$events), sum(avc$dead == 1))
+  expect_equal(sum(cal60$expected), sum(cal120$expected), tolerance = 1e-8)
 })
 
-test_that("hzr_deciles risk ordering is monotone", {
+test_that("hzr_deciles risk ordering is monotone in horizon survival", {
   fit <- .fit_avc_weibull()
   cal <- hzr_deciles(fit, time = 120)
 
-  # Mean cumhaz should increase across groups (group 1 = lowest risk)
-  expect_true(all(diff(cal$mean_cumhaz) >= -1e-10),
-              label = "mean cumulative hazard should increase across groups")
-  # Mean survival should decrease across groups
+  # Groups are ranked by predicted survival at the horizon, group 1 = lowest
+  # risk (highest survival), so mean horizon survival decreases across groups.
   expect_true(all(diff(cal$mean_survival) <= 1e-10),
-              label = "mean survival should decrease across groups")
+              label = "mean horizon survival should decrease across groups")
 })
 
 test_that("hzr_deciles chi-square values are non-negative", {
@@ -117,13 +109,13 @@ test_that("hzr_deciles works with intercept-only model", {
     fit   = TRUE
   )
   cal <- hzr_deciles(fit, time = 12)
-  included <- with(cabgkul, dead == 1 | int_dead >= 12)
 
   expect_s3_class(cal, "hzr_deciles")
   expect_equal(nrow(cal), 10)
-  expect_equal(sum(cal$n), sum(included))
-  # All expected rates should be equal (same prediction for everyone)
-  expect_true(max(cal$expected_rate) - min(cal$expected_rate) < 1e-10)
+  expect_equal(sum(cal$n), nrow(cabgkul))
+  # Everyone shares the same horizon survival, so risk grouping is arbitrary
+  # but mean horizon survival is identical across groups.
+  expect_true(max(cal$mean_survival) - min(cal$mean_survival) < 1e-8)
 })
 
 test_that("hzr_deciles works with multiphase model", {
@@ -143,11 +135,10 @@ test_that("hzr_deciles works with multiphase model", {
     control = list(n_starts = 3, maxit = 500)
   )
   cal <- hzr_deciles(fit_mp, time = 60)
-  included <- with(cabgkul, dead == 1 | int_dead >= 60)
 
   expect_s3_class(cal, "hzr_deciles")
   expect_equal(nrow(cal), 10)
-  expect_equal(sum(cal$n), sum(included))
+  expect_equal(sum(cal$n), nrow(cabgkul))
 })
 
 test_that("hzr_deciles rejects invalid inputs", {
@@ -157,7 +148,7 @@ test_that("hzr_deciles rejects invalid inputs", {
   expect_error(hzr_deciles(fit, time = -1), "positive")
   expect_error(hzr_deciles(fit, time = 120, groups = 1), "at least 2")
   expect_error(hzr_deciles(fit, time = 120, groups = nrow(avc) + 1),
-               "included observations")
+               "number of observations")
   expect_error(hzr_deciles("not_a_model", time = 12), "hazard object")
 })
 

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -423,6 +423,9 @@ test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
   # cohort. hzr_deciles() labels group 1 = lowest risk, the reverse of SAS
   # _DECILE_ 0 = highest risk, so align by reversing R's group order.
   sas_dec <- .hzr_parse_sas_deciles(file.path(dir, "hm.death.AVC.deciles.lst"))
+  expect_false(is.null(sas_dec),
+               label = "SAS decile table parsed from the .lst")
+  expect_equal(nrow(sas_dec), 6L)                        # overall row + 5 groups
   sas_grp <- sas_dec[!is.na(sas_dec$decile), ]
   sas_grp <- sas_grp[order(sas_grp$decile), ]           # deciles 0..4
 

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -303,6 +303,126 @@ test_that("hm.death.patient: 2-phase both-phase covariate model matches SAS", {
 })
 
 # ---------------------------------------------------------------------------
+# hm.death.AVC.deciles: 2-phase Early(CDF, free THALF/NU, M fixed) + Constant,
+# 6 Early covariates + 3 Constant covariates, with STATUS shared across both
+# phases. Plus a %DECILES goodness-of-fit call -> hzr_deciles() smoke check.
+# ---------------------------------------------------------------------------
+# Same warm-start rationale as hm.death.patient (blind multi-start does not
+# reach this basin -- note the extreme MUC ~ 4.4e-7 constant phase). Validates
+# likelihood/spec parity. The SAS %DECILES output is NOT captured in the .lst,
+# so the decile goodness-of-fit table has no SAS reference to assert against;
+# hzr_deciles() is exercised as a smoke check only (see gap-list: "deciles
+# comparison needs hzr_deciles() parity tolerance defined" -- blocked on a
+# captured %DECILES reference).
+test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
+  testthat::skip_on_cran()
+  dir <- skip_if_no_sas_fixtures()
+
+  # Be RNG-neutral: seed for our own determinism, but restore the global RNG
+  # state on exit so later tests in this file (which inherit RNG state for
+  # their multi-start fits) are unaffected by anything we draw here.
+  old_seed <- if (exists(".Random.seed", envir = .GlobalEnv)) {
+    get(".Random.seed", envir = .GlobalEnv)
+  } else {
+    NULL
+  }
+  on.exit({
+    if (is.null(old_seed)) {
+      if (exists(".Random.seed", envir = .GlobalEnv)) {
+        rm(".Random.seed", envir = .GlobalEnv)
+      }
+    } else {
+      assign(".Random.seed", old_seed, envir = .GlobalEnv)
+    }
+  }, add = TRUE)
+  set.seed(20260605)
+
+  ref <- .hzr_parse_sas_lst(file.path(dir, "hm.death.AVC.deciles.lst"))$fits[[1]]
+  expect_equal(ref$loglik,   -160.408, tolerance = 1e-2)
+  expect_equal(ref$n_obs,    310L)
+  expect_equal(ref$n_events, 70L)
+
+  nat <- ref$natural
+  mue <- nat$estimate[nat$name == "MUE"]
+  muc <- nat$estimate[nat$name == "MUC"]
+  thalf <- nat$estimate[nat$name == "THALF" & nat$phase == "Early"]
+  nu    <- nat$estimate[nat$name == "NU"    & nat$phase == "Early"]
+  par_beta <- function(phase, name) {
+    ref$params$estimate[ref$params$phase == phase & ref$params$name == name]
+  }
+  # SAS covariate labels -> R `avc` column names (lowercase, identical here).
+  early_cov <- c(AGE = "age", COM_IV = "com_iv", MAL = "mal",
+                 OPMOS = "opmos", OP_AGE = "op_age", STATUS = "status")
+  const_cov <- c(INC_SURG = "inc_surg", ORIFICE = "orifice", STATUS = "status")
+  beta_early <- vapply(names(early_cov), par_beta, numeric(1), phase = "Early")
+  beta_const <- vapply(names(const_cov), par_beta, numeric(1), phase = "Constant")
+
+  data(avc, package = "TemporalHazard")
+  d <- avc
+  # SAS PROC STANDARD ... REPLACE fills missing INC_SURG with the variable mean.
+  d$inc_surg[is.na(d$inc_surg)] <- mean(d$inc_surg, na.rm = TRUE)
+
+  theta0 <- c(log(mue), log(thalf), nu, 1, unname(beta_early),
+              log(muc), unname(beta_const))
+
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = thalf, nu = nu, m = 1, fixed = "m",
+                           formula = ~ age + com_iv + mal + opmos + op_age + status),
+      constant = hzr_phase("constant", formula = ~ inc_surg + orifice + status)
+    ),
+    theta   = theta0,
+    fit     = TRUE,
+    control = list(n_starts = 1, maxit = 2000, conserve = TRUE)
+  )
+
+  expect_true(isTRUE(fit$fit$converged))
+  expect_equal(fit$fit$objective, ref$loglik, tolerance = 1e-2,
+               label = "R log-likelihood vs SAS reference")
+
+  th <- fit$fit$theta
+  expect_equal(unname(exp(th[["early.log_mu"]])),     mue,   tolerance = 1e-4,
+               label = "MUE (Early) natural-scale")
+  expect_equal(unname(exp(th[["early.log_t_half"]])), thalf, tolerance = 5e-3,
+               label = "THALF (Early) natural-scale")
+  expect_equal(unname(th[["early.nu"]]),              nu,    tolerance = 5e-3,
+               label = "NU (Early) natural-scale")
+  # MUC ~ 4.4e-7: the constant phase is barely identified here (near-singular
+  # Hessian), so compare on the log scale with a relative tolerance rather than
+  # an absolute one on a tiny number.
+  expect_equal(unname(th[["constant.log_mu"]]),       log(muc), tolerance = 5e-3,
+               label = "log MUC (Constant) internal-scale")
+
+  for (nm in names(early_cov)) {
+    expect_equal(unname(th[[paste0("early.", early_cov[[nm]])]]),
+                 unname(beta_early[[nm]]), tolerance = 5e-3,
+                 label = paste0("early.", nm, " coefficient"))
+  }
+  for (nm in names(const_cov)) {
+    expect_equal(unname(th[[paste0("constant.", const_cov[[nm]])]]),
+                 unname(beta_const[[nm]]), tolerance = 5e-3,
+                 label = paste0("constant.", nm, " coefficient"))
+  }
+
+  # STATUS enters both phases and must resolve to distinct named vcov slots.
+  V <- vcov(fit)
+  expect_true(is.matrix(V))
+  expect_true(all(c("early.status", "constant.status") %in% rownames(V)))
+
+  # %DECILES smoke check: hzr_deciles() runs on the fit and returns a
+  # well-formed 5-group calibration table at the 120-month horizon. No SAS
+  # decile reference is captured, so we do not assert numeric GOF parity here.
+  dec <- hzr_deciles(fit, time = 120, groups = 5)
+  expect_s3_class(dec, "hzr_deciles")
+  expect_equal(nrow(dec), 5L)
+  expect_true(all(c("group", "events", "expected") %in% names(dec)))
+  expect_true(all(is.finite(dec$expected)) && sum(dec$expected) > 0)
+})
+
+# ---------------------------------------------------------------------------
 # hz.te123.OMC: 2-phase (Early CDF + Late Weibull) repeated TE events
 # ---------------------------------------------------------------------------
 # Two fits:

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -305,15 +305,17 @@ test_that("hm.death.patient: 2-phase both-phase covariate model matches SAS", {
 # ---------------------------------------------------------------------------
 # hm.death.AVC.deciles: 2-phase Early(CDF, free THALF/NU, M fixed) + Constant,
 # 6 Early covariates + 3 Constant covariates, with STATUS shared across both
-# phases. Plus a %DECILES goodness-of-fit call -> hzr_deciles() smoke check.
+# phases. Plus a %DECILES goodness-of-fit table that hzr_deciles() reproduces.
 # ---------------------------------------------------------------------------
-# Same warm-start rationale as hm.death.patient (blind multi-start does not
-# reach this basin -- note the extreme MUC ~ 4.4e-7 constant phase). Validates
-# likelihood/spec parity. The SAS %DECILES output is NOT captured in the .lst,
-# so the decile goodness-of-fit table has no SAS reference to assert against;
-# hzr_deciles() is exercised as a smoke check only (see gap-list: "deciles
-# comparison needs hzr_deciles() parity tolerance defined" -- blocked on a
-# captured %DECILES reference).
+# The fit starts from the SAS job's documented PARMS starting values (NOT the
+# converged .lst estimates), with n_starts = 1: a deterministic, non-circular
+# convergence test (start where SAS started, check R reaches where SAS
+# finished). Blind multi-start lands in a different basin for this 12-parameter
+# CoE model (extreme MUC ~ 4.4e-7 constant phase), so we seed deterministically.
+#
+# The %DECILES goodness-of-fit table IS captured in the .lst (under the spaced
+# title "D E C I L E   A N A L Y S I S"); .hzr_parse_sas_deciles() reads it and
+# we assert full CASES/EXPECTED/ACTUAL parity against hzr_deciles().
 test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
   testthat::skip_on_cran()
   dir <- skip_if_no_sas_fixtures()
@@ -362,15 +364,24 @@ test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
   # SAS PROC STANDARD ... REPLACE fills missing INC_SURG with the variable mean.
   d$inc_surg[is.na(d$inc_surg)] <- mean(d$inc_surg, na.rm = TRUE)
 
-  theta0 <- c(log(mue), log(thalf), nu, 1, unname(beta_early),
-              log(muc), unname(beta_const))
+  # Deterministic start from the SAS job's PARMS statement (the documented
+  # starting values, not the converged answer). Order: early log_mu, log_t_half,
+  # nu, m(fixed), early betas; then constant log_mu, constant betas.
+  start_thalf <- 0.1905077
+  start_nu    <- 1.437416
+  theta0 <- c(
+    log(0.3504743), log(start_thalf), start_nu, 1,
+    -0.03205774, 1.336675, 0.6872028, -0.01963377, 0.0002086689, 0.5169533,
+    log(4.391673e-07), 1.375285, 3.11765, 1.054988
+  )
 
   fit <- hazard(
     survival::Surv(int_dead, dead) ~ 1,
     data   = d,
     dist   = "multiphase",
     phases = list(
-      early    = hzr_phase("cdf", t_half = thalf, nu = nu, m = 1, fixed = "m",
+      early    = hzr_phase("cdf", t_half = start_thalf, nu = start_nu, m = 1,
+                           fixed = "m",
                            formula = ~ age + com_iv + mal + opmos + op_age + status),
       constant = hzr_phase("constant", formula = ~ inc_surg + orifice + status)
     ),
@@ -384,7 +395,10 @@ test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
                label = "R log-likelihood vs SAS reference")
 
   th <- fit$fit$theta
-  expect_equal(unname(exp(th[["early.log_mu"]])),     mue,   tolerance = 1e-4,
+  # Tolerances are looser than the previous (circular) warm-start-from-the-
+  # answer version: starting from SAS's PARMS, R converges to its own optimum,
+  # which agrees with SAS's reported MLEs to ~1e-4 on a flat likelihood.
+  expect_equal(unname(exp(th[["early.log_mu"]])),     mue,   tolerance = 1e-3,
                label = "MUE (Early) natural-scale")
   expect_equal(unname(exp(th[["early.log_t_half"]])), thalf, tolerance = 5e-3,
                label = "THALF (Early) natural-scale")
@@ -412,14 +426,28 @@ test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
   expect_true(is.matrix(V))
   expect_true(all(c("early.status", "constant.status") %in% rownames(V)))
 
-  # %DECILES smoke check: hzr_deciles() runs on the fit and returns a
-  # well-formed 5-group calibration table at the 120-month horizon. No SAS
-  # decile reference is captured, so we do not assert numeric GOF parity here.
+  # %DECILES goodness-of-fit parity. SAS GROUPS=5 at TIME=120 over the same
+  # cohort. hzr_deciles() labels group 1 = lowest risk, the reverse of SAS
+  # _DECILE_ 0 = highest risk, so align by reversing R's group order.
+  sas_dec <- .hzr_parse_sas_deciles(file.path(dir, "hm.death.AVC.deciles.lst"))
+  sas_grp <- sas_dec[!is.na(sas_dec$decile), ]
+  sas_grp <- sas_grp[order(sas_grp$decile), ]           # deciles 0..4
+
   dec <- hzr_deciles(fit, time = 120, groups = 5)
   expect_s3_class(dec, "hzr_deciles")
-  expect_equal(nrow(dec), 5L)
-  expect_true(all(c("group", "events", "expected") %in% names(dec)))
-  expect_true(all(is.finite(dec$expected)) && sum(dec$expected) > 0)
+  r <- dec[order(-dec$group), ]                         # group 5..1 == decile 0..4
+
+  expect_equal(r$n, sas_grp$cases,
+               label = "decile group sizes (CASES) vs SAS")
+  expect_equal(r$events, sas_grp$actual,
+               label = "observed events per decile (ACTUAL) vs SAS")
+  expect_equal(r$expected, sas_grp$expected, tolerance = 1e-2,
+               label = "expected events per decile vs SAS")
+
+  # Conservation of events: total expected == total observed == SAS total (70).
+  ov <- attr(dec, "overall")
+  expect_equal(ov$total_expected, ov$total_events, tolerance = 1e-3)
+  expect_equal(ov$total_events, 70L)
 })
 
 # ---------------------------------------------------------------------------

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -22,6 +22,7 @@ skip_if_no_omc_raw <- function() {
 test_that("hz.deadp.KUL: 3-phase fixed-shape Weibull-tail matches SAS LL/MLEs", {
   testthat::skip_on_cran()
   dir <- skip_if_no_sas_fixtures()
+  set.seed(101)  # deterministic multi-start; independent of test order
 
   ref <- .hzr_parse_sas_lst(file.path(dir, "hz.deadp.KUL.lst"))$fits[[1]]
   expect_equal(ref$loglik,           -3740.52,  tolerance = 1e-2)
@@ -91,6 +92,7 @@ test_that("hz.deadp.KUL: 3-phase fixed-shape Weibull-tail matches SAS LL/MLEs", 
 test_that("hz.death.AVC: 2-phase free-shape Early matches SAS LL/MLEs", {
   testthat::skip_on_cran()
   dir <- skip_if_no_sas_fixtures()
+  set.seed(102)  # deterministic multi-start; independent of test order
 
   ref <- .hzr_parse_sas_lst(file.path(dir, "hz.death.AVC.lst"))$fits[[1]]
   expect_equal(ref$loglik,    -210.501, tolerance = 1e-2)
@@ -166,6 +168,7 @@ test_that("hz.death.AVC: 2-phase free-shape Early matches SAS LL/MLEs", {
 test_that("hm.deadp.VALVES: null model nu=0 m<0 LL matches SAS initial (Case 2L check)", {
   testthat::skip_on_cran()
   skip_if_no_sas_fixtures()
+  set.seed(103)  # deterministic multi-start; independent of test order
 
   # SAS Initial Summary LL (no covariates, before stepwise selection):
   # shapes THALF=0.6781774 FIXTHALF, NU=0 FIXNU, M=-2.15596 FIXM; free: MUE, MUC.
@@ -230,7 +233,9 @@ test_that("hm.death.patient: 2-phase both-phase covariate model matches SAS", {
   muc <- nat$estimate[nat$name == "MUC"]
   thalf <- nat$estimate[nat$name == "THALF" & nat$phase == "Early"]
   nu    <- nat$estimate[nat$name == "NU"    & nat$phase == "Early"]
-  par_beta <- function(phase, name) {
+  # name first so vapply(names(cov), par_beta, ..., phase = "Early") reads
+  # unambiguously: the positional covariate name fills `name`, `phase` is named.
+  par_beta <- function(name, phase) {
     ref$params$estimate[ref$params$phase == phase & ref$params$name == name]
   }
   # SAS covariate labels paired with the R `valves` column names (DOUBLE maps
@@ -320,24 +325,10 @@ test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
   testthat::skip_on_cran()
   dir <- skip_if_no_sas_fixtures()
 
-  # Be RNG-neutral: seed for our own determinism, but restore the global RNG
-  # state on exit so later tests in this file (which inherit RNG state for
-  # their multi-start fits) are unaffected by anything we draw here.
-  old_seed <- if (exists(".Random.seed", envir = .GlobalEnv)) {
-    get(".Random.seed", envir = .GlobalEnv)
-  } else {
-    NULL
-  }
-  on.exit({
-    if (is.null(old_seed)) {
-      if (exists(".Random.seed", envir = .GlobalEnv)) {
-        rm(".Random.seed", envir = .GlobalEnv)
-      }
-    } else {
-      assign(".Random.seed", old_seed, envir = .GlobalEnv)
-    }
-  }, add = TRUE)
-  set.seed(20260605)
+  # Seed for determinism. Every multi-start parity test in this file now seeds
+  # itself, so the previous save/restore RNG-neutral workaround is unnecessary:
+  # tests no longer depend on the RNG state left by whatever ran before them.
+  set.seed(107)
 
   ref <- .hzr_parse_sas_lst(file.path(dir, "hm.death.AVC.deciles.lst"))$fits[[1]]
   expect_equal(ref$loglik,   -160.408, tolerance = 1e-2)
@@ -349,7 +340,9 @@ test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
   muc <- nat$estimate[nat$name == "MUC"]
   thalf <- nat$estimate[nat$name == "THALF" & nat$phase == "Early"]
   nu    <- nat$estimate[nat$name == "NU"    & nat$phase == "Early"]
-  par_beta <- function(phase, name) {
+  # name first so vapply(names(cov), par_beta, ..., phase = "Early") reads
+  # unambiguously: the positional covariate name fills `name`, `phase` is named.
+  par_beta <- function(name, phase) {
     ref$params$estimate[ref$params$phase == phase & ref$params$name == name]
   }
   # SAS covariate labels -> R `avc` column names (lowercase, identical here).
@@ -471,6 +464,7 @@ test_that("hz.te123.OMC fit 1: left-truncated 2-phase shape params match SAS", {
   testthat::skip_on_cran()
   dir  <- skip_if_no_sas_fixtures()
   skip_if_no_omc_raw()
+  set.seed(104)  # deterministic multi-start; independent of test order
 
   ref  <- .hzr_parse_sas_lst(file.path(dir, "hz.te123.OMC.lst"))$fits[[1]]
   expect_equal(ref$loglik,   -322.226, tolerance = 1e-2)
@@ -523,6 +517,7 @@ test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS L
   testthat::skip_on_cran()
   dir  <- skip_if_no_sas_fixtures()
   skip_if_no_omc_raw()
+  set.seed(105)  # deterministic multi-start; independent of test order
 
   ref  <- .hzr_parse_sas_lst(file.path(dir, "hz.te123.OMC.lst"))$fits[[2]]
   expect_equal(ref$loglik,   -311.597, tolerance = 1e-2)
@@ -605,6 +600,7 @@ test_that("hz.tm123.OMC: morbidity-weighted 2-phase shape params match SAS", {
   testthat::skip_on_cran()
   dir  <- skip_if_no_sas_fixtures()
   skip_if_no_omc_raw()
+  set.seed(106)  # deterministic multi-start; independent of test order
 
   ref  <- .hzr_parse_sas_lst(file.path(dir, "hz.tm123.OMC.lst"))$fits[[1]]
   expect_equal(ref$loglik,   -581.528, tolerance = 1e-2)


### PR DESCRIPTION
Completes the second Group A fixture parity test **and** resolves both scope notes from the prior session by leaning on the C/SAS 4.3.0 source.

## hzr_deciles() aligned to SAS %DECILES (behavior change)
Reworked `hzr_deciles()` to reproduce the SAS `deciles.hazard` macro exactly:
- **All** subjects ranked into equal-sized risk groups by predicted survival at the horizon.
- Per-group **expected** = Σ predicted cumulative hazard at each subject's *own follow-up time* (group totals sum to total observed events under conservation of events).
- `time` now only stratifies into risk groups — it no longer excludes censored subjects, and expected/observed totals are horizon-independent.
- Previously: excluded censored-before-horizon subjects, expected = `Σ(1 − S(horizon))` — a different statistic.
- Output columns unchanged; definitions updated in `?hzr_deciles` and NEWS.

## True decile GOF parity (scope note 2 resolved)
The SAS decile table **was** in the `.lst` all along — under the spaced title `D E C I L E   A N A L Y S I S`, which an earlier `grep "decile"` missed (the "not captured" note was wrong). Added `.hzr_parse_sas_deciles()` and the test now asserts full **CASES / EXPECTED / ACTUAL** parity, reproduced to print precision (62 each; 36.3/18.3/10.7/3.8/0.8; 36/20/11/2/1; total 70/70), plus the CoE identity (total expected = total observed = 70).

## Deterministic, non-circular start (scope note 1 resolved)
The model-parity test now starts from the SAS job's documented `PARMS` values with `n_starts = 1` — **deterministic** (no RNG) and **non-circular** (start where SAS started, converge to where SAS finished), instead of warm-starting from the converged answer. The honest result: R agrees with SAS MLEs to ~1e-4 on a flat likelihood (the prior 1e-4 tolerance was loosened to 1e-3 to reflect this real, tiny R-vs-SAS optimizer difference the circular start was hiding).

The same `.sas`-`PARMS` deterministic-start pattern is the proper fix for the RNG-order-dependent multi-start parity tests (KUL/AVC/OMC) flagged earlier — follow-up task updated.

Full suite: **0 failures, 1504 passed**. Vignette `.html` will pick up the new decile semantics on next render (prose is unchanged and still accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)