### PR TITLE
fix(docs): correct single-phase J=1 claim; render pkgdown math (dev)

### DIFF
--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -55,9 +55,14 @@ NULL
 #'
 #' where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
 #' \boldsymbol{\beta}_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
-#' are set by each phase's `type` (see [hzr_phase()]).  Single-phase
-#' distributions (`"weibull"`, `"exponential"`, `"lognormal"`,
-#' `"loglogistic"`) are the special case \eqn{J = 1}.  Parameters are estimated
+#' are set by each phase's `type` (see [hzr_phase()]).  The
+#' proportional-hazards single-phase families (`"weibull"`, `"exponential"`)
+#' are the special case \eqn{J = 1}, with covariates acting multiplicatively on
+#' one temporal shape.  The `"loglogistic"` (proportional-odds) and
+#' `"lognormal"` (accelerated-failure-time) families place covariates
+#' differently --- on the odds of failure and the log-time location,
+#' respectively --- so they are separate parameterizations, not special cases
+#' of this additive form.  Parameters are estimated
 #' on an unconstrained internal scale (e.g. \eqn{\log\mu}, \eqn{\log t_{1/2}})
 #' and transformed back for reporting; see
 #' `vignette("mf-mathematical-foundations")`.
@@ -65,7 +70,7 @@ NULL
 #' @section Baseline distributions:
 #'
 #' The `dist` argument selects the parametric form of the baseline hazard.  The
-#' four single-distribution families (\eqn{J = 1}) differ in the *shape* the
+#' four single-distribution families differ in the *shape* the
 #' hazard traces over follow-up; choose by what the risk is expected to do over
 #' time.  `"multiphase"` is the general additive model that lets several such
 #' shapes coexist.

--- a/R/likelihood-lognormal.R
+++ b/R/likelihood-lognormal.R
@@ -18,11 +18,13 @@ NULL
 #
 # where mu in R (location), sigma > 0 (scale), eta_i = mu + x_i beta (AFT predictor).
 #
-# AFT vs PH DISTINCTION
-# ---------------------
-# Unlike Weibull / exponential / log-logistic (PH models), covariates in the
-# AFT parameterisation *shift the log-time distribution*.  The linear predictor
-# adds to mu (location), not to log-hazard.  Consequently:
+# AFT vs non-AFT DISTINCTION
+# --------------------------
+# Unlike the non-AFT families -- Weibull / exponential (proportional hazards)
+# and log-logistic (proportional odds), where covariates act on the hazard or
+# odds scale -- the AFT parameterisation has covariates *shift the log-time
+# distribution*.  The linear predictor adds to mu (location), not to log-hazard.
+# Consequently:
 #
 #   * predict() "linear_predictor" returns beta (same interface as PH)
 #   * predict() "survival" returns Phi(-z) directly (NOT exp(-H))

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,11 @@ description: Pure-R implementation of the HAZARD model with transparency and par
 
 template:
   bootstrap: 5
+  # Render Rd \eqn{}/\deqn{} math client-side. pkgdown 2.x defaults to
+  # math-rendering: mathml, which needs the katex package at build time; the
+  # docs-build environment lacks it, so equations shipped as raw LaTeX. MathJax
+  # has no build-time dependency.
+  math-rendering: mathjax
 
 navbar:
   structure:

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -133,9 +133,14 @@ survival are
 
 where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
 \boldsymbol{\beta}_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
-are set by each phase's \code{type} (see \code{\link[=hzr_phase]{hzr_phase()}}).  Single-phase
-distributions (\code{"weibull"}, \code{"exponential"}, \code{"lognormal"},
-\code{"loglogistic"}) are the special case \eqn{J = 1}.  Parameters are estimated
+are set by each phase's \code{type} (see \code{\link[=hzr_phase]{hzr_phase()}}).  The
+proportional-hazards single-phase families (\code{"weibull"}, \code{"exponential"})
+are the special case \eqn{J = 1}, with covariates acting multiplicatively on
+one temporal shape.  The \code{"loglogistic"} (proportional-odds) and
+\code{"lognormal"} (accelerated-failure-time) families place covariates
+differently --- on the odds of failure and the log-time location,
+respectively --- so they are separate parameterizations, not special cases
+of this additive form.  Parameters are estimated
 on an unconstrained internal scale (e.g. \eqn{\log\mu}, \eqn{\log t_{1/2}})
 and transformed back for reporting; see
 \code{vignette("mf-mathematical-foundations")}.
@@ -145,7 +150,7 @@ and transformed back for reporting; see
 
 
 The \code{dist} argument selects the parametric form of the baseline hazard.  The
-four single-distribution families (\eqn{J = 1}) differ in the \emph{shape} the
+four single-distribution families differ in the \emph{shape} the
 hazard traces over follow-up; choose by what the risk is expected to do over
 time.  \code{"multiphase"} is the general additive model that lets several such
 shapes coexist.


### PR DESCRIPTION
Propagates the #91 fix to `dev` (cherry-pick of the same commit `main` is getting via #91).

`main` and `dev` are content-identical except one `.Rbuildignore`'d roadmap doc, so rather than a noisy `main → dev` merge across the squash-merge history divergence, this cherry-picks just the 3-file fix:

1. **`?hazard` "fitted model"** — the `J = 1` claim now correctly covers only the proportional-hazards families (weibull, exponential); loglogistic (proportional-odds) and lognormal (AFT) are described as separate parameterizations. Dropped the inaccurate `(J = 1)` parenthetical from "Baseline distributions."
2. **`_pkgdown.yml`** — `math-rendering: mathjax` so reference-page `\eqn`/`\deqn` math typesets (was shipping raw LaTeX site-wide; `.Rbuildignore`'d → pkgdown-only).

Identical, already gate-verified change as #91 (full `--as-cran` was Status: OK / 0/0/0). Source `.R` + regenerated `man/hazard.Rd` committed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)