### PR TITLE
test: SAS parity for ac.death.AVC Kaplan-Meier / Nelson-Aalen life tables (Group A)

### DIFF
--- a/tests/testthat/helper-sas-parity.R
+++ b/tests/testthat/helper-sas-parity.R
@@ -450,6 +450,63 @@
   do.call(rbind, rows)
 }
 
+# Parse a SAS %KAPLAN / %NELSONT life-table block. These are printed by the
+# kaplan.sas / nelsont.sas actuarial macros as a wide table with a header line
+#   Obs INT_DEAD NUMBER CENSORED DEAD CUM_SURV SE_EXACT CL_LOWER ... PROPLIFE
+# (KAPLAN) or a slightly different column set (NELSONT adds NUMRISK, drops
+# SE_EXACT). Header-driven so it tolerates either layout. `which` selects the
+# block: "kaplan" (first block with an SE_EXACT column), "nelson" (block with a
+# NUMRISK column), or a `_CATG=<x>` stratum marker like "catg0"/"catg1".
+# Returns a data frame named by the header columns (leading Obs dropped, "."
+# -> NA), or NULL if the block is absent.
+.hzr_parse_sas_lifetable <- function(path, which = c("kaplan", "nelson",
+                                                     "catg0", "catg1")) {
+  which <- match.arg(which)
+  lines <- .hzr_read_lst(path)
+  headers <- grep("^\\s*Obs\\s+INT_DEAD\\s+NUMBER", lines)
+  if (!length(headers)) return(NULL)
+
+  pick <- NULL
+  if (which == "nelson") {
+    pick <- headers[grepl("NUMRISK", lines[headers])][1]
+  } else if (which == "kaplan") {
+    # First KAPLAN-style header (has SE_EXACT, no NUMRISK).
+    cand <- headers[grepl("SE_EXACT", lines[headers]) &
+                      !grepl("NUMRISK", lines[headers])]
+    pick <- cand[1]
+  } else {
+    # Stratum: the header following the matching _CATG=<n> rule line.
+    n <- sub("catg", "", which)
+    catg <- grep(paste0("_CATG=", n, "\\b"), lines)
+    if (length(catg)) {
+      after <- headers[headers > catg[1]]
+      pick <- after[1]
+    }
+  }
+  if (is.null(pick) || is.na(pick)) return(NULL)
+
+  cols <- strsplit(trimws(lines[pick]), "\\s+")[[1]]
+  rows <- list()
+  for (ln in lines[(pick + 1L):length(lines)]) {
+    if (grepl("^\\s*-{5,}", ln)) break          # summary rule ends the block
+    if (!nzchar(trimws(ln))) next
+    toks <- strsplit(trimws(ln), "\\s+")[[1]]
+    # Data rows lead with the integer Obs counter.
+    if (!grepl("^[0-9]+$", toks[1])) {
+      if (length(rows)) break else next
+    }
+    if (length(toks) < length(cols)) next
+    vals <- toks[seq_along(cols)]
+    vals[vals == "."] <- NA
+    rows[[length(rows) + 1L]] <- as.numeric(vals)
+  }
+  if (!length(rows)) return(NULL)
+  df <- as.data.frame(do.call(rbind, rows))
+  names(df) <- cols
+  df[["Obs"]] <- NULL
+  df
+}
+
 # Default discovery: ~/Documents/GitHub/hazard/examples/ if it exists,
 # else NULL.  Skip tests when fixtures are unavailable.
 .hzr_sas_fixture_dir <- function() {

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -458,6 +458,9 @@ test_that("ac.death.AVC: Kaplan-Meier and Nelson-Aalen life tables match SAS", {
   testthat::skip_on_cran()
   dir <- skip_if_no_sas_fixtures()
   lst <- file.path(dir, "ac.death.AVC.lst")
+  # An older local fixture set may predate this capture; skip cleanly rather
+  # than hard-error in readLines() if this specific .lst is absent.
+  testthat::skip_if_not(file.exists(lst), "ac.death.AVC.lst fixture not present")
 
   data(avc, package = "TemporalHazard")
 

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -447,6 +447,60 @@ test_that("hm.death.AVC.deciles: 2-phase multivariable model matches SAS", {
 })
 
 # ---------------------------------------------------------------------------
+# ac.death.AVC: actuarial life tables -- Kaplan-Meier (%KAPLAN) and
+# Nelson-Aalen (%NELSONT), overall and KM stratified by COM_IV.
+# ---------------------------------------------------------------------------
+# No model fit: hzr_kaplan()/hzr_nelson() are non-parametric, deterministic.
+# SAS prints times to ~3 decimals, so rows are aligned by index (both tables
+# are sorted by time with the same event times). Tolerances reflect SAS print
+# rounding (~5e-6 in practice).
+test_that("ac.death.AVC: Kaplan-Meier and Nelson-Aalen life tables match SAS", {
+  testthat::skip_on_cran()
+  dir <- skip_if_no_sas_fixtures()
+  lst <- file.path(dir, "ac.death.AVC.lst")
+
+  data(avc, package = "TemporalHazard")
+
+  # --- Kaplan-Meier, overall (%KAPLAN _CATG=ALL) ---------------------------
+  km <- hzr_kaplan(avc$int_dead, avc$dead)
+  sk <- .hzr_parse_sas_lifetable(lst, "kaplan")
+  expect_false(is.null(sk), label = "KAPLAN life table parsed")
+  expect_equal(nrow(km), nrow(sk))
+  expect_equal(km$n_risk,  sk$NUMBER)
+  expect_equal(km$n_event, sk$DEAD)
+  expect_equal(km$survival, sk$CUM_SURV, tolerance = 1e-4,
+               label = "KM survival vs SAS CUM_SURV")
+  expect_equal(km$std_err, sk$SE_EXACT, tolerance = 1e-4,
+               label = "KM standard error vs SAS SE_EXACT")
+  # CUM_HAZ = -log(CUM_SURV); the final all-events row is S=0 (NA in SAS).
+  ok <- !is.na(sk$CUM_HAZ)
+  expect_equal(km$cumhaz[ok], sk$CUM_HAZ[ok], tolerance = 1e-4,
+               label = "KM cumulative hazard (-log S) vs SAS CUM_HAZ")
+
+  # --- Nelson-Aalen, overall (%NELSONT _CATG=ALL) --------------------------
+  ne <- hzr_nelson(avc$int_dead, avc$dead)
+  sn <- .hzr_parse_sas_lifetable(lst, "nelson")
+  expect_false(is.null(sn), label = "NELSONT life table parsed")
+  expect_equal(nrow(ne), nrow(sn))
+  ok_n <- !is.na(sn$CUM_HAZ)
+  expect_equal(ne$cumhaz[ok_n], sn$CUM_HAZ[ok_n], tolerance = 1e-4,
+               label = "Nelson-Aalen cumulative hazard vs SAS CUM_HAZ")
+
+  # --- Kaplan-Meier stratified by COM_IV (%KAPLAN STRATIFY=COM_IV) ----------
+  for (g in 0:1) {
+    sub <- avc[avc$com_iv == g, ]
+    kg  <- hzr_kaplan(sub$int_dead, sub$dead)
+    sg  <- .hzr_parse_sas_lifetable(lst, paste0("catg", g))
+    expect_false(is.null(sg), label = paste0("COM_IV=", g, " stratum parsed"))
+    expect_equal(nrow(kg), nrow(sg))
+    expect_equal(kg$n_risk, sg$NUMBER,
+                 label = paste0("COM_IV=", g, " n at risk"))
+    expect_equal(kg$survival, sg$CUM_SURV, tolerance = 1e-4,
+                 label = paste0("COM_IV=", g, " KM survival"))
+  }
+})
+
+# ---------------------------------------------------------------------------
 # hz.te123.OMC: 2-phase (Early CDF + Late Weibull) repeated TE events
 # ---------------------------------------------------------------------------
 # Two fits:


### PR DESCRIPTION
Third Group A fixture — the actuarial life tables (`ac.death.AVC`). Validates `hzr_kaplan()` and `hzr_nelson()` against the SAS `%KAPLAN` / `%NELSONT` macro output.

## Coverage
- **KM overall** (`_CATG=ALL`): n at risk, events, survival, Greenwood SE, and −log(S) cumulative hazard — match to print precision (~5e-6).
- **Nelson-Aalen overall** (`%NELSONT`): cumulative hazard matches.
- **KM stratified by `COM_IV`** (=0, n=154; =1, n=156): n at risk + survival.

## New parser
`.hzr_parse_sas_lifetable()` — header-driven, so it handles both the KAPLAN column layout (`SE_EXACT`) and the NELSONT layout (`NUMRISK`), plus the `_CATG=<n>` strata. Rows are aligned by index since SAS prints event times to 3 decimals.

No model fit — `hzr_kaplan`/`hzr_nelson` are non-parametric and deterministic (no RNG). Skips when fixtures are absent.

Full suite: **0 failures, 1524 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)