### PR TITLE
test: hs.death.AVC.hm1 stratified calibration parity (Group A)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -246,6 +246,17 @@
   rows each carry their own covariate vector) and a shared
   `.hzr_fit_avc_hmdeath()` helper.
 
+* **Stratified HAZPRED calibration parity** (Group A fixture
+  `hs.death.AVC.hm1`).  New `test-sas-parity.R` blocks reproduce the
+  population-averaged, stratified-by-`COM_IV` outputs from the same HMDEATH
+  model: (1) the observed-vs-expected "predict number of deaths" table --
+  per stratum, EXPECTED = sum of predicted cumulative hazard at each subject's
+  own follow-up, PEXPECT = sum of predicted death probability, ACTUAL =
+  observed deaths (totals conserve events, 14.76 + 55.24 = 70), to ~5e-3; and
+  (2) the per-stratum mean survival curve (MSURVIV) at the digital time grid, to
+  ~5e-4.  Adds `.hzr_parse_sas_calibration()` and
+  `.hzr_parse_sas_strata_survival()`.
+
 * **Phase-specific covariate recovery tests** (Phase 7d).  New
   `test-phase-specific-covariates.R` confirms that `hzr_phase(formula = ~ ...)`
   is correct, not just runnable: simulation-based recovery tests verify that a

--- a/inst/dev/FIXTURE-GAP-LIST.md
+++ b/inst/dev/FIXTURE-GAP-LIST.md
@@ -46,8 +46,8 @@ the parser handles them, and we just need to write the `test_that` blocks.
 | `hm.death.AVC` fit 2 | Shaping modifiers `/S`, `/I`, `/E` on covariates | Not in R public API — defer to v1.1 or hand-translate; mark as known gap |
 | `ac.death.AVC` | `%KAPLAN` + `%NELSONT` (actuarial Kaplan-Meier and Nelson-Aalen) | Write `hzr_kaplan()` / `hzr_nelson()` parity expectations |
 | `hp.death.AVC` | `%HAZPRED` predictions overlaid on KM (hazard, survival, cumulative hazard types) | Define parity tolerance for predict outputs; coordinates with `predict.hazard()` CI tests |
-| `hp.death.AVC.hm1`, `hm2` | Pure prediction from saved estimates — two covariate profiles | Same as above |
-| `hs.death.AVC.hm1` | Stratified predictions (two strata, two covariate vectors) | `predict.hazard()` newdata path |
+| `hp.death.AVC.hm1`, `hm2` | Pure prediction from saved estimates — two covariate profiles | **DONE (PR #76).** Per-patient survival + hazard nomograms (logit survival CLs / log hazard CLs) from HMDEATH for two profiles each, to ~5e-4 / ~8e-3; `.hzr_parse_sas_nomogram_mv()` + `.hzr_fit_avc_hmdeath()`. |
+| `hs.death.AVC.hm1` | Stratified predictions (two strata, two covariate vectors) | **DONE.** Stratified-by-`COM_IV` calibration from HMDEATH: observed-vs-expected "predict number of deaths" (EXPECTED = Σ cumhaz at own follow-up, PEXPECT = Σ(1−S), ACTUAL = deaths; totals conserve events) to ~5e-3, and per-stratum mean survival curve (MSURVIV) to ~5e-4; `.hzr_parse_sas_calibration()` + `.hzr_parse_sas_strata_survival()`. |
 | `bs.death.AVC` | `%HAZBOOT(RESAMPL=5)` with embedded stepwise (SLE=0.12, SLS=0.1) | Bootstrap output is non-deterministic; parity metric = variable selection frequency + mean LL, not point estimates |
 
 ---

--- a/tests/testthat/helper-sas-parity.R
+++ b/tests/testthat/helper-sas-parity.R
@@ -647,7 +647,6 @@
   lines <- .hzr_read_lst(path)
   rules <- grep("Interventricular communication=([0-9])", lines)
   if (!length(rules)) return(NULL)
-  cols <- c("YEARS", "NSURVIV", "MSURVIV", "MCLLSURV", "MCLUSURV")
   out <- list()
   for (r in rules) {
     g <- as.integer(sub(".*communication=([0-9]).*", "\\1", lines[r]))

--- a/tests/testthat/helper-sas-parity.R
+++ b/tests/testthat/helper-sas-parity.R
@@ -605,6 +605,75 @@
   )
 }
 
