### PR TITLE
fix: full-information vcov for Conservation-of-Events fits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,9 @@
   conserved `log_mu`), matching an all-`mu`-free (`conserve = FALSE`) fit at the
   same point. On `hz.death.AVC` every parameter SE now matches the SAS HAZARD
   reference (e.g. the conserved early `log_mu`: 0.133 vs the previous ~0.059).
+  The recomputation uses `numDeriv` (Suggests) and an invertible Hessian; if
+  either is unavailable the fit emits a warning and the conserved `log_mu`
+  retains an `NA` standard error (as before).
 
 * **Conservation of Events ignored left-truncation (counting-process entry
   times).** For multiphase fits on `Surv(start, stop, event)` data, the CoE

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,18 @@
 
 ## Bug fixes
 
+* **Conservation-of-Events fits now report the full-information variance.**
+  CoE removes one phase's `log_mu` from the optimizer *search* (its score
+  equation is the CoE constraint), but the previous code also dropped it from
+  the *uncertainty* -- the conserved phase got an `NA` standard error, and
+  anything depending on it (other SEs, `se(H)`, prediction confidence limits)
+  was understated wherever that phase contributed. At the optimum the CoE
+  solution is the unconstrained MLE, so `vcov()` is now recomputed from the
+  unconstrained-objective Hessian over the full free set (including the
+  conserved `log_mu`), matching an all-`mu`-free (`conserve = FALSE`) fit at the
+  same point. On `hz.death.AVC` every parameter SE now matches the SAS HAZARD
+  reference (e.g. the conserved early `log_mu`: 0.133 vs the previous ~0.059).
+
 * **Conservation of Events ignored left-truncation (counting-process entry
   times).** For multiphase fits on `Surv(start, stop, event)` data, the CoE
   reparameterization conserved `Sum H(stop)` while the likelihood scores the

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1312,11 +1312,13 @@ coef.hazard <- function(object, ...) {
 #'   and columns for parameters held fixed (e.g. fixed shape parameters) are
 #'   \code{NA} because they carry no variance; the finite free-parameter block
 #'   is still usable. For Conservation-of-Events fits the conserved phase
-#'   \code{log_mu} \emph{does} carry a variance: it is removed from the
+#'   \code{log_mu} \emph{normally} carries a variance: it is removed from the
 #'   optimizer search but the vcov is the full-information matrix at the optimum
-#'   (the CoE solution is the unconstrained MLE). Returns a scalar \code{NA}
-#'   only when the model has not been fitted or no covariance matrix is
-#'   available.
+#'   (the CoE solution is the unconstrained MLE). That recomputation requires
+#'   \pkg{numDeriv} and an invertible Hessian; if either is unavailable the fit
+#'   emits a warning and the conserved \code{log_mu} stays \code{NA} (the rest
+#'   of the matrix is unaffected). Returns a scalar \code{NA} only when the
+#'   model has not been fitted or no covariance matrix is available.
 #' @export
 vcov.hazard <- function(object, ...) {
   v <- object$fit$vcov
@@ -1329,8 +1331,9 @@ vcov.hazard <- function(object, ...) {
   # two coefficients are indistinguishable. NA variance rows are retained
   # rather than collapsing the whole matrix to a scalar NA -- a multiphase fit
   # legitimately has NA rows for parameters held fixed (e.g. early shapes),
-  # which carry no Hessian-based variance. (The CoE-conserved log_mu is NOT
-  # NA: it is removed from the search but gets the full-information variance.)
+  # which carry no Hessian-based variance. (The CoE-conserved log_mu is
+  # normally NOT NA -- it gets the full-information variance -- but stays NA if
+  # that recomputation was unavailable; the fit warns in that case.)
   # The finite free-parameter block is still usable.
   theta <- object$fit$theta
   nm <- names(theta)

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1279,11 +1279,14 @@ coef.hazard <- function(object, ...) {
 #' @return A numeric matrix containing the estimated variance-covariance matrix
 #'   of the fitted coefficients, with rows and columns named by the coefficient
 #'   labels (phase-prefixed for multiphase models, e.g. \code{early.x}). Rows
-#'   and columns for parameters held fixed, or for the
-#'   Conservation-of-Events-conserved phase \code{log_mu}, are \code{NA} because
-#'   those parameters carry no Hessian-based variance; the finite free-parameter
-#'   block is still usable. Returns a scalar \code{NA} only when the model has
-#'   not been fitted or no covariance matrix is available.
+#'   and columns for parameters held fixed (e.g. fixed shape parameters) are
+#'   \code{NA} because they carry no variance; the finite free-parameter block
+#'   is still usable. For Conservation-of-Events fits the conserved phase
+#'   \code{log_mu} \emph{does} carry a variance: it is removed from the
+#'   optimizer search but the vcov is the full-information matrix at the optimum
+#'   (the CoE solution is the unconstrained MLE). Returns a scalar \code{NA}
+#'   only when the model has not been fitted or no covariance matrix is
+#'   available.
 #' @export
 vcov.hazard <- function(object, ...) {
   v <- object$fit$vcov
@@ -1295,9 +1298,10 @@ vcov.hazard <- function(object, ...) {
   # enter more than one phase (e.g. early.x vs constant.x): without names the
   # two coefficients are indistinguishable. NA variance rows are retained
   # rather than collapsing the whole matrix to a scalar NA -- a multiphase fit
-  # legitimately has NA rows for parameters held fixed (e.g. early shapes) and
-  # for the Conservation-of-Events-conserved phase log_mu, neither of which has
-  # a Hessian-based variance. The finite free-parameter block is still usable.
+  # legitimately has NA rows for parameters held fixed (e.g. early shapes),
+  # which carry no Hessian-based variance. (The CoE-conserved log_mu is NOT
+  # NA: it is removed from the search but gets the full-information variance.)
+  # The finite free-parameter block is still usable.
   theta <- object$fit$theta
   nm <- names(theta)
   if (is.null(nm) || !all(nzchar(nm))) {

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1391,6 +1391,46 @@
     }
 
     best_result$fixed_mask <- !free_mask
+
+    # --- Full-information vcov for Conservation-of-Events fits ---------------
+    # CoE removes the conserved phase's log_mu from the *search* (its score
+    # equation IS the CoE constraint), so the optimizer's Hessian leaves that
+    # parameter with no variance. But at the optimum the CoE solution is the
+    # unconstrained MLE, so the reported *uncertainty* should be the full-
+    # information vcov -- exactly what an all-mu-free (conserve = FALSE) fit
+    # gives at the same point. Recompute the vcov from the unconstrained-
+    # objective Hessian over the free set with the conserved log_mu restored,
+    # so the conserved phase (and anything depending on it, e.g. se(H) and
+    # survival CLs) gets a proper standard error.
+    if (use_conserve && !is.null(fixmu_pos) &&
+        requireNamespace("numDeriv", quietly = TRUE)) {
+      free_unc <- free_mask
+      free_unc[fixmu_pos] <- TRUE
+      idx_unc <- which(free_unc)
+      base_theta <- best_result$par
+      neg_ll_unc <- function(th_free) {
+        th <- base_theta
+        th[idx_unc] <- th_free
+        -logl_fn_pre_coe(th, time, status, time_lower, time_upper, x,
+                         weights = weights, return_gradient = FALSE)
+      }
+      H_unc <- tryCatch(numDeriv::hessian(neg_ll_unc, base_theta[idx_unc]),
+                        error = function(e) NULL)
+      if (is.matrix(H_unc)) {
+        inv_unc <- .hzr_safe_solve(H_unc)
+        if (is.matrix(inv_unc$vcov)) {
+          p_full <- length(base_theta)
+          vcov_full <- matrix(NA_real_, p_full, p_full)
+          vcov_full[idx_unc, idx_unc] <- inv_unc$vcov
+          best_result$vcov  <- vcov_full
+          best_result$rcond <- inv_unc$rcond
+          best_result$pd    <- inv_unc$pd
+          # The conserved log_mu now carries a variance; it is fixed only for
+          # the search, not for inference.
+          best_result$fixed_mask <- !free_unc
+        }
+      }
+    }
   }
 
   # Restore parameter names

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1402,33 +1402,47 @@
     # objective Hessian over the free set with the conserved log_mu restored,
     # so the conserved phase (and anything depending on it, e.g. se(H) and
     # survival CLs) gets a proper standard error.
-    if (use_conserve && !is.null(fixmu_pos) &&
-        requireNamespace("numDeriv", quietly = TRUE)) {
-      free_unc <- free_mask
-      free_unc[fixmu_pos] <- TRUE
-      idx_unc <- which(free_unc)
-      base_theta <- best_result$par
-      neg_ll_unc <- function(th_free) {
-        th <- base_theta
-        th[idx_unc] <- th_free
-        -logl_fn_pre_coe(th, time, status, time_lower, time_upper, x,
-                         weights = weights, return_gradient = FALSE)
-      }
-      H_unc <- tryCatch(numDeriv::hessian(neg_ll_unc, base_theta[idx_unc]),
-                        error = function(e) NULL)
-      if (is.matrix(H_unc)) {
-        inv_unc <- .hzr_safe_solve(H_unc)
-        if (is.matrix(inv_unc$vcov)) {
-          p_full <- length(base_theta)
-          vcov_full <- matrix(NA_real_, p_full, p_full)
-          vcov_full[idx_unc, idx_unc] <- inv_unc$vcov
-          best_result$vcov  <- vcov_full
-          best_result$rcond <- inv_unc$rcond
-          best_result$pd    <- inv_unc$pd
-          # The conserved log_mu now carries a variance; it is fixed only for
-          # the search, not for inference.
-          best_result$fixed_mask <- !free_unc
+    if (use_conserve && !is.null(fixmu_pos)) {
+      recomputed <- FALSE
+      if (requireNamespace("numDeriv", quietly = TRUE)) {
+        free_unc <- free_mask
+        free_unc[fixmu_pos] <- TRUE
+        idx_unc <- which(free_unc)
+        base_theta <- best_result$par
+        neg_ll_unc <- function(th_free) {
+          th <- base_theta
+          th[idx_unc] <- th_free
+          -logl_fn_pre_coe(th, time, status, time_lower, time_upper, x,
+                           weights = weights, return_gradient = FALSE)
         }
+        H_unc <- tryCatch(numDeriv::hessian(neg_ll_unc, base_theta[idx_unc]),
+                          error = function(e) NULL)
+        if (is.matrix(H_unc)) {
+          inv_unc <- .hzr_safe_solve(H_unc)
+          if (is.matrix(inv_unc$vcov)) {
+            p_full <- length(base_theta)
+            vcov_full <- matrix(NA_real_, p_full, p_full)
+            vcov_full[idx_unc, idx_unc] <- inv_unc$vcov
+            best_result$vcov  <- vcov_full
+            best_result$rcond <- inv_unc$rcond
+            best_result$pd    <- inv_unc$pd
+            # The conserved log_mu now carries a variance; it is fixed only for
+            # the search, not for inference.
+            best_result$fixed_mask <- !free_unc
+            recomputed <- TRUE
+          }
+        }
+      }
+      if (!recomputed) {
+        # Fall back to the reduced (search-only) vcov, in which the conserved
+        # log_mu has no variance. Warn loudly so the understated uncertainty is
+        # visible rather than silent.
+        warning(
+          "Could not compute the full-information variance for the ",
+          "Conservation-of-Events-conserved phase 'log_mu' (numDeriv ",
+          "unavailable or the Hessian was not invertible). Its standard error ",
+          "stays NA and downstream standard errors / confidence limits for ",
+          "that phase may be understated.", call. = FALSE)
       }
     }
   }

--- a/R/predict-cl.R
+++ b/R/predict-cl.R
@@ -321,10 +321,12 @@ NULL
 
 #' Free-parameter vcov submatrix for the delta-method sandwich
 #'
-#' Fixed parameters (from `fixed = "shapes"` or CoE) leave NA rows/cols in the
-#' expanded vcov. Treat them as known-with-zero-variance: restrict the sandwich
-#' to the free submatrix. Returns `NULL` (with a warning) when CLs cannot be
-#' computed. Shared by the aggregate and decomposed se.fit paths.
+#' Fixed parameters (e.g. `fixed = "shapes"`) leave NA rows/cols in the expanded
+#' vcov. Treat them as known-with-zero-variance: restrict the sandwich to the
+#' free submatrix. (The CoE-conserved `log_mu` is not NA here -- CoE fits use
+#' the full-information vcov, so it participates in the sandwich.) Returns `NULL`
+#' (with a warning) when CLs cannot be computed. Shared by the aggregate and
+#' decomposed se.fit paths.
 #'
 #' @param vcov_mat The fitted vcov (or NULL / wrong shape).
 #' @param p Length of the parameter vector.

--- a/R/predict-cl.R
+++ b/R/predict-cl.R
@@ -323,10 +323,11 @@ NULL
 #'
 #' Fixed parameters (e.g. `fixed = "shapes"`) leave NA rows/cols in the expanded
 #' vcov. Treat them as known-with-zero-variance: restrict the sandwich to the
-#' free submatrix. (The CoE-conserved `log_mu` is not NA here -- CoE fits use
-#' the full-information vcov, so it participates in the sandwich.) Returns `NULL`
-#' (with a warning) when CLs cannot be computed. Shared by the aggregate and
-#' decomposed se.fit paths.
+#' free submatrix. (The CoE-conserved `log_mu` normally participates -- CoE fits
+#' use the full-information vcov -- but it leaves an NA row, like a fixed
+#' parameter, when that recomputation was unavailable.) Returns `NULL` (with a
+#' warning) when CLs cannot be computed. Shared by the aggregate and decomposed
+#' se.fit paths.
 #'
 #' @param vcov_mat The fitted vcov (or NULL / wrong shape).
 #' @param p Length of the parameter vector.

--- a/man/dot-hzr_free_vcov.Rd
+++ b/man/dot-hzr_free_vcov.Rd
@@ -15,9 +15,11 @@
 \code{list(vcov_use, free_idx)}, or \code{NULL} if unusable.
 }
 \description{
-Fixed parameters (from \code{fixed = "shapes"} or CoE) leave NA rows/cols in the
-expanded vcov. Treat them as known-with-zero-variance: restrict the sandwich
-to the free submatrix. Returns \code{NULL} (with a warning) when CLs cannot be
-computed. Shared by the aggregate and decomposed se.fit paths.
+Fixed parameters (e.g. \code{fixed = "shapes"}) leave NA rows/cols in the expanded
+vcov. Treat them as known-with-zero-variance: restrict the sandwich to the
+free submatrix. (The CoE-conserved \code{log_mu} is not NA here -- CoE fits use
+the full-information vcov, so it participates in the sandwich.) Returns \code{NULL}
+(with a warning) when CLs cannot be computed. Shared by the aggregate and
+decomposed se.fit paths.
 }
 \keyword{internal}

--- a/man/dot-hzr_free_vcov.Rd
+++ b/man/dot-hzr_free_vcov.Rd
@@ -17,9 +17,10 @@
 \description{
 Fixed parameters (e.g. \code{fixed = "shapes"}) leave NA rows/cols in the expanded
 vcov. Treat them as known-with-zero-variance: restrict the sandwich to the
-free submatrix. (The CoE-conserved \code{log_mu} is not NA here -- CoE fits use
-the full-information vcov, so it participates in the sandwich.) Returns \code{NULL}
-(with a warning) when CLs cannot be computed. Shared by the aggregate and
-decomposed se.fit paths.
+free submatrix. (The CoE-conserved \code{log_mu} normally participates -- CoE fits
+use the full-information vcov -- but it leaves an NA row, like a fixed
+parameter, when that recomputation was unavailable.) Returns \code{NULL} (with a
+warning) when CLs cannot be computed. Shared by the aggregate and decomposed
+se.fit paths.
 }
 \keyword{internal}

--- a/man/vcov.hazard.Rd
+++ b/man/vcov.hazard.Rd
@@ -18,11 +18,13 @@ labels (phase-prefixed for multiphase models, e.g. \code{early.x}). Rows
 and columns for parameters held fixed (e.g. fixed shape parameters) are
 \code{NA} because they carry no variance; the finite free-parameter block
 is still usable. For Conservation-of-Events fits the conserved phase
-\code{log_mu} \emph{does} carry a variance: it is removed from the
+\code{log_mu} \emph{normally} carries a variance: it is removed from the
 optimizer search but the vcov is the full-information matrix at the optimum
-(the CoE solution is the unconstrained MLE). Returns a scalar \code{NA}
-only when the model has not been fitted or no covariance matrix is
-available.
+(the CoE solution is the unconstrained MLE). That recomputation requires
+\pkg{numDeriv} and an invertible Hessian; if either is unavailable the fit
+emits a warning and the conserved \code{log_mu} stays \code{NA} (the rest
+of the matrix is unaffected). Returns a scalar \code{NA} only when the
+model has not been fitted or no covariance matrix is available.
 }
 \description{
 Returns the estimated variance-covariance matrix of the fitted coefficients.

--- a/man/vcov.hazard.Rd
+++ b/man/vcov.hazard.Rd
@@ -15,11 +15,14 @@
 A numeric matrix containing the estimated variance-covariance matrix
 of the fitted coefficients, with rows and columns named by the coefficient
 labels (phase-prefixed for multiphase models, e.g. \code{early.x}). Rows
-and columns for parameters held fixed, or for the
-Conservation-of-Events-conserved phase \code{log_mu}, are \code{NA} because
-those parameters carry no Hessian-based variance; the finite free-parameter
-block is still usable. Returns a scalar \code{NA} only when the model has
-not been fitted or no covariance matrix is available.
+and columns for parameters held fixed (e.g. fixed shape parameters) are
+\code{NA} because they carry no variance; the finite free-parameter block
+is still usable. For Conservation-of-Events fits the conserved phase
+\code{log_mu} \emph{does} carry a variance: it is removed from the
+optimizer search but the vcov is the full-information matrix at the optimum
+(the CoE solution is the unconstrained MLE). Returns a scalar \code{NA}
+only when the model has not been fitted or no covariance matrix is
+available.
 }
 \description{
 Returns the estimated variance-covariance matrix of the fitted coefficients.

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -133,21 +133,19 @@ test_that("hz.death.AVC: 2-phase free-shape Early matches SAS LL/MLEs", {
   expect_equal(unname(exp(th["constant.log_mu"])),  muc_ref,   tolerance = 1e-3,
                label = "MUC natural-scale (CoE-constrained)")
 
-  # SE comparison: SAS reports log-scale SEs for E2=log_t_half and E0=log_mu;
-  # E3=NU is on natural scale.  We compare log-scale SEs where R also
-  # parameterizes on log scale.  CoE constraint zeroes C0 SE in R; SAS
-  # still reports one — note as gap, don't assert.
-  V <- fit$fit$vcov
-  idx <- c(log_t_half = which(names(th) == "early.log_t_half"),
-           log_mu     = which(names(th) == "early.log_mu"))
-
-  se_e2_ref <- ref$params$se[ref$params$name == "E2"]
-  expect_equal(sqrt(V[idx["log_t_half"], idx["log_t_half"]]), se_e2_ref,
-               tolerance = 5e-3, label = "SE(log_t_half / E2)")
-  # NOTE: SE(log_mu / E0) disagrees with SAS (R ~0.059 vs SAS 0.133).
-  # SAS reports asymptotic vcov projected onto the CoE conservation
-  # manifold; R returns the raw inverse Hessian on the free-parameter
-  # submatrix.  Logged as P2 gap #11 in PRE-CRAN-PARITY-INVENTORY.md.
+  # SE comparison (log-mu / log-t_half scale). With the full-information vcov
+  # for CoE fits, all three log-scale SEs match SAS -- including E0, the
+  # CoE-conserved early log_mu, whose variance was previously dropped (the old
+  # ~0.059-vs-0.133 gap; now resolved).
+  se <- sqrt(diag(fit$fit$vcov))
+  names(se) <- names(th)
+  se_ref <- function(nm) ref$params$se[ref$params$name == nm]
+  expect_equal(unname(se[["early.log_t_half"]]), se_ref("E2"), tolerance = 5e-3,
+               label = "SE(log_t_half / E2)")
+  expect_equal(unname(se[["early.log_mu"]]),     se_ref("E0"), tolerance = 5e-3,
+               label = "SE(early log_mu / E0) -- conserved phase, full-info vcov")
+  expect_equal(unname(se[["constant.log_mu"]]),  se_ref("C0"), tolerance = 5e-3,
+               label = "SE(constant log_mu / C0)")
 })
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves the conserved-μ variance item (correctness strategy §3). CoE removes one phase's `log_mu` from the optimizer **search** — its score equation *is* the CoE constraint — but the code also dropped it from the reported **uncertainty**: the conserved `log_mu` got an `NA` standard error, and anything depending on it (other SEs, `se(H)`, prediction confidence limits) was understated wherever that phase contributed.

## Fix
At the optimum the CoE solution **is** the unconstrained MLE (the conserved-μ score=0 condition is exactly the CoE constraint). So the reported uncertainty should be the full-information vcov. After convergence, recompute the vcov from the **unconstrained-objective** Hessian (`logl_fn_pre_coe`) over the full free set with the conserved `log_mu` restored — exactly what an all-μ-free (`conserve = FALSE`) fit yields at the same point. `fixed_mask` is updated so the conserved `log_mu` is fixed only for the *search*, not for *inference*.

## Validation
On `hz.death.AVC`, **every** parameter SE now matches the SAS HAZARD reference:
- conserved early `log_mu` (E0): **0.133** vs SAS 0.1330 (was ~0.059)
- constant `log_mu` (C0): 0.4561 vs 0.4561; early `log_t_half` (E2): 0.3605 vs 0.3605

The parity test's previously-noted E0 gap is resolved and now asserted (plus C0). This also fixes `se(H)` everywhere, so combined with the logit transform the HAZPRED survival CLs reproduce SAS to ~8e-6 (the logit CL **option** follows in a separate PR).

Full suite: **0 failures, 1594 passed** — no test relied on the old NA behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)