### PR TITLE
fix(docs): correct single-phase J=1 claim; render pkgdown math

### DIFF
--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -55,9 +55,14 @@ NULL
 #'
 #' where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
 #' \boldsymbol{\beta}_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
-#' are set by each phase's `type` (see [hzr_phase()]).  Single-phase
-#' distributions (`"weibull"`, `"exponential"`, `"lognormal"`,
-#' `"loglogistic"`) are the special case \eqn{J = 1}.  Parameters are estimated
+#' are set by each phase's `type` (see [hzr_phase()]).  The
+#' proportional-hazards single-phase families (`"weibull"`, `"exponential"`)
+#' are the special case \eqn{J = 1}, with covariates acting multiplicatively on
+#' one temporal shape.  The `"loglogistic"` (proportional-odds) and
+#' `"lognormal"` (accelerated-failure-time) families place covariates
+#' differently --- on the odds of failure and the log-time location,
+#' respectively --- so they are separate parameterizations, not special cases
+#' of this additive form.  Parameters are estimated
 #' on an unconstrained internal scale (e.g. \eqn{\log\mu}, \eqn{\log t_{1/2}})
 #' and transformed back for reporting; see
 #' `vignette("mf-mathematical-foundations")`.
@@ -65,7 +70,7 @@ NULL
 #' @section Baseline distributions:
 #'
 #' The `dist` argument selects the parametric form of the baseline hazard.  The
-#' four single-distribution families (\eqn{J = 1}) differ in the *shape* the
+#' four single-distribution families differ in the *shape* the
 #' hazard traces over follow-up; choose by what the risk is expected to do over
 #' time.  `"multiphase"` is the general additive model that lets several such
 #' shapes coexist.

--- a/R/likelihood-lognormal.R
+++ b/R/likelihood-lognormal.R
@@ -18,11 +18,13 @@ NULL
 #
 # where mu in R (location), sigma > 0 (scale), eta_i = mu + x_i beta (AFT predictor).
 #
-# AFT vs PH DISTINCTION
-# ---------------------
-# Unlike Weibull / exponential / log-logistic (PH models), covariates in the
-# AFT parameterisation *shift the log-time distribution*.  The linear predictor
-# adds to mu (location), not to log-hazard.  Consequently:
+# AFT vs non-AFT DISTINCTION
+# --------------------------
+# Unlike the non-AFT families -- Weibull / exponential (proportional hazards)
+# and log-logistic (proportional odds), where covariates act on the hazard or
+# odds scale -- the AFT parameterisation has covariates *shift the log-time
+# distribution*.  The linear predictor adds to mu (location), not to log-hazard.
+# Consequently:
 #
 #   * predict() "linear_predictor" returns beta (same interface as PH)
 #   * predict() "survival" returns Phi(-z) directly (NOT exp(-H))

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,11 @@ description: Pure-R implementation of the HAZARD model with transparency and par
 
 template:
   bootstrap: 5
+  # Render Rd \eqn{}/\deqn{} math client-side. pkgdown 2.x defaults to
+  # math-rendering: mathml, which needs the katex package at build time; the
+  # docs-build environment lacks it, so equations shipped as raw LaTeX. MathJax
+  # has no build-time dependency.
+  math-rendering: mathjax
 
 navbar:
   structure:

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -133,9 +133,14 @@ survival are
 
 where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
 \boldsymbol{\beta}_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
-are set by each phase's \code{type} (see \code{\link[=hzr_phase]{hzr_phase()}}).  Single-phase
-distributions (\code{"weibull"}, \code{"exponential"}, \code{"lognormal"},
-\code{"loglogistic"}) are the special case \eqn{J = 1}.  Parameters are estimated
+are set by each phase's \code{type} (see \code{\link[=hzr_phase]{hzr_phase()}}).  The
+proportional-hazards single-phase families (\code{"weibull"}, \code{"exponential"})
+are the special case \eqn{J = 1}, with covariates acting multiplicatively on
+one temporal shape.  The \code{"loglogistic"} (proportional-odds) and
+\code{"lognormal"} (accelerated-failure-time) families place covariates
+differently --- on the odds of failure and the log-time location,
+respectively --- so they are separate parameterizations, not special cases
+of this additive form.  Parameters are estimated
 on an unconstrained internal scale (e.g. \eqn{\log\mu}, \eqn{\log t_{1/2}})
 and transformed back for reporting; see
 \code{vignette("mf-mathematical-foundations")}.
@@ -145,7 +150,7 @@ and transformed back for reporting; see
 
 
 The \code{dist} argument selects the parametric form of the baseline hazard.  The
-four single-distribution families (\eqn{J = 1}) differ in the \emph{shape} the
+four single-distribution families differ in the \emph{shape} the
 hazard traces over follow-up; choose by what the risk is expected to do over
 time.  \code{"multiphase"} is the general additive model that lets several such
 shapes coexist.


### PR DESCRIPTION
Targeted at `main` (the release branch) — a doc-correctness fix to land in 1.1.0 before CRAN submission.

## 1. Math correctness — `?hazard` "fitted model"
The section claimed all four single-phase families are the `J = 1` special case of the additive multiphase form `H = Σⱼ μⱼ(x)·Φⱼ(t)`. That form is **proportional-hazards / multiplicative**, so only two families reduce to it:

| Family | `H(t\|x)` | `μ(x)·Φ(t)`? |
|---|---|---|
| exponential | `λ t exp(η)` | ✅ PH |
| weibull | `(μt)^ν exp(η)` | ✅ PH |
| loglogistic | `log(1 + α t^β exp(η))` | ❌ proportional-odds (covariate inside the log) |
| lognormal | `−log Φ(−(log t−η)/σ)` | ❌ AFT (covariate shifts log-time) |

Corrected the claim (PH families are `J=1`; loglogistic/lognormal are separate parameterizations) and dropped the inaccurate `(J = 1)` parenthetical from the "Baseline distributions" section. Same conflation we fixed in #85 (loglogistic = proportional-odds).

## 2. pkgdown math rendering — `_pkgdown.yml`
The reference pages were shipping `\eqn`/`\deqn` math as **raw LaTeX** — the live HTML has *no* math engine (0 MathJax / 0 KaTeX / 0 MathML), so `$$\sum…$$` and `\(…\)` never typeset. pkgdown 2.x defaults to `math-rendering: mathml`, which needs the `katex` package at build time; the docs-build environment lacks it. Set `math-rendering: mathjax` (client-side, no build dependency). `_pkgdown.yml` is `.Rbuildignore`'d, so **pkgdown-only — does not touch the CRAN tarball**.

## Verification
Full `R CMD check --as-cran` (with manual) on the rebuilt 1.1.0 tarball → **Status: OK (0/0/0)**; `build/vignette.rds` present. Lint clean; Rd renders; ASCII-only.

After this merges, `main` is ready to submit, and `dev` should be synced (`main → dev`) so the correction isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)