+# Parse the stratified "Predict number of deaths" observed-vs-expected table
+# printed by hs.death.AVC.hm1.sas: one row per stratum (PROC SUMMARY BY COM_IV)
+# with the printed header
+#   Obs STATUS INC_SURG OPMOS AGE MAL COM_IV ORIFICE DEAD INT_DEAD PROB
+#       CUM_HAZ DEAD PEXPECT EXPECTED ACTUAL
+# (note the duplicated DEAD column, so we read by position).  Returns a data
+# frame with one row per stratum: com_iv, pexpect (Sum 1 - S), expected
+# (Sum cumulative hazard), actual (observed deaths).  NULL if absent.
+.hzr_parse_sas_calibration <- function(path) {
+  lines <- .hzr_read_lst(path)
+  h <- grep("COM_IV.*PEXPECT.*EXPECTED.*ACTUAL", lines)
+  if (!length(h)) return(NULL)
+  rows <- list()
+  for (ln in lines[(h[1] + 1L):length(lines)]) {
+    if (!nzchar(trimws(ln))) next                  # SAS double-spaces the rows
+    toks <- strsplit(trimws(ln), "[[:space:]]+")[[1]]
+    if (!grepl("^[0-9]+$", toks[1])) {
+      if (length(rows)) break else next
+    }
+    if (length(toks) < 16L) next
+    v <- suppressWarnings(as.numeric(toks[1:16]))
+    rows[[length(rows) + 1L]] <- data.frame(
+      com_iv   = v[7],
+      pexpect  = v[14],
+      expected = v[15],
+      actual   = v[16]
+    )
+  }
+  if (!length(rows)) return(NULL)
+  do.call(rbind, rows)
+}
+
+# Parse the per-stratum mean-survival "digital" table printed by
+# hs.death.AVC.hm1.sas: blocks delimited by "Interventricular communication=<g>"
+# rule lines, each with header  Obs YEARS NSURVIV MSURVIV MCLLSURV MCLUSURV
+# (NSURVIV = stratum size; MSURVIV/MCLLSURV/MCLUSURV = mean of per-subject
+# survival and its CL across the stratum).  Returns a long data frame with a
+# leading `com_iv` column; NULL if absent.
+.hzr_parse_sas_strata_survival <- function(path) {
+  lines <- .hzr_read_lst(path)
+  rules <- grep("Interventricular communication=([0-9])", lines)
+  if (!length(rules)) return(NULL)
+  cols <- c("YEARS", "NSURVIV", "MSURVIV", "MCLLSURV", "MCLUSURV")
+  out <- list()
+  for (r in rules) {
+    g <- as.integer(sub(".*communication=([0-9]).*", "\\1", lines[r]))
+    hdr <- grep("Obs[[:space:]]+YEARS[[:space:]]+NSURVIV", lines)
+    hdr <- hdr[hdr > r][1]
+    if (is.na(hdr)) next
+    started <- FALSE
+    for (ln in lines[(hdr + 1L):length(lines)]) {
+      if (!nzchar(trimws(ln))) next                # tolerate blank spacer rows
+      toks <- strsplit(trimws(ln), "[[:space:]]+")[[1]]
+      if (!grepl("^[0-9]+$", toks[1])) {
+        if (started) break else next
+      }
+      if (length(toks) < 6L) next
+      started <- TRUE
+      v <- suppressWarnings(as.numeric(toks[2:6]))
+      out[[length(out) + 1L]] <- data.frame(
+        com_iv = g, YEARS = v[1], NSURVIV = v[2],
+        MSURVIV = v[3], MCLLSURV = v[4], MCLUSURV = v[5]
+      )
+    }
+  }
+  if (!length(out)) return(NULL)
+  do.call(rbind, out)
+}
+
 # Default discovery: ~/Documents/GitHub/hazard/examples/ if it exists,
 # else NULL.  Skip tests when fixtures are unavailable.
 .hzr_sas_fixture_dir <- function() {

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -667,6 +667,102 @@ test_that("hp.death.AVC.hm2: predictions by date of repair (COM_IV 0/1) match SA
 })
 
 # ---------------------------------------------------------------------------
