### PR TITLE
docs: explain remaining enumerated options (dist, stepwise direction/criterion)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,14 @@
 * Added methodological references to the nonparametric diagnostics
   (Kaplan-Meier/Greenwood, Nelson-Aalen, Aalen-Johansen) and filled in missing
   cross-references across the exported help pages.
+* Explained the remaining enumerated options in the style of the `hzr_phase()`
+  phase-type help. `?hazard` gains a **Baseline distributions** section
+  describing each `dist` value (`"weibull"`, `"exponential"`, `"loglogistic"`,
+  `"lognormal"`, `"multiphase"`) by its hazard shape and when to use it;
+  `?hzr_stepwise` gains a **Selection direction and criterion** section
+  explaining each `direction` (`"forward"`/`"backward"`/`"both"`) and
+  `criterion` (`"wald"`/`"aic"`), including how Wald selection differs from
+  C/SAS HAZARD's score-statistic path.
 
 # TemporalHazard 1.1.0
 

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -62,6 +62,42 @@ NULL
 #' and transformed back for reporting; see
 #' `vignette("mf-mathematical-foundations")`.
 #'
+#' @section Baseline distributions:
+#'
+#' The `dist` argument selects the parametric form of the baseline hazard.  The
+#' four single-distribution families (\eqn{J = 1}) differ in the *shape* the
+#' hazard traces over follow-up; choose by what the risk is expected to do over
+#' time.  `"multiphase"` is the general additive model that lets several such
+#' shapes coexist.
+#'
+#' \describe{
+#'   \item{`"weibull"` --- monotone rising or falling hazard (default)}{The
+#'     workhorse parametric model: \eqn{H(t \mid \mathbf{x}) = (\mu t)^\nu
+#'     \exp(\eta)}, with hazard \eqn{h \propto t^{\nu - 1}}.  The single shape
+#'     \eqn{\nu} makes risk increase over time (\eqn{\nu > 1}), decrease
+#'     (\eqn{\nu < 1}), or stay flat (\eqn{\nu = 1}).  Use it as the default when
+#'     a single monotone trend describes the hazard.}
+#'   \item{`"exponential"` --- constant hazard}{The memoryless special case
+#'     \eqn{\nu = 1}: a time-invariant baseline rate, \eqn{H(t \mid \mathbf{x}) =
+#'     \mu t \exp(\eta)}.  Use it when the event rate does not change with
+#'     follow-up time (the constant background risk also appears as the
+#'     `"constant"` phase in a multiphase model).}
+#'   \item{`"loglogistic"` --- unimodal (rise-then-fall) hazard}{A log-logistic
+#'     accelerated-failure-time form whose hazard rises to a single peak and then
+#'     declines when the shape exceeds 1 (and is monotone decreasing otherwise),
+#'     with heavier tails than the log-normal.  Use it when risk climbs to an
+#'     early peak and then eases off.}
+#'   \item{`"lognormal"` --- early-peaking, resolving hazard}{An
+#'     accelerated-failure-time form in which \eqn{\log} time is Gaussian; the
+#'     hazard rises to an early peak and then decays toward zero.  Use it for
+#'     risk that is concentrated early and resolves over time.}
+#'   \item{`"multiphase"` --- additive N-phase hazard}{Sums several phase shapes
+#'     into one model, \eqn{H = \sum_j \mu_j(\mathbf{x}) \Phi_j(t)}, so the
+#'     overall hazard can fall, level off, and rise again within one fit.
+#'     Requires `phases`; see [hzr_phase()] for the available phase shapes.  This
+#'     is the form that reproduces the classic C/SAS HAZARD models.}
+#' }
+#'
 #' @param time Numeric follow-up time vector.
 #' @param status Numeric or logical event indicator vector.
 #' @param time_lower Optional numeric lower bound vector for censoring intervals.
@@ -78,8 +114,12 @@ NULL
 #'   `x` is expanded into one column per time window so each window gets its own
 #'   coefficient.
 #' @param theta Optional numeric coefficient vector (starting values for optimization).
