### PR TITLE
fix(cran): ship build/vignette.rds — drop over-broad ^build$ Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,5 +26,4 @@
 ^CRAN-SUBMISSION$
 ^CONTRIBUTORS\.md$
 ^RELEASE\.md$
-^build$
 ^inst/extdata/weights-fixtures/payload/capture/\.gitkeep$


### PR DESCRIPTION
## Summary

Fixes the `R CMD check --as-cran` NOTE **"Package has a VignetteBuilder field but no prebuilt vignette index,"** which surfaced on the 1.1.0 release tarball.

## Root cause
`.Rbuildignore` line `^build$` (added in `3666878` to drop the `build/partial.rdb` roxygen2 cache artifact) also excluded **`build/vignette.rds`** — the prebuilt vignette index that `R CMD build` generates. With the index stripped from the tarball, CRAN's incoming-feasibility check raises the NOTE.

`build/partial.rdb` is a standard, harmless CRAN source-tarball artifact (the staged-install partial database), so excluding the whole `build/` directory was unnecessary in the first place. Removing the one line restores the index.

## Verification
Full `R CMD check --as-cran` (with manual PDF) on the rebuilt 1.1.0 tarball:

```
Status: OK
```

**0 errors / 0 warnings / 0 notes** locally. The tarball now contains `build/vignette.rds`. The only remaining CRAN-*incoming* note is the expected aspell proper-noun one (Naftel/Rajeswaran/UAB/…), which is already documented in `cran-comments.md` and is not package-fixable.

This makes the existing `cran-comments.md` "0/0/0 local" claim actually true — it wasn't, before this fix.

One-line change to `.Rbuildignore`; no code, docs, or tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)