### PR TITLE
docs: fix `\boldsymbol` rendering red in pkgdown Rd math (#96)

### DIFF
--- a/R/TemporalHazard-package.R
+++ b/R/TemporalHazard-package.R
@@ -21,7 +21,7 @@
 #'       \Phi_j(t)}
 #'
 #' where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
-#' \boldsymbol{\beta}_j)} is the phase-specific log-linear scale (intercept plus
+#' \beta_j)} is the phase-specific log-linear scale (intercept plus
 #' covariate effects) and \eqn{\Phi_j(t)} is the temporal shape contributed by
 #' phase \eqn{j}, with its own parameters depending on the phase `type` (see the
 #' phase vocabulary below).  The instantaneous hazard and survival follow

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -54,7 +54,7 @@ NULL
 #'       S(t \mid \mathbf{x}) = \exp\!\bigl(-H(t \mid \mathbf{x})\bigr)}
 #'
 #' where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
-#' \boldsymbol{\beta}_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
+#' \beta_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
 #' are set by each phase's `type` (see [hzr_phase()]).  The
 #' proportional-hazards single-phase families (`"weibull"`, `"exponential"`)
 #' are the special case \eqn{J = 1}, with covariates acting multiplicatively on

--- a/R/phase-spec.R
+++ b/R/phase-spec.R
@@ -47,7 +47,7 @@
 #'       \Phi_j(t)}
 #'
 #' where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
-#' \boldsymbol{\beta}_j)} is the phase-specific log-linear scale and
+#' \beta_j)} is the phase-specific log-linear scale and
 #' \eqn{\Phi_j(t)} is the temporal shape selected by `type` (below).  The
 #' `t_half`/`nu`/`m` (or g3 `tau`/`gamma`/`alpha`/`eta`) arguments set the
 #' starting values for that shape; `formula` attaches the covariates

--- a/man/TemporalHazard-package.Rd
+++ b/man/TemporalHazard-package.Rd
@@ -22,7 +22,7 @@ The total cumulative hazard decomposes additively across \eqn{J} phases:
       \Phi_j(t)}
 
 where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
-\boldsymbol{\beta}_j)} is the phase-specific log-linear scale (intercept plus
+\beta_j)} is the phase-specific log-linear scale (intercept plus
 covariate effects) and \eqn{\Phi_j(t)} is the temporal shape contributed by
 phase \eqn{j}, with its own parameters depending on the phase \code{type} (see the
 phase vocabulary below).  The instantaneous hazard and survival follow

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -132,7 +132,7 @@ survival are
       S(t \mid \mathbf{x}) = \exp\!\bigl(-H(t \mid \mathbf{x})\bigr)}
 
 where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
-\boldsymbol{\beta}_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
+\beta_j)} and the temporal shapes \eqn{\Phi_j}, \eqn{\varphi_j}
 are set by each phase's \code{type} (see \code{\link[=hzr_phase]{hzr_phase()}}).  The
 proportional-hazards single-phase families (\code{"weibull"}, \code{"exponential"})
 are the special case \eqn{J = 1}, with covariates acting multiplicatively on

--- a/man/hzr_phase.Rd
+++ b/man/hzr_phase.Rd
@@ -96,7 +96,7 @@ Each phase is one term \eqn{j} in the additive cumulative hazard
       \Phi_j(t)}
 
 where \eqn{\mu_j(\mathbf{x}) = \exp(\alpha_j + \mathbf{x}_j^\top
-\boldsymbol{\beta}_j)} is the phase-specific log-linear scale and
+\beta_j)} is the phase-specific log-linear scale and
 \eqn{\Phi_j(t)} is the temporal shape selected by \code{type} (below).  The
 \code{t_half}/\code{nu}/\code{m} (or g3 \code{tau}/\code{gamma}/\code{alpha}/\code{eta}) arguments set the
 starting values for that shape; \code{formula} attaches the covariates


### PR DESCRIPTION
Fixes #96. pkgdown's MathJax (we use `math-rendering: mathjax`) doesn't autoload the `boldsymbol` extension, so `\boldsymbol{\beta}_j` rendered as red literal text on the **hazard**, **hzr_phase**, and **TemporalHazard-package** doc pages.

**Fix (option A):** dropped `\boldsymbol` → plain `\beta_j` in the 3 roxygen blocks + re-documented. Matches our plain-Rd-math convention (cf. the `\hat{\beta}` fix); the data vector `\mathbf{x}` stays bold. The `mf-mathematical-foundations` vignette is untouched — Quarto's MathJax renders `\boldsymbol` fine there.

Doc-only; for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)