-#' @param dist Character baseline distribution label (default "weibull").
-#'   Use `"multiphase"` for N-phase additive hazard models (requires `phases`).
+#' @param dist Character baseline distribution label (default `"weibull"`).
+#'   One of `"weibull"`, `"exponential"`, `"loglogistic"`, `"lognormal"`, or
+#'   `"multiphase"`.  The single-distribution families differ in the *shape* the
+#'   hazard traces over time; `"multiphase"` builds an additive N-phase hazard
+#'   and requires `phases`.  See the **Baseline distributions** section for what
+#'   each means and when to use it.
 #' @param phases Optional named list of [hzr_phase()] objects specifying the
 #'   phases for a multiphase model (`dist = "multiphase"`).  See Examples.
 #' @param fit Logical; if TRUE, fit the model via maximum likelihood (default FALSE).

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -83,10 +83,11 @@ NULL
 #'     follow-up time (the constant background risk also appears as the
 #'     `"constant"` phase in a multiphase model).}
 #'   \item{`"loglogistic"` --- unimodal (rise-then-fall) hazard}{A log-logistic
-#'     accelerated-failure-time form whose hazard rises to a single peak and then
-#'     declines when the shape exceeds 1 (and is monotone decreasing otherwise),
-#'     with heavier tails than the log-normal.  Use it when risk climbs to an
-#'     early peak and then eases off.}
+#'     proportional-odds form (covariates act multiplicatively on the odds of
+#'     failure, \eqn{\exp(\eta)}, not as an AFT time shift) whose hazard rises to
+#'     a single peak and then declines when the shape exceeds 1 (and is monotone
+#'     decreasing otherwise), with heavier tails than the log-normal.  Use it
+#'     when risk climbs to an early peak and then eases off.}
 #'   \item{`"lognormal"` --- early-peaking, resolving hazard}{An
 #'     accelerated-failure-time form in which \eqn{\log} time is Gaussian; the
 #'     hazard rises to an early peak and then decays toward zero.  Use it for

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -22,6 +22,40 @@
 #' retention criterion.  Phase-specific entry is supported for
 #' multiphase models: a covariate can enter one phase and not another.
 #'
+#' @section Selection direction and criterion:
+#'
+#' Two arguments shape the search.  `direction` decides which moves are
+#' allowed at each step; `criterion` decides how a candidate move is scored
+#' and whether it is accepted.
+#'
+#' \describe{
+#'   \item{`direction = "forward"`}{Start from the base model and only
+#'     *add* variables --- the best eligible candidate enters each step
+#'     until none clears the entry rule.  Variables never leave once in.}
+#'   \item{`direction = "backward"`}{Start from the full candidate model and
+#'     only *drop* variables --- the weakest term leaves each step until all
+#'     survivors clear the retention rule.}
+#'   \item{`direction = "both"` (default)}{Two-way stepwise: after each
+#'     entry, already-selected variables are re-tested and may be dropped.
+#'     This is the SAS `SELECTION = STEPWISE` strategy.  `max_move` caps how
+#'     often a single variable may oscillate before it is frozen.}
+#' }
+#'
+#' \describe{
+#'   \item{`criterion = "wald"` (default)}{Score each move by the Wald
+#'     \eqn{\chi^2} of the affected coefficient(s) from a refit, and accept on
+#'     SAS-style significance thresholds: a candidate enters if its p-value is
+#'     below `slentry`, and a term is dropped if its p-value rises above
+#'     `slstay`.  Note this differs algorithmically from C/SAS HAZARD, which
+#'     selects on a *score* (Q) statistic evaluated without refitting; the two
+#'     can take different step paths even when they converge to a similar final
+#'     model.}
+#'   \item{`criterion = "aic"`}{Score each move by the change in AIC from the
+#'     refit and accept any move with \eqn{\Delta\mathrm{AIC} < 0} (a strictly
+#'     better penalised fit), ignoring `slentry` / `slstay`.  Use this for a
+#'     non-significance-based, information-criterion search.}
+#' }
+#'
 #' @param fit A fitted `hazard` object built via the
 #'   `formula = Surv(...) ~ predictors, data = df` interface.
 #' @param scope Candidate set.  `NULL` (default) uses every data-frame
