### PR TITLE
chore(release): open 1.1.0.9000 dev cycle (1.1.0 on CRAN)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
 BugReports: https://github.com/ehrlinger/temporal_hazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# TemporalHazard 1.1.0.9000 (development version)
+
 # TemporalHazard 1.1.0
 
 ## New features


### PR DESCRIPTION
1.1.0 was **accepted and published on CRAN** 2026-06-12 (tag [v1.1.0](https://github.com/ehrlinger/temporal_hazard/releases/tag/v1.1.0), DOI `10.32614/CRAN.package.TemporalHazard`).

Opens the next dev cycle per the **single-line decide-bump-at-release** strategy:
- `DESCRIPTION`: `1.1.0` → `1.1.0.9000` (released version + `.9000`; next release number decided at release from NEWS, **not** pre-stamped)
- `NEWS.md`: new `1.1.0.9000 (development version)` section

`main` stays clean at `1.1.0` (the released version). Metadata-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)