### PR TITLE
fix: analytic multiphase Hessian at m=0/nu<0 and nu=0/m<0 shape boundaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,13 @@
   recompute. The boundary direction now uses a one-sided finite difference
   instead.
 
+* Multiphase fits with a single free parameter (a two-phase model with all
+  shapes fixed, where Conservation of Events fixes one of the two `log_mu`)
+  now use the analytic Hessian for standard errors instead of silently
+  falling back to a numerical one. Restricting the Hessian to the lone free
+  parameter dropped it from a 1x1 matrix to a scalar, which was rejected as
+  non-conformant; it is now kept as a matrix (`drop = FALSE`).
+
 # TemporalHazard 1.1.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,17 @@
   `...` to `hzr_stepwise()` alongside an explicit `trace = FALSE`, so any
   caller-supplied `trace=` collided with it.
 
+* Multiphase models with a `"cdf"`/`"hazard"` phase whose shape sits exactly
+  at the `m = 0` (Case 3L) or `nu = 0` (Case 2L) limiting-case boundary no
+  longer lose their analytic Hessian. The finite-difference second
+  derivative used to probe the *other* shape parameter's `-h` side, which
+  can cross into the mathematically undefined `m < 0 && nu < 0` region and
+  raise an error; this silently fell back to a numerical Hessian (or, if
+  that also failed to invert, to `NA` standard errors) for every affected
+  fit, not just `hzr_bootstrap()`'s Conservation-of-Events full-information
+  recompute. The boundary direction now uses a one-sided finite difference
+  instead.
+
 # TemporalHazard 1.1.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+* `hzr_bootstrap(verbose = TRUE)` now shows a text progress bar over the
+  bootstrap replicates (via `utils::txtProgressBar()`) instead of an
+  every-50-replicates message.
+
 * `hzr_bootstrap()` gains a `scope` argument for embedded stepwise variable
   selection during each bootstrap replicate -- the R equivalent of SAS's
   `%HAZBOOT` procedure. Each replicate runs a fresh `hzr_stepwise()`
@@ -12,6 +16,12 @@
   (the default) preserves the original fixed-formula bootstrap unchanged.
 
 ## Bug fixes