@@ -31,10 +65,14 @@
 #'   fits, pass a named list of one-sided formulas keyed by phase.
 #' @param data Data frame the base fit was built on.  Required for
 #'   refits.
-#' @param direction One of `"both"` (default), `"forward"`,
-#'   `"backward"`.
-#' @param criterion One of `"wald"` (default) or `"aic"`.  SAS-style
-#'   p-value thresholds apply to Wald; AIC uses `DeltaAIC < 0` uniformly.
+#' @param direction Search strategy --- one of `"both"` (default),
+#'   `"forward"`, or `"backward"`.  Controls whether variables may only
+#'   enter, only leave, or both.  See the **Selection direction and
+#'   criterion** section.
+#' @param criterion Entry / retention rule --- one of `"wald"` (default)
+#'   or `"aic"`.  `"wald"` applies SAS-style p-value thresholds
+#'   (`slentry` / `slstay`); `"aic"` adds or drops whenever it lowers the
+#'   AIC.  See the **Selection direction and criterion** section.
 #' @param slentry Entry p-value threshold for the Wald criterion.
 #'   Default `0.30` matches SAS `SLENTRY`.
 #' @param slstay Retention p-value threshold for the Wald criterion.

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -42,18 +42,26 @@
 #' }
 #'
 #' \describe{
-#'   \item{`criterion = "wald"` (default)}{Score each move by the Wald
-#'     \eqn{\chi^2} of the affected coefficient(s) from a refit, and accept on
-#'     SAS-style significance thresholds: a candidate enters if its p-value is
-#'     below `slentry`, and a term is dropped if its p-value rises above
-#'     `slstay`.  Note this differs algorithmically from C/SAS HAZARD, which
-#'     selects on a *score* (Q) statistic evaluated without refitting; the two
-#'     can take different step paths even when they converge to a similar final
-#'     model.}
-#'   \item{`criterion = "aic"`}{Score each move by the change in AIC from the
-#'     refit and accept any move with \eqn{\Delta\mathrm{AIC} < 0} (a strictly
-#'     better penalised fit), ignoring `slentry` / `slstay`.  Use this for a
-#'     non-significance-based, information-criterion search.}
+#'   \item{`criterion = "wald"` (default)}{Accept moves on SAS-style
+#'     significance thresholds, using the Wald \eqn{\chi^2} of the affected
+#'     coefficient(s): a candidate enters if its p-value is below `slentry`, and
+#'     a term is dropped if its p-value rises above `slstay`.  Entry candidates
+#'     are scored from a refit that adds the candidate (so its new coefficient
+#'     can be tested); drop candidates are scored from the *current* model's
+#'     Wald p-values without a per-candidate refit, and a single refit is run
+#'     only after a drop is chosen.  Note this differs algorithmically from
+#'     C/SAS HAZARD, which selects on a *score* (Q) statistic evaluated without
+#'     refitting; the two can take different step paths even when they converge
+#'     to a similar final model.}
+#'   \item{`criterion = "aic"`}{Accept any move with
+#'     \eqn{\Delta\mathrm{AIC} < 0} (a strictly better penalised fit), ignoring
+#'     `slentry` / `slstay`.  Entry candidates use the actual
+#'     \eqn{\Delta\mathrm{AIC}} from the candidate refit; drop candidates use a
+#'     Wald-to-likelihood-ratio approximation,
+#'     \eqn{\Delta\mathrm{AIC} \approx W - 2\,\mathrm{df}}, computed from the
+#'     current model without a per-candidate refit (the chosen drop is refit
+#'     afterwards).  Use this for a non-significance-based,
+#'     information-criterion search.}
 #' }
 #'
 #' @param fit A fitted `hazard` object built via the

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -163,10 +163,11 @@ a single monotone trend describes the hazard.}
 follow-up time (the constant background risk also appears as the
 \code{"constant"} phase in a multiphase model).}
 \item{\code{"loglogistic"} --- unimodal (rise-then-fall) hazard}{A log-logistic
-accelerated-failure-time form whose hazard rises to a single peak and then
-declines when the shape exceeds 1 (and is monotone decreasing otherwise),
-with heavier tails than the log-normal.  Use it when risk climbs to an
-early peak and then eases off.}
+proportional-odds form (covariates act multiplicatively on the odds of
+failure, \eqn{\exp(\eta)}, not as an AFT time shift) whose hazard rises to
+a single peak and then declines when the shape exceeds 1 (and is monotone
+decreasing otherwise), with heavier tails than the log-normal.  Use it
+when risk climbs to an early peak and then eases off.}
 \item{\code{"lognormal"} --- early-peaking, resolving hazard}{An
 accelerated-failure-time form in which \eqn{\log} time is Gaussian; the
 hazard rises to an early peak and then decays toward zero.  Use it for

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -48,8 +48,12 @@ coefficient.}
 
 \item{theta}{Optional numeric coefficient vector (starting values for optimization).}
 
