### PR TITLE
chore(release): fold dev work into 1.1.0 (never shipped to CRAN)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.0.9000
+Version: 1.1.0
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
 BugReports: https://github.com/ehrlinger/temporal_hazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,62 +1,3 @@
-# TemporalHazard 1.2.0.9000 (development version)
-
-## Testing
-
-* Added fractional (non-integer) weight coverage to close the roadmap 7a gap.
-  Prior weight tests verified weighting only via integer row duplication, which
-  cannot express fractional (e.g. inverse-probability) weights. The new tests
-  assert the two properties that define a correct per-row weighted
-  log-likelihood: an **additive split** (a row of weight `a + b` equals two
-  identical copies of weights `a` and `b`) and **linear scaling**
-  (`L(theta; c*w) = c * L(theta; w)`, gradient likewise, MLE invariant), across
-  the Weibull, exponential, and multiphase-with-covariates paths.
-* Made the single-distribution weighted-fit tests exercise a real fit. They
-  previously omitted `theta` start values, so `hazard(fit = TRUE)` took its
-  unfitted branch and the assertions compared `NULL`/`NA` vacuously; they now
-  supply starts and genuinely compare the weighted MLE to the duplicated-row
-  MLE.
-* Added interval-censoring coverage under the multiphase model (roadmap 7c).
-  The multiphase likelihood's interval-/left-censored branch had a working code
-  path but no isolated test. New R-only self-consistency invariants in
-  `test-interval-censoring-multiphase.R` verify the interval contribution equals
-  `log(S(lower) - S(upper))`, the left-censored term equals
-  `log(1 - exp(-H(u)))`, right-censoring stays `-(H(stop) - H(start))`
-  (including left truncation), invalid bounds (`lower > upper`) yield `-Inf`,
-  integer weights match row duplication on interval rows, and an
-  interval-censored multiphase fit converges.
-* Added a SAS fractional-weight parity capture scaffold under
-  `inst/extdata/weights-fixtures/` (roadmap 7a / FIXTURE-GAP-LIST B5): a
-  `PROC HAZARD ... WEIGHT IPW` template, a deterministic non-integer weight
-  dataset, a `.lst` parser, and `test-weights-sas-parity.R`. The parity test
-  re-fits the SAS specification in R and compares covariate estimates and
-  log-likelihood; it skips when the capture fixture is absent (as it is by
-  default), so CI and installation are unaffected until a SAS run is dropped
-  in. R-side fractional-weight correctness is already proven by the invariants
-  above; this is the drop-in external SAS confirmation.
-
-## Documentation
-
-* Added a package-level overview help page (`?TemporalHazard`) giving the
-  additive multiphase model, the phase-type vocabulary, the SAS/C HAZARD
-  bridge, and a map of the main entry points.
-* Expanded the mathematical content of the core help files in the style of
-  `randomForestSRC`: explicit display equations for the generalized temporal
-  decomposition `G(t)` (`?hzr_decompos`), the additive cumulative-hazard model
-  on `?hzr_phase` and `?hazard`, and defining formulas plus the
-  Mächler (2012) reference for the numerical primitives (`?hzr_log1pexp`,
-  `?hzr_log1mexp`, `?hzr_clamp_prob`).
-* Added methodological references to the nonparametric diagnostics
-  (Kaplan-Meier/Greenwood, Nelson-Aalen, Aalen-Johansen) and filled in missing
-  cross-references across the exported help pages.
-* Explained the remaining enumerated options in the style of the `hzr_phase()`
-  phase-type help. `?hazard` gains a **Baseline distributions** section
-  describing each `dist` value (`"weibull"`, `"exponential"`, `"loglogistic"`,
-  `"lognormal"`, `"multiphase"`) by its hazard shape and when to use it;
-  `?hzr_stepwise` gains a **Selection direction and criterion** section
-  explaining each `direction` (`"forward"`/`"backward"`/`"both"`) and
-  `criterion` (`"wald"`/`"aic"`), including how Wald selection differs from
-  C/SAS HAZARD's score-statistic path.
-
 # TemporalHazard 1.1.0
 
 ## New features
@@ -303,6 +244,26 @@
   values (log-log plot), when to fix shape parameters vs. estimate freely,
   diagnosing overparameterization via near-zero phase scales and `NA` from
   `vcov()`, and `control` options (`n_starts`, `maxit`).