+# hs.death.AVC.hm1: stratified observed-vs-expected calibration + mean survival
+# ---------------------------------------------------------------------------
+# Patient-specific HAZPRED predictions from the saved HMDEATH model, summarized
+# BY type of AV canal (COM_IV).  Two SAS tables are reproduced:
+#   1. "Predict number of deaths" -- per stratum, EXPECTED = sum of predicted
+#      cumulative hazard at each subject's own follow-up, PEXPECT = sum of
+#      predicted death probability (1 - S), ACTUAL = observed deaths.  Totals
+#      conserve events (14.76 + 55.24 = 70 = ACTUAL total).
+#   2. Per-stratum mean survival at a digital time grid (MSURVIV = mean over the
+#      stratum of each subject's predicted survival; NSURVIV = stratum size).
+# This is the population-averaged / calibration counterpart to the per-patient
+# hp.death.AVC.hm1/hm2 nomograms.  Same fit; tolerances reflect the same
+# near-singular 9-coefficient model (sums over 154/156 subjects, so absolute
+# tolerances are scaled up accordingly).
+test_that("hs.death.AVC.hm1: stratified observed-vs-expected calibration matches SAS", {
+  testthat::skip_on_cran()
+  dir <- skip_if_no_sas_fixtures()
+  lst <- file.path(dir, "hs.death.AVC.hm1.lst")
+  testthat::skip_if_not(file.exists(lst), "hs.death.AVC.hm1.lst fixture not present")
+
+  cal <- .hzr_parse_sas_calibration(lst)
+  expect_false(is.null(cal), label = "SAS observed-vs-expected table parsed")
+  expect_equal(nrow(cal), 2L)                       # two COM_IV strata
+  cal <- cal[order(cal$com_iv), ]
+
+  set.seed(112)
+  fit <- .hzr_fit_avc_hmdeath()
+  expect_equal(fit$fit$objective, -160.408, tolerance = 1e-2)
+
+  data(avc, package = "TemporalHazard")
+  d <- avc
+  d$inc_surg[is.na(d$inc_surg)] <- mean(d$inc_surg, na.rm = TRUE)
+  nd <- data.frame(
+    time = d$int_dead, age = d$age, com_iv = d$com_iv, mal = d$mal,
+    opmos = d$opmos, op_age = d$opmos * d$age, status = d$status,
+    inc_surg = d$inc_surg, orifice = d$orifice)
+  ch <- predict(fit, newdata = nd, type = "cumulative_hazard")
+  sv <- predict(fit, newdata = nd, type = "survival")
+
+  for (k in seq_len(nrow(cal))) {
+    g <- cal$com_iv[k]
+    i <- d$com_iv == g
+    expect_equal(sum(ch[i]),       cal$expected[k], tolerance = 5e-3,
+                 label = paste0("EXPECTED (sum cumhaz), COM_IV=", g))
+    expect_equal(sum(1 - sv[i]),   cal$pexpect[k],  tolerance = 5e-3,
+                 label = paste0("PEXPECT (sum 1-S), COM_IV=", g))
+    expect_equal(sum(d$dead[i]),   cal$actual[k],
+                 label = paste0("ACTUAL (observed deaths), COM_IV=", g))
+  }
+  # Conservation of events across strata: total expected == total observed.
+  expect_equal(sum(ch), sum(cal$actual), tolerance = 1e-2,
+               label = "total expected == total observed (CoE)")
+})
+
+test_that("hs.death.AVC.hm1: per-stratum mean survival curve matches SAS", {
+  testthat::skip_on_cran()
+  dir <- skip_if_no_sas_fixtures()
+  lst <- file.path(dir, "hs.death.AVC.hm1.lst")
+  testthat::skip_if_not(file.exists(lst), "hs.death.AVC.hm1.lst fixture not present")
+
+  ms <- .hzr_parse_sas_strata_survival(lst)
+  expect_false(is.null(ms), label = "SAS per-stratum mean-survival table parsed")
+  expect_setequal(unique(ms$com_iv), c(0, 1))
+
+  set.seed(113)
+  fit <- .hzr_fit_avc_hmdeath()
+
+  data(avc, package = "TemporalHazard")
+  d <- avc
+  d$inc_surg[is.na(d$inc_surg)] <- mean(d$inc_surg, na.rm = TRUE)
+
+  # NSURVIV (stratum size) must match the cohort.
+  for (g in c(0, 1)) {
+    n_sas <- ms$NSURVIV[ms$com_iv == g][1]
+    expect_equal(sum(d$com_iv == g), n_sas,
+                 label = paste0("stratum size NSURVIV, COM_IV=", g))
+  }
+
+  # MSURVIV = mean over the stratum of each subject's predicted survival at the
+  # grid time (MONTHS = YEARS * 12).  Compare row by row.
+  r_msurviv <- numeric(nrow(ms))
+  for (k in seq_len(nrow(ms))) {
+    g <- ms$com_iv[k]
+    i <- which(d$com_iv == g)
+    nd <- data.frame(
+      time = rep(ms$YEARS[k] * 12, length(i)),
+      age = d$age[i], com_iv = d$com_iv[i], mal = d$mal[i], opmos = d$opmos[i],
+      op_age = d$opmos[i] * d$age[i], status = d$status[i],
+      inc_surg = d$inc_surg[i], orifice = d$orifice[i])
+    r_msurviv[k] <- mean(predict(fit, newdata = nd, type = "survival"))
+  }
+  expect_equal(r_msurviv, ms$MSURVIV, tolerance = 5e-4,
+               label = "per-stratum mean survival (MSURVIV) vs SAS")
+})
+
+# ---------------------------------------------------------------------------
 # hz.te123.OMC: 2-phase (Early CDF + Late Weibull) repeated TE events
 # ---------------------------------------------------------------------------
 # Two fits:


### PR DESCRIPTION
## Summary

Adds the `hs.death.AVC.hm1` Group A parity test — the **population-averaged, stratified-by-`COM_IV` calibration** counterpart to the per-patient nomograms in #76. Both reproduced from the same saved `HMDEATH` model.

> **Stacked on #76** (`test/group-a-predict-variants`) — it reuses the `.hzr_fit_avc_hmdeath()` helper introduced there. Base will auto-retarget to `dev` once #76 merges. Review/merge #76 first.

## What's reproduced

**1. Observed-vs-expected ("predict number of deaths") by stratum** — for each `COM_IV` group:
- `EXPECTED` = Σ predicted cumulative hazard at each subject's own follow-up
- `PEXPECT` = Σ predicted death probability (1 − S)
- `ACTUAL` = observed deaths

| COM_IV | EXPECTED (R / SAS) | ACTUAL |
|---|---|---|
| 0 | 14.763 / 14.7635 | 17 |
| 1 | 55.237 / 55.2365 | 53 |

Totals conserve events: 14.76 + 55.24 = **70** = ACTUAL total. Matches to **~5e-3**.

**2. Per-stratum mean survival curve** (`MSURVIV` = mean over the stratum of each subject's predicted survival; `NSURVIV` = stratum size) at the digital time grid — matches to **~5e-4**.

## Changes

- `tests/testthat/test-sas-parity.R` — two new `test_that` blocks.
- `tests/testthat/helper-sas-parity.R` — `.hzr_parse_sas_calibration()` and `.hzr_parse_sas_strata_survival()` (both tolerate the blank spacer rows SAS prints between records — the bug found and fixed during development).
- `NEWS.md`, `inst/dev/FIXTURE-GAP-LIST.md` (marks hm1/hm2 + hs.hm1 DONE).

No package code changed. With this, **all four implementable Group A predict fixtures are done**; stepwise (#77) and bootstrap (#78) are documented gaps, and `hm.dthar.TGA` remains blocked on a CCF SAS run.

## Test plan

- [x] Full suite: **0 failures, 0 errors, 1653 pass**
- [x] hs.hm1 tests: 10 + 5 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)