-\item{dist}{Character baseline distribution label (default "weibull").
-Use \code{"multiphase"} for N-phase additive hazard models (requires \code{phases}).}
+\item{dist}{Character baseline distribution label (default \code{"weibull"}).
+One of \code{"weibull"}, \code{"exponential"}, \code{"loglogistic"}, \code{"lognormal"}, or
+\code{"multiphase"}.  The single-distribution families differ in the \emph{shape} the
+hazard traces over time; \code{"multiphase"} builds an additive N-phase hazard
+and requires \code{phases}.  See the \strong{Baseline distributions} section for what
+each means and when to use it.}
 
 \item{phases}{Optional named list of \code{\link[=hzr_phase]{hzr_phase()}} objects specifying the
 phases for a multiphase model (\code{dist = "multiphase"}).  See Examples.}
@@ -135,6 +139,44 @@ distributions (\code{"weibull"}, \code{"exponential"}, \code{"lognormal"},
 on an unconstrained internal scale (e.g. \eqn{\log\mu}, \eqn{\log t_{1/2}})
 and transformed back for reporting; see
 \code{vignette("mf-mathematical-foundations")}.
+}
+
+\section{Baseline distributions}{
+
+
+The \code{dist} argument selects the parametric form of the baseline hazard.  The
+four single-distribution families (\eqn{J = 1}) differ in the \emph{shape} the
+hazard traces over follow-up; choose by what the risk is expected to do over
+time.  \code{"multiphase"} is the general additive model that lets several such
+shapes coexist.
+
+\describe{
+\item{\code{"weibull"} --- monotone rising or falling hazard (default)}{The
+workhorse parametric model: \eqn{H(t \mid \mathbf{x}) = (\mu t)^\nu
+    \exp(\eta)}, with hazard \eqn{h \propto t^{\nu - 1}}.  The single shape
+\eqn{\nu} makes risk increase over time (\eqn{\nu > 1}), decrease
+(\eqn{\nu < 1}), or stay flat (\eqn{\nu = 1}).  Use it as the default when
+a single monotone trend describes the hazard.}
+\item{\code{"exponential"} --- constant hazard}{The memoryless special case
+\eqn{\nu = 1}: a time-invariant baseline rate, \eqn{H(t \mid \mathbf{x}) =
+    \mu t \exp(\eta)}.  Use it when the event rate does not change with
+follow-up time (the constant background risk also appears as the
+\code{"constant"} phase in a multiphase model).}
+\item{\code{"loglogistic"} --- unimodal (rise-then-fall) hazard}{A log-logistic
+accelerated-failure-time form whose hazard rises to a single peak and then
+declines when the shape exceeds 1 (and is monotone decreasing otherwise),
+with heavier tails than the log-normal.  Use it when risk climbs to an
+early peak and then eases off.}
+\item{\code{"lognormal"} --- early-peaking, resolving hazard}{An
+accelerated-failure-time form in which \eqn{\log} time is Gaussian; the
+hazard rises to an early peak and then decays toward zero.  Use it for
+risk that is concentrated early and resolves over time.}
+\item{\code{"multiphase"} --- additive N-phase hazard}{Sums several phase shapes
+into one model, \eqn{H = \sum_j \mu_j(\mathbf{x}) \Phi_j(t)}, so the
+overall hazard can fall, level off, and rise again within one fit.
+Requires \code{phases}; see \code{\link[=hzr_phase]{hzr_phase()}} for the available phase shapes.  This
+is the form that reproduces the classic C/SAS HAZARD models.}
+}
 }
 
 \examples{

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -155,18 +155,26 @@ often a single variable may oscillate before it is frozen.}
 }
 
 \describe{
-\item{\code{criterion = "wald"} (default)}{Score each move by the Wald
-\eqn{\chi^2} of the affected coefficient(s) from a refit, and accept on
-SAS-style significance thresholds: a candidate enters if its p-value is
-below \code{slentry}, and a term is dropped if its p-value rises above
-\code{slstay}.  Note this differs algorithmically from C/SAS HAZARD, which
-selects on a \emph{score} (Q) statistic evaluated without refitting; the two
-can take different step paths even when they converge to a similar final
-model.}
-\item{\code{criterion = "aic"}}{Score each move by the change in AIC from the
-refit and accept any move with \eqn{\Delta\mathrm{AIC} < 0} (a strictly
-better penalised fit), ignoring \code{slentry} / \code{slstay}.  Use this for a
-non-significance-based, information-criterion search.}
+\item{\code{criterion = "wald"} (default)}{Accept moves on SAS-style
+significance thresholds, using the Wald \eqn{\chi^2} of the affected
+coefficient(s): a candidate enters if its p-value is below \code{slentry}, and
+a term is dropped if its p-value rises above \code{slstay}.  Entry candidates
+are scored from a refit that adds the candidate (so its new coefficient
+can be tested); drop candidates are scored from the \emph{current} model's
+Wald p-values without a per-candidate refit, and a single refit is run
+only after a drop is chosen.  Note this differs algorithmically from
+C/SAS HAZARD, which selects on a \emph{score} (Q) statistic evaluated without
+refitting; the two can take different step paths even when they converge
+to a similar final model.}
+\item{\code{criterion = "aic"}}{Accept any move with
+\eqn{\Delta\mathrm{AIC} < 0} (a strictly better penalised fit), ignoring
+\code{slentry} / \code{slstay}.  Entry candidates use the actual
+\eqn{\Delta\mathrm{AIC}} from the candidate refit; drop candidates use a
+Wald-to-likelihood-ratio approximation,
+\eqn{\Delta\mathrm{AIC} \approx W - 2\,\mathrm{df}}, computed from the
+current model without a per-candidate refit (the chosen drop is refit
+afterwards).  Use this for a non-significance-based,
+information-criterion search.}
 }
 }
 

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -45,11 +45,15 @@ fits, pass a named list of one-sided formulas keyed by phase.}
 \item{data}{Data frame the base fit was built on.  Required for
 refits.}
 