+* Added a package-level overview help page (`?TemporalHazard`) giving the
+  additive multiphase model, the phase-type vocabulary, the SAS/C HAZARD
+  bridge, and a map of the main entry points.
+* Expanded the mathematical content of the core help files in the style of
+  `randomForestSRC`: explicit display equations for the generalized temporal
+  decomposition `G(t)` (`?hzr_decompos`), the additive cumulative-hazard model
+  on `?hzr_phase` and `?hazard`, and defining formulas plus the
+  Mächler (2012) reference for the numerical primitives (`?hzr_log1pexp`,
+  `?hzr_log1mexp`, `?hzr_clamp_prob`).
+* Added methodological references to the nonparametric diagnostics
+  (Kaplan-Meier/Greenwood, Nelson-Aalen, Aalen-Johansen) and filled in missing
+  cross-references across the exported help pages.
+* Explained the remaining enumerated options in the style of the `hzr_phase()`
+  phase-type help. `?hazard` gains a **Baseline distributions** section
+  describing each `dist` value (`"weibull"`, `"exponential"`, `"loglogistic"`,
+  `"lognormal"`, `"multiphase"`) by its hazard shape and when to use it;
+  `?hzr_stepwise` gains a **Selection direction and criterion** section
+  explaining each `direction` (`"forward"`/`"backward"`/`"both"`) and
+  `criterion` (`"wald"`/`"aic"`), including how Wald selection differs from
+  C/SAS HAZARD's score-statistic path.
 
 ## Testing
 
@@ -362,6 +323,37 @@
   is the honest substitute for a SAS parity fixture and guards against the
   "accepts the formal but never applies it" regression that has surfaced
   before with weights and counting-process times.
+* Added fractional (non-integer) weight coverage to close the roadmap 7a gap.
+  Prior weight tests verified weighting only via integer row duplication, which
+  cannot express fractional (e.g. inverse-probability) weights. The new tests
+  assert the two properties that define a correct per-row weighted
+  log-likelihood: an **additive split** (a row of weight `a + b` equals two
+  identical copies of weights `a` and `b`) and **linear scaling**
+  (`L(theta; c*w) = c * L(theta; w)`, gradient likewise, MLE invariant), across
+  the Weibull, exponential, and multiphase-with-covariates paths.
+* Made the single-distribution weighted-fit tests exercise a real fit. They
+  previously omitted `theta` start values, so `hazard(fit = TRUE)` took its
+  unfitted branch and the assertions compared `NULL`/`NA` vacuously; they now
+  supply starts and genuinely compare the weighted MLE to the duplicated-row
+  MLE.
+* Added interval-censoring coverage under the multiphase model (roadmap 7c).
+  The multiphase likelihood's interval-/left-censored branch had a working code
+  path but no isolated test. New R-only self-consistency invariants in
+  `test-interval-censoring-multiphase.R` verify the interval contribution equals
+  `log(S(lower) - S(upper))`, the left-censored term equals
+  `log(1 - exp(-H(u)))`, right-censoring stays `-(H(stop) - H(start))`
+  (including left truncation), invalid bounds (`lower > upper`) yield `-Inf`,
+  integer weights match row duplication on interval rows, and an
+  interval-censored multiphase fit converges.
+* Added a SAS fractional-weight parity capture scaffold under
+  `inst/extdata/weights-fixtures/` (roadmap 7a / FIXTURE-GAP-LIST B5): a
+  `PROC HAZARD ... WEIGHT IPW` template, a deterministic non-integer weight
+  dataset, a `.lst` parser, and `test-weights-sas-parity.R`. The parity test
+  re-fits the SAS specification in R and compares covariate estimates and
+  log-likelihood; it skips when the capture fixture is absent (as it is by
+  default), so CI and installation are unaffected until a SAS run is dropped
+  in. R-side fractional-weight correctness is already proven by the invariants
+  above; this is the drop-in external SAS confirmation.
 
 ---
 


### PR DESCRIPTION
## Summary

Reconciles the version label so the **pending CRAN release is 1.1.0**, folding this development cycle's work into it.

### Why
1.1.0 was content-frozen on `main` (`chore: release TemporalHazard 1.1.0`) and the dev cycle was opened as `1.2.0.9000` — but **1.1.0 was never actually submitted/accepted to CRAN**: there's no `v1.1.0` git tag (per the tag-after-acceptance policy), and `cran-comments.md` is still written for 1.1.0. Since the release never went out, this cycle's work belongs in 1.1.0, not a separate 1.2.0.

### Changes
- **NEWS.md** — merged the `1.2.0.9000 (development version)` section into `1.1.0`:
  - **Testing** (4): fractional-weight invariants (#84), real weighted-fit fix (#84), interval-censoring under multiphase (#86), SAS fractional-weight scaffold (#87)
  - **Documentation** (4): package overview page (#83), rfsrc-style math (#83), diagnostics references (#83), enumerated-option explanations (#85)
  - bullets moved into the existing 1.1.0 `## Testing` / `## Documentation` subsections; the `1.2.0.9000` heading is dropped.
- **DESCRIPTION** — `Version: 1.2.0.9000` → `1.1.0`.

### Verification
- `DESCRIPTION` and the NEWS top heading now agree (`1.1.0`).
- Each of the 8 folded bullets appears exactly once (no loss/duplication); zero remaining `1.2.0.9000` references; one `1.1.0` heading.
- `CITATION` reads the version dynamically (no change). No R code changed; package loads and tests pass.

### Next (separate, when you're ready to submit)
Full release gate on the merged result: `R CMD check --as-cran` with manual (0/0/0, <10 min), tarball ≤5 MB, rev-dep + url checks, refresh `cran-comments.md` NOTE/test-env for 1.1.0. **No tag** until CRAN accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)