+
+* `hzr_bootstrap()` no longer floods the console with per-replicate numerical
+  warnings (e.g. ill-conditioned-Hessian notes from unstable resamples), which
+  are not individually actionable when the bootstrap aggregates over replicates.
+  Structural problems (a mistyped `scope` column, an invalid scope) still
+  surface once, up front.
 
 * `hzr_bootstrap(scope = ..., trace = ...)` no longer errors with "formal
   argument matched by multiple actual arguments". Select-mode forwarded

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1414,13 +1414,16 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   # per-candidate warning() rather than an error (see
   # inst/dev/BOOTSTRAP-SELECTION-DESIGN.md, "Error handling").
   if (select_mode) {
-    # Muffle only the numerical post-fit Hessian-conditioning warnings
-    # (.hzr_safe_solve: ill-conditioned / not invertible / not
-    # positive-definite -- every message contains "Hessian"). Those are the
-    # per-fit noise this screen aggregates over, and would otherwise fire on
-    # the real-data selected model here. Structural warnings (e.g. a
-    # nonexistent scope column, "candidate refit failed for ...") and all
-    # errors still surface, so a bad scope is caught once, up front.
+    # Muffle only .hzr_safe_solve()'s numerical post-fit warnings
+    # (ill-conditioned / non-invertible / non-positive-definite Hessian,
+    # non-positive variance) -- the per-fit noise this screen aggregates
+    # over, which would otherwise fire on the real-data selected model here.
+    # Identify them by their originating call, not message text, so all of
+    # them are caught (including messages without the word "Hessian") while
+    # unrelated warnings still surface: a mistyped scope column
+    # ("candidate refit failed for ..."), the optimizer's
+    # non-conformant-Hessian note, and all errors -- so a bad scope is caught
+    # once, up front.
     withCallingHandlers(
       do.call(hzr_stepwise, c(
         list(
@@ -1434,7 +1437,8 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
         extra_args
       )),
       warning = function(w) {
-        if (grepl("Hessian", conditionMessage(w), ignore.case = TRUE)) {
+        if (any(grepl("hzr_safe_solve", deparse(conditionCall(w)),
+                      fixed = TRUE))) {
           invokeRestart("muffleWarning")
         }
       }

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1255,7 +1255,8 @@ print.hzr_nelson <- function(x, digits = 4, ...) {
 #'   random numbers either way, so the global RNG state will advance
 #'   during the call -- `seed = NULL` avoids the *reset* at entry, not
 #'   the advance during resampling.
-#' @param verbose Logical; if `TRUE`, print progress every 50 replicates.
+#' @param verbose Logical; if `TRUE`, display a text progress bar over the
+#'   `n_boot` replicates (via [utils::txtProgressBar()]).
 #' @param scope Candidate variable scope for embedded stepwise selection
 #'   during each bootstrap replicate. `NULL` (default) preserves the
 #'   original fixed-formula bootstrap: every replicate refits `object`'s
@@ -1413,17 +1414,31 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   # per-candidate warning() rather than an error (see
   # inst/dev/BOOTSTRAP-SELECTION-DESIGN.md, "Error handling").
   if (select_mode) {
-    do.call(hzr_stepwise, c(
-      list(
-        object, scope = scope, data = orig_data,
-        direction = direction, criterion = criterion,
-        slentry = slentry, slstay = slstay,
-        max_steps = max_steps, max_move = max_move,
-        force_in = force_in, force_out = force_out,
-        trace = FALSE
-      ),
-      extra_args
-    ))
+    # Muffle only the numerical post-fit Hessian-conditioning warnings
+    # (.hzr_safe_solve: ill-conditioned / not invertible / not
+    # positive-definite -- every message contains "Hessian"). Those are the
+    # per-fit noise this screen aggregates over, and would otherwise fire on
+    # the real-data selected model here. Structural warnings (e.g. a
+    # nonexistent scope column, "candidate refit failed for ...") and all
+    # errors still surface, so a bad scope is caught once, up front.
+    withCallingHandlers(
+      do.call(hzr_stepwise, c(
+        list(
+          object, scope = scope, data = orig_data,
+          direction = direction, criterion = criterion,
+          slentry = slentry, slstay = slstay,
+          max_steps = max_steps, max_move = max_move,
+          force_in = force_in, force_out = force_out,
+          trace = FALSE
+        ),
+        extra_args
+      )),
+      warning = function(w) {
+        if (grepl("Hessian", conditionMessage(w), ignore.case = TRUE)) {
+          invokeRestart("muffleWarning")
+        }
+      }
+    )
   }
 
   # Parameter names from the fitted model. In fixed-refit mode every
@@ -1437,53 +1452,65 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   n_success <- 0L
   n_failed <- 0L
 
-  for (b in seq_len(n_boot)) {
-    if (verbose && b %% 50 == 0) {
-      cat("Bootstrap replicate", b, "/", n_boot, "\n")
-    }
+  # Progress bar over replicates (verbose only). Closed after the loop.
+  pb <- if (verbose) utils::txtProgressBar(min = 0, max = n_boot, style = 3)
+  if (verbose) on.exit(close(pb), add = TRUE)
 
+  for (b in seq_len(n_boot)) {
     # Resample with replacement
     idx <- sample.int(n_obs, size = sample_size, replace = TRUE)
     boot_data <- orig_data[idx, , drop = FALSE] # nolint: object_usage_linter.
     # boot_weights is referenced via quote() inside eval -- lintr cannot trace it
     boot_weights <- if (is.null(orig_weights)) NULL else orig_weights[idx] # nolint: object_usage_linter.
 
+    # Per-replicate fits routinely hit ill-conditioned Hessians and other
+    # numerical warnings on individual resamples; these are not individually
+    # actionable (the bootstrap aggregates over replicates) and would swamp
+    # the console over n_boot fits. Suppress them here -- structural problems
+    # (e.g. a mistyped `scope` column) still surface once from the up-front
+    # validation call above, and hard failures are caught below and counted.
     if (select_mode) {
       # Refit the (shape-fixed) base model on the resampled data first, so
       # the stepwise search's entry/retention tests compare candidates
       # against a base likelihood computed on the SAME resampled data --
       # then run a fresh stepwise selection from that base.
-      boot_fit <- tryCatch({
-        cl_base <- cl
-        cl_base$data <- quote(boot_data)
-        if (!is.null(orig_weights)) cl_base$weights <- quote(boot_weights)
-        cl_base$fit <- TRUE
-        base_boot <- eval(cl_base)
-        if (!is.finite(base_boot$fit$objective)) {
-          stop("base refit did not converge")
-        }
-        do.call(hzr_stepwise, c(
-          list(
-            base_boot, scope = scope, data = boot_data,
-            direction = direction, criterion = criterion,
-            slentry = slentry, slstay = slstay,
-            max_steps = max_steps, max_move = max_move,
-            force_in = force_in, force_out = force_out,
-            trace = FALSE
-          ),
-          extra_args
-        ))
-      }, error = function(e) NULL)
+      boot_fit <- tryCatch(
+        suppressWarnings({
+          cl_base <- cl
+          cl_base$data <- quote(boot_data)
+          if (!is.null(orig_weights)) cl_base$weights <- quote(boot_weights)
+          cl_base$fit <- TRUE
+          base_boot <- eval(cl_base)
+          if (!is.finite(base_boot$fit$objective)) {
+            stop("base refit did not converge")
+          }
+          do.call(hzr_stepwise, c(
+            list(
+              base_boot, scope = scope, data = boot_data,
+              direction = direction, criterion = criterion,
+              slentry = slentry, slstay = slstay,
+              max_steps = max_steps, max_move = max_move,
+              force_in = force_in, force_out = force_out,
+              trace = FALSE
+            ),
+            extra_args
+          ))
+        }),
+        error = function(e) NULL
+      )
     } else {
       # Refit using the same call but with resampled data (and weights, if any)
       # (boot_data/boot_weights are referenced via quote() inside eval)
-      boot_fit <- tryCatch({
-        cl_boot <- cl
-        cl_boot$data <- quote(boot_data)
-        if (!is.null(orig_weights)) cl_boot$weights <- quote(boot_weights)
-        cl_boot$fit <- TRUE
-        eval(cl_boot)
-      }, error = function(e) NULL)
+      boot_fit <- tryCatch(
+        suppressWarnings({
+          cl_boot <- cl
+          cl_boot$data <- quote(boot_data)
+          if (!is.null(orig_weights)) cl_boot$weights <- quote(boot_weights)
+          cl_boot$fit <- TRUE
+          eval(cl_boot)
+        }),
+        error = function(e) NULL
+      )
     }
 
     if (!is.null(boot_fit) && is.finite(boot_fit$fit$objective)) {
@@ -1503,6 +1530,8 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     } else {
       n_failed <- n_failed + 1L
     }
+
+    if (verbose) utils::setTxtProgressBar(pb, b)
   }
 
   # Combine replicates

--- a/R/hessian-multiphase.R
+++ b/R/hessian-multiphase.R
@@ -44,57 +44,135 @@ NULL
 
   d00 <- eval_at(t_half, nu, m)
 
+  # hzr_decompos() rejects m < 0 && nu < 0 as mathematically undefined. A
+  # fixed shape sitting exactly at m = 0 (nu < 0, Case 3L) or nu = 0 (m < 0,
+  # Case 2L) is a valid, documented limiting case, but the central-difference
+  # step below would probe the OTHER parameter's -h side, which crosses into
+  # that undefined region. Detect it and fall back to a forward-only
+  # (one-sided) difference in just that one direction; every other
+  # direction/pair keeps the ordinary central-difference formula. (The two
+  # conditions can't both hold: that would require m < 0 && nu < 0
+  # simultaneously, which d00 above would already have rejected.)
+  m_boundary  <- nu < 0 && abs(m)  < h
+  nu_boundary <- m  < 0 && abs(nu) < h
+
   # Perturbed values on each internal scale:
   #   log_t_half: steps are multiplicative -> t_half * exp(+/-h)
   #   nu, m:      additive steps
   t_p  <- t_half * exp(h)
   t_m  <- t_half * exp(-h)
   nu_p <- nu + h
-  nu_m <- nu - h
+  nu_m <- if (nu_boundary) NA_real_ else nu - h
   m_p  <- m  + h
-  m_m  <- m  - h
+  m_m  <- if (m_boundary)  NA_real_ else m  - h
 
   # Six single-parameter perturbations for diagonal second differences
+  # (skip the -h evaluation in a boundary direction -- it would error)
   d_tp  <- eval_at(t_p,    nu,   m)
   d_tm  <- eval_at(t_m,    nu,   m)
   d_np  <- eval_at(t_half, nu_p, m)
-  d_nm  <- eval_at(t_half, nu_m, m)
+  d_nm  <- if (nu_boundary) NULL else eval_at(t_half, nu_m, m)
   d_mp  <- eval_at(t_half, nu,   m_p)
-  d_mm  <- eval_at(t_half, nu,   m_m)
+  d_mm  <- if (m_boundary)  NULL else eval_at(t_half, nu,   m_m)
 
   h2 <- h * h
 
-  # Diagonal second differences
-  d2Phi_tt  <- (d_tp$Phi - 2 * d00$Phi + d_tm$Phi) / h2
-  d2Phi_nn  <- (d_np$Phi - 2 * d00$Phi + d_nm$Phi) / h2
-  d2Phi_mm_ <- (d_mp$Phi - 2 * d00$Phi + d_mm$Phi) / h2
-  d2phi_tt  <- (d_tp$phi - 2 * d00$phi + d_tm$phi) / h2
-  d2phi_nn  <- (d_np$phi - 2 * d00$phi + d_nm$phi) / h2
-  d2phi_mm_ <- (d_mp$phi - 2 * d00$phi + d_mm$phi) / h2
+  # Diagonal second differences. At a boundary, use the forward second
+  # difference (f(x+2h) - 2f(x+h) + f(x)) / h^2 -- valid but O(h) rather
+  # than O(h^2) locally, exactly at these two named limiting cases.
+  d2Phi_tt <- (d_tp$Phi - 2 * d00$Phi + d_tm$Phi) / h2
+  d2phi_tt <- (d_tp$phi - 2 * d00$phi + d_tm$phi) / h2
 
-  # t_half / nu cross: corners (t_p, nu_p), (t_p, nu_m), (t_m, nu_p), (t_m, nu_m)
-  e_tn_pp <- eval_at(t_p, nu_p, m)
-  e_tn_pm <- eval_at(t_p, nu_m, m)
-  e_tn_mp <- eval_at(t_m, nu_p, m)
-  e_tn_mm <- eval_at(t_m, nu_m, m)
-  d2_tn_Phi <- (e_tn_pp$Phi - e_tn_pm$Phi - e_tn_mp$Phi + e_tn_mm$Phi) / (4 * h2)
-  d2_tn_phi <- (e_tn_pp$phi - e_tn_pm$phi - e_tn_mp$phi + e_tn_mm$phi) / (4 * h2)
+  if (nu_boundary) {
+    d_np2 <- eval_at(t_half, nu + 2 * h, m)
+    d2Phi_nn <- (d_np2$Phi - 2 * d_np$Phi + d00$Phi) / h2
+    d2phi_nn <- (d_np2$phi - 2 * d_np$phi + d00$phi) / h2
+  } else {
+    d2Phi_nn <- (d_np$Phi - 2 * d00$Phi + d_nm$Phi) / h2
+    d2phi_nn <- (d_np$phi - 2 * d00$phi + d_nm$phi) / h2
+  }
 
-  # t_half / m cross
-  e_tm_pp <- eval_at(t_p, nu, m_p)
-  e_tm_pm <- eval_at(t_p, nu, m_m)
-  e_tm_mp <- eval_at(t_m, nu, m_p)
-  e_tm_mm <- eval_at(t_m, nu, m_m)
-  d2_tm_Phi <- (e_tm_pp$Phi - e_tm_pm$Phi - e_tm_mp$Phi + e_tm_mm$Phi) / (4 * h2)
-  d2_tm_phi <- (e_tm_pp$phi - e_tm_pm$phi - e_tm_mp$phi + e_tm_mm$phi) / (4 * h2)
+  if (m_boundary) {
+    d_mp2 <- eval_at(t_half, nu, m + 2 * h)
+    d2Phi_mm_ <- (d_mp2$Phi - 2 * d_mp$Phi + d00$Phi) / h2
+    d2phi_mm_ <- (d_mp2$phi - 2 * d_mp$phi + d00$phi) / h2
+  } else {
+    d2Phi_mm_ <- (d_mp$Phi - 2 * d00$Phi + d_mm$Phi) / h2
+    d2phi_mm_ <- (d_mp$phi - 2 * d00$phi + d_mm$phi) / h2
+  }
 
-  # nu / m cross
-  e_nm_pp <- eval_at(t_half, nu_p, m_p)
-  e_nm_pm <- eval_at(t_half, nu_p, m_m)
-  e_nm_mp <- eval_at(t_half, nu_m, m_p)
-  e_nm_mm <- eval_at(t_half, nu_m, m_m)
-  d2_nm_Phi <- (e_nm_pp$Phi - e_nm_pm$Phi - e_nm_mp$Phi + e_nm_mm$Phi) / (4 * h2)
-  d2_nm_phi <- (e_nm_pp$phi - e_nm_pm$phi - e_nm_mp$phi + e_nm_mm$phi) / (4 * h2)
+  # t_half / nu cross: corners (t_p, nu_p), (t_p, nu_m), (t_m, nu_p), (t_m, nu_m).
+  # Under nu_boundary, use forward-in-nu / central-in-t_half instead (drops
+  # the nu_m corners).
+  if (nu_boundary) {
+    e_tn_p0 <- eval_at(t_p, nu,   m)
+    e_tn_pp <- eval_at(t_p, nu_p, m)
+    e_tn_m0 <- eval_at(t_m, nu,   m)
+    e_tn_mp <- eval_at(t_m, nu_p, m)
+    d2_tn_Phi <- ((e_tn_pp$Phi - e_tn_p0$Phi) -
+                    (e_tn_mp$Phi - e_tn_m0$Phi)) / (2 * h2)
+    d2_tn_phi <- ((e_tn_pp$phi - e_tn_p0$phi) -
+                    (e_tn_mp$phi - e_tn_m0$phi)) / (2 * h2)
+  } else {
+    e_tn_pp <- eval_at(t_p, nu_p, m)
+    e_tn_pm <- eval_at(t_p, nu_m, m)
+    e_tn_mp <- eval_at(t_m, nu_p, m)
+    e_tn_mm <- eval_at(t_m, nu_m, m)
+    d2_tn_Phi <- (e_tn_pp$Phi - e_tn_pm$Phi - e_tn_mp$Phi + e_tn_mm$Phi) / (4 * h2)
+    d2_tn_phi <- (e_tn_pp$phi - e_tn_pm$phi - e_tn_mp$phi + e_tn_mm$phi) / (4 * h2)
+  }
+
+  # t_half / m cross: corners (t_p, m_p), (t_p, m_m), (t_m, m_p), (t_m, m_m).
+  # Under m_boundary, use forward-in-m / central-in-t_half instead (drops
+  # the m_m corners).
+  if (m_boundary) {
+    e_tm_p0 <- eval_at(t_p, nu, m)
+    e_tm_pp <- eval_at(t_p, nu, m_p)
+    e_tm_m0 <- eval_at(t_m, nu, m)
+    e_tm_mp <- eval_at(t_m, nu, m_p)
+    d2_tm_Phi <- ((e_tm_pp$Phi - e_tm_p0$Phi) -
+                    (e_tm_mp$Phi - e_tm_m0$Phi)) / (2 * h2)
+    d2_tm_phi <- ((e_tm_pp$phi - e_tm_p0$phi) -
+                    (e_tm_mp$phi - e_tm_m0$phi)) / (2 * h2)
+  } else {
+    e_tm_pp <- eval_at(t_p, nu, m_p)
+    e_tm_pm <- eval_at(t_p, nu, m_m)
+    e_tm_mp <- eval_at(t_m, nu, m_p)
+    e_tm_mm <- eval_at(t_m, nu, m_m)
+    d2_tm_Phi <- (e_tm_pp$Phi - e_tm_pm$Phi - e_tm_mp$Phi + e_tm_mm$Phi) / (4 * h2)
+    d2_tm_phi <- (e_tm_pp$phi - e_tm_pm$phi - e_tm_mp$phi + e_tm_mm$phi) / (4 * h2)
+  }
+
+  # nu / m cross: corners (nu_p, m_p), (nu_p, m_m), (nu_m, m_p), (nu_m, m_m).
+  # Under m_boundary, use forward-in-m / central-in-nu (nu_m is valid here --
+  # only m is boundary-restricted). Under nu_boundary, use forward-in-nu /
+  # central-in-m (m_m is valid here -- only nu is boundary-restricted).
+  if (m_boundary) {
+    e_nm_p0 <- eval_at(t_half, nu_p, m)
+    e_nm_pp <- eval_at(t_half, nu_p, m_p)
+    e_nm_m0 <- eval_at(t_half, nu_m, m)
+    e_nm_mp <- eval_at(t_half, nu_m, m_p)
+    d2_nm_Phi <- ((e_nm_pp$Phi - e_nm_p0$Phi) -
+                    (e_nm_mp$Phi - e_nm_m0$Phi)) / (2 * h2)
+    d2_nm_phi <- ((e_nm_pp$phi - e_nm_p0$phi) -
+                    (e_nm_mp$phi - e_nm_m0$phi)) / (2 * h2)
+  } else if (nu_boundary) {
+    e_nm_0p <- eval_at(t_half, nu,   m_p)
+    e_nm_pp <- eval_at(t_half, nu_p, m_p)
+    e_nm_0m <- eval_at(t_half, nu,   m_m)
+    e_nm_pm <- eval_at(t_half, nu_p, m_m)
+    d2_nm_Phi <- ((e_nm_pp$Phi - e_nm_0p$Phi) -
+                    (e_nm_pm$Phi - e_nm_0m$Phi)) / (2 * h2)
+    d2_nm_phi <- ((e_nm_pp$phi - e_nm_0p$phi) -
+                    (e_nm_pm$phi - e_nm_0m$phi)) / (2 * h2)
+  } else {
+    e_nm_pp <- eval_at(t_half, nu_p, m_p)
+    e_nm_pm <- eval_at(t_half, nu_p, m_m)
+    e_nm_mp <- eval_at(t_half, nu_m, m_p)
+    e_nm_mm <- eval_at(t_half, nu_m, m_m)
+    d2_nm_Phi <- (e_nm_pp$Phi - e_nm_pm$Phi - e_nm_mp$Phi + e_nm_mm$Phi) / (4 * h2)
+    d2_nm_phi <- (e_nm_pp$phi - e_nm_pm$phi - e_nm_mp$phi + e_nm_mm$phi) / (4 * h2)
+  }
 
   list(
     d2Phi_dlog_thalf2    = d2Phi_tt,

--- a/R/hessian-multiphase.R
+++ b/R/hessian-multiphase.R
@@ -105,14 +105,13 @@ NULL
   # Under nu_boundary, use forward-in-nu / central-in-t_half instead (drops
   # the nu_m corners).
   if (nu_boundary) {
-    e_tn_p0 <- eval_at(t_p, nu,   m)
+    # d_tp/d_tm (= eval_at(t_p/t_m, nu, m)) already computed above
     e_tn_pp <- eval_at(t_p, nu_p, m)
-    e_tn_m0 <- eval_at(t_m, nu,   m)
     e_tn_mp <- eval_at(t_m, nu_p, m)
-    d2_tn_Phi <- ((e_tn_pp$Phi - e_tn_p0$Phi) -
-                    (e_tn_mp$Phi - e_tn_m0$Phi)) / (2 * h2)
-    d2_tn_phi <- ((e_tn_pp$phi - e_tn_p0$phi) -
-                    (e_tn_mp$phi - e_tn_m0$phi)) / (2 * h2)
+    d2_tn_Phi <- ((e_tn_pp$Phi - d_tp$Phi) -
+                    (e_tn_mp$Phi - d_tm$Phi)) / (2 * h2)
+    d2_tn_phi <- ((e_tn_pp$phi - d_tp$phi) -
+                    (e_tn_mp$phi - d_tm$phi)) / (2 * h2)
   } else {
     e_tn_pp <- eval_at(t_p, nu_p, m)
     e_tn_pm <- eval_at(t_p, nu_m, m)
@@ -126,14 +125,13 @@ NULL
   # Under m_boundary, use forward-in-m / central-in-t_half instead (drops
   # the m_m corners).
   if (m_boundary) {
-    e_tm_p0 <- eval_at(t_p, nu, m)
+    # d_tp/d_tm (= eval_at(t_p/t_m, nu, m)) already computed above
     e_tm_pp <- eval_at(t_p, nu, m_p)
-    e_tm_m0 <- eval_at(t_m, nu, m)
     e_tm_mp <- eval_at(t_m, nu, m_p)
-    d2_tm_Phi <- ((e_tm_pp$Phi - e_tm_p0$Phi) -
-                    (e_tm_mp$Phi - e_tm_m0$Phi)) / (2 * h2)
-    d2_tm_phi <- ((e_tm_pp$phi - e_tm_p0$phi) -
-                    (e_tm_mp$phi - e_tm_m0$phi)) / (2 * h2)
+    d2_tm_Phi <- ((e_tm_pp$Phi - d_tp$Phi) -
+                    (e_tm_mp$Phi - d_tm$Phi)) / (2 * h2)
+    d2_tm_phi <- ((e_tm_pp$phi - d_tp$phi) -
+                    (e_tm_mp$phi - d_tm$phi)) / (2 * h2)
   } else {
     e_tm_pp <- eval_at(t_p, nu, m_p)
     e_tm_pm <- eval_at(t_p, nu, m_m)
@@ -148,23 +146,21 @@ NULL
   # only m is boundary-restricted). Under nu_boundary, use forward-in-nu /
   # central-in-m (m_m is valid here -- only nu is boundary-restricted).
   if (m_boundary) {
-    e_nm_p0 <- eval_at(t_half, nu_p, m)
+    # d_np/d_nm (= eval_at(t_half, nu_p/nu_m, m)) already computed above
     e_nm_pp <- eval_at(t_half, nu_p, m_p)
-    e_nm_m0 <- eval_at(t_half, nu_m, m)
     e_nm_mp <- eval_at(t_half, nu_m, m_p)
-    d2_nm_Phi <- ((e_nm_pp$Phi - e_nm_p0$Phi) -
-                    (e_nm_mp$Phi - e_nm_m0$Phi)) / (2 * h2)
-    d2_nm_phi <- ((e_nm_pp$phi - e_nm_p0$phi) -
-                    (e_nm_mp$phi - e_nm_m0$phi)) / (2 * h2)
+    d2_nm_Phi <- ((e_nm_pp$Phi - d_np$Phi) -
+                    (e_nm_mp$Phi - d_nm$Phi)) / (2 * h2)
+    d2_nm_phi <- ((e_nm_pp$phi - d_np$phi) -
+                    (e_nm_mp$phi - d_nm$phi)) / (2 * h2)
   } else if (nu_boundary) {
-    e_nm_0p <- eval_at(t_half, nu,   m_p)
+    # d_mp/d_mm (= eval_at(t_half, nu, m_p/m_m)) already computed above
     e_nm_pp <- eval_at(t_half, nu_p, m_p)
-    e_nm_0m <- eval_at(t_half, nu,   m_m)
     e_nm_pm <- eval_at(t_half, nu_p, m_m)
-    d2_nm_Phi <- ((e_nm_pp$Phi - e_nm_0p$Phi) -
-                    (e_nm_pm$Phi - e_nm_0m$Phi)) / (2 * h2)
-    d2_nm_phi <- ((e_nm_pp$phi - e_nm_0p$phi) -
-                    (e_nm_pm$phi - e_nm_0m$phi)) / (2 * h2)
+    d2_nm_Phi <- ((e_nm_pp$Phi - d_mp$Phi) -
+                    (e_nm_pm$Phi - d_mm$Phi)) / (2 * h2)
+    d2_nm_phi <- ((e_nm_pp$phi - d_mp$phi) -
+                    (e_nm_pm$phi - d_mm$phi)) / (2 * h2)
   } else {
     e_nm_pp <- eval_at(t_half, nu_p, m_p)
     e_nm_pm <- eval_at(t_half, nu_p, m_m)

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1324,8 +1324,12 @@
       phases = phases, covariate_counts = covariate_counts, x_list = x_list
     )
     if (is.null(H_full)) return(NULL)
-    # Restrict to the free-parameter block that the optimizer sees
-    if (any_fixed) H_full[free_idx_eff, free_idx_eff] else H_full
+    # Restrict to the free-parameter block that the optimizer sees.
+    # drop = FALSE keeps a single free parameter (e.g. a 2-phase fixed-shape
+    # CoE fit, where CoE fixes one of the two log_mu) as a 1x1 matrix rather
+    # than a scalar; otherwise .hzr_optim_generic rejects it as non-conformant
+    # and needlessly discards the analytic Hessian for a numerical one.
+    if (any_fixed) H_full[free_idx_eff, free_idx_eff, drop = FALSE] else H_full
   }
 
   for (start_i in seq_len(n_starts)) {

--- a/man/hzr_bootstrap.Rd
+++ b/man/hzr_bootstrap.Rd
@@ -42,7 +42,8 @@ random numbers either way, so the global RNG state will advance
 during the call -- \code{seed = NULL} avoids the \emph{reset} at entry, not
 the advance during resampling.}
 
-\item{verbose}{Logical; if \code{TRUE}, print progress every 50 replicates.}
+\item{verbose}{Logical; if \code{TRUE}, display a text progress bar over the
+\code{n_boot} replicates (via \code{\link[utils:txtProgressBar]{utils::txtProgressBar()}}).}
 
 \item{scope}{Candidate variable scope for embedded stepwise selection
 during each bootstrap replicate. \code{NULL} (default) preserves the

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -816,6 +816,45 @@ test_that("hzr_bootstrap scope runs embedded stepwise selection per replicate", 
   expect_true(all(shape_rows$n == bs$n_success))
 })
 
+test_that("hzr_bootstrap verbose = TRUE shows a progress bar", {
+  fit <- .fit_avc_weibull()
+  out <- capture.output(
+    bs <- hzr_bootstrap(fit, n_boot = 5, seed = 42, verbose = TRUE),
+    type = "output"
+  )
+  # txtProgressBar(style = 3) draws a bar with a percentage; some output must
+  # have been written, and the run must still return a valid object.
+  expect_true(any(nzchar(out)))
+  expect_true(any(grepl("100%|=====", paste(out, collapse = ""))))
+  expect_s3_class(bs, "hzr_bootstrap")
+  expect_gt(bs$n_success, 0)
+})
+
+test_that("hzr_bootstrap suppresses per-replicate fit warnings", {
+  # A fixed-shape multiphase base with covariate scope produces
+  # ill-conditioned per-replicate Hessians (.hzr_safe_solve warns). Those are
+  # not individually actionable and must not leak to the caller; the tryCatch
+  # only catches errors, so this relies on the in-loop suppressWarnings().
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  base <- hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.2, nu = 1.4, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE
+  )
+  expect_no_warning(
+    hzr_bootstrap(base, n_boot = 5, seed = 7,
+                  scope = list(early    = ~ age + mal + com_iv,
+                               constant = ~ age + mal + com_iv),
+                  slentry = 0.3, slstay = 0.2,
+                  control = list(n_starts = 1))
+  )
+})
+
 test_that("hzr_bootstrap scope raises immediately on a structurally invalid scope", {
   data(avc, package = "TemporalHazard")
   avc <- na.omit(avc)

--- a/tests/testthat/test-multiphase-hessian.R
+++ b/tests/testthat/test-multiphase-hessian.R
@@ -124,6 +124,37 @@ test_that(".hzr_hessian_multiphase succeeds at the Case 3L fixed-shape boundary"
   expect_true(all(is.finite(H)))
 })
 
+test_that("fixed-shape 2-phase CoE fit uses the analytic Hessian (single free param, no drop)", {
+  # A 2-phase model with all shapes fixed leaves the two log_mu free; CoE then
+  # fixes one of them, so exactly ONE parameter is optimized. hessian_fn's
+  # restriction H_full[free, free] with a single index used to drop to a
+  # scalar (R drop = TRUE), which .hzr_optim_generic flagged as
+  # "hessian_fn returned a non-conformant result" and silently fell back to a
+  # numerical Hessian. Assert the analytic Hessian is used instead: no such
+  # warning, and a finite standard error is produced.
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  warns <- character(0)
+  fit <- withCallingHandlers(
+    hazard(
+      survival::Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+      phases = list(
+        early    = hzr_phase("cdf", t_half = 0.2, nu = 1.4, m = 1,
+                             fixed = "shapes"),
+        constant = hzr_phase("constant")
+      ),
+      fit = TRUE
+    ),
+    warning = function(cnd) {
+      warns <<- c(warns, conditionMessage(cnd))
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_false(any(grepl("non-conformant", warns)))
+  expect_true(is.matrix(fit$fit$vcov))
+  expect_true(isTRUE(fit$fit$pd))
+})
+
 test_that(".hzr_g3_phase_second_derivatives diagonals match numDeriv", {
   skip_if_not_installed("numDeriv")
   t <- c(0.5, 1.0, 3.0, 8.0)

--- a/tests/testthat/test-multiphase-hessian.R
+++ b/tests/testthat/test-multiphase-hessian.R
@@ -62,6 +62,68 @@ test_that(".hzr_phase_second_derivatives phi second derivs match numDeriv", {
   }
 })
 
+# ---------------------------------------------------------------------------
+# Task 1b: Case-boundary robustness (Case 3L: m=0,nu<0; Case 2L: nu=0,m<0)
+# ---------------------------------------------------------------------------
+# hzr_decompos() rejects m<0 && nu<0 as mathematically undefined. A shape
+# sitting exactly at m=0 (with nu<0) or nu=0 (with m<0) is a legitimate,
+# documented limiting case (Case 3L / Case 2L respectively), but the naive
+# central-difference perturbation used below steps the OTHER side of the
+# fixed value by -h, which crosses into that undefined region and used to
+# raise "Decomposition undefined when both m < 0 and nu < 0 ...".
+
+test_that(".hzr_phase_second_derivatives does not error at the Case 3L boundary (m=0, nu<0)", {
+  t <- c(0.2, 0.5, 1.0, 2.0, 4.0)
+  d2 <- .hzr_phase_second_derivatives(t, t_half = 1.666871, nu = -0.7462,
+                                       m = 0, type = "cdf")
+  expect_true(all(vapply(d2, function(v) all(is.finite(v)), logical(1))))
+})
+
+test_that(".hzr_phase_second_derivatives does not error at the Case 2L boundary (nu=0, m<0)", {
+  t <- c(0.2, 0.5, 1.0, 2.0, 4.0)
+  d2 <- .hzr_phase_second_derivatives(t, t_half = 1.0, nu = 0, m = -0.5,
+                                       type = "cdf")
+  expect_true(all(vapply(d2, function(v) all(is.finite(v)), logical(1))))
+})
+
+test_that(".hzr_phase_second_derivatives boundary values are continuous with the interior", {
+  # m = 1e-3 is far enough from 0 (relative to h ~ 1.2e-4) that both m+h and
+  # m-h stay positive, so this interior point still uses the ordinary
+  # central-difference formula. Phi/phi are smooth in m here (m=0 is a
+  # formula/case-dispatch artifact, not a true singularity), so the boundary
+  # (forward-diff) value at m=0 should be close to the interior value.
+  t <- c(0.5, 1.0, 2.0)
+  d2_boundary <- .hzr_phase_second_derivatives(
+    t, t_half = 1.666871, nu = -0.7462, m = 0, type = "cdf")
+  d2_interior <- .hzr_phase_second_derivatives(
+    t, t_half = 1.666871, nu = -0.7462, m = 1e-3, type = "cdf")
+  expect_equal(d2_boundary$d2Phi_dm2, d2_interior$d2Phi_dm2, tolerance = 0.05)
+  expect_equal(d2_boundary$d2Phi_dnu_dm, d2_interior$d2Phi_dnu_dm,
+               tolerance = 0.05)
+  expect_equal(d2_boundary$d2Phi_dlog_thalf_dm,
+               d2_interior$d2Phi_dlog_thalf_dm, tolerance = 0.05)
+})
+
+test_that(".hzr_hessian_multiphase succeeds at the Case 3L fixed-shape boundary", {
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 1.666871, nu = -0.7462, m = 0,
+                         fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  theta <- c(early.log_mu = -1, early.log_t_half = log(1.666871),
+             early.nu = -0.7462, early.m = 0, constant.log_mu = -1)
+  cov_counts <- c(early = 0L, constant = 0L)
+  H <- .hzr_hessian_multiphase(
+    theta, time = avc$int_dead, status = avc$dead,
+    phases = phases, covariate_counts = cov_counts,
+    x_list = list(early = NULL, constant = NULL)
+  )
+  expect_true(is.matrix(H))
+  expect_true(all(is.finite(H)))
+})
+
 test_that(".hzr_g3_phase_second_derivatives diagonals match numDeriv", {
   skip_if_not_installed("numDeriv")
   t <- c(0.5, 1.0, 3.0, 8.0)


### PR DESCRIPTION
## Summary
- `.hzr_phase_second_derivatives()` perturbed shape parameters `±h` symmetrically with no domain check. `hzr_decompos()` rejects `m < 0 && nu < 0` as undefined; `m = 0` with `nu < 0` (Case 3L) and `nu = 0` with `m < 0` (Case 2L) are legitimate limiting cases sitting exactly on that boundary, so the `-h` step on the *other* parameter crossed into the undefined region and threw.
- That error was silently swallowed by the `tryCatch(..., error = function(e) NULL)` around `.hzr_hessian_multiphase()`, forcing a fallback to a numerical (numDeriv) Hessian for *any* multiphase fit with a boundary-valued fixed shape — not just `hzr_bootstrap()`'s CoE full-information recompute (where the bug surfaced as "Could not compute the full-information variance for the Conservation-of-Events-conserved phase").
- Fix: detect the boundary and use a one-sided (forward) finite difference in just that direction; every other direction/pair is unchanged.
- v1.2.0 hasn't been tagged/submitted to CRAN yet, so this lands in the same release (no version bump).

## Test plan
- [x] New regression tests confirmed failing on pre-fix code, passing after the fix (`tests/testthat/test-multiphase-hessian.R`)
- [x] All pre-existing hessian tests (including numDeriv cross-checks on the non-boundary path) still pass unchanged
- [x] Full `devtools::test()`: 0 failures (1800 passing, up from 1793)