-\item{direction}{One of \code{"both"} (default), \code{"forward"},
-\code{"backward"}.}
+\item{direction}{Search strategy --- one of \code{"both"} (default),
+\code{"forward"}, or \code{"backward"}.  Controls whether variables may only
+enter, only leave, or both.  See the \strong{Selection direction and
+criterion} section.}
 
-\item{criterion}{One of \code{"wald"} (default) or \code{"aic"}.  SAS-style
-p-value thresholds apply to Wald; AIC uses \code{DeltaAIC < 0} uniformly.}
+\item{criterion}{Entry / retention rule --- one of \code{"wald"} (default)
+or \code{"aic"}.  \code{"wald"} applies SAS-style p-value thresholds
+(\code{slentry} / \code{slstay}); \code{"aic"} adds or drops whenever it lowers the
+AIC.  See the \strong{Selection direction and criterion} section.}
 
 \item{slentry}{Entry p-value threshold for the Wald criterion.
 Default \code{0.30} matches SAS \code{SLENTRY}.}
@@ -130,6 +134,42 @@ computable, regardless of the active criterion.}
 diagnostics of the model \emph{after} this step.}
 }
 }
+\section{Selection direction and criterion}{
+
+
+Two arguments shape the search.  \code{direction} decides which moves are
+allowed at each step; \code{criterion} decides how a candidate move is scored
+and whether it is accepted.
+
+\describe{
+\item{\code{direction = "forward"}}{Start from the base model and only
+\emph{add} variables --- the best eligible candidate enters each step
+until none clears the entry rule.  Variables never leave once in.}
+\item{\code{direction = "backward"}}{Start from the full candidate model and
+only \emph{drop} variables --- the weakest term leaves each step until all
+survivors clear the retention rule.}
+\item{\code{direction = "both"} (default)}{Two-way stepwise: after each
+entry, already-selected variables are re-tested and may be dropped.
+This is the SAS \code{SELECTION = STEPWISE} strategy.  \code{max_move} caps how
+often a single variable may oscillate before it is frozen.}
+}
+
+\describe{
+\item{\code{criterion = "wald"} (default)}{Score each move by the Wald
+\eqn{\chi^2} of the affected coefficient(s) from a refit, and accept on
+SAS-style significance thresholds: a candidate enters if its p-value is
+below \code{slentry}, and a term is dropped if its p-value rises above
+\code{slstay}.  Note this differs algorithmically from C/SAS HAZARD, which
+selects on a \emph{score} (Q) statistic evaluated without refitting; the two
+can take different step paths even when they converge to a similar final
+model.}
+\item{\code{criterion = "aic"}}{Score each move by the change in AIC from the
+refit and accept any move with \eqn{\Delta\mathrm{AIC} < 0} (a strictly
+better penalised fit), ignoring \code{slentry} / \code{slstay}.  Use this for a
+non-significance-based, information-criterion search.}
+}
+}
+
 \examples{
 data(avc)
 avc <- na.omit(avc)


### PR DESCRIPTION
## Summary

Completes the rfsrc-style **option-explanation** doc pass started in #83. That PR explained `hzr_phase()`'s `type` options; this one extends the same pattern to the last enumerated arguments that listed values without saying what they mean.

### `?hazard` — new **Baseline distributions** section
`@param dist` previously named only `"weibull"` and `"multiphase"`. It now enumerates all five values, and a new section describes each by **hazard shape and when to use it**, mirroring the phase-type `\describe` style:

- `"weibull"` — monotone rising/falling (default)
- `"exponential"` — constant hazard (the `ν = 1` special case)
- `"loglogistic"` — unimodal (rise-then-fall)
- `"lognormal"` — early-peaking, resolving
- `"multiphase"` — additive N-phase

### `?hzr_stepwise` — new **Selection direction and criterion** section
`direction` and `criterion` previously just listed their allowed values. The new section explains what each does:

- `direction`: forward (enter only) / backward (drop only) / both (two-way, SAS `SELECTION = STEPWISE`)
- `criterion`: wald (SAS-style `slentry`/`slstay` p-value thresholds) / aic (ΔAIC < 0). Includes the note that Wald refit selection differs algorithmically from C/SAS HAZARD's **score (Q) statistic** path — so step paths can differ even when the final models agree (the same point documented in `test-stepwise-parity.R`).

### `predict(type=)`
Already fully explained — each of the four types carries its formula in `@param type`. Left as-is (no change for its own sake).

## Validation
- Source `.R` and regenerated `man/*.Rd` committed together (avoids the roxygen-freshness CI failure pattern from #83).
- `lintr` clean on both changed files; both Rd files render via `tools::Rd2txt`; all additions are pure ASCII with Rd math via `\eqn{}` (no raw Unicode for the manual-PDF build).

Docs only — no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)