### PR TITLE
docs: surface CORRECTNESS-STRATEGY from dev entry points

### DIFF
--- a/inst/dev/DEVELOPMENT-PLAN.md
+++ b/inst/dev/DEVELOPMENT-PLAN.md
@@ -9,6 +9,11 @@ parametric hazard model of Blackstone, Naftel, and Turner (1986).
 For detailed feature-level parity analysis against the original C/SAS HAZARD
 system, see `SAS-PARITY-GAP-ANALYSIS.md` in this directory.
 
+For how the R and SAS/C codebases are used together to assure correctness
+**efficiently** — the tiered model (R-only invariants → cross-engine
+differential gate → frozen golden anchors), the reference-authority principle,
+and when to stop hand-porting fixtures — see `CORRECTNESS-STRATEGY.md`.
+
 ---
 
 ## Phase 1: Migration from C/SAS — COMPLETE

--- a/inst/dev/FIXTURE-GAP-LIST.md
+++ b/inst/dev/FIXTURE-GAP-LIST.md
@@ -9,6 +9,14 @@ complete cross-codebase parity harness.
 primary fixtures in `~/Documents/GitHub/hazard/examples/`. The gaps below are
 everything not yet covered.
 
+> **Read first — strategy context:** [CORRECTNESS-STRATEGY.md](CORRECTNESS-STRATEGY.md)
+> reframes this exhaustive-parity goal. Direct SAS parity was the right tool for
+> *porting/debugging*; steady-state correctness now leans on R-only invariant
+> tests (Tier 1, shipped) + a cross-engine differential gate (Tier 2, the v5 V9
+> gate), with a small **frozen** golden-anchor set rather than hand-porting
+> every fixture. Treat the "remaining" items below as *optional* unless they buy
+> new structural coverage (see the feature-coverage matrix in the strategy).
+
 ---
 
 ## How fixtures are consumed


### PR DESCRIPTION
Cross-links the merged correctness strategy (#70) from the discoverable dev docs so it isn't orphaned under `inst/dev/`:

- **FIXTURE-GAP-LIST.md** — a 'read first' banner noting the strategy reframes the exhaustive-parity goal: steady-state correctness leans on Tier-1 R-only invariants (#71) + a cross-engine differential gate (Tier 2 / v5 V9) + a *frozen* golden-anchor set, so the 'remaining' fixtures are optional unless they buy structural coverage.
- **DEVELOPMENT-PLAN.md** — added to the see-also pointers alongside `SAS-PARITY-GAP-ANALYSIS.md`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)