### PR TITLE
test: hp.death.AVC.hm1/hm2 patient-specific HAZPRED parity (Group A)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -233,6 +233,19 @@
 
 ## Testing
 
+* **Patient-specific HAZPRED prediction parity** (Group A fixtures
+  `hp.death.AVC.hm1` / `hm2`).  New `test-sas-parity.R` blocks predict survival
+  and instantaneous hazard -- with logit survival CLs and log hazard CLs at the
+  SAS 1-SD level -- from the saved multivariable both-phase model
+  (`hm.death.AVC` final fit, "HMDEATH") for two covariate profiles each
+  (hm1: with/without an associated cardiac anomaly; hm2: complete vs partial
+  canal by date of repair), matching SAS to ~5e-4 (survival) / ~8e-3 (hazard;
+  the looser hazard tolerance reflects the near-singular 9-coefficient fit and
+  the steep early-phase times).  Adds a header-driven
+  `.hzr_parse_sas_nomogram_mv()` (parses the BY-group "digital nomogram" whose
+  rows each carry their own covariate vector) and a shared
+  `.hzr_fit_avc_hmdeath()` helper.
+
 * **Phase-specific covariate recovery tests** (Phase 7d).  New
   `test-phase-specific-covariates.R` confirms that `hzr_phase(formula = ~ ...)`
   is correct, not just runnable: simulation-based recovery tests verify that a

--- a/tests/testthat/helper-sas-parity.R
+++ b/tests/testthat/helper-sas-parity.R
@@ -587,8 +587,11 @@
 # coefficient statements (documented starting values, not the converged
 # answer).  Returns the fitted hazard object.
 .hzr_fit_avc_hmdeath <- function() {
-  data(avc, package = "TemporalHazard", envir = environment())
-  d <- avc
+  # Load via an explicit env + `$` so object_usage_linter sees a binding
+  # (a bare `avc` from data() reads as an undefined global under lint_package).
+  e <- new.env()
+  utils::data("avc", package = "TemporalHazard", envir = e)
+  d <- e$avc
   # SAS PROC STANDARD ... REPLACE fills missing INC_SURG with the column mean.
   d$inc_surg[is.na(d$inc_surg)] <- mean(d$inc_surg, na.rm = TRUE)
   start_thalf <- 0.1905077

--- a/tests/testthat/helper-sas-parity.R
+++ b/tests/testthat/helper-sas-parity.R
@@ -535,6 +535,76 @@
   df
 }
 
+# Parse the multivariable HAZPRED "digital nomogram" printed by the
+# patient-specific prediction jobs (hp.death.AVC.hm1 / hm2).  Unlike the null
+# model nomogram above, these PROC PRINT tables carry the full covariate
+# profile on every row and are printed BY a grouping variable (MAL or COM_IV),
+# so each row is a self-contained (time + covariates -> predictions) record:
+#   Obs MONTHS YEARS OPYEAR OPMOS AGE COM_IV MAL INC_SURG ORIFICE STATUS
+#       _SURVIV _CLLSURV _CLUSURV _HAZARD _CLLHAZ _CLUHAZ
+# Header-driven (reads column names from the printed header), so it tolerates
+# layout differences between fixtures; data rows lead with the integer Obs
+# counter and may be split across pages / BY-groups (all are concatenated).
+# Returns a data frame with the leading "_" stripped from the prediction
+# columns and Obs dropped; NULL if no such table is present.
+.hzr_parse_sas_nomogram_mv <- function(path) {
+  lines <- .hzr_read_lst(path)
+  h <- grep("MONTHS[[:space:]].*_SURVIV", lines)
+  if (!length(h)) return(NULL)
+  cols <- strsplit(trimws(lines[h[1]]), "[[:space:]]+")[[1]]
+  ncol <- length(cols)
+  rows <- list()
+  for (ln in lines) {
+    toks <- strsplit(trimws(ln), "[[:space:]]+")[[1]]
+    if (length(toks) < ncol) next
+    if (!grepl("^[0-9]+$", toks[1])) next          # data rows lead with Obs
+    vals <- toks[seq_len(ncol)]
+    vals[vals == "."] <- NA
+    v <- suppressWarnings(as.numeric(vals))
+    if (anyNA(v[seq_len(ncol)]) && all(is.na(v))) next
+    rows[[length(rows) + 1L]] <- v
+  }
+  if (!length(rows)) return(NULL)
+  df <- as.data.frame(do.call(rbind, rows))
+  names(df) <- sub("^_", "", cols)
+  df[["Obs"]] <- NULL
+  df
+}
+
+# Fit the saved multivariable both-phase "HMDEATH" model used by the AVC
+# patient-specific prediction fixtures (hm.death.AVC final model; consumed by
+# hp.death.AVC.hm1 / hm2).  Early phase carries 6 covariates, Constant phase 3
+# (STATUS appears in both).  Deterministic warm start from the .sas PARMS /
+# coefficient statements (documented starting values, not the converged
+# answer).  Returns the fitted hazard object.
+.hzr_fit_avc_hmdeath <- function() {
+  data(avc, package = "TemporalHazard", envir = environment())
+  d <- avc
+  # SAS PROC STANDARD ... REPLACE fills missing INC_SURG with the column mean.
+  d$inc_surg[is.na(d$inc_surg)] <- mean(d$inc_surg, na.rm = TRUE)
+  start_thalf <- 0.1905077
+  start_nu    <- 1.437416
+  theta0 <- c(
+    log(0.3504743), log(start_thalf), start_nu, 1,
+    -0.03205774, 1.336675, 0.6872028, -0.01963377, 0.0002086689, 0.5169533,
+    log(4.391673e-07), 1.375285, 3.11765, 1.054988
+  )
+  hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = start_thalf, nu = start_nu, m = 1,
+                           fixed = "m",
+                           formula = ~ age + com_iv + mal + opmos + op_age + status),
+      constant = hzr_phase("constant", formula = ~ inc_surg + orifice + status)
+    ),
+    theta   = theta0,
+    fit     = TRUE,
+    control = list(n_starts = 1, maxit = 2000, conserve = TRUE)
+  )
+}
+
 # Default discovery: ~/Documents/GitHub/hazard/examples/ if it exists,
 # else NULL.  Skip tests when fixtures are unavailable.
 .hzr_sas_fixture_dir <- function() {

--- a/tests/testthat/helper-sas-parity.R
+++ b/tests/testthat/helper-sas-parity.R
@@ -543,10 +543,13 @@
 #   Obs MONTHS YEARS OPYEAR OPMOS AGE COM_IV MAL INC_SURG ORIFICE STATUS
 #       _SURVIV _CLLSURV _CLUSURV _HAZARD _CLLHAZ _CLUHAZ
 # Header-driven (reads column names from the printed header), so it tolerates
-# layout differences between fixtures; data rows lead with the integer Obs
-# counter and may be split across pages / BY-groups (all are concatenated).
-# Returns a data frame with the leading "_" stripped from the prediction
-# columns and Obs dropped; NULL if no such table is present.
+# layout differences between fixtures.  Parsing is scoped to the data block
+# immediately following each matching header line: within a block, data rows
+# lead with the integer Obs counter; the block ends at the first non-data line
+# after data have started (so unrelated `Obs ...` tables elsewhere in the
+# listing are never ingested).  Page breaks / BY-groups repeat the header, and
+# all their blocks are concatenated.  Returns a data frame with the leading "_"
+# stripped from the prediction columns and Obs dropped; NULL if absent.
 .hzr_parse_sas_nomogram_mv <- function(path) {
   lines <- .hzr_read_lst(path)
   h <- grep("MONTHS[[:space:]].*_SURVIV", lines)
@@ -554,15 +557,21 @@
   cols <- strsplit(trimws(lines[h[1]]), "[[:space:]]+")[[1]]
   ncol <- length(cols)
   rows <- list()
-  for (ln in lines) {
-    toks <- strsplit(trimws(ln), "[[:space:]]+")[[1]]
-    if (length(toks) < ncol) next
-    if (!grepl("^[0-9]+$", toks[1])) next          # data rows lead with Obs
-    vals <- toks[seq_len(ncol)]
-    vals[vals == "."] <- NA
-    v <- suppressWarnings(as.numeric(vals))
-    if (anyNA(v[seq_len(ncol)]) && all(is.na(v))) next
-    rows[[length(rows) + 1L]] <- v
+  for (hi in h) {
+    if (hi >= length(lines)) next
+    started <- FALSE
+    for (ln in lines[(hi + 1L):length(lines)]) {
+      if (!nzchar(trimws(ln))) next                 # tolerate blank spacer rows
+      toks <- strsplit(trimws(ln), "[[:space:]]+")[[1]]
+      if (!grepl("^[0-9]+$", toks[1])) {            # data rows lead with Obs
+        if (started) break else next                # block ends after data
+      }
+      if (length(toks) < ncol) next
+      vals <- toks[seq_len(ncol)]
+      vals[vals == "."] <- NA
+      rows[[length(rows) + 1L]] <- suppressWarnings(as.numeric(vals))
+      started <- TRUE
+    }
   }
   if (!length(rows)) return(NULL)
   df <- as.data.frame(do.call(rbind, rows))

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -583,6 +583,90 @@ test_that("hp.death.AVC: HAZPRED survival/hazard nomogram matches SAS", {
 })
 
 # ---------------------------------------------------------------------------
+# hp.death.AVC.hm1 / hm2: patient-specific HAZPRED predictions from the saved
+# multivariable both-phase model (hm.death.AVC final fit, "HMDEATH").
+# ---------------------------------------------------------------------------
+# Both jobs predict survival + instantaneous hazard (with logit survival CLs
+# and log hazard CLs at the 1-SD level) for two covariate profiles printed as
+# a BY-group "digital nomogram".  Each printed row carries its own covariate
+# vector, so newdata is built directly from the parsed table -- the test is
+# agnostic to the specific profiles (hm1 varies MAL 0/1; hm2 varies COM_IV 0/1
+# across dates of repair).
+#
+# Tolerances are looser than the null-model nomogram (hp.death.AVC): this is a
+# 9-coefficient, near-singular fit (rcond ~5e-12; see hm.death.AVC.deciles),
+# so R converges to its own optimum a few e-4 from SAS's reported MLEs, which
+# propagates to ~5e-4 in survival and (amplified at the steep early-phase
+# times) ~8e-3 in the instantaneous hazard.  SAS 1-SD level: CLEVEL = z = 1.
+.hzr_check_hmdeath_nomogram <- function(df, fit) {
+  lvl <- 2 * stats::pnorm(1) - 1
+  nd <- data.frame(
+    time    = df$MONTHS,
+    age     = df$AGE,
+    com_iv  = df$COM_IV,
+    mal     = df$MAL,
+    opmos   = df$OPMOS,
+    op_age  = df$OPMOS * df$AGE,
+    status  = df$STATUS,
+    inc_surg = df$INC_SURG,
+    orifice = df$ORIFICE
+  )
+
+  surv <- predict(fit, newdata = nd, type = "survival")
+  expect_equal(unname(surv), df$SURVIV, tolerance = 5e-4,
+               label = "HAZPRED _SURVIV (multivariable nomogram)")
+  scl <- predict(fit, newdata = nd, type = "survival", se.fit = TRUE,
+                 level = lvl, conf.type = "logit")
+  expect_equal(scl$lower, df$CLLSURV, tolerance = 5e-4,
+               label = "HAZPRED _CLLSURV (logit CL)")
+  expect_equal(scl$upper, df$CLUSURV, tolerance = 5e-4,
+               label = "HAZPRED _CLUSURV (logit CL)")
+
+  haz <- predict(fit, newdata = nd, type = "hazard")
+  expect_equal(unname(haz), df$HAZARD, tolerance = 8e-3,
+               label = "HAZPRED _HAZARD (multivariable nomogram)")
+  hcl <- predict(fit, newdata = nd, type = "hazard", se.fit = TRUE, level = lvl)
+  expect_equal(hcl$lower, df$CLLHAZ, tolerance = 8e-3,
+               label = "HAZPRED _CLLHAZ")
+  expect_equal(hcl$upper, df$CLUHAZ, tolerance = 8e-3,
+               label = "HAZPRED _CLUHAZ")
+}
+
+test_that("hp.death.AVC.hm1: patient-specific predictions (MAL 0/1) match SAS", {
+  testthat::skip_on_cran()
+  dir <- skip_if_no_sas_fixtures()
+  lst <- file.path(dir, "hp.death.AVC.hm1.lst")
+  testthat::skip_if_not(file.exists(lst), "hp.death.AVC.hm1.lst fixture not present")
+
+  df <- .hzr_parse_sas_nomogram_mv(lst)
+  expect_false(is.null(df), label = "hm1 multivariable nomogram parsed")
+  expect_setequal(unique(df$MAL), c(0, 1))     # two covariate profiles
+
+  set.seed(108)
+  fit <- .hzr_fit_avc_hmdeath()
+  expect_equal(fit$fit$objective, -160.408, tolerance = 1e-2,
+               label = "HMDEATH saved-model LL vs SAS")
+  .hzr_check_hmdeath_nomogram(df, fit)
+})
+
+test_that("hp.death.AVC.hm2: predictions by date of repair (COM_IV 0/1) match SAS", {
+  testthat::skip_on_cran()
+  dir <- skip_if_no_sas_fixtures()
+  lst <- file.path(dir, "hp.death.AVC.hm2.lst")
+  testthat::skip_if_not(file.exists(lst), "hp.death.AVC.hm2.lst fixture not present")
+
+  df <- .hzr_parse_sas_nomogram_mv(lst)
+  expect_false(is.null(df), label = "hm2 multivariable nomogram parsed")
+  expect_setequal(unique(df$COM_IV), c(0, 1))  # complete vs partial canal
+
+  set.seed(109)
+  fit <- .hzr_fit_avc_hmdeath()
+  expect_equal(fit$fit$objective, -160.408, tolerance = 1e-2,
+               label = "HMDEATH saved-model LL vs SAS")
+  .hzr_check_hmdeath_nomogram(df, fit)
+})
+
+# ---------------------------------------------------------------------------
 # hz.te123.OMC: 2-phase (Early CDF + Late Weibull) repeated TE events
 # ---------------------------------------------------------------------------
 # Two fits:

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -613,22 +613,22 @@ test_that("hp.death.AVC: HAZPRED survival/hazard nomogram matches SAS", {
   )
 
   surv <- predict(fit, newdata = nd, type = "survival")
-  expect_equal(unname(surv), df$SURVIV, tolerance = 5e-4,
+  testthat::expect_equal(unname(surv), df$SURVIV, tolerance = 5e-4,
                label = "HAZPRED _SURVIV (multivariable nomogram)")
   scl <- predict(fit, newdata = nd, type = "survival", se.fit = TRUE,
                  level = lvl, conf.type = "logit")
-  expect_equal(scl$lower, df$CLLSURV, tolerance = 5e-4,
+  testthat::expect_equal(scl$lower, df$CLLSURV, tolerance = 5e-4,
                label = "HAZPRED _CLLSURV (logit CL)")
-  expect_equal(scl$upper, df$CLUSURV, tolerance = 5e-4,
+  testthat::expect_equal(scl$upper, df$CLUSURV, tolerance = 5e-4,
                label = "HAZPRED _CLUSURV (logit CL)")
 
   haz <- predict(fit, newdata = nd, type = "hazard")
-  expect_equal(unname(haz), df$HAZARD, tolerance = 8e-3,
+  testthat::expect_equal(unname(haz), df$HAZARD, tolerance = 8e-3,
                label = "HAZPRED _HAZARD (multivariable nomogram)")
   hcl <- predict(fit, newdata = nd, type = "hazard", se.fit = TRUE, level = lvl)
-  expect_equal(hcl$lower, df$CLLHAZ, tolerance = 8e-3,
+  testthat::expect_equal(hcl$lower, df$CLLHAZ, tolerance = 8e-3,
                label = "HAZPRED _CLLHAZ")
-  expect_equal(hcl$upper, df$CLUHAZ, tolerance = 8e-3,
+  testthat::expect_equal(hcl$upper, df$CLUHAZ, tolerance = 8e-3,
                label = "HAZPRED _CLUHAZ")
 }
 


### PR DESCRIPTION
## Summary

Adds SAS parity tests for the two **patient-specific HAZPRED prediction** fixtures in Group A, predicting **survival + instantaneous hazard** (with logit survival CLs and log hazard CLs at the SAS 1-SD level) from the saved multivariable both-phase model — `hm.death.AVC`'s final fit, saved as `HMDEATH` — for two covariate profiles each:

- **`hp.death.AVC.hm1`** — with vs without an associated major cardiac anomaly (`MAL` 0/1)
- **`hp.death.AVC.hm2`** — complete vs partial canal (`COM_IV` 0/1) across dates of repair

This is the direct extension of the #74/#75 HAZPRED CL reconciliation: the same `predict(type="survival", conf.type="logit")` and `predict(type="hazard")` paths, now exercised on a 9-coefficient both-phase covariate model with covariate `newdata`.

## How it's verified

Each printed row of the SAS "digital nomogram" carries its own covariate vector, so `newdata` is built directly from the parsed table and predictions are compared row-by-row. Matches SAS to:

- **~5e-4** survival (point + logit CLs)
- **~8e-3** hazard (point + log CLs)

The looser hazard tolerance is principled: this is a near-singular fit (rcond ~5e-12, exactly as already documented for `hm.death.AVC.deciles`), so R converges to its own optimum a few e-4 from SAS's reported MLEs, amplified at the steep early-phase times (t = 1 day, hazard ~0.7). The full-information vcov (#74) holds up — CLs match at the same scale as the points despite the ill-conditioning.

## Changes

- `tests/testthat/test-sas-parity.R` — two new `test_that` blocks + shared `.hzr_check_hmdeath_nomogram()` assertion helper.
- `tests/testthat/helper-sas-parity.R` — `.hzr_parse_sas_nomogram_mv()` (header-driven BY-group nomogram parser) + `.hzr_fit_avc_hmdeath()` (shared HMDEATH fit; deciles test left untouched).
- `NEWS.md` — Testing entry.

No package code changed — tests only, against existing `predict.hazard()`.

## Scope note

`hs.death.AVC.hm1` (the third predict variant) is **not** in this PR: it's a *stratified population-averaged calibration* (predict every subject, then aggregate observed-vs-expected and mean survival by `COM_IV` stratum), and its `.lst` is plot-only with no per-row nomogram table. That's a distinct test pattern and will get its own follow-up.

## Test plan

- [x] Full suite: **0 failures, 1638 pass** (up from 1620; +18 = 2 tests × 9 assertions)
- [x] Warnings are only the expected ill-conditioning notices

🤖 Generated with [Claude Code](https://claude.com/claude-code)