### PR TITLE
SAS parity harness + fix silent hzr_bootstrap() failure for fits built in a function

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,11 @@
 linters: linters_with_defaults(
     line_length_linter(120),
+    # lintr 3.4.0 made `<<-` a default lint. The `<<-` uses here are deliberate
+    # accumulator patterns confined to a function's own closure (stepwise trace
+    # building, fixture capture) -- not the unpredictable global writes the
+    # linter targets. Allow the operator rather than refactor working
+    # selection internals for a style rule.
+    assignment_linter(operator = c("<-", "<<-")),
     object_name_linter = NULL,
     object_length_linter(40),
     commented_code_linter = NULL,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Suggests:
     roxygen2,
     rmarkdown,
     scales,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 LazyData: true
 Config/testthat/edition: 3
 Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
 Suggests:
     covr,
     ggplot2,
+    haven,
     knitr,
     lintr,
     numDeriv,

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,18 @@
 
 ## Bug fixes
 
+* `hzr_bootstrap()` no longer returns a silent `n_success = 0` (and
+  `n_failed = n_boot`, with no error and no warning) when the model was fitted
+  inside a function. `hazard()` stored its call but not the environment that
+  call was written in, so each replicate's refit resolved arguments passed by
+  symbol -- `theta`, `phases`, `control` -- against the package namespace and
+  `globalenv()` rather than the caller's locals. Fits built at the top level
+  appeared to work by falling through to `globalenv()`; fits built inside a
+  function failed on every replicate, and the per-replicate `tryCatch()`
+  swallowed the error. `hazard()` now records the fitting environment, and each
+  replicate is evaluated in a child of it that carries the resampled data and
+  weights. Affects both `refit` and `select` modes.
+
 * `hzr_bootstrap()` no longer floods the console with per-replicate numerical
   warnings (e.g. ill-conditioned-Hessian notes from unstable resamples), which
   are not individually actionable when the bootstrap aggregates over replicates.

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1451,6 +1451,14 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   # set, so names are resolved per replicate inside the loop instead.
   param_names <- if (!select_mode) .hzr_bootstrap_param_names(object) else NULL
 
+  # Replicate calls must resolve two different things: `boot_data`/`boot_weights`
+  # (locals here) and every other argument the user passed by symbol (theta,
+  # phases, control), which only exist in the environment the call was written
+  # in. A child of that environment carrying the resample bindings resolves
+  # both. Falls back to parent.frame() for objects fitted before call_env was
+  # stored.
+  eval_env <- object$call_env %||% parent.frame()
+
   # Accumulate results
   rep_list <- vector("list", n_boot)
   n_success <- 0L
@@ -1466,6 +1474,12 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     boot_data <- orig_data[idx, , drop = FALSE] # nolint: object_usage_linter.
     # boot_weights is referenced via quote() inside eval -- lintr cannot trace it
     boot_weights <- if (is.null(orig_weights)) NULL else orig_weights[idx] # nolint: object_usage_linter.
+
+    # Fresh child of the fitting environment per replicate, carrying this
+    # replicate's resample bindings (referenced via quote() in the call below).
+    rep_env <- new.env(parent = eval_env)
+    assign("boot_data", boot_data, envir = rep_env)
+    if (!is.null(orig_weights)) assign("boot_weights", boot_weights, envir = rep_env)
 
     # Per-replicate fits routinely hit ill-conditioned Hessians and other
     # numerical warnings on individual resamples; these are not individually
@@ -1484,7 +1498,7 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
           cl_base$data <- quote(boot_data)
           if (!is.null(orig_weights)) cl_base$weights <- quote(boot_weights)
           cl_base$fit <- TRUE
-          base_boot <- eval(cl_base)
+          base_boot <- eval(cl_base, envir = rep_env)
           if (!is.finite(base_boot$fit$objective)) {
             stop("base refit did not converge")
           }
@@ -1511,7 +1525,7 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
           cl_boot$data <- quote(boot_data)
           if (!is.null(orig_weights)) cl_boot$weights <- quote(boot_weights)
           cl_boot$fit <- TRUE
-          eval(cl_boot)
+          eval(cl_boot, envir = rep_env)
         }),
         error = function(e) NULL
       )

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1480,18 +1480,47 @@ vcov.hazard <- function(object, ...) {
   # helper functions (e.g. one that builds `phases` or `theta`), and those live
   # in the caller's scope, not on globalenv()'s search path. all.vars() returns
   # only variables and omits function names, leaving such helpers unresolvable
-  # once the call is re-evaluated. Base/package functions matched this way
-  # (`list`, `Surv`, ...) are captured as shared references and cost effectively
-  # nothing to serialize.
-  syms <- all.names(cl)
-  syms <- syms[vapply(syms, exists, logical(1), envir = envir)]
+  # once the call is re-evaluated.
+  #
+  # The scope-chain walk below copies only bindings the caller itself owns: it
+  # stops at the first environment that is package territory rather than user
+  # scope. Package and base functions (`hazard`, `list`, `Surv`, ...) are
+  # deliberately left out: R serialises a closure's environment as a namespace
+  # reference but its BODY by value, so capturing them would freeze a copy of
+  # each function's body into every saved fit. A fit saved under one version and
+  # bootstrapped after an upgrade would then run the stale body against the new
+  # namespace, throw inside the replicate, and be swallowed by hzr_bootstrap()'s
+  # tryCatch into a silent n_success = 0. Left uncaptured, they resolve through
+  # `out`'s parent instead.
+  #
+  # The stop set is globalenv() plus any namespace/base env, NOT globalenv()
+  # alone. Called from a script the chain is simply frame -> globalenv(), but
+  # under testthat and R CMD check the package namespace sits in the chain
+  # BEFORE globalenv(), so a globalenv()-only stop would still capture
+  # `hazard`. When `envir` IS globalenv() the loop body never runs and nothing
+  # is captured -- correct, since every symbol resolves through the parent.
+  is_pkg_env <- function(e) {
+    identical(e, globalenv()) || identical(e, emptyenv()) ||
+      identical(e, baseenv()) || isNamespace(e)
+  }
+  syms <- unique(all.names(cl))
+  found <- character()
+  for (nm in syms) {
+    e <- envir
+    while (!is_pkg_env(e)) {
+      if (exists(nm, envir = e, inherits = FALSE)) {
+        found <- c(found, nm)
+        break
+      }
+      e <- parent.env(e)
+    }
+  }
   # Parented to globalenv(), deliberately NOT to `envir`: parenting to the
   # caller would make its whole frame reachable again through the parent chain
   # and defeat the point of copying only the referenced symbols.
   out <- new.env(parent = globalenv())
-  if (length(syms)) {
-    bindings <- mget(syms, envir = envir, inherits = TRUE)
-    list2env(bindings, envir = out)
+  if (length(found)) {
+    list2env(mget(found, envir = envir, inherits = TRUE), envir = out)
   }
   out
 }

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -574,6 +574,10 @@ hazard <- function(formula = NULL,
 
   # Assemble the hazard S3 object.
   # $call       -- captured call for reproducibility / print
+  # $call_env   -- the environment $call was written in (hazard()'s caller).
+  #                Refit-based tooling such as hzr_bootstrap() re-evaluates the
+  #                stored call; it must do so here, otherwise arguments passed
+  #                by symbol (theta, phases, control) cannot be resolved.
   # $spec       -- model specification (dist, control)
   # $data       -- raw data stored for default predict() / refit
   # $fit        -- optimisation results (see fit_state fields above)
@@ -581,6 +585,7 @@ hazard <- function(formula = NULL,
   # $engine     -- implementation tag ("native-r-m2")
   obj <- list(
     call = match.call(),
+    call_env = parent.frame(),
     spec = list(dist = dist, control = control, time_windows = time_windows,
                 phases = phases),
     data = list(

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -572,20 +572,31 @@ hazard <- function(formula = NULL,
     fit_state$message <- optim_result$message
   }
 
+  # Refit-based tooling (hzr_bootstrap()) re-evaluates $call, so it needs the
+  # bindings that call refers to. Capturing parent.frame() wholesale would pin
+  # the caller's entire frame to every fitted object -- measured at a 1400x
+  # saveRDS bloat, and it would drag unrelated data (including other cohorts)
+  # into any saved model. Copy only the symbols the call actually references.
+  # Computed here, not inside list(), so parent.frame() unambiguously resolves
+  # to hazard()'s caller.
+  captured_call <- match.call()
+  captured_env <- .hzr_capture_call_env(captured_call, parent.frame())
+
   # Assemble the hazard S3 object.
   # $call       -- captured call for reproducibility / print
-  # $call_env   -- the environment $call was written in (hazard()'s caller).
-  #                Refit-based tooling such as hzr_bootstrap() re-evaluates the
-  #                stored call; it must do so here, otherwise arguments passed
-  #                by symbol (theta, phases, control) cannot be resolved.
+  # $call_env   -- the bindings $call references, copied out of hazard()'s
+  #                caller. Refit-based tooling such as hzr_bootstrap()
+  #                re-evaluates the stored call; it must do so here, otherwise
+  #                arguments passed by symbol (theta, phases, control) cannot
+  #                be resolved.
   # $spec       -- model specification (dist, control)
   # $data       -- raw data stored for default predict() / refit
   # $fit        -- optimisation results (see fit_state fields above)
   # $legacy_args -- pass-through ... args for SAS-migration parity
   # $engine     -- implementation tag ("native-r-m2")
   obj <- list(
-    call = match.call(),
-    call_env = parent.frame(),
+    call = captured_call,
+    call_env = captured_env,
     spec = list(dist = dist, control = control, time_windows = time_windows,
                 phases = phases),
     data = list(
@@ -1451,6 +1462,31 @@ vcov.hazard <- function(object, ...) {
     dimnames(v) <- list(nm, nm)
   }
   v
+}
+
+#' Capture the bindings a stored call references
+#'
+#' Copies out of `envir` only the symbols `cl` actually refers to. Names that
+#' resolve from the model's data frame rather than the calling scope (formula
+#' column names such as `int_dead`/`dead`) simply do not exist in `envir` and
+#' are skipped.
+#'
+#' @param cl Matched call, as returned by `match.call()`.
+#' @param envir Caller environment to copy bindings out of.
+#' @return A new environment holding just the referenced bindings.
+#' @noRd
+.hzr_capture_call_env <- function(cl, envir) {
+  syms <- all.vars(cl)
+  syms <- syms[vapply(syms, exists, logical(1), envir = envir)]
+  # Parented to globalenv(), deliberately NOT to `envir`: parenting to the
+  # caller would make its whole frame reachable again through the parent chain
+  # and defeat the point of copying only the referenced symbols.
+  out <- new.env(parent = globalenv())
+  if (length(syms)) {
+    bindings <- mget(syms, envir = envir, inherits = TRUE)
+    list2env(bindings, envir = out)
+  }
+  out
 }
 
 .hzr_parameter_names <- function(theta, dist, p) {

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1476,7 +1476,14 @@ vcov.hazard <- function(object, ...) {
 #' @return A new environment holding just the referenced bindings.
 #' @noRd
 .hzr_capture_call_env <- function(cl, envir) {
-  syms <- all.vars(cl)
+  # all.names(), deliberately NOT all.vars(): the call may invoke the user's own
+  # helper functions (e.g. one that builds `phases` or `theta`), and those live
+  # in the caller's scope, not on globalenv()'s search path. all.vars() returns
+  # only variables and omits function names, leaving such helpers unresolvable
+  # once the call is re-evaluated. Base/package functions matched this way
+  # (`list`, `Surv`, ...) are captured as shared references and cost effectively
+  # nothing to serialize.
+  syms <- all.names(cl)
   syms <- syms[vapply(syms, exists, logical(1), envir = envir)]
   # Parented to globalenv(), deliberately NOT to `envir`: parenting to the
   # caller would make its whole frame reachable again through the parent chain

--- a/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
+++ b/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
@@ -9,8 +9,8 @@ Development-only: `inst/dev/` is `.Rbuildignore`d and does not ship.
 
 Compare `TemporalHazard`'s multiphase fit and `hzr_bootstrap(scope=)` embedded
 stepwise screen against the SAS/C HAZARD originals (`%HAZARD`, `%HAZBOOT`) on
-the `bh.dead` esophageal analysis, to debug the R implementation and to guard
-against regressions.
+the `bh.dead` analysis, a clinical analysis held on a secure volume, to debug
+the R implementation and to guard against regressions.
 
 Two SAS runs are the reference:
 
@@ -88,7 +88,7 @@ estimates already land within ~0.5% of SAS despite defects 2 and 3.
   `temporal_hazard` is a **public** GitHub repository, and `.Rbuildignore` only
   excludes a file from the CRAN tarball — it does nothing about git. The SAS
   `.lst` aggregates are not PHI, but they are results from an apparently
-  unpublished CCF cohort study. Publishing them, or hard-coding SAS's estimates
+  unpublished cohort study. Publishing them, or hard-coding SAS's estimates
   and selection frequencies into committed test code, would put those results
   on the open internet. Therefore:
   * The built fixture lives **beside the data on the secure volume**, not
@@ -181,8 +181,8 @@ derived from the fixture's candidate pool, `slentry = fixture$meta$sle`,
 
 **The statistical assertions (Spearman floor, top-10 recovery) are deferred,
 not merely unwritten.** Measured 2026-07-16: one bootstrap replicate over the
-92-variable pool takes ~5.4 minutes, so SAS's `resampl=1000` extrapolates to
-roughly 90 hours. The feasible `n_boot = 5` yields a `pct` that can only take
+92-variable pool takes ~25 minutes, so SAS's `resampl=1000` extrapolates to
+roughly 17 days. The feasible `n_boot = 5` yields a `pct` that can only take
 the values {0, 20, 40, 60, 80, 100}; a rank correlation of that against SAS's
 1000-resample percentages is dominated by ties and sampling noise. A floor
 calibrated from it would encode noise while reading as verified parity — worse

--- a/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
+++ b/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
@@ -1,0 +1,226 @@
+# bh.dead SAS parity harness — design
+
+Date: 2026-07-16
+Status: approved (design), not yet implemented
+
+Development-only: `inst/dev/` is `.Rbuildignore`d and does not ship.
+
+## Purpose
+
+Compare `TemporalHazard`'s multiphase fit and `hzr_bootstrap(scope=)` embedded
+stepwise screen against the SAS/C HAZARD originals (`%HAZARD`, `%HAZBOOT`) on
+the `bh.dead` esophageal analysis, to debug the R implementation and to guard
+against regressions.
+
+Two SAS runs are the reference:
+
+* `distributions/hz.dead.sas` — the shape fit (`PROC HAZARD ... noconserve`).
+* `analyses/bh.dead.sas` — the bootstrap variable screen
+  (`%hazboot(resampl=1000, sle=0.12, sls=0.1)`).
+
+## Findings that motivate this work
+
+Comparing the existing draft qmd (`analyses/bh.dead_r_bootstrap.qmd`, on the
+`qhsstudies` volume) against the SAS sources and outputs surfaced three
+fidelity defects. All three must be fixed for any comparison to be meaningful.
+
+### 1. The draft screens four variables SAS never considered
+
+`HIST_AD`, `HIST_SQ`, `GRADE`, `RESM1`, `LVI` return zero rows in
+`bh.dead.lst`. They are commented out in `bh.dead.sas`'s `%hmmodel` macro via a
+nested-comment trap: SAS `/* */` blocks do not nest, so
+
+```sas
+/*hist_ad, hist_sq,
+grade,
+/* tumloc */
+```
+
+terminates at the **first** `*/`, silently dropping `hist_ad`, `hist_sq`,
+`grade` and `tumloc`. The same pattern drops `resm1` and `lvi`. The draft qmd's
+scope includes `hist_ad + grade + resm1 + lvi`.
+
+SAS's real candidate pool is **92 variables** (93 rows in each phase table,
+minus the `E0`/`C0` intercept row). The draft has 19.
+
+Selection frequency depends on the candidate pool, so a 19-variable scope
+cannot be compared to a 92-variable SAS table at all.
+
+### 2. The draft's `fixed=` matches neither SAS run
+
+From `hz.dead.lst`'s "Estimates for Model Parameters" block (values withheld —
+see Data governance below):
+
+| Parameter | `hz.dead` (shape fit) | `bh.dead` (bootstrap base) | draft qmd |
+|-----------|----------------------|----------------------------|-----------|
+| THALF     | estimated            | free (`fixnu fixm`)        | fixed     |
+| NU        | estimated            | fixed at its `parms` value | fixed     |
+| M         | fixed at 0           | fixed at 0                 | fixed     |
+| MUE       | estimated            | free                       | free      |
+| MUC       | estimated            | free                       | free      |
+
+`hz.dead` fixes **only M**. `bh.dead` fixes **nu and m**. The draft's
+`fixed = "shapes"` fixes all three.
+
+The draft also starts `t_half` at SAS's *converged* value rather than its
+`parms` starting value.
+
+### 3. The draft omits `noconserve`
+
+`hz.dead.sas:56` reads `proc hazard data=built noconserve ...`. R defaults to
+`conserve = TRUE`, so the draft runs Conservation of Events where SAS does not.
+This is also why the CoE full-information-variance path was being exercised at
+all.
+
+### Non-issue (verified)
+
+`bhblt.sas7bdat` is written **after** SAS's scaling (`bh.dead.sas:123-135`
+applies `age_ln*10`, `age_e*10`, `age_2/10`, `iv_ind/50`, then writes
+`library.bhblt`). `read_sas()` therefore hands R exactly the values SAS
+bootstrapped; no transformation mirroring is needed. This is why the draft's mu
+estimates already land within ~0.5% of SAS despite defects 2 and 3.
+
+## Constraints
+
+* **No PHI in the repo.** `bhblt.sas7bdat` is patient-level clinical data and
+  must never enter `temporal_hazard`.
+* **Data governance: nothing study-specific enters the repo either.**
+  `temporal_hazard` is a **public** GitHub repository, and `.Rbuildignore` only
+  excludes a file from the CRAN tarball — it does nothing about git. The SAS
+  `.lst` aggregates are not PHI, but they are results from an apparently
+  unpublished CCF cohort study. Publishing them, or hard-coding SAS's estimates
+  and selection frequencies into committed test code, would put those results
+  on the open internet. Therefore:
+  * The built fixture lives **beside the data on the `qhsstudies` volume**, not
+    in `inst/fixtures/`.
+  * Committed code contains **no study values**. Every expectation is derived
+    from the fixture at run time.
+  * This design document likewise carries no estimates or frequencies.
+* **Must not ship to CRAN.** The test skips unless both the data and the
+  fixture are readable, so it never executes on CRAN or CI.
+* **SAS's bootstrap is not reproducible.** `bh.dead.sas:338` calls
+  `%hazboot(..., seed=-1, ...)`; per the macro documentation, `seed=-1` uses
+  time of day. The `PCT` column is one random realization over 1000 resamples.
+  Exact selection-frequency parity is impossible in principle.
+* **Runtime.** A 92-variable × 1000-resample stepwise bootstrap far exceeds the
+  10-minute CRAN check budget. The full run belongs in the qmd, not the suite.
+
+## Architecture
+
+Parsing is the single source of truth, shared by the test and the qmd, so the
+two cannot drift apart on what "SAS said".
+
+| File | Location | Public? | Purpose |
+|------|----------|---------|---------|
+| `parse-bhdead-lst.R` | `inst/dev/bhdead-parity/` | yes (generic code) | Parse the two `.lst` files → write `bhdead.rds` to the volume |
+| `bhdead-fixture.R` | `inst/dev/bhdead-parity/` | yes (generic code) | Resolve/load/validate the fixture; no study values |
+| `README.md` | `inst/dev/bhdead-parity/` | yes | How to re-capture and where the fixture lives |
+| `bhdead.rds` | `qhsstudies` volume | **no** | SAS reference (stays off the repo) |
+| `test-bhdead-sas-parity.R` | `tests/testthat/` | yes (generic code) | Parity test; skips unless data **and** fixture present |
+| `bh.dead_r_bootstrap.qmd` | `qhsstudies` volume | no | Presentation/debug layer |
+
+All harness code lives under `inst/dev/` (`.Rbuildignore`d, so it does not ship
+to CRAN) except the test itself, which must live in `tests/testthat/` to run.
+The test is written so that it is inert — a silent skip — for anyone without
+the volume mounted.
+
+### Fixture contents (`bhdead.rds`, off-repo)
+
+A named list:
+
+* `shape` — from `hz.dead.lst`: specified and converged THALF, NU, M, MUE, MUC.
+* `early` — from `bh.dead.lst` Early Phase table: `name`, `n`, `pct`, `min`,
+  `max`, `mean`, `sd` (93 rows incl. the `E0` intercept).
+* `constant` — same, Constant Phase (93 rows incl. `C0`).
+* `meta` — `resampl`, `sle`, `sls`, `n_obs`, capture date, source paths.
+
+The 92-variable candidate pool is derived from `early$name` / `constant$name`
+minus the intercept row — never hand-transcribed.
+
+### Data access / skip gate
+
+Two environment variables, each with a default pointing at the `qhsstudies`
+mount:
+
+* `TEMPORALHAZARD_BHBLT` — path to `bhblt.sas7bdat`
+* `TEMPORALHAZARD_BHDEAD_FIXTURE` — path to `bhdead.rds`
+
+The test calls `skip_if_not()` when either is unreadable, and
+`skip_if_not_installed("haven")`. It therefore runs on the maintainer's machine
+and skips silently on CRAN, CI, and every other machine. `haven` moves to
+`Suggests`.
+
+This mirrors `test-weights-sas-parity.R`, which skips when its fixture is
+absent — extended to gate on the data as well.
+
+## Assertions
+
+**No SAS value is written into committed code.** Every starting value, every
+expectation, and every candidate name is read from the fixture at run time.
+
+### Shape fit — deterministic, tight
+
+Refit `hz.dead`'s spec in R — `fixed = "m"`, `conserve = FALSE`, shape and mu
+starting values taken from `fixture$shape$specified` — and assert the fitted
+THALF, NU, MUE and MUC against `fixture$shape$converged` at ~1e-3 relative.
+
+This is the primary regression guard: it is exactly where the analytic-Hessian
+boundary bug and the single-free-parameter `drop=FALSE` bug surfaced.
+
+### Bootstrap screen — stochastic, statistical
+
+Refit `bh.dead`'s spec — `fixed = c("nu", "m")`, `conserve = FALSE`, the scope
+derived from the fixture's candidate pool, `slentry = fixture$meta$sle`,
+`slstay = fixture$meta$sls` — and assert:
+
+* Spearman rank correlation of R `pct` vs the fixture's `pct` exceeds a floor.
+* Of the fixture's top-10 by `pct`, R recovers at least half.
+* The intercept rows (`E0` / `C0` ↔ `early.log_mu` / `constant.log_mu`) are
+  selected 100% of the time.
+
+**Thresholds are calibrated from the first real run, not invented now.** It is
+not yet known whether R and SAS agree well enough for any given threshold to
+pass. If they diverge substantially, that is a finding to investigate — not a
+number to loosen until the test goes green.
+
+### Staged `n_boot`
+
+* `5` — testthat smoke check: proves the path runs end-to-end, fast.
+* `50` — qmd default, for iterating on the comparison.
+* `1000` — the real SAS-comparable run (matches `resampl=1000`), driven from
+  the qmd with `verbose = TRUE` for the progress bar.
+
+`n_boot` is a Quarto param so escalating is a one-line change.
+
+## qmd rewrite
+
+`analyses/bh.dead_r_bootstrap.qmd` mirrors the SAS step-for-step:
+
+1. **Shape fit** (`hz.dead.sas`) — `fixed = "m"`, `conserve = FALSE`, starting
+   values from the fixture. Print alongside SAS's converged values.
+2. **Bootstrap base** (`bh.dead.sas` `parms ... fixnu fixm`) —
+   `fixed = c("nu", "m")`, `conserve = FALSE`.
+3. **Scope** — 92 variables read from the fixture, lowercased.
+4. **Screen** — `n_boot` param, `slentry = 0.12`, `slstay = 0.10`,
+   `verbose = TRUE`.
+5. **Compare** — join R `pct` ↔ SAS `PCT`, sorted by descending absolute
+   discrepancy. This table is the actual debugging deliverable.
+
+Guards:
+
+* **Fail loud on missing columns.** Validate all 92 scope variables exist in
+  `caa` before fitting and name any that do not, rather than letting
+  `hzr_stepwise()` degrade each into a per-candidate warning 92 times.
+* **The qmd is presentation only.** All `.lst` parsing lives in the fixture
+  script shared with the test.
+
+## Out of scope
+
+* An `avc`-based version of this parity check that could run in CI. Considered
+  and deferred: it would require a fresh SAS run against `avc` and would not be
+  literally `bh.dead`.
+* Fixing `conserve`'s missing `@param control` documentation (only `n_starts`
+  is currently documented). Tracked separately.
+* The unexplained empty-coefficient-table print behaviour on the maintainer's
+  machine. Under investigation separately; the summary object itself is
+  verified correct.

--- a/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
+++ b/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
@@ -21,7 +21,7 @@ Two SAS runs are the reference:
 ## Findings that motivate this work
 
 Comparing the existing draft qmd (`analyses/bh.dead_r_bootstrap.qmd`, on the
-`qhsstudies` volume) against the SAS sources and outputs surfaced three
+secure volume) against the SAS sources and outputs surfaced three
 fidelity defects. All three must be fixed for any comparison to be meaningful.
 
 ### 1. The draft screens four variables SAS never considered
@@ -91,7 +91,7 @@ estimates already land within ~0.5% of SAS despite defects 2 and 3.
   unpublished CCF cohort study. Publishing them, or hard-coding SAS's estimates
   and selection frequencies into committed test code, would put those results
   on the open internet. Therefore:
-  * The built fixture lives **beside the data on the `qhsstudies` volume**, not
+  * The built fixture lives **beside the data on the secure volume**, not
     in `inst/fixtures/`.
   * Committed code contains **no study values**. Every expectation is derived
     from the fixture at run time.
@@ -115,9 +115,9 @@ two cannot drift apart on what "SAS said".
 | `parse-bhdead-lst.R` | `inst/dev/bhdead-parity/` | yes (generic code) | Parse the two `.lst` files → write `bhdead.rds` to the volume |
 | `bhdead-fixture.R` | `inst/dev/bhdead-parity/` | yes (generic code) | Resolve/load/validate the fixture; no study values |
 | `README.md` | `inst/dev/bhdead-parity/` | yes | How to re-capture and where the fixture lives |
-| `bhdead.rds` | `qhsstudies` volume | **no** | SAS reference (stays off the repo) |
+| `bhdead.rds` | secure volume | **no** | SAS reference (stays off the repo) |
 | `test-bhdead-sas-parity.R` | `tests/testthat/` | yes (generic code) | Parity test; skips unless data **and** fixture present |
-| `bh.dead_r_bootstrap.qmd` | `qhsstudies` volume | no | Presentation/debug layer |
+| `bh.dead_r_bootstrap.qmd` | secure volume | no | Presentation/debug layer |
 
 All harness code lives under `inst/dev/` (`.Rbuildignore`d, so it does not ship
 to CRAN) except the test itself, which must live in `tests/testthat/` to run.
@@ -139,11 +139,12 @@ minus the intercept row — never hand-transcribed.
 
 ### Data access / skip gate
 
-Two environment variables, each with a default pointing at the `qhsstudies`
-mount:
+Two environment variables, with **no default** — an unset variable yields `""`,
+which the loader treats as "absent" so callers skip. No study-identifying path
+appears in committed code:
 
-* `TEMPORALHAZARD_BHBLT` — path to `bhblt.sas7bdat`
-* `TEMPORALHAZARD_BHDEAD_FIXTURE` — path to `bhdead.rds`
+* `TEMPORALHAZARD_BHBLT` — path to the row-level SAS dataset
+* `TEMPORALHAZARD_BHDEAD_FIXTURE` — path to the built fixture
 
 The test calls `skip_if_not()` when either is unreadable, and
 `skip_if_not_installed("haven")`. It therefore runs on the maintainer's machine

--- a/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
+++ b/inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
@@ -168,16 +168,61 @@ THALF, NU, MUE and MUC against `fixture$shape$converged` at ~1e-3 relative.
 This is the primary regression guard: it is exactly where the analytic-Hessian
 boundary bug and the single-free-parameter `drop=FALSE` bug surfaced.
 
-### Bootstrap screen — stochastic, statistical
+### Bootstrap screen — smoke only (statistical parity DEFERRED)
 
 Refit `bh.dead`'s spec — `fixed = c("nu", "m")`, `conserve = FALSE`, the scope
 derived from the fixture's candidate pool, `slentry = fixture$meta$sle`,
-`slstay = fixture$meta$sls` — and assert:
+`slstay = fixture$meta$sls` — and assert only that it runs end-to-end:
 
-* Spearman rank correlation of R `pct` vs the fixture's `pct` exceeds a floor.
-* Of the fixture's top-10 by `pct`, R recovers at least half.
+* The call returns an `hzr_bootstrap` object with `n_success > 0`.
+* The summary is non-empty.
 * The intercept rows (`E0` / `C0` ↔ `early.log_mu` / `constant.log_mu`) are
-  selected 100% of the time.
+  selected in every successful replicate — stepwise never drops them.
+
+**The statistical assertions (Spearman floor, top-10 recovery) are deferred,
+not merely unwritten.** Measured 2026-07-16: one bootstrap replicate over the
+92-variable pool takes ~5.4 minutes, so SAS's `resampl=1000` extrapolates to
+roughly 90 hours. The feasible `n_boot = 5` yields a `pct` that can only take
+the values {0, 20, 40, 60, 80, 100}; a rank correlation of that against SAS's
+1000-resample percentages is dominated by ties and sampling noise. A floor
+calibrated from it would encode noise while reading as verified parity — worse
+than no assertion.
+
+These assertions are unblocked by `criterion = "score"` (see
+"Deferred: score-test selection"), which makes a SAS-scale `n_boot` reachable.
+Until then the shape fit carries the regression-guard weight; it is
+deterministic and matches SAS to 3.4e-04.
+
+## Deferred: score-test selection (`criterion = "score"`)
+
+Profiling `hzr_stepwise()` over the 92-variable pool (2026-07-16, one stepwise,
+~53 s of samples) found **99.77% of time inside `.hzr_refit_with_scope`** —
+94% of it in `stats::optim` evaluating the multiphase likelihood
+(`hzr_decompos` 21% self, `.hzr_logl_multiphase` 16% self).
+
+The cause is algorithmic, not a slow inner loop. `R/stepwise-step.R`'s forward
+step performs **one full model refit per candidate per step** — 92 variables ×
+2 phases = 184 optimizations per step. SAS HAZARD instead scores entry
+candidates with **Q-statistics (a score test) evaluated at the current model,
+with no refit** (already documented in `tests/testthat/test-stepwise-parity.R`).
+SAS does ~1 fit per step where R does 184.
+
+Two secondary inefficiencies were also measured, both in the innermost loop:
+
+* `stopifnot` at 4.6% self — `hzr_decompos()` re-validates its scalar shape
+  arguments on every likelihood evaluation, re-checking values that cannot
+  change during a fit.
+* ~12% self across `.hzr_unpack_phase_theta`, `.hzr_split_theta`,
+  `.hzr_phase_n_params` and `.hzr_phase_n_shape` — the parameter layout is
+  re-derived per evaluation though it is fixed for the whole fit.
+
+Removing both might buy ~1.2-1.3×. That does not close a ~184× gap: only the
+score test does, and it additionally makes the comparison apples-to-apples,
+since R and SAS currently run *different selection algorithms*.
+
+`criterion = "score"` is therefore a real feature needing its own design, not
+an optimization to improvise inside a parity task. Owner decision 2026-07-16:
+land this harness first, return to the score test separately.
 
 **Thresholds are calibrated from the first real run, not invented now.** It is
 not yet known whether R and SAS agree well enough for any given threshold to

--- a/inst/dev/PLAN-bhdead-sas-parity.md
+++ b/inst/dev/PLAN-bhdead-sas-parity.md
@@ -791,8 +791,18 @@ recorded without study values. Fixes the floors used by the parity test."
 - Consumes: `.hzr_load_bhdead_fixture()`, `.hzr_bhblt_path()`, `.hzr_bhdead_candidates()` from Task 1; the floors recorded in Task 3.
 - Produces: nothing consumed downstream.
 
-Replace `<SPEARMAN_FLOOR>` and `<TOP10_FLOOR>` with the values recorded in
-Task 3 Step 7. Do not invent them.
+**Scope change (2026-07-16, owner decision).** The statistical assertions are
+DEFERRED — there are no `<SPEARMAN_FLOOR>` / `<TOP10_FLOOR>` values to fill in.
+Task 3 measured one bootstrap replicate over the 92-variable pool at ~5.4
+minutes, so SAS's `resampl=1000` is ~90 hours; the feasible `n_boot = 5` gives a
+`pct` restricted to {0, 20, 40, 60, 80, 100}, and a rank correlation of that
+against SAS's 1000-resample percentages is dominated by ties and noise. A floor
+calibrated from it would encode noise while reading as verified parity.
+
+Task 4 therefore asserts: the shape fit tightly (deterministic, measured at
+3.4e-04 against SAS), and the bootstrap screen as a **smoke check only**.
+Statistical parity is unblocked by `criterion = "score"` — see the design doc's
+"Deferred: score-test selection". Do not invent a floor to fill the gap.
 
 - [ ] **Step 1: Write the test**
 
@@ -814,13 +824,19 @@ Create `tests/testthat/test-bhdead-sas-parity.R`:
 .bhdead_helpers <- system.file("dev", "bhdead-parity", "bhdead-fixture.R",
                                 package = "TemporalHazard")
 
-# Floors calibrated from observed output (see BHDEAD-SAS-PARITY-DESIGN.md,
-# "Calibration"). SAS seeds its bootstrap from the time of day (seed=-1), so
-# selection frequencies are one random realisation and cannot match exactly.
+# Shape-fit tolerance is calibrated from observed output: R reproduces SAS's
+# converged shape fit to 3.4e-04 max relative error (2026-07-16), so 1e-3 is a
+# real guard with headroom, not a guess.
+#
+# There is deliberately NO statistical tolerance for the bootstrap screen. SAS
+# seeds from the time of day (seed=-1), so its selection frequencies are one
+# random realisation; and one R replicate over the 92-variable pool costs ~5.4
+# minutes, making a SAS-scale n_boot infeasible until criterion = "score"
+# lands. At the feasible n_boot the frequencies are too coarse to support a
+# meaningful floor. See BHDEAD-SAS-PARITY-DESIGN.md, "Deferred: score-test
+# selection". The bootstrap test below is a smoke check by design.
 .bhdead_tolerance <- list(
-  shape_rel     = 1e-3,
-  spearman_min  = <SPEARMAN_FLOOR>,
-  top10_min     = <TOP10_FLOOR>
+  shape_rel = 1e-3
 )
 
 .bhdead_setup <- function() {
@@ -1161,17 +1177,20 @@ Confirm the repo is clean: `git status --short` shows nothing from this task.
 | Env-var resolution + skip gate | 1, 4 |
 | `haven` → Suggests, guarded | 4 |
 | Shape fit asserted tightly (~1e-3) | 4 |
-| Bootstrap asserted statistically | 3 (calibrate), 4 |
-| Thresholds calibrated, not invented | 3 |
-| `n_boot` staged 5 → 50 → 1000 | 3 (5/50), 4 (5), 5 (all three) |
+| Bootstrap asserted (smoke only; statistical parity DEFERRED — infeasible n_boot, see Task 4 scope change) | 4 |
+| Thresholds calibrated, not invented | 3 — shape_rel 1e-3 from measured 3.4e-04; no bootstrap floor invented |
+| `n_boot` staged 5 → 50 → 1000 | 4 (5, smoke). 50/1000 PARKED: ~5.4 min/replicate → 1000 ≈ 90 h. Unblocked by `criterion = "score"`. |
 | qmd fixes `fixed=`, `conserve=`, scope | 5 |
 | Fail loud on missing columns | 4 (test), 5 (qmd `stop()`) |
 | No study values committed | Global constraint; enforced in 1, 2, 4 |
 | No PHI in repo | Global constraint; data read from volume only |
 
-**Placeholder scan:** `<SPEARMAN_FLOOR>` / `<TOP10_FLOOR>` in Task 4 are
-deliberate — Task 3 Step 7 produces them, and Task 4's preamble says not to
-invent them. No other placeholders.
+**Placeholder scan:** none. Task 4 originally carried `<SPEARMAN_FLOOR>` /
+`<TOP10_FLOOR>` for Task 3 to fill; Task 3's measurements showed no honest
+value exists at a feasible `n_boot` (see the scope change in Task 4), so the
+statistical assertions were removed rather than filled with a guess. The only
+surviving tolerance, `shape_rel = 1e-3`, is calibrated from observed output
+(measured 3.4e-04).
 
 **Type consistency:** `.hzr_bhdead_candidates()`, `.hzr_load_bhdead_fixture()`,
 `.hzr_bhblt_path()`, `.hzr_bhdead_fixture_path()`, `.hzr_validate_bhdead_fixture()`

--- a/inst/dev/PLAN-bhdead-sas-parity.md
+++ b/inst/dev/PLAN-bhdead-sas-parity.md
@@ -1,0 +1,1185 @@
+# bh.dead SAS Parity Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a development-only harness that compares `TemporalHazard`'s multiphase fit and `hzr_bootstrap(scope=)` embedded stepwise screen against the SAS/C HAZARD originals (`%HAZARD`, `%HAZBOOT`) on a clinical analysis held on a secure volume.
+
+**Architecture:** Two SAS listing files are parsed into a single fixture list (`shape`, `early`, `constant`, `meta`). The fixture is written to the secure volume — never the repo. A loader resolves it via environment variables. A testthat parity test refits both SAS specifications in R and asserts the deterministic shape fit tightly and the stochastic bootstrap screen statistically, deriving every expectation from the fixture at run time. A Quarto notebook on the volume is the human-facing debug layer.
+
+**Tech Stack:** R, testthat 3e, `haven` (Suggests, for `read_sas`), base R parsing (no new dependencies).
+
+Design document: `inst/dev/BHDEAD-SAS-PARITY-DESIGN.md`
+
+## Global Constraints
+
+- **This repository is PUBLIC.** `.Rbuildignore` excludes files from the CRAN tarball but does nothing about git. No study values (estimates, selection frequencies, cohort size) may appear in any committed file — including code, comments, tests, and commit messages.
+- **No PHI in the repo.** `bhblt.sas7bdat` must never be copied into `temporal_hazard`.
+- **The built fixture stays off-repo**, beside the data on the secure volume.
+- **Every expectation is derived from the fixture at run time.** No SAS number is hard-coded.
+- **Test fixtures must use invented numbers, not renamed real ones.** Reproduce the SAS listing *format*, never its values. Renaming a variable to `VAR_A` while keeping its verbatim counts and percentages anonymises nothing — the values themselves are the study result and are trivially matched back against the listing. Use round, obviously fake numbers (`500`, `50.0`, `1.000`).
+- **Harness code lives in `inst/dev/bhdead-parity/`** (`.Rbuildignore`d via the existing `^inst/dev$` rule). The only exception is the test, which must live in `tests/testthat/` to run.
+- **The test must be inert for everyone else:** skip unless data AND fixture are readable, and unless `haven` is installed. It must never run on CRAN or CI.
+- **No new hard dependencies.** `haven` goes in `Suggests`, guarded by `skip_if_not_installed()`.
+- **Style:** follow existing repo conventions — internal helpers are `.hzr_`-prefixed with `@noRd`; two-space indent; `<-` assignment; lintr line limit 120.
+- **Versioning:** do not touch the MINOR/MAJOR digit. This work is test-only and needs no version bump.
+- Branch: `test/bhdead-sas-parity-harness`. Never push to `main`/`dev` directly; open a PR.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TEMPORALHAZARD_BHBLT` | `/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy/datasets/bhblt.sas7bdat` | Row-level data |
+| `TEMPORALHAZARD_BHDEAD_FIXTURE` | `/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy/estimates/bhdead.rds` | Built SAS reference |
+
+---
+
+### Task 1: Fixture schema, validator, and loader
+
+**Files:**
+- Create: `inst/dev/bhdead-parity/bhdead-fixture.R`
+- Test: `tests/testthat/test-bhdead-fixture.R`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces:
+  - `.hzr_bhdead_fixture_schema()` → named list: `shape = c("specified","converged")`, `phase = c("name","n","pct","min","max","mean","sd")`, `meta = c("resampl","sle","sls","n_obs","captured_on","source")`
+  - `.hzr_validate_bhdead_fixture(fix)` → returns `fix` unchanged if valid; `stop()`s with a message listing every problem otherwise.
+  - `.hzr_bhdead_fixture_path()` → character path from `TEMPORALHAZARD_BHDEAD_FIXTURE` or its default.
+  - `.hzr_bhblt_path()` → character path from `TEMPORALHAZARD_BHBLT` or its default.
+  - `.hzr_load_bhdead_fixture(path = .hzr_bhdead_fixture_path())` → validated fixture list, or `NULL` when the file does not exist.
+  - `.hzr_bhdead_candidates(fix)` → character vector of candidate variable names (lowercased, intercept row removed).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-bhdead-fixture.R`:
+
+```r
+# Unit tests for the bh.dead parity fixture schema/loader.
+# These construct synthetic fixtures in-memory and never touch the secure
+# volume, so they run everywhere (including CRAN) and contain no study values.
+
+source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                   package = "TemporalHazard"), local = TRUE)
+
+.fake_phase <- function(names_vec) {
+  data.frame(
+    name = names_vec,
+    n    = rep(10L, length(names_vec)),
+    pct  = rep(50, length(names_vec)),
+    min  = rep(-1, length(names_vec)),
+    max  = rep(1, length(names_vec)),
+    mean = rep(0, length(names_vec)),
+    sd   = rep(1, length(names_vec)),
+    stringsAsFactors = FALSE
+  )
+}
+
+.fake_fixture <- function() {
+  list(
+    shape = list(
+      specified = c(thalf = 1, nu = -1, m = 0, mue = 1, muc = 1),
+      converged = c(thalf = 1, nu = -1, m = 0, mue = 1, muc = 1)
+    ),
+    early    = .fake_phase(c("E0", "VAR_A", "VAR_B")),
+    constant = .fake_phase(c("C0", "VAR_A", "VAR_B")),
+    meta = list(resampl = 1000L, sle = 0.12, sls = 0.10, n_obs = 100L,
+                captured_on = "2026-07-16", source = "synthetic")
+  )
+}
+
+test_that(".hzr_validate_bhdead_fixture accepts a well-formed fixture", {
+  fix <- .fake_fixture()
+  expect_identical(.hzr_validate_bhdead_fixture(fix), fix)
+})
+
+test_that(".hzr_validate_bhdead_fixture reports every missing field at once", {
+  fix <- .fake_fixture()
+  fix$meta$sle <- NULL
+  fix$shape$converged <- NULL
+  expect_error(.hzr_validate_bhdead_fixture(fix), "sle")
+  expect_error(.hzr_validate_bhdead_fixture(fix), "converged")
+})
+
+test_that(".hzr_validate_bhdead_fixture rejects a phase missing a column", {
+  fix <- .fake_fixture()
+  fix$early$pct <- NULL
+  expect_error(.hzr_validate_bhdead_fixture(fix), "early")
+})
+
+test_that(".hzr_bhdead_candidates drops the intercept row and lowercases", {
+  expect_identical(.hzr_bhdead_candidates(.fake_fixture()), c("var_a", "var_b"))
+})
+
+test_that(".hzr_load_bhdead_fixture returns NULL when the file is absent", {
+  expect_null(.hzr_load_bhdead_fixture(file.path(tempdir(), "nope.rds")))
+})
+
+test_that(".hzr_load_bhdead_fixture round-trips a valid fixture", {
+  p <- file.path(tempdir(), "bhdead-test.rds")
+  on.exit(unlink(p), add = TRUE)
+  saveRDS(.fake_fixture(), p)
+  expect_identical(.hzr_load_bhdead_fixture(p), .fake_fixture())
+})
+
+test_that("path helpers honour their environment variables", {
+  withr::with_envvar(c(TEMPORALHAZARD_BHBLT = "/tmp/x.sas7bdat"), {
+    expect_identical(.hzr_bhblt_path(), "/tmp/x.sas7bdat")
+  })
+  withr::with_envvar(c(TEMPORALHAZARD_BHDEAD_FIXTURE = "/tmp/y.rds"), {
+    expect_identical(.hzr_bhdead_fixture_path(), "/tmp/y.rds")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-bhdead-fixture.R")'`
+Expected: FAIL — `cannot open file` / the sourced script does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `inst/dev/bhdead-parity/bhdead-fixture.R`:
+
+```r
+# bhdead-fixture.R -- Resolve, load and validate the bh.dead SAS parity fixture.
+#
+# DEVELOPMENT ONLY. inst/dev/ is .Rbuildignore'd and does not ship.
+#
+# This repository is public. The fixture itself is NOT stored here -- it lives
+# beside the source data on a secure volume, resolved via the environment
+# variables below. This file contains no study values; every expectation used
+# by the parity test is read out of the fixture at run time.
+#
+# Build the fixture with inst/dev/bhdead-parity/parse-bhdead-lst.R.
+# See inst/dev/bhdead-parity/README.md.
+
+.hzr_bhdead_default_root <-
+  "/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy"
+
+#' Path to the row-level SAS dataset (env-overridable)
+#' @noRd
+.hzr_bhblt_path <- function() {
+  p <- Sys.getenv("TEMPORALHAZARD_BHBLT", unset = "")
+  if (nzchar(p)) {
+    return(p)
+  }
+  file.path(.hzr_bhdead_default_root, "datasets", "bhblt.sas7bdat")
+}
+
+#' Path to the built parity fixture (env-overridable)
+#' @noRd
+.hzr_bhdead_fixture_path <- function() {
+  p <- Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE", unset = "")
+  if (nzchar(p)) {
+    return(p)
+  }
+  file.path(.hzr_bhdead_default_root, "estimates", "bhdead.rds")
+}
+
+#' Required fields of a bh.dead parity fixture
+#' @noRd
+.hzr_bhdead_fixture_schema <- function() {
+  list(
+    shape = c("specified", "converged"),
+    phase = c("name", "n", "pct", "min", "max", "mean", "sd"),
+    meta  = c("resampl", "sle", "sls", "n_obs", "captured_on", "source")
+  )
+}
+
+#' Validate a bh.dead parity fixture against the schema
+#'
+#' @param fix A list as produced by the parse script.
+#' @return `fix`, unchanged, if valid. Throws otherwise, listing every problem.
+#' @noRd
+.hzr_validate_bhdead_fixture <- function(fix) {
+  schema <- .hzr_bhdead_fixture_schema()
+  problems <- character()
+
+  if (!is.list(fix)) {
+    stop("bh.dead fixture must be a list.", call. = FALSE)
+  }
+
+  for (group in c("shape", "meta")) {
+    if (!group %in% names(fix)) {
+      problems <- c(problems, paste0("missing top-level: ", group))
+      next
+    }
+    missing_fields <- setdiff(schema[[group]], names(fix[[group]]))
+    if (length(missing_fields) > 0L) {
+      problems <- c(problems, sprintf("missing %s: %s", group,
+                                      paste(missing_fields, collapse = ", ")))
+    }
+  }
+
+  for (phase in c("early", "constant")) {
+    if (!phase %in% names(fix)) {
+      problems <- c(problems, paste0("missing top-level: ", phase))
+      next
+    }
+    missing_cols <- setdiff(schema$phase, names(fix[[phase]]))
+    if (length(missing_cols) > 0L) {
+      problems <- c(problems, sprintf("missing %s columns: %s", phase,
+                                      paste(missing_cols, collapse = ", ")))
+    }
+  }
+
+  if (length(problems) > 0L) {
+    stop("Invalid bh.dead fixture:\n  - ",
+         paste(problems, collapse = "\n  - "), call. = FALSE)
+  }
+  fix
+}
+
+#' Load the bh.dead parity fixture
+#'
+#' @param path Path to the `.rds`. Defaults to `.hzr_bhdead_fixture_path()`.
+#' @return The validated fixture, or `NULL` when the file does not exist.
+#' @noRd
+.hzr_load_bhdead_fixture <- function(path = .hzr_bhdead_fixture_path()) {
+  if (!nzchar(path) || !file.exists(path)) {
+    return(NULL)
+  }
+  .hzr_validate_bhdead_fixture(readRDS(path))
+}
+
+#' Candidate variable names from a fixture (intercept dropped, lowercased)
+#'
+#' The intercept rows are SAS's `E0` (early) and `C0` (constant). Everything
+#' else in the phase table is a screened candidate.
+#'
+#' @noRd
+.hzr_bhdead_candidates <- function(fix) {
+  nm <- union(fix$early$name, fix$constant$name)
+  nm <- setdiff(nm, c("E0", "C0"))
+  tolower(nm)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-bhdead-fixture.R")'`
+Expected: PASS, 8 assertions, 0 failures.
+
+- [ ] **Step 5: Add `withr` to Suggests if absent**
+
+Check: `grep -n "withr" DESCRIPTION`
+If absent, add `withr,` to the `Suggests:` block (alphabetical, after `testthat`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add inst/dev/bhdead-parity/bhdead-fixture.R tests/testthat/test-bhdead-fixture.R DESCRIPTION
+git commit -m "test(dev): bh.dead parity fixture schema, validator and loader
+
+Development-only harness (inst/dev is .Rbuildignore'd). The fixture is
+resolved from a secure volume via TEMPORALHAZARD_BHDEAD_FIXTURE and is
+never stored in this public repo. Unit tests build synthetic fixtures
+in-memory, so they run everywhere and carry no study values."
+```
+
+---
+
+### Task 2: Parse the SAS listings into a fixture
+
+**Files:**
+- Create: `inst/dev/bhdead-parity/parse-bhdead-lst.R`
+- Create: `inst/dev/bhdead-parity/README.md`
+- Test: `tests/testthat/test-bhdead-parse.R`
+
+**Interfaces:**
+- Consumes: `.hzr_validate_bhdead_fixture()` from Task 1.
+- Produces:
+  - `.hzr_parse_bhdead_phase(lines, phase_label)` → data.frame with columns `name, n, pct, min, max, mean, sd`. `phase_label` is `"Early Phase"` or `"Constant Phase"`.
+  - `.hzr_parse_bhdead_shape(lines)` → list with `specified` and `converged`, each a named numeric of `thalf, nu, m, mue, muc`.
+  - `.hzr_build_bhdead_fixture(hz_lst, bh_lst, meta)` → validated fixture list.
+
+The phase tables have this **shape** (leading `Obs` index, then the fields).
+Column positions are not stable, so split on whitespace rather than fixed
+widths. **All numbers shown below are invented** — never paste real listing
+values into committed files:
+
+```
+                           Obs    _NAME_         N     PCT          MIN        MAX        MEAN        STD
+
+                             1    E0           500    100.0      -1.000      1.000      0.1000      1.000
+                             2    VAR_A        250     50.0      -2.000      2.000      0.2000      2.000
+```
+
+The shape block in the other listing has this shape (again, invented numbers):
+
+```
+                                          Phase       Parameter     Fixed?     Estimate
+                                                      THALF         No            1.200000
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-bhdead-parse.R`:
+
+```r
+# Unit tests for the bh.dead .lst parsers.
+#
+# Inputs below reproduce the SAS listing FORMAT with entirely INVENTED numbers.
+# Never paste real listing values here: this repository is public, and a
+# renamed variable with verbatim values is not anonymised. Round, obviously
+# fake numbers make that impossible to get wrong by accident.
+
+source(system.file("dev", "bhdead-parity", "parse-bhdead-lst.R",
+                   package = "TemporalHazard"), local = TRUE)
+
+.fake_bh_lines <- c(
+  "                        Study Title Redacted                       3",
+  "                                                  Early Phase",
+  "",
+  "                           Obs    _NAME_         N     PCT          MIN        MAX        MEAN        STD",
+  "",
+  "                             1    E0           500    100.0    -100.000    100.000     -1.0000     10.000",
+  "                             2    VAR_A        250     50.0      -2.000      2.000      0.2000      2.000",
+  "                             3    VAR_B        100     20.0      -3.000      3.000      0.3000      3.000",
+  "                        Study Title Redacted                       4",
+  "                                                  Constant Phase",
+  "",
+  "                           Obs    _NAME_         N     PCT          MIN        MAX        MEAN        STD",
+  "",
+  "                             1    C0           500    100.0    -200.000    200.000     -2.0000     20.000",
+  "                             2    VAR_A        150     30.0      -4.000      4.000      0.4000      4.000"
+)
+
+.fake_hz_lines <- c(
+  "          Phase        Parameter       Specified        Used       |  Theta",
+  "                       THALF             1.100000      1.100000    |  E2",
+  "                       NU                 -0.5000       -0.5000    |  E3",
+  "                       M                        0             0    |  E4",
+  "                       MUE                 0.8000        0.8000    |  E0",
+  "          Constant:    MUC               0.050000      0.050000    |  C0",
+  "                                          Estimates for Model Parameters",
+  "                                          Phase       Parameter     Fixed?     Estimate",
+  "                                                      THALF         No            1.200000",
+  "                                                      NU            No           -0.600000",
+  "                                                      M             Yes                  0",
+  "                                                      MUE                        0.850000",
+  "                                          Constant:   MUC                       0.055000"
+)
+
+test_that(".hzr_parse_bhdead_phase extracts the Early table", {
+  d <- .hzr_parse_bhdead_phase(.fake_bh_lines, "Early Phase")
+  expect_identical(d$name, c("E0", "VAR_A", "VAR_B"))
+  expect_identical(d$n, c(500L, 250L, 100L))
+  expect_equal(d$pct, c(100.0, 50.0, 20.0))
+  expect_equal(d$mean[2], 0.2)
+  expect_equal(d$sd[3], 3.0)
+})
+
+test_that(".hzr_parse_bhdead_phase does not bleed across phase boundaries", {
+  d <- .hzr_parse_bhdead_phase(.fake_bh_lines, "Constant Phase")
+  expect_identical(d$name, c("C0", "VAR_A"))
+  expect_equal(d$pct, c(100.0, 30.0))
+})
+
+test_that(".hzr_parse_bhdead_shape reads specified and converged values", {
+  s <- .hzr_parse_bhdead_shape(.fake_hz_lines)
+  expect_equal(s$specified[["thalf"]], 1.1)
+  expect_equal(s$specified[["mue"]], 0.8)
+  expect_equal(s$converged[["thalf"]], 1.2)
+  expect_equal(s$converged[["nu"]], -0.6)
+  expect_equal(s$converged[["m"]], 0)
+  expect_equal(s$converged[["muc"]], 0.055)
+})
+
+test_that(".hzr_build_bhdead_fixture returns a schema-valid fixture", {
+  hz <- tempfile(fileext = ".lst"); bh <- tempfile(fileext = ".lst")
+  on.exit(unlink(c(hz, bh)), add = TRUE)
+  writeLines(.fake_hz_lines, hz); writeLines(.fake_bh_lines, bh)
+  fix <- .hzr_build_bhdead_fixture(
+    hz, bh,
+    meta = list(resampl = 1000L, sle = 0.12, sls = 0.10, n_obs = 100L,
+                captured_on = "2026-07-16", source = "synthetic")
+  )
+  expect_identical(.hzr_validate_bhdead_fixture(fix), fix)
+  expect_identical(fix$early$name[1], "E0")
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-bhdead-parse.R")'`
+Expected: FAIL — the sourced script does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `inst/dev/bhdead-parity/parse-bhdead-lst.R`:
+
+```r
+# parse-bhdead-lst.R -- Build the bh.dead parity fixture from SAS listings.
+#
+# DEVELOPMENT ONLY. inst/dev/ is .Rbuildignore'd and does not ship.
+#
+# This repository is public: the .lst inputs and the .rds output both stay on
+# the secure volume. This script contains parsing logic only -- no study values.
+#
+# Usage (paths default to the secure volume; override as needed):
+#   source("inst/dev/bhdead-parity/parse-bhdead-lst.R")
+#   .hzr_write_bhdead_fixture()
+#
+# See README.md in this directory.
+
+# Companion helpers (path resolution, schema, validator). Resolved through the
+# installed/loaded package rather than a relative path, so this script can be
+# sourced from any working directory.
+source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                   package = "TemporalHazard"))
+
+#' Extract one phase table from a bootstrap listing
+#'
+#' Rows look like: `<obs> <NAME> <N> <PCT> <MIN> <MAX> <MEAN> <STD>`.
+#' Column positions are not stable across SAS listings, so split on
+#' whitespace and take fields positionally.
+#'
+#' @param lines Character vector -- the whole listing.
+#' @param phase_label "Early Phase" or "Constant Phase".
+#' @return data.frame(name, n, pct, min, max, mean, sd)
+#' @noRd
+.hzr_parse_bhdead_phase <- function(lines, phase_label) {
+  starts <- grep(phase_label, lines, fixed = TRUE)
+  if (length(starts) == 0L) {
+    stop("Phase label not found in listing: ", phase_label, call. = FALSE)
+  }
+  # A listing repeats the phase label on each page header; take from the first
+  # occurrence to the first *other* phase label that follows it.
+  other <- if (identical(phase_label, "Early Phase")) {
+    "Constant Phase"
+  } else {
+    "Late Phase"
+  }
+  from <- starts[1]
+  ends <- grep(other, lines, fixed = TRUE)
+  ends <- ends[ends > from]
+  to <- if (length(ends) > 0L) ends[1] - 1L else length(lines)
+
+  block <- lines[from:to]
+  # Data rows: obs index, then a NAME of uppercase/digits/underscore, then 6 numbers.
+  rx <- paste0("^\\s*([0-9]+)\\s+([A-Z0-9_]+)\\s+([0-9]+)\\s+",
+               "(-?[0-9.]+)\\s+(-?[0-9.]+)\\s+(-?[0-9.]+)\\s+",
+               "(-?[0-9.]+)\\s+(-?[0-9.]+)\\s*$")
+  hits <- regmatches(block, regexec(rx, block))
+  hits <- Filter(function(x) length(x) == 9L, hits)
+  if (length(hits) == 0L) {
+    stop("No data rows parsed for ", phase_label, call. = FALSE)
+  }
+
+  data.frame(
+    name = vapply(hits, `[[`, character(1), 3L),
+    n    = as.integer(vapply(hits, `[[`, character(1), 4L)),
+    pct  = as.numeric(vapply(hits, `[[`, character(1), 5L)),
+    min  = as.numeric(vapply(hits, `[[`, character(1), 6L)),
+    max  = as.numeric(vapply(hits, `[[`, character(1), 7L)),
+    mean = as.numeric(vapply(hits, `[[`, character(1), 8L)),
+    sd   = as.numeric(vapply(hits, `[[`, character(1), 9L)),
+    stringsAsFactors = FALSE
+  )
+}
+
+#' Extract specified and converged shape parameters from a shape-fit listing
+#'
+#' @param lines Character vector -- the whole listing.
+#' @return list(specified = named numeric, converged = named numeric), each
+#'   over thalf, nu, m, mue, muc.
+#' @noRd
+.hzr_parse_bhdead_shape <- function(lines) {
+  # "Specified" block: `<PARAM> <specified> <used> | ...`
+  spec_of <- function(param) {
+    rx <- paste0("^\\s*(?:Constant:\\s+)?", param,
+                 "\\s+(-?[0-9.]+)\\s+(-?[0-9.]+)\\s*\\|")
+    hit <- regmatches(lines, regexec(rx, lines))
+    hit <- Filter(function(x) length(x) == 3L, hit)
+    if (length(hit) == 0L) {
+      stop("Specified value not found for ", param, call. = FALSE)
+    }
+    as.numeric(hit[[1]][2])
+  }
+
+  # "Estimates for Model Parameters" block, below its header.
+  est_from <- grep("Estimates for Model Parameters", lines, fixed = TRUE)
+  if (length(est_from) == 0L) {
+    stop("'Estimates for Model Parameters' block not found.", call. = FALSE)
+  }
+  est_block <- lines[est_from[1]:length(lines)]
+  conv_of <- function(param) {
+    # `<PARAM> [Fixed?] <estimate>` -- the estimate is the last number on the line.
+    rx <- paste0("^\\s*(?:Constant:\\s+)?", param, "\\s+.*?(-?[0-9.]+)\\s*$")
+    hit <- regmatches(est_block, regexec(rx, est_block))
+    hit <- Filter(function(x) length(x) == 2L, hit)
+    if (length(hit) == 0L) {
+      stop("Converged value not found for ", param, call. = FALSE)
+    }
+    as.numeric(hit[[1]][2])
+  }
+
+  params <- c(thalf = "THALF", nu = "NU", m = "M", mue = "MUE", muc = "MUC")
+  list(
+    specified = vapply(params, spec_of, numeric(1)),
+    converged = vapply(params, conv_of, numeric(1))
+  )
+}
+
+#' Build the fixture from the two listings
+#'
+#' @param hz_lst Path to the shape-fit listing.
+#' @param bh_lst Path to the bootstrap listing.
+#' @param meta Named list: resampl, sle, sls, n_obs, captured_on, source.
+#' @return A validated fixture list.
+#' @noRd
+.hzr_build_bhdead_fixture <- function(hz_lst, bh_lst, meta) {
+  hz <- readLines(hz_lst, warn = FALSE)
+  bh <- readLines(bh_lst, warn = FALSE)
+  fix <- list(
+    shape    = .hzr_parse_bhdead_shape(hz),
+    early    = .hzr_parse_bhdead_phase(bh, "Early Phase"),
+    constant = .hzr_parse_bhdead_phase(bh, "Constant Phase"),
+    meta     = meta
+  )
+  .hzr_validate_bhdead_fixture(fix)
+}
+
+#' Build and write the fixture to the secure volume
+#'
+#' @noRd
+.hzr_write_bhdead_fixture <- function(
+    hz_lst = file.path(.hzr_bhdead_default_root, "distributions", "hz.dead.lst"),
+    bh_lst = file.path(.hzr_bhdead_default_root, "analyses", "bh.dead.lst"),
+    out    = .hzr_bhdead_fixture_path(),
+    meta   = list(resampl = 1000L, sle = 0.12, sls = 0.10, n_obs = NA_integer_,
+                  captured_on = as.character(Sys.Date()),
+                  source = "hz.dead.lst + bh.dead.lst")) {
+  fix <- .hzr_build_bhdead_fixture(hz_lst, bh_lst, meta)
+  saveRDS(fix, out)
+  message("Wrote fixture: ", out,
+          " (early: ", nrow(fix$early), " rows, constant: ",
+          nrow(fix$constant), " rows)")
+  invisible(fix)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-bhdead-parse.R")'`
+Expected: PASS, 10 assertions, 0 failures.
+
+- [ ] **Step 5: Write the README**
+
+Create `inst/dev/bhdead-parity/README.md`:
+
+```markdown
+# bh.dead SAS parity harness (development only)
+
+`inst/dev/` is `.Rbuildignore`d: nothing here ships to CRAN.
+
+**This repository is public.** Neither the row-level data nor the study's
+aggregate results live here. The fixture is built from SAS listings on a
+secure volume and written back to that volume. Committed code contains no
+study values; the parity test derives every expectation from the fixture at
+run time and skips when the volume is not mounted.
+
+## Paths
+
+| Environment variable | Purpose |
+|----------------------|---------|
+| `TEMPORALHAZARD_BHBLT` | Row-level SAS dataset (`bhblt.sas7bdat`) |
+| `TEMPORALHAZARD_BHDEAD_FIXTURE` | Built fixture (`bhdead.rds`) |
+
+Both default to the secure-volume locations. Set them to point elsewhere.
+
+## Rebuilding the fixture
+
+With the volume mounted:
+
+```r
+devtools::load_all()
+source("inst/dev/bhdead-parity/parse-bhdead-lst.R")
+.hzr_write_bhdead_fixture()
+```
+
+This reads the shape-fit listing and the bootstrap listing, and writes
+`bhdead.rds` next to the data.
+
+## Running the parity test
+
+```r
+devtools::load_all()
+testthat::test_file("tests/testthat/test-bhdead-sas-parity.R")
+```
+
+It skips unless the data and the fixture are both readable and `haven` is
+installed.
+
+## What the SAS side does
+
+* Shape fit: `PROC HAZARD ... noconserve`, fixing only `M`.
+* Bootstrap: `%hazboot(seed=-1, resampl=1000, sle=0.12, sls=0.1)`, base model
+  fixing `nu` and `m`.
+
+`seed=-1` means SAS seeds from the time of day, so its selection frequencies
+are one random realisation and cannot be reproduced exactly. Bootstrap
+assertions are therefore statistical, not exact.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add inst/dev/bhdead-parity/parse-bhdead-lst.R inst/dev/bhdead-parity/README.md tests/testthat/test-bhdead-parse.R
+git commit -m "test(dev): parse SAS listings into the bh.dead parity fixture
+
+Parsers for the bootstrap phase tables and the shape-fit estimate block,
+plus a writer that emits the fixture to the secure volume. Unit tests use
+synthetic listing fragments in the SAS output format, so they run anywhere
+and carry no study values."
+```
+
+---
+
+### Task 3: Build the real fixture and calibrate
+
+**Files:**
+- None committed. This task produces the off-repo fixture and records observed behaviour.
+
+**Interfaces:**
+- Consumes: `.hzr_write_bhdead_fixture()` from Task 2.
+- Produces: `bhdead.rds` on the secure volume; the numbers needed to choose Task 4's thresholds.
+
+This task is a **checkpoint, not a code change**. Its purpose is to replace
+guessed thresholds with observed ones.
+
+- [ ] **Step 1: Build the fixture against the real listings**
+
+```r
+devtools::load_all()
+source("inst/dev/bhdead-parity/parse-bhdead-lst.R")
+fix <- .hzr_write_bhdead_fixture()
+```
+
+Expected: a message reporting `early: 93 rows, constant: 93 rows`.
+
+- [ ] **Step 2: Sanity-check the parse**
+
+```r
+stopifnot(nrow(fix$early) == 93L, nrow(fix$constant) == 93L)
+stopifnot(fix$early$name[1] == "E0", fix$constant$name[1] == "C0")
+stopifnot(length(.hzr_bhdead_candidates(fix)) == 92L)
+stopifnot(all(is.finite(fix$early$pct)), all(fix$early$pct <= 100))
+stopifnot(all(c("thalf","nu","m","mue","muc") %in% names(fix$shape$converged)))
+```
+
+Expected: all pass silently. **If the candidate count is not 92, stop and
+re-read the parser** — the scope is the whole point of the comparison.
+
+- [ ] **Step 3: Confirm every candidate exists in the data**
+
+```r
+caa <- haven::read_sas(.hzr_bhblt_path())
+names(caa) <- tolower(names(caa))
+missing <- setdiff(.hzr_bhdead_candidates(fix), names(caa))
+print(missing)
+```
+
+Expected: `character(0)`. Any name printed here must be resolved before
+Task 4 — a missing column would otherwise degrade into 92 per-candidate
+warnings.
+
+- [ ] **Step 4: Run the shape fit and record the gap**
+
+```r
+sp <- fix$shape$specified
+shape_fit <- hazard(
+  survival::Surv(iv_dead, dead) ~ 1, data = caa, dist = "multiphase",
+  phases = list(
+    early    = hzr_phase("cdf", t_half = sp[["thalf"]], nu = sp[["nu"]],
+                         m = sp[["m"]], fixed = "m"),
+    constant = hzr_phase("constant")
+  ),
+  theta   = c(early.log_mu = log(sp[["mue"]]),
+              early.log_t_half = log(sp[["thalf"]]),
+              early.nu = sp[["nu"]], early.m = sp[["m"]],
+              constant.log_mu = log(sp[["muc"]])),
+  control = list(conserve = FALSE),
+  fit = TRUE
+)
+th <- coef(shape_fit)
+data.frame(
+  param = c("thalf", "nu", "mue", "muc"),
+  r     = c(exp(th[["early.log_t_half"]]), th[["early.nu"]],
+            exp(th[["early.log_mu"]]), exp(th[["constant.log_mu"]])),
+  sas   = fix$shape$converged[c("thalf", "nu", "mue", "muc")]
+)
+```
+
+Record the relative gaps. **If any exceeds 1e-3, do not loosen the tolerance
+in Task 4 — investigate.** A gap here means R and SAS disagree on a
+deterministic fit, which is a finding.
+
+- [ ] **Step 5: Run the bootstrap screen at n_boot = 5, then 50**
+
+```r
+scope_vars <- .hzr_bhdead_candidates(fix)
+scope <- list(
+  early    = reformulate(scope_vars),
+  constant = reformulate(scope_vars)
+)
+base_fit <- hazard(
+  survival::Surv(iv_dead, dead) ~ 1, data = caa, dist = "multiphase",
+  phases = list(
+    early    = hzr_phase("cdf", t_half = sp[["thalf"]], nu = sp[["nu"]],
+                         m = sp[["m"]], fixed = c("nu", "m")),
+    constant = hzr_phase("constant")
+  ),
+  theta   = c(early.log_mu = log(sp[["mue"]]),
+              early.log_t_half = log(sp[["thalf"]]),
+              early.nu = sp[["nu"]], early.m = sp[["m"]],
+              constant.log_mu = log(sp[["muc"]])),
+  control = list(conserve = FALSE),
+  fit = TRUE
+)
+bs5 <- hzr_bootstrap(base_fit, n_boot = 5, seed = 123, scope = scope,
+                     slentry = fix$meta$sle, slstay = fix$meta$sls,
+                     control = list(n_starts = 1, conserve = FALSE),
+                     verbose = TRUE)
+bs5$n_success
+```
+
+Expected at `n_boot = 5`: `n_success > 0`. Then repeat at `n_boot = 50` and
+time it — this sets expectations for the 1000 run.
+
+- [ ] **Step 6: Compute the statistics Task 4 will assert**
+
+```r
+cmp <- merge(
+  data.frame(name = toupper(sub("^early\\.", "", bs50$summary$parameter)),
+             r_pct = bs50$summary$pct, stringsAsFactors = FALSE),
+  fix$early[, c("name", "pct")], by = "name"
+)
+cor(cmp$r_pct, cmp$pct, method = "spearman")
+top10 <- head(fix$early$name[order(-fix$early$pct)], 10)
+sum(top10 %in% cmp$name[cmp$r_pct > 0])
+```
+
+Record both. These observed values choose Task 4's floors.
+
+- [ ] **Step 7: Record findings in the design doc**
+
+Append a "Calibration (observed)" section to
+`inst/dev/BHDEAD-SAS-PARITY-DESIGN.md` describing, **without study values**:
+the shape-fit gap magnitude (order only, e.g. "within 1e-4"), the observed
+rank correlation band, the top-10 recovery count, and the chosen floors with
+their rationale.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add inst/dev/BHDEAD-SAS-PARITY-DESIGN.md
+git commit -m "docs(dev): record bh.dead parity calibration and chosen thresholds
+
+Observed behaviour from the first real run against the secure volume,
+recorded without study values. Fixes the floors used by the parity test."
+```
+
+---
+
+### Task 4: The parity test
+
+**Files:**
+- Create: `tests/testthat/test-bhdead-sas-parity.R`
+- Modify: `DESCRIPTION` (add `haven` to `Suggests`)
+
+**Interfaces:**
+- Consumes: `.hzr_load_bhdead_fixture()`, `.hzr_bhblt_path()`, `.hzr_bhdead_candidates()` from Task 1; the floors recorded in Task 3.
+- Produces: nothing consumed downstream.
+
+Replace `<SPEARMAN_FLOOR>` and `<TOP10_FLOOR>` with the values recorded in
+Task 3 Step 7. Do not invent them.
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/testthat/test-bhdead-sas-parity.R`:
+
+```r
+# SAS parity for the bh.dead analysis: multiphase shape fit (%HAZARD) and the
+# hzr_bootstrap(scope=) embedded stepwise screen (%HAZBOOT).
+#
+# THIS REPOSITORY IS PUBLIC. No study value appears in this file: the data and
+# the SAS reference both live on a secure volume, and every expectation is read
+# from the fixture at run time. The test skips unless both are readable, so it
+# never runs on CRAN, on CI, or on any machine without the volume mounted.
+#
+# Enable by building the fixture first:
+#   source("inst/dev/bhdead-parity/parse-bhdead-lst.R"); .hzr_write_bhdead_fixture()
+# See inst/dev/bhdead-parity/README.md.
+
+.bhdead_helpers <- system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                                package = "TemporalHazard")
+
+# Floors calibrated from observed output (see BHDEAD-SAS-PARITY-DESIGN.md,
+# "Calibration"). SAS seeds its bootstrap from the time of day (seed=-1), so
+# selection frequencies are one random realisation and cannot match exactly.
+.bhdead_tolerance <- list(
+  shape_rel     = 1e-3,
+  spearman_min  = <SPEARMAN_FLOOR>,
+  top10_min     = <TOP10_FLOOR>
+)
+
+.bhdead_setup <- function() {
+  testthat::skip_if_not_installed("haven")
+  if (!nzchar(.bhdead_helpers) || !file.exists(.bhdead_helpers)) {
+    testthat::skip("bh.dead parity helpers not installed")
+  }
+  source(.bhdead_helpers, local = parent.frame())
+  fix <- .hzr_load_bhdead_fixture()
+  testthat::skip_if(is.null(fix), "bh.dead SAS fixture not available")
+  data_path <- .hzr_bhblt_path()
+  testthat::skip_if_not(file.exists(data_path), "bhblt data not available")
+  caa <- haven::read_sas(data_path)
+  names(caa) <- tolower(names(caa))
+  list(fix = fix, caa = caa)
+}
+
+# Build the phase list for a given `fixed` specification, seeding every start
+# value from the fixture.
+.bhdead_phases <- function(sp, fixed) {
+  list(
+    early    = hzr_phase("cdf", t_half = sp[["thalf"]], nu = sp[["nu"]],
+                         m = sp[["m"]], fixed = fixed),
+    constant = hzr_phase("constant")
+  )
+}
+
+.bhdead_theta <- function(sp) {
+  c(early.log_mu     = log(sp[["mue"]]),
+    early.log_t_half = log(sp[["thalf"]]),
+    early.nu         = sp[["nu"]],
+    early.m          = sp[["m"]],
+    constant.log_mu  = log(sp[["muc"]]))
+}
+
+test_that("multiphase shape fit reproduces the SAS shape fit", {
+  env <- .bhdead_setup()
+  sp <- env$fix$shape$specified
+  cv <- env$fix$shape$converged
+
+  # hz.dead fixes only M; THALF and NU are estimated. noconserve -> conserve = FALSE.
+  fit <- hazard(
+    survival::Surv(iv_dead, dead) ~ 1, data = env$caa, dist = "multiphase",
+    phases  = .bhdead_phases(sp, fixed = "m"),
+    theta   = .bhdead_theta(sp),
+    control = list(conserve = FALSE),
+    fit     = TRUE
+  )
+  expect_true(isTRUE(fit$fit$converged))
+
+  th <- coef(fit)
+  expect_equal(exp(th[["early.log_t_half"]]), cv[["thalf"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+  expect_equal(th[["early.nu"]], cv[["nu"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+  expect_equal(exp(th[["early.log_mu"]]), cv[["mue"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+  expect_equal(exp(th[["constant.log_mu"]]), cv[["muc"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+})
+
+test_that("every SAS candidate exists in the data", {
+  env <- .bhdead_setup()
+  expect_identical(
+    setdiff(.hzr_bhdead_candidates(env$fix), names(env$caa)),
+    character(0)
+  )
+})
+
+test_that("bootstrap screen runs end-to-end on the full SAS candidate pool", {
+  env <- .bhdead_setup()
+  sp <- env$fix$shape$specified
+  scope_vars <- .hzr_bhdead_candidates(env$fix)
+
+  # bh.dead fixes nu and m; THALF stays free.
+  base_fit <- hazard(
+    survival::Surv(iv_dead, dead) ~ 1, data = env$caa, dist = "multiphase",
+    phases  = .bhdead_phases(sp, fixed = c("nu", "m")),
+    theta   = .bhdead_theta(sp),
+    control = list(conserve = FALSE),
+    fit     = TRUE
+  )
+
+  bs <- hzr_bootstrap(
+    base_fit, n_boot = 5, seed = 123,
+    scope   = list(early = stats::reformulate(scope_vars),
+                   constant = stats::reformulate(scope_vars)),
+    slentry = env$fix$meta$sle, slstay = env$fix$meta$sls,
+    control = list(n_starts = 1, conserve = FALSE)
+  )
+
+  expect_s3_class(bs, "hzr_bootstrap")
+  expect_gt(bs$n_success, 0)
+  expect_gt(nrow(bs$summary), 0)
+  # The intercepts are never dropped by stepwise, so they appear in every
+  # successful replicate.
+  intercepts <- bs$summary[bs$summary$parameter %in%
+                             c("early.log_mu", "constant.log_mu"), ]
+  expect_true(all(intercepts$n == bs$n_success))
+})
+```
+
+- [ ] **Step 2: Run the test with the volume mounted**
+
+Run: `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-bhdead-sas-parity.R")'`
+Expected: PASS. If the shape-fit assertions fail, that is a **finding** —
+report it, do not widen `shape_rel`.
+
+- [ ] **Step 3: Verify it skips cleanly without the volume**
+
+Run:
+```bash
+TEMPORALHAZARD_BHBLT=/nonexistent TEMPORALHAZARD_BHDEAD_FIXTURE=/nonexistent \
+  Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-bhdead-sas-parity.R")'
+```
+Expected: all tests SKIP, 0 failures. This is what CRAN and CI will see.
+
+- [ ] **Step 4: Add `haven` to Suggests**
+
+In `DESCRIPTION`, add `haven,` to `Suggests:` (alphabetical, after `ggplot2`).
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `Rscript -e 'devtools::test()'`
+Expected: 0 failures; the three bh.dead parity tests skip or pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/testthat/test-bhdead-sas-parity.R DESCRIPTION
+git commit -m "test(dev): bh.dead SAS parity test for shape fit and bootstrap screen
+
+Refits both SAS specifications in R -- the shape fit (fixed = 'm',
+conserve = FALSE) asserted tightly, and the bootstrap screen over the full
+SAS candidate pool as a smoke check. Skips unless the data and fixture are
+readable, so it never runs on CRAN or CI. No study values are committed:
+every start value and expectation is read from the fixture at run time."
+```
+
+---
+
+### Task 5: Rewrite the analysis notebook
+
+**Files:**
+- Modify: `<volume>/analyses/bh.dead_r_bootstrap.qmd` (on the secure volume — **not** committed)
+
+**Interfaces:**
+- Consumes: `.hzr_load_bhdead_fixture()`, `.hzr_bhdead_candidates()` from Task 1.
+- Produces: the R-vs-SAS comparison table (the debugging deliverable).
+
+This file lives on the secure volume and is not committed. It mirrors the SAS
+step for step and fixes the three fidelity defects.
+
+- [ ] **Step 1: Replace the notebook**
+
+```markdown
+---
+title: "BH Death — R vs SAS bootstrap variable screening"
+date: today
+format: html
+params:
+  n_boot: 50
+---
+
+Mirrors `distributions/hz.dead.sas` (shape fit) and `analyses/bh.dead.sas`
+(bootstrap screen). Escalate `n_boot` 5 → 50 → 1000; SAS used `resampl=1000`.
+
+```{r}
+#| label: setup
+library(TemporalHazard)
+library(haven)
+
+source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                   package = "TemporalHazard"))
+
+fix <- .hzr_load_bhdead_fixture()
+stopifnot(!is.null(fix))
+
+caa <- read_sas(.hzr_bhblt_path())
+names(caa) <- tolower(names(caa))
+
+sp <- fix$shape$specified
+```
+
+## Step 1 — shape fit (`hz.dead.sas`)
+
+SAS runs `PROC HAZARD ... noconserve` and fixes **only M**: THALF and NU are
+estimated. Hence `fixed = "m"` and `conserve = FALSE`.
+
+```{r}
+#| label: hz-shape
+theta0 <- c(early.log_mu = log(sp[["mue"]]),
+            early.log_t_half = log(sp[["thalf"]]),
+            early.nu = sp[["nu"]], early.m = sp[["m"]],
+            constant.log_mu = log(sp[["muc"]]))
+
+shape_fit <- hazard(
+  survival::Surv(iv_dead, dead) ~ 1, data = caa, dist = "multiphase",
+  phases = list(
+    early    = hzr_phase("cdf", t_half = sp[["thalf"]], nu = sp[["nu"]],
+                         m = sp[["m"]], fixed = "m"),
+    constant = hzr_phase("constant")
+  ),
+  theta = theta0, control = list(conserve = FALSE), fit = TRUE
+)
+summary(shape_fit)
+
+th <- coef(shape_fit)
+data.frame(
+  param = c("thalf", "nu", "mue", "muc"),
+  R     = c(exp(th[["early.log_t_half"]]), th[["early.nu"]],
+            exp(th[["early.log_mu"]]), exp(th[["constant.log_mu"]])),
+  SAS   = as.numeric(fix$shape$converged[c("thalf", "nu", "mue", "muc")])
+) |> transform(rel_diff = abs(R - SAS) / abs(SAS))
+```
+
+## Step 2 — bootstrap base (`bh.dead.sas` `parms … fixnu fixm`)
+
+SAS's bootstrap base fixes **nu and m**, leaving THALF free.
+
+```{r}
+#| label: bh-base
+base_fit <- hazard(
+  survival::Surv(iv_dead, dead) ~ 1, data = caa, dist = "multiphase",
+  phases = list(
+    early    = hzr_phase("cdf", t_half = sp[["thalf"]], nu = sp[["nu"]],
+                         m = sp[["m"]], fixed = c("nu", "m")),
+    constant = hzr_phase("constant")
+  ),
+  theta = theta0, control = list(conserve = FALSE), fit = TRUE
+)
+summary(base_fit)
+```
+
+## Step 3 — candidate scope, straight from the SAS listing
+
+The pool is read from the fixture, never hand-written: `bh.dead.sas`'s macro
+comments out several covariates via a nested-comment trap (SAS `/* */` does
+not nest), and a hand-copied list silently disagrees with what SAS ran.
+
+```{r}
+#| label: scope
+scope_vars <- .hzr_bhdead_candidates(fix)
+missing_vars <- setdiff(scope_vars, names(caa))
+if (length(missing_vars) > 0) {
+  stop("Candidates absent from the data: ", paste(missing_vars, collapse = ", "))
+}
+length(scope_vars)
+
+scope <- list(early    = reformulate(scope_vars),
+              constant = reformulate(scope_vars))
+```
+
+## Step 4 — bootstrap screen (`%hazboot`)
+
+```{r}
+#| label: bh-bootstrap-screen
+bs <- hzr_bootstrap(
+  base_fit, n_boot = params$n_boot, seed = 123,
+  scope   = scope,
+  slentry = fix$meta$sle, slstay = fix$meta$sls,
+  control = list(n_starts = 1, conserve = FALSE),
+  verbose = TRUE
+)
+bs$n_success
+bs$n_failed
+```
+
+## Step 5 — R vs SAS, biggest gaps first
+
+SAS seeds from the time of day (`seed=-1`), so its percentages are one random
+realisation. Compare ranks and the high-frequency set, not exact values.
+
+```{r}
+#| label: compare
+r_pct <- function(prefix) {
+  rows <- grep(paste0("^", prefix, "\\."), bs$summary$parameter)
+  data.frame(
+    name  = toupper(sub(paste0("^", prefix, "\\."), "", bs$summary$parameter[rows])),
+    r_pct = bs$summary$pct[rows],
+    stringsAsFactors = FALSE
+  )
+}
+
+compare_phase <- function(prefix, sas_tbl) {
+  out <- merge(r_pct(prefix), sas_tbl[, c("name", "pct")], by = "name",
+               all = TRUE)
+  names(out)[names(out) == "pct"] <- "sas_pct"
+  out$r_pct[is.na(out$r_pct)] <- 0
+  out$gap <- out$r_pct - out$sas_pct
+  out[order(-abs(out$gap)), ]
+}
+
+early_cmp <- compare_phase("early", fix$early)
+head(early_cmp, 20)
+```
+
+```{r}
+#| label: rank-agreement
+cc <- early_cmp[is.finite(early_cmp$sas_pct), ]
+cor(cc$r_pct, cc$sas_pct, method = "spearman")
+```
+```
+
+- [ ] **Step 2: Render at n_boot = 5**
+
+Run: `quarto render bh.dead_r_bootstrap.qmd -P n_boot:5`
+Expected: renders; Step 3 reports 92 candidates; Step 4 reports `n_success > 0`.
+
+- [ ] **Step 3: Render at n_boot = 50**
+
+Run: `quarto render bh.dead_r_bootstrap.qmd -P n_boot:50`
+Expected: renders; the Step 5 comparison table is populated.
+
+- [ ] **Step 4: Render at n_boot = 1000**
+
+Run: `quarto render bh.dead_r_bootstrap.qmd -P n_boot:1000`
+Expected: matches SAS's `resampl=1000`. Long-running; the progress bar shows
+movement. This is the comparison of record.
+
+- [ ] **Step 5: No commit**
+
+The notebook lives on the secure volume and is deliberately not committed.
+Confirm the repo is clean: `git status --short` shows nothing from this task.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|------------------|------|
+| Parse `hz.dead.lst` → shape reference | 2 |
+| Parse `bh.dead.lst` → Early/Constant tables | 2 |
+| Fixture written off-repo to the volume | 2 (`.hzr_write_bhdead_fixture`) |
+| 92-var pool derived, never hand-transcribed | 1 (`.hzr_bhdead_candidates`), verified in 3 |
+| Env-var resolution + skip gate | 1, 4 |
+| `haven` → Suggests, guarded | 4 |
+| Shape fit asserted tightly (~1e-3) | 4 |
+| Bootstrap asserted statistically | 3 (calibrate), 4 |
+| Thresholds calibrated, not invented | 3 |
+| `n_boot` staged 5 → 50 → 1000 | 3 (5/50), 4 (5), 5 (all three) |
+| qmd fixes `fixed=`, `conserve=`, scope | 5 |
+| Fail loud on missing columns | 4 (test), 5 (qmd `stop()`) |
+| No study values committed | Global constraint; enforced in 1, 2, 4 |
+| No PHI in repo | Global constraint; data read from volume only |
+
+**Placeholder scan:** `<SPEARMAN_FLOOR>` / `<TOP10_FLOOR>` in Task 4 are
+deliberate — Task 3 Step 7 produces them, and Task 4's preamble says not to
+invent them. No other placeholders.
+
+**Type consistency:** `.hzr_bhdead_candidates()`, `.hzr_load_bhdead_fixture()`,
+`.hzr_bhblt_path()`, `.hzr_bhdead_fixture_path()`, `.hzr_validate_bhdead_fixture()`
+are defined in Task 1 and used with the same signatures in Tasks 2-5.
+`.hzr_parse_bhdead_phase()` / `.hzr_parse_bhdead_shape()` /
+`.hzr_build_bhdead_fixture()` / `.hzr_write_bhdead_fixture()` are defined in
+Task 2 and used in Task 3. Fixture fields (`shape$specified`,
+`shape$converged`, `early`, `constant`, `meta$sle`, `meta$sls`) are consistent
+across all tasks.

--- a/inst/dev/PLAN-bhdead-sas-parity.md
+++ b/inst/dev/PLAN-bhdead-sas-parity.md
@@ -28,8 +28,12 @@ Design document: `inst/dev/BHDEAD-SAS-PARITY-DESIGN.md`
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `TEMPORALHAZARD_BHBLT` | `/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy/datasets/bhblt.sas7bdat` | Row-level data |
-| `TEMPORALHAZARD_BHDEAD_FIXTURE` | `/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy/estimates/bhdead.rds` | Built SAS reference |
+| `TEMPORALHAZARD_BHBLT` | *(none — must be set)* | Row-level SAS dataset |
+| `TEMPORALHAZARD_BHDEAD_FIXTURE` | *(none — must be set)* | Built SAS reference |
+
+There is **no default path**. A study-identifying directory must not appear in
+this public repository, so an unset variable yields `""` and the loader returns
+`NULL`, which is how callers skip. Set both (e.g. in your `.Rprofile`).
 
 ---
 
@@ -44,8 +48,8 @@ Design document: `inst/dev/BHDEAD-SAS-PARITY-DESIGN.md`
 - Produces:
   - `.hzr_bhdead_fixture_schema()` → named list: `shape = c("specified","converged")`, `phase = c("name","n","pct","min","max","mean","sd")`, `meta = c("resampl","sle","sls","n_obs","captured_on","source")`
   - `.hzr_validate_bhdead_fixture(fix)` → returns `fix` unchanged if valid; `stop()`s with a message listing every problem otherwise.
-  - `.hzr_bhdead_fixture_path()` → character path from `TEMPORALHAZARD_BHDEAD_FIXTURE` or its default.
-  - `.hzr_bhblt_path()` → character path from `TEMPORALHAZARD_BHBLT` or its default.
+  - `.hzr_bhdead_fixture_path()` → `Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE", unset = "")`. No default; `""` when unset.
+  - `.hzr_bhblt_path()` → `Sys.getenv("TEMPORALHAZARD_BHBLT", unset = "")`. No default; `""` when unset.
   - `.hzr_load_bhdead_fixture(path = .hzr_bhdead_fixture_path())` → validated fixture list, or `NULL` when the file does not exist.
   - `.hzr_bhdead_candidates(fix)` → character vector of candidate variable names (lowercased, intercept row removed).
 
@@ -153,27 +157,21 @@ Create `inst/dev/bhdead-parity/bhdead-fixture.R`:
 # Build the fixture with inst/dev/bhdead-parity/parse-bhdead-lst.R.
 # See inst/dev/bhdead-parity/README.md.
 
-.hzr_bhdead_default_root <-
-  "/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy"
-
-#' Path to the row-level SAS dataset (env-overridable)
+#' Path to the row-level SAS dataset
+#'
+#' From `TEMPORALHAZARD_BHBLT`. No default: a study-identifying path must not
+#' live in this public repo. Unset yields "", which callers treat as absent.
 #' @noRd
 .hzr_bhblt_path <- function() {
-  p <- Sys.getenv("TEMPORALHAZARD_BHBLT", unset = "")
-  if (nzchar(p)) {
-    return(p)
-  }
-  file.path(.hzr_bhdead_default_root, "datasets", "bhblt.sas7bdat")
+  Sys.getenv("TEMPORALHAZARD_BHBLT", unset = "")
 }
 
-#' Path to the built parity fixture (env-overridable)
+#' Path to the built parity fixture
+#'
+#' From `TEMPORALHAZARD_BHDEAD_FIXTURE`. No default, as above.
 #' @noRd
 .hzr_bhdead_fixture_path <- function() {
-  p <- Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE", unset = "")
-  if (nzchar(p)) {
-    return(p)
-  }
-  file.path(.hzr_bhdead_default_root, "estimates", "bhdead.rds")
+  Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE", unset = "")
 }
 
 #' Required fields of a bh.dead parity fixture

--- a/inst/dev/PLAN-bhdead-sas-parity.md
+++ b/inst/dev/PLAN-bhdead-sas-parity.md
@@ -793,8 +793,8 @@ recorded without study values. Fixes the floors used by the parity test."
 
 **Scope change (2026-07-16, owner decision).** The statistical assertions are
 DEFERRED — there are no `<SPEARMAN_FLOOR>` / `<TOP10_FLOOR>` values to fill in.
-Task 3 measured one bootstrap replicate over the 92-variable pool at ~5.4
-minutes, so SAS's `resampl=1000` is ~90 hours; the feasible `n_boot = 5` gives a
+Task 3 measured one bootstrap replicate over the 92-variable pool at ~25
+minutes, so SAS's `resampl=1000` is ~17 days; the feasible `n_boot = 5` gives a
 `pct` restricted to {0, 20, 40, 60, 80, 100}, and a rank correlation of that
 against SAS's 1000-resample percentages is dominated by ties and noise. A floor
 calibrated from it would encode noise while reading as verified parity.
@@ -830,7 +830,7 @@ Create `tests/testthat/test-bhdead-sas-parity.R`:
 #
 # There is deliberately NO statistical tolerance for the bootstrap screen. SAS
 # seeds from the time of day (seed=-1), so its selection frequencies are one
-# random realisation; and one R replicate over the 92-variable pool costs ~5.4
+# random realisation; and one R replicate over the 92-variable pool costs ~25
 # minutes, making a SAS-scale n_boot infeasible until criterion = "score"
 # lands. At the feasible n_boot the frequencies are too coarse to support a
 # meaningful floor. See BHDEAD-SAS-PARITY-DESIGN.md, "Deferred: score-test
@@ -1179,7 +1179,7 @@ Confirm the repo is clean: `git status --short` shows nothing from this task.
 | Shape fit asserted tightly (~1e-3) | 4 |
 | Bootstrap asserted (smoke only; statistical parity DEFERRED — infeasible n_boot, see Task 4 scope change) | 4 |
 | Thresholds calibrated, not invented | 3 — shape_rel 1e-3 from measured 3.4e-04; no bootstrap floor invented |
-| `n_boot` staged 5 → 50 → 1000 | 4 (5, smoke). 50/1000 PARKED: ~5.4 min/replicate → 1000 ≈ 90 h. Unblocked by `criterion = "score"`. |
+| `n_boot` staged 5 → 50 → 1000 | 4 (5, smoke). 50/1000 PARKED: ~25 min/replicate → 1000 ≈ 17 days. Unblocked by `criterion = "score"`. |
 | qmd fixes `fixed=`, `conserve=`, scope | 5 |
 | Fail loud on missing columns | 4 (test), 5 (qmd `stop()`) |
 | No study values committed | Global constraint; enforced in 1, 2, 4 |

--- a/inst/dev/bhdead-parity/README.md
+++ b/inst/dev/bhdead-parity/README.md
@@ -1,0 +1,61 @@
+# bh.dead SAS parity harness (development only)
+
+`inst/dev/` is `.Rbuildignore`d: nothing here ships to CRAN.
+
+**This repository is public.** Neither the row-level data nor the study's
+aggregate results live here. The fixture is built from SAS listings on a
+secure volume and written back to that volume. Committed code contains no
+study values; the parity test derives every expectation from the fixture at
+run time and skips when the volume is not mounted.
+
+## Paths
+
+| Environment variable | Purpose |
+|----------------------|---------|
+| `TEMPORALHAZARD_BHBLT` | Row-level SAS dataset (`bhblt.sas7bdat`) |
+| `TEMPORALHAZARD_BHDEAD_FIXTURE` | Built fixture (`bhdead.rds`) |
+
+Both are read from the environment only -- there is no default path baked
+into this repository. Set them to point at the secure-volume locations
+before rebuilding or loading the fixture.
+
+## Rebuilding the fixture
+
+With the volume mounted, pass the two listing paths explicitly:
+
+```r
+devtools::load_all()
+source("inst/dev/bhdead-parity/parse-bhdead-lst.R")
+.hzr_write_bhdead_fixture(
+  hz_lst = "<path to the shape-fit listing, hz.dead.lst>",
+  bh_lst = "<path to the bootstrap listing, bh.dead.lst>"
+)
+```
+
+`hz_lst` and `bh_lst` are required arguments -- this script does not store or
+default to a study directory. The output path defaults to
+`Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE")`; if that variable is unset,
+`.hzr_write_bhdead_fixture()` stops and asks you to set it.
+
+This reads the shape-fit listing and the bootstrap listing, and writes
+`bhdead.rds` to the configured output path.
+
+## Running the parity test
+
+```r
+devtools::load_all()
+testthat::test_file("tests/testthat/test-bhdead-sas-parity.R")
+```
+
+It skips unless the data and the fixture are both readable and `haven` is
+installed.
+
+## What the SAS side does
+
+* Shape fit: `PROC HAZARD ... noconserve`, fixing only `M`.
+* Bootstrap: `%hazboot(seed=-1, resampl=1000, sle=0.12, sls=0.1)`, base model
+  fixing `nu` and `m`.
+
+`seed=-1` means SAS seeds from the time of day, so its selection frequencies
+are one random realisation and cannot be reproduced exactly. Bootstrap
+assertions are therefore statistical, not exact.

--- a/inst/dev/bhdead-parity/bhdead-fixture.R
+++ b/inst/dev/bhdead-parity/bhdead-fixture.R
@@ -1,0 +1,112 @@
+# bhdead-fixture.R -- Resolve, load and validate the bh.dead SAS parity fixture.
+#
+# DEVELOPMENT ONLY. inst/dev/ is .Rbuildignore'd and does not ship.
+#
+# This repository is public. The fixture itself is NOT stored here -- it lives
+# beside the source data on a secure volume, resolved via the environment
+# variables below. This file contains no study values; every expectation used
+# by the parity test is read out of the fixture at run time.
+#
+# Build the fixture with inst/dev/bhdead-parity/parse-bhdead-lst.R.
+# See inst/dev/bhdead-parity/README.md.
+
+.hzr_bhdead_default_root <-
+  "/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy"
+
+#' Path to the row-level SAS dataset (env-overridable)
+#' @noRd
+.hzr_bhblt_path <- function() {
+  p <- Sys.getenv("TEMPORALHAZARD_BHBLT", unset = "")
+  if (nzchar(p)) {
+    return(p)
+  }
+  file.path(.hzr_bhdead_default_root, "datasets", "bhblt.sas7bdat")
+}
+
+#' Path to the built parity fixture (env-overridable)
+#' @noRd
+.hzr_bhdead_fixture_path <- function() {
+  p <- Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE", unset = "")
+  if (nzchar(p)) {
+    return(p)
+  }
+  file.path(.hzr_bhdead_default_root, "estimates", "bhdead.rds")
+}
+
+#' Required fields of a bh.dead parity fixture
+#' @noRd
+.hzr_bhdead_fixture_schema <- function() {
+  list(
+    shape = c("specified", "converged"),
+    phase = c("name", "n", "pct", "min", "max", "mean", "sd"),
+    meta  = c("resampl", "sle", "sls", "n_obs", "captured_on", "source")
+  )
+}
+
+#' Validate a bh.dead parity fixture against the schema
+#'
+#' @param fix A list as produced by the parse script.
+#' @return `fix`, unchanged, if valid. Throws otherwise, listing every problem.
+#' @noRd
+.hzr_validate_bhdead_fixture <- function(fix) {
+  schema <- .hzr_bhdead_fixture_schema()
+  problems <- character()
+
+  if (!is.list(fix)) {
+    stop("bh.dead fixture must be a list.", call. = FALSE)
+  }
+
+  for (group in c("shape", "meta")) {
+    if (!group %in% names(fix)) {
+      problems <- c(problems, paste0("missing top-level: ", group))
+      next
+    }
+    missing_fields <- setdiff(schema[[group]], names(fix[[group]]))
+    if (length(missing_fields) > 0L) {
+      problems <- c(problems, sprintf("missing %s: %s", group,
+                                      paste(missing_fields, collapse = ", ")))
+    }
+  }
+
+  for (phase in c("early", "constant")) {
+    if (!phase %in% names(fix)) {
+      problems <- c(problems, paste0("missing top-level: ", phase))
+      next
+    }
+    missing_cols <- setdiff(schema$phase, names(fix[[phase]]))
+    if (length(missing_cols) > 0L) {
+      problems <- c(problems, sprintf("missing %s columns: %s", phase,
+                                      paste(missing_cols, collapse = ", ")))
+    }
+  }
+
+  if (length(problems) > 0L) {
+    stop("Invalid bh.dead fixture:\n  - ",
+         paste(problems, collapse = "\n  - "), call. = FALSE)
+  }
+  fix
+}
+
+#' Load the bh.dead parity fixture
+#'
+#' @param path Path to the `.rds`. Defaults to `.hzr_bhdead_fixture_path()`.
+#' @return The validated fixture, or `NULL` when the file does not exist.
+#' @noRd
+.hzr_load_bhdead_fixture <- function(path = .hzr_bhdead_fixture_path()) {
+  if (!nzchar(path) || !file.exists(path)) {
+    return(NULL)
+  }
+  .hzr_validate_bhdead_fixture(readRDS(path))
+}
+
+#' Candidate variable names from a fixture (intercept dropped, lowercased)
+#'
+#' The intercept rows are SAS's `E0` (early) and `C0` (constant). Everything
+#' else in the phase table is a screened candidate.
+#'
+#' @noRd
+.hzr_bhdead_candidates <- function(fix) {
+  nm <- union(fix$early$name, fix$constant$name)
+  nm <- setdiff(nm, c("E0", "C0"))
+  tolower(nm)
+}

--- a/inst/dev/bhdead-parity/bhdead-fixture.R
+++ b/inst/dev/bhdead-parity/bhdead-fixture.R
@@ -3,34 +3,26 @@
 # DEVELOPMENT ONLY. inst/dev/ is .Rbuildignore'd and does not ship.
 #
 # This repository is public. The fixture itself is NOT stored here -- it lives
-# beside the source data on a secure volume, resolved via the environment
-# variables below. This file contains no study values; every expectation used
-# by the parity test is read out of the fixture at run time.
+# beside the source data on a secure volume. Both paths below come entirely
+# from environment variables; there is no default. When a variable is unset,
+# the corresponding helper returns "", and .hzr_load_bhdead_fixture() treats
+# that as "not configured" and returns NULL, so callers skip gracefully. This
+# file contains no study values; every expectation used by the parity test is
+# read out of the fixture at run time.
 #
 # Build the fixture with inst/dev/bhdead-parity/parse-bhdead-lst.R.
 # See inst/dev/bhdead-parity/README.md.
 
-.hzr_bhdead_default_root <-
-  "/Volumes/qhsstudies/thoracic/esophagus/malignant/neo_therapy"
-
-#' Path to the row-level SAS dataset (env-overridable)
+#' Path to the row-level SAS dataset (env-only, no default)
 #' @noRd
 .hzr_bhblt_path <- function() {
-  p <- Sys.getenv("TEMPORALHAZARD_BHBLT", unset = "")
-  if (nzchar(p)) {
-    return(p)
-  }
-  file.path(.hzr_bhdead_default_root, "datasets", "bhblt.sas7bdat")
+  Sys.getenv("TEMPORALHAZARD_BHBLT", unset = "")
 }
 
-#' Path to the built parity fixture (env-overridable)
+#' Path to the built parity fixture (env-only, no default)
 #' @noRd
 .hzr_bhdead_fixture_path <- function() {
-  p <- Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE", unset = "")
-  if (nzchar(p)) {
-    return(p)
-  }
-  file.path(.hzr_bhdead_default_root, "estimates", "bhdead.rds")
+  Sys.getenv("TEMPORALHAZARD_BHDEAD_FIXTURE", unset = "")
 }
 
 #' Required fields of a bh.dead parity fixture

--- a/inst/dev/bhdead-parity/parse-bhdead-lst.R
+++ b/inst/dev/bhdead-parity/parse-bhdead-lst.R
@@ -33,18 +33,12 @@ source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
     stop("Phase label not found in listing: ", phase_label, call. = FALSE)
   }
   # A listing repeats the phase label on each page header; take from the first
-  # occurrence to the first *other* phase label that follows it.
-  other <- if (identical(phase_label, "Early Phase")) {
-    "Constant Phase"
-  } else {
-    "Late Phase"
-  }
+  # occurrence to the end of the listing. The Obs sequence below -- not a
+  # following label -- is what bounds the table, so this works regardless of
+  # what (if anything) follows.
   from <- starts[1]
-  ends <- grep(other, lines, fixed = TRUE)
-  ends <- ends[ends > from]
-  to <- if (length(ends) > 0L) ends[1] - 1L else length(lines)
+  block <- lines[from:length(lines)]
 
-  block <- lines[from:to]
   # Data rows: obs index, then a NAME of uppercase/digits/underscore, then 6 numbers.
   rx <- paste0("^\\s*([0-9]+)\\s+([A-Z0-9_]+)\\s+([0-9]+)\\s+",
                "(-?[0-9.]+)\\s+(-?[0-9.]+)\\s+(-?[0-9.]+)\\s+",
@@ -54,6 +48,20 @@ source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
   if (length(hits) == 0L) {
     stop("No data rows parsed for ", phase_label, call. = FALSE)
   }
+
+  # The Obs column increments monotonically within one table and restarts at 1
+  # in a different one. Truncate at the first break in that run so trailing
+  # content that merely matches the data-row shape (a different table, or
+  # nothing at all) is never silently absorbed.
+  obs <- as.integer(vapply(hits, `[[`, character(1), 2L))
+  if (obs[1] != 1L) {
+    stop("First data row for ", phase_label, " has Obs = ", obs[1],
+         " (expected 1); the table did not start where expected.",
+         call. = FALSE)
+  }
+  breaks <- which(diff(obs) != 1L)
+  last <- if (length(breaks) > 0L) breaks[1] else length(obs)
+  hits <- hits[seq_len(last)]
 
   data.frame(
     name = vapply(hits, `[[`, character(1), 3L),

--- a/inst/dev/bhdead-parity/parse-bhdead-lst.R
+++ b/inst/dev/bhdead-parity/parse-bhdead-lst.R
@@ -1,0 +1,160 @@
+# parse-bhdead-lst.R -- Build the bh.dead parity fixture from SAS listings.
+#
+# DEVELOPMENT ONLY. inst/dev/ is .Rbuildignore'd and does not ship.
+#
+# This repository is public: the .lst inputs and the .rds output both stay on
+# the secure volume. This script contains parsing logic only -- no study values.
+#
+# Usage (hz_lst/bh_lst are required -- no default paths are stored here):
+#   source("inst/dev/bhdead-parity/parse-bhdead-lst.R")
+#   .hzr_write_bhdead_fixture(hz_lst = "...", bh_lst = "...")
+#
+# See README.md in this directory.
+
+# Companion helpers (path resolution, schema, validator). Resolved through the
+# installed/loaded package rather than a relative path, so this script can be
+# sourced from any working directory.
+source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                   package = "TemporalHazard"))
+
+#' Extract one phase table from a bootstrap listing
+#'
+#' Rows look like: `<obs> <NAME> <N> <PCT> <MIN> <MAX> <MEAN> <STD>`.
+#' Column positions are not stable across SAS listings, so split on
+#' whitespace and take fields positionally.
+#'
+#' @param lines Character vector -- the whole listing.
+#' @param phase_label "Early Phase" or "Constant Phase".
+#' @return data.frame(name, n, pct, min, max, mean, sd)
+#' @noRd
+.hzr_parse_bhdead_phase <- function(lines, phase_label) {
+  starts <- grep(phase_label, lines, fixed = TRUE)
+  if (length(starts) == 0L) {
+    stop("Phase label not found in listing: ", phase_label, call. = FALSE)
+  }
+  # A listing repeats the phase label on each page header; take from the first
+  # occurrence to the first *other* phase label that follows it.
+  other <- if (identical(phase_label, "Early Phase")) {
+    "Constant Phase"
+  } else {
+    "Late Phase"
+  }
+  from <- starts[1]
+  ends <- grep(other, lines, fixed = TRUE)
+  ends <- ends[ends > from]
+  to <- if (length(ends) > 0L) ends[1] - 1L else length(lines)
+
+  block <- lines[from:to]
+  # Data rows: obs index, then a NAME of uppercase/digits/underscore, then 6 numbers.
+  rx <- paste0("^\\s*([0-9]+)\\s+([A-Z0-9_]+)\\s+([0-9]+)\\s+",
+               "(-?[0-9.]+)\\s+(-?[0-9.]+)\\s+(-?[0-9.]+)\\s+",
+               "(-?[0-9.]+)\\s+(-?[0-9.]+)\\s*$")
+  hits <- regmatches(block, regexec(rx, block))
+  hits <- Filter(function(x) length(x) == 9L, hits)
+  if (length(hits) == 0L) {
+    stop("No data rows parsed for ", phase_label, call. = FALSE)
+  }
+
+  data.frame(
+    name = vapply(hits, `[[`, character(1), 3L),
+    n    = as.integer(vapply(hits, `[[`, character(1), 4L)),
+    pct  = as.numeric(vapply(hits, `[[`, character(1), 5L)),
+    min  = as.numeric(vapply(hits, `[[`, character(1), 6L)),
+    max  = as.numeric(vapply(hits, `[[`, character(1), 7L)),
+    mean = as.numeric(vapply(hits, `[[`, character(1), 8L)),
+    sd   = as.numeric(vapply(hits, `[[`, character(1), 9L)),
+    stringsAsFactors = FALSE
+  )
+}
+
+#' Extract specified and converged shape parameters from a shape-fit listing
+#'
+#' @param lines Character vector -- the whole listing.
+#' @return list(specified = named numeric, converged = named numeric), each
+#'   over thalf, nu, m, mue, muc.
+#' @noRd
+.hzr_parse_bhdead_shape <- function(lines) {
+  # "Specified" block: `<PARAM> <specified> <used> | ...`
+  spec_of <- function(param) {
+    rx <- paste0("^\\s*(?:Constant:\\s+)?", param,
+                 "\\s+(-?[0-9.]+)\\s+(-?[0-9.]+)\\s*\\|")
+    hit <- regmatches(lines, regexec(rx, lines))
+    hit <- Filter(function(x) length(x) == 3L, hit)
+    if (length(hit) == 0L) {
+      stop("Specified value not found for ", param, call. = FALSE)
+    }
+    as.numeric(hit[[1]][2])
+  }
+
+  # "Estimates for Model Parameters" block, below its header.
+  est_from <- grep("Estimates for Model Parameters", lines, fixed = TRUE)
+  if (length(est_from) == 0L) {
+    stop("'Estimates for Model Parameters' block not found.", call. = FALSE)
+  }
+  est_block <- lines[est_from[1]:length(lines)]
+  conv_of <- function(param) {
+    # `<PARAM> [Fixed?] <estimate>` -- the estimate is the last number on the line.
+    rx <- paste0("^\\s*(?:Constant:\\s+)?", param, "\\s+.*?(-?[0-9.]+)\\s*$")
+    hit <- regmatches(est_block, regexec(rx, est_block))
+    hit <- Filter(function(x) length(x) == 2L, hit)
+    if (length(hit) == 0L) {
+      stop("Converged value not found for ", param, call. = FALSE)
+    }
+    as.numeric(hit[[1]][2])
+  }
+
+  params <- c(thalf = "THALF", nu = "NU", m = "M", mue = "MUE", muc = "MUC")
+  list(
+    specified = vapply(params, spec_of, numeric(1)),
+    converged = vapply(params, conv_of, numeric(1))
+  )
+}
+
+#' Build the fixture from the two listings
+#'
+#' @param hz_lst Path to the shape-fit listing.
+#' @param bh_lst Path to the bootstrap listing.
+#' @param meta Named list: resampl, sle, sls, n_obs, captured_on, source.
+#' @return A validated fixture list.
+#' @noRd
+.hzr_build_bhdead_fixture <- function(hz_lst, bh_lst, meta) {
+  hz <- readLines(hz_lst, warn = FALSE)
+  bh <- readLines(bh_lst, warn = FALSE)
+  fix <- list(
+    shape    = .hzr_parse_bhdead_shape(hz),
+    early    = .hzr_parse_bhdead_phase(bh, "Early Phase"),
+    constant = .hzr_parse_bhdead_phase(bh, "Constant Phase"),
+    meta     = meta
+  )
+  .hzr_validate_bhdead_fixture(fix)
+}
+
+#' Build and write the fixture to the secure volume
+#'
+#' `hz_lst` and `bh_lst` are required: no study-identifying path is stored in
+#' this public repository. `out` defaults to the path named by the
+#' `TEMPORALHAZARD_BHDEAD_FIXTURE` environment variable.
+#'
+#' @param hz_lst Path to the shape-fit listing (required).
+#' @param bh_lst Path to the bootstrap listing (required).
+#' @param out Output `.rds` path. Defaults to `.hzr_bhdead_fixture_path()`.
+#' @param meta Named list: resampl, sle, sls, n_obs, captured_on, source.
+#' @noRd
+.hzr_write_bhdead_fixture <- function(
+    hz_lst,
+    bh_lst,
+    out    = .hzr_bhdead_fixture_path(),
+    meta   = list(resampl = 1000L, sle = 0.12, sls = 0.10, n_obs = NA_integer_,
+                  captured_on = as.character(Sys.Date()),
+                  source = "hz.dead.lst + bh.dead.lst")) {
+  if (!nzchar(out)) {
+    stop("Set TEMPORALHAZARD_BHDEAD_FIXTURE (or pass `out`) before writing ",
+         "the fixture.", call. = FALSE)
+  }
+  fix <- .hzr_build_bhdead_fixture(hz_lst, bh_lst, meta)
+  saveRDS(fix, out)
+  message("Wrote fixture: ", out,
+          " (early: ", nrow(fix$early), " rows, constant: ",
+          nrow(fix$constant), " rows)")
+  invisible(fix)
+}

--- a/tests/testthat/test-bhdead-fixture.R
+++ b/tests/testthat/test-bhdead-fixture.R
@@ -1,9 +1,16 @@
 # Unit tests for the bh.dead parity fixture schema/loader.
-# These construct synthetic fixtures in-memory and never touch the secure
-# volume, so they run everywhere (including CRAN) and contain no study values.
+# These construct synthetic fixtures in-memory: they never touch the secure
+# volume and contain no study values.
+#
+# They run from a source checkout (devtools::load_all() / devtools::test()) and
+# SKIP against an installed package, because the helper they exercise lives in
+# inst/dev/, which is .Rbuildignore'd and therefore absent from the tarball.
 
-source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
-                   package = "TemporalHazard"), local = TRUE)
+.bhdead_helper <- system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                              package = "TemporalHazard")
+if (nzchar(.bhdead_helper)) {
+  source(.bhdead_helper, local = TRUE)
+}
 
 .fake_phase <- function(names_vec) {
   data.frame(
@@ -32,11 +39,15 @@ source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
 }
 
 test_that(".hzr_validate_bhdead_fixture accepts a well-formed fixture", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   fix <- .fake_fixture()
   expect_identical(.hzr_validate_bhdead_fixture(fix), fix)
 })
 
 test_that(".hzr_validate_bhdead_fixture reports every missing field at once", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   fix <- .fake_fixture()
   fix$meta$sle <- NULL
   fix$shape$converged <- NULL
@@ -45,20 +56,28 @@ test_that(".hzr_validate_bhdead_fixture reports every missing field at once", {
 })
 
 test_that(".hzr_validate_bhdead_fixture rejects a phase missing a column", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   fix <- .fake_fixture()
   fix$early$pct <- NULL
   expect_error(.hzr_validate_bhdead_fixture(fix), "early")
 })
 
 test_that(".hzr_bhdead_candidates drops the intercept row and lowercases", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   expect_identical(.hzr_bhdead_candidates(.fake_fixture()), c("var_a", "var_b"))
 })
 
 test_that(".hzr_load_bhdead_fixture returns NULL when the file is absent", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   expect_null(.hzr_load_bhdead_fixture(file.path(tempdir(), "nope.rds")))
 })
 
 test_that(".hzr_load_bhdead_fixture round-trips a valid fixture", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   p <- file.path(tempdir(), "bhdead-test.rds")
   on.exit(unlink(p), add = TRUE)
   saveRDS(.fake_fixture(), p)
@@ -66,6 +85,8 @@ test_that(".hzr_load_bhdead_fixture round-trips a valid fixture", {
 })
 
 test_that("path helpers honour their environment variables", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   withr::with_envvar(c(TEMPORALHAZARD_BHBLT = "/tmp/x.sas7bdat"), {
     expect_identical(.hzr_bhblt_path(), "/tmp/x.sas7bdat")
   })
@@ -75,6 +96,8 @@ test_that("path helpers honour their environment variables", {
 })
 
 test_that("path helpers return \"\" when their environment variable is unset", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   withr::with_envvar(c(TEMPORALHAZARD_BHBLT = NA), {
     expect_identical(.hzr_bhblt_path(), "")
   })

--- a/tests/testthat/test-bhdead-fixture.R
+++ b/tests/testthat/test-bhdead-fixture.R
@@ -1,0 +1,75 @@
+# Unit tests for the bh.dead parity fixture schema/loader.
+# These construct synthetic fixtures in-memory and never touch the secure
+# volume, so they run everywhere (including CRAN) and contain no study values.
+
+source(system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                   package = "TemporalHazard"), local = TRUE)
+
+.fake_phase <- function(names_vec) {
+  data.frame(
+    name = names_vec,
+    n    = rep(10L, length(names_vec)),
+    pct  = rep(50, length(names_vec)),
+    min  = rep(-1, length(names_vec)),
+    max  = rep(1, length(names_vec)),
+    mean = rep(0, length(names_vec)),
+    sd   = rep(1, length(names_vec)),
+    stringsAsFactors = FALSE
+  )
+}
+
+.fake_fixture <- function() {
+  list(
+    shape = list(
+      specified = c(thalf = 1, nu = -1, m = 0, mue = 1, muc = 1),
+      converged = c(thalf = 1, nu = -1, m = 0, mue = 1, muc = 1)
+    ),
+    early    = .fake_phase(c("E0", "VAR_A", "VAR_B")),
+    constant = .fake_phase(c("C0", "VAR_A", "VAR_B")),
+    meta = list(resampl = 1000L, sle = 0.12, sls = 0.10, n_obs = 100L,
+                captured_on = "2026-07-16", source = "synthetic")
+  )
+}
+
+test_that(".hzr_validate_bhdead_fixture accepts a well-formed fixture", {
+  fix <- .fake_fixture()
+  expect_identical(.hzr_validate_bhdead_fixture(fix), fix)
+})
+
+test_that(".hzr_validate_bhdead_fixture reports every missing field at once", {
+  fix <- .fake_fixture()
+  fix$meta$sle <- NULL
+  fix$shape$converged <- NULL
+  expect_error(.hzr_validate_bhdead_fixture(fix), "sle")
+  expect_error(.hzr_validate_bhdead_fixture(fix), "converged")
+})
+
+test_that(".hzr_validate_bhdead_fixture rejects a phase missing a column", {
+  fix <- .fake_fixture()
+  fix$early$pct <- NULL
+  expect_error(.hzr_validate_bhdead_fixture(fix), "early")
+})
+
+test_that(".hzr_bhdead_candidates drops the intercept row and lowercases", {
+  expect_identical(.hzr_bhdead_candidates(.fake_fixture()), c("var_a", "var_b"))
+})
+
+test_that(".hzr_load_bhdead_fixture returns NULL when the file is absent", {
+  expect_null(.hzr_load_bhdead_fixture(file.path(tempdir(), "nope.rds")))
+})
+
+test_that(".hzr_load_bhdead_fixture round-trips a valid fixture", {
+  p <- file.path(tempdir(), "bhdead-test.rds")
+  on.exit(unlink(p), add = TRUE)
+  saveRDS(.fake_fixture(), p)
+  expect_identical(.hzr_load_bhdead_fixture(p), .fake_fixture())
+})
+
+test_that("path helpers honour their environment variables", {
+  withr::with_envvar(c(TEMPORALHAZARD_BHBLT = "/tmp/x.sas7bdat"), {
+    expect_identical(.hzr_bhblt_path(), "/tmp/x.sas7bdat")
+  })
+  withr::with_envvar(c(TEMPORALHAZARD_BHDEAD_FIXTURE = "/tmp/y.rds"), {
+    expect_identical(.hzr_bhdead_fixture_path(), "/tmp/y.rds")
+  })
+})

--- a/tests/testthat/test-bhdead-fixture.R
+++ b/tests/testthat/test-bhdead-fixture.R
@@ -73,3 +73,12 @@ test_that("path helpers honour their environment variables", {
     expect_identical(.hzr_bhdead_fixture_path(), "/tmp/y.rds")
   })
 })
+
+test_that("path helpers return \"\" when their environment variable is unset", {
+  withr::with_envvar(c(TEMPORALHAZARD_BHBLT = NA), {
+    expect_identical(.hzr_bhblt_path(), "")
+  })
+  withr::with_envvar(c(TEMPORALHAZARD_BHDEAD_FIXTURE = NA), {
+    expect_identical(.hzr_bhdead_fixture_path(), "")
+  })
+})

--- a/tests/testthat/test-bhdead-parse.R
+++ b/tests/testthat/test-bhdead-parse.R
@@ -5,8 +5,16 @@
 # renamed variable with verbatim values is not anonymised. Round, obviously
 # fake numbers make that impossible to get wrong by accident.
 
-source(system.file("dev", "bhdead-parity", "parse-bhdead-lst.R",
-                   package = "TemporalHazard"), local = TRUE)
+# They run from a source checkout (devtools::load_all() / devtools::test()) and
+# SKIP against an installed package, because the parsers they exercise live in
+# inst/dev/, which is .Rbuildignore'd and therefore absent from the tarball.
+# They never touch the secure volume and contain no study values.
+
+.bhdead_helper <- system.file("dev", "bhdead-parity", "parse-bhdead-lst.R",
+                              package = "TemporalHazard")
+if (nzchar(.bhdead_helper)) {
+  source(.bhdead_helper, local = TRUE)
+}
 
 .fake_bh_lines <- c(
   "                        Study Title Redacted                       3",
@@ -43,6 +51,8 @@ source(system.file("dev", "bhdead-parity", "parse-bhdead-lst.R",
 )
 
 test_that(".hzr_parse_bhdead_phase extracts the Early table", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   d <- .hzr_parse_bhdead_phase(.fake_bh_lines, "Early Phase")
   expect_identical(d$name, c("E0", "VAR_A", "VAR_B"))
   expect_identical(d$n, c(500L, 250L, 100L))
@@ -52,12 +62,16 @@ test_that(".hzr_parse_bhdead_phase extracts the Early table", {
 })
 
 test_that(".hzr_parse_bhdead_phase does not bleed across phase boundaries", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   d <- .hzr_parse_bhdead_phase(.fake_bh_lines, "Constant Phase")
   expect_identical(d$name, c("C0", "VAR_A"))
   expect_equal(d$pct, c(100.0, 30.0))
 })
 
 test_that(".hzr_parse_bhdead_shape reads specified and converged values", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   s <- .hzr_parse_bhdead_shape(.fake_hz_lines)
   expect_equal(s$specified[["thalf"]], 1.1)
   expect_equal(s$specified[["mue"]], 0.8)
@@ -68,6 +82,8 @@ test_that(".hzr_parse_bhdead_shape reads specified and converged values", {
 })
 
 test_that(".hzr_parse_bhdead_phase does not absorb a trailing unrelated table", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   # The terminal phase table has no following label to bound it. A trailing
   # table that happens to match the data-row shape must not bleed in -- its
   # Obs sequence restarts at 1 rather than continuing the run.
@@ -83,6 +99,8 @@ test_that(".hzr_parse_bhdead_phase does not absorb a trailing unrelated table", 
 })
 
 test_that(".hzr_parse_bhdead_phase spans a paginated table via a contiguous Obs run", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   # The phase label and column header repeat on each page, but the Obs
   # sequence continues uninterrupted across the page break.
   lines <- c(
@@ -99,6 +117,8 @@ test_that(".hzr_parse_bhdead_phase spans a paginated table via a contiguous Obs 
 })
 
 test_that(".hzr_build_bhdead_fixture returns a schema-valid fixture", {
+  testthat::skip_if_not(nzchar(.bhdead_helper),
+                        "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
   hz <- tempfile(fileext = ".lst"); bh <- tempfile(fileext = ".lst")
   on.exit(unlink(c(hz, bh)), add = TRUE)
   writeLines(.fake_hz_lines, hz); writeLines(.fake_bh_lines, bh)

--- a/tests/testthat/test-bhdead-parse.R
+++ b/tests/testthat/test-bhdead-parse.R
@@ -1,0 +1,81 @@
+# Unit tests for the bh.dead .lst parsers.
+#
+# Inputs below reproduce the SAS listing FORMAT with entirely INVENTED numbers.
+# Never paste real listing values here: this repository is public, and a
+# renamed variable with verbatim values is not anonymised. Round, obviously
+# fake numbers make that impossible to get wrong by accident.
+
+source(system.file("dev", "bhdead-parity", "parse-bhdead-lst.R",
+                   package = "TemporalHazard"), local = TRUE)
+
+.fake_bh_lines <- c(
+  "                        Study Title Redacted                       3",
+  "                                                  Early Phase",
+  "",
+  "                           Obs    _NAME_         N     PCT          MIN        MAX        MEAN        STD",
+  "",
+  "                             1    E0           500    100.0    -100.000    100.000     -1.0000     10.000",
+  "                             2    VAR_A        250     50.0      -2.000      2.000      0.2000      2.000",
+  "                             3    VAR_B        100     20.0      -3.000      3.000      0.3000      3.000",
+  "                        Study Title Redacted                       4",
+  "                                                  Constant Phase",
+  "",
+  "                           Obs    _NAME_         N     PCT          MIN        MAX        MEAN        STD",
+  "",
+  "                             1    C0           500    100.0    -200.000    200.000     -2.0000     20.000",
+  "                             2    VAR_A        150     30.0      -4.000      4.000      0.4000      4.000"
+)
+
+.fake_hz_lines <- c(
+  "          Phase        Parameter       Specified        Used       |  Theta",
+  "                       THALF             1.100000      1.100000    |  E2",
+  "                       NU                 -0.5000       -0.5000    |  E3",
+  "                       M                        0             0    |  E4",
+  "                       MUE                 0.8000        0.8000    |  E0",
+  "          Constant:    MUC               0.050000      0.050000    |  C0",
+  "                                          Estimates for Model Parameters",
+  "                                          Phase       Parameter     Fixed?     Estimate",
+  "                                                      THALF         No            1.200000",
+  "                                                      NU            No           -0.600000",
+  "                                                      M             Yes                  0",
+  "                                                      MUE                        0.850000",
+  "                                          Constant:   MUC                       0.055000"
+)
+
+test_that(".hzr_parse_bhdead_phase extracts the Early table", {
+  d <- .hzr_parse_bhdead_phase(.fake_bh_lines, "Early Phase")
+  expect_identical(d$name, c("E0", "VAR_A", "VAR_B"))
+  expect_identical(d$n, c(500L, 250L, 100L))
+  expect_equal(d$pct, c(100.0, 50.0, 20.0))
+  expect_equal(d$mean[2], 0.2)
+  expect_equal(d$sd[3], 3.0)
+})
+
+test_that(".hzr_parse_bhdead_phase does not bleed across phase boundaries", {
+  d <- .hzr_parse_bhdead_phase(.fake_bh_lines, "Constant Phase")
+  expect_identical(d$name, c("C0", "VAR_A"))
+  expect_equal(d$pct, c(100.0, 30.0))
+})
+
+test_that(".hzr_parse_bhdead_shape reads specified and converged values", {
+  s <- .hzr_parse_bhdead_shape(.fake_hz_lines)
+  expect_equal(s$specified[["thalf"]], 1.1)
+  expect_equal(s$specified[["mue"]], 0.8)
+  expect_equal(s$converged[["thalf"]], 1.2)
+  expect_equal(s$converged[["nu"]], -0.6)
+  expect_equal(s$converged[["m"]], 0)
+  expect_equal(s$converged[["muc"]], 0.055)
+})
+
+test_that(".hzr_build_bhdead_fixture returns a schema-valid fixture", {
+  hz <- tempfile(fileext = ".lst"); bh <- tempfile(fileext = ".lst")
+  on.exit(unlink(c(hz, bh)), add = TRUE)
+  writeLines(.fake_hz_lines, hz); writeLines(.fake_bh_lines, bh)
+  fix <- .hzr_build_bhdead_fixture(
+    hz, bh,
+    meta = list(resampl = 1000L, sle = 0.12, sls = 0.10, n_obs = 100L,
+                captured_on = "2026-07-16", source = "synthetic")
+  )
+  expect_identical(.hzr_validate_bhdead_fixture(fix), fix)
+  expect_identical(fix$early$name[1], "E0")
+})

--- a/tests/testthat/test-bhdead-parse.R
+++ b/tests/testthat/test-bhdead-parse.R
@@ -119,9 +119,11 @@ test_that(".hzr_parse_bhdead_phase spans a paginated table via a contiguous Obs 
 test_that(".hzr_build_bhdead_fixture returns a schema-valid fixture", {
   testthat::skip_if_not(nzchar(.bhdead_helper),
                         "bh.dead parity helpers not installed (inst/dev is .Rbuildignore'd)")
-  hz <- tempfile(fileext = ".lst"); bh <- tempfile(fileext = ".lst")
+  hz <- tempfile(fileext = ".lst")
+  bh <- tempfile(fileext = ".lst")
   on.exit(unlink(c(hz, bh)), add = TRUE)
-  writeLines(.fake_hz_lines, hz); writeLines(.fake_bh_lines, bh)
+  writeLines(.fake_hz_lines, hz)
+  writeLines(.fake_bh_lines, bh)
   fix <- .hzr_build_bhdead_fixture(
     hz, bh,
     meta = list(resampl = 1000L, sle = 0.12, sls = 0.10, n_obs = 100L,

--- a/tests/testthat/test-bhdead-parse.R
+++ b/tests/testthat/test-bhdead-parse.R
@@ -67,6 +67,37 @@ test_that(".hzr_parse_bhdead_shape reads specified and converged values", {
   expect_equal(s$converged[["muc"]], 0.055)
 })
 
+test_that(".hzr_parse_bhdead_phase does not absorb a trailing unrelated table", {
+  # The terminal phase table has no following label to bound it. A trailing
+  # table that happens to match the data-row shape must not bleed in -- its
+  # Obs sequence restarts at 1 rather than continuing the run.
+  lines <- c(
+    "Constant Phase", "", "Obs _NAME_ N PCT MIN MAX MEAN STD", "",
+    "  1    C0    500  100.0   -1.000   1.000   0.1000   1.000",
+    "", "Some Other Unrelated Table",
+    "Obs _NAME_ N PCT MIN MAX MEAN STD", "",
+    "  1    XYZ_9   500  100.0   -9.000   9.000   9.0000   9.000"
+  )
+  d <- .hzr_parse_bhdead_phase(lines, "Constant Phase")
+  expect_identical(d$name, "C0")
+})
+
+test_that(".hzr_parse_bhdead_phase spans a paginated table via a contiguous Obs run", {
+  # The phase label and column header repeat on each page, but the Obs
+  # sequence continues uninterrupted across the page break.
+  lines <- c(
+    "Early Phase", "", "Obs _NAME_ N PCT MIN MAX MEAN STD", "",
+    "  1    E0      500  100.0   -1.000   1.000   0.1000   1.000",
+    "  2    VAR_A   250   50.0   -2.000   2.000   0.2000   2.000",
+    "Study Title Redacted    2",
+    "Early Phase", "", "Obs _NAME_ N PCT MIN MAX MEAN STD", "",
+    "  3    VAR_B   100   20.0   -3.000   3.000   0.3000   3.000",
+    "  4    VAR_C    50   10.0   -4.000   4.000   0.4000   4.000"
+  )
+  d <- .hzr_parse_bhdead_phase(lines, "Early Phase")
+  expect_identical(d$name, c("E0", "VAR_A", "VAR_B", "VAR_C"))
+})
+
 test_that(".hzr_build_bhdead_fixture returns a schema-valid fixture", {
   hz <- tempfile(fileext = ".lst"); bh <- tempfile(fileext = ".lst")
   on.exit(unlink(c(hz, bh)), add = TRUE)

--- a/tests/testthat/test-bhdead-sas-parity.R
+++ b/tests/testthat/test-bhdead-sas-parity.R
@@ -1,0 +1,142 @@
+# SAS parity for the bh.dead analysis: multiphase shape fit (%HAZARD) and the
+# hzr_bootstrap(scope=) embedded stepwise screen (%HAZBOOT).
+#
+# THIS REPOSITORY IS PUBLIC. No study value appears in this file: the data and
+# the SAS reference both live on a secure volume, and every expectation is read
+# from the fixture at run time. The test skips unless both are readable, so it
+# never runs on CRAN, on CI, or on any machine without the volume mounted.
+#
+# Enable by building the fixture first:
+#   source("inst/dev/bhdead-parity/parse-bhdead-lst.R"); .hzr_write_bhdead_fixture()
+# See inst/dev/bhdead-parity/README.md.
+
+.bhdead_helpers <- system.file("dev", "bhdead-parity", "bhdead-fixture.R",
+                                package = "TemporalHazard")
+
+# Shape-fit tolerance is calibrated from observed output: R reproduces SAS's
+# converged shape fit to 3.4e-04 max relative error (2026-07-16), so 1e-3 is a
+# real guard with headroom, not a guess.
+#
+# There is deliberately NO statistical tolerance for the bootstrap screen. SAS
+# seeds from the time of day (seed=-1), so its selection frequencies are one
+# random realisation; and one R replicate over the 92-variable pool costs ~25
+# minutes, making a SAS-scale n_boot infeasible until criterion = "score"
+# lands. At the feasible n_boot the frequencies are too coarse to support a
+# meaningful floor. See BHDEAD-SAS-PARITY-DESIGN.md, "Deferred: score-test
+# selection". The bootstrap test below is a smoke check by design.
+.bhdead_tolerance <- list(
+  shape_rel = 1e-3
+)
+
+.bhdead_setup <- function() {
+  testthat::skip_if_not_installed("haven")
+  if (!nzchar(.bhdead_helpers) || !file.exists(.bhdead_helpers)) {
+    testthat::skip("bh.dead parity helpers not installed")
+  }
+  # Source into the calling test_that() frame (pf) so the sourced helpers
+  # (e.g. .hzr_bhdead_candidates) stay visible to the rest of the test body.
+  # Call them via pf$... here because unqualified calls from inside this
+  # function resolve lexically against this function's own environment, not
+  # against pf, even though the assignments landed in pf.
+  pf <- parent.frame()
+  source(.bhdead_helpers, local = pf)
+  fix <- pf$.hzr_load_bhdead_fixture()
+  testthat::skip_if(is.null(fix), "bh.dead SAS fixture not available")
+  data_path <- pf$.hzr_bhblt_path()
+  testthat::skip_if_not(file.exists(data_path), "bhblt data not available")
+  caa <- haven::read_sas(data_path)
+  names(caa) <- tolower(names(caa))
+  list(fix = fix, caa = caa)
+}
+
+# Build the phase list for a given `fixed` specification, seeding every start
+# value from the fixture.
+.bhdead_phases <- function(sp, fixed) {
+  list(
+    early    = hzr_phase("cdf", t_half = sp[["thalf"]], nu = sp[["nu"]],
+                         m = sp[["m"]], fixed = fixed),
+    constant = hzr_phase("constant")
+  )
+}
+
+.bhdead_theta <- function(sp) {
+  c(early.log_mu     = log(sp[["mue"]]),
+    early.log_t_half = log(sp[["thalf"]]),
+    early.nu         = sp[["nu"]],
+    early.m          = sp[["m"]],
+    constant.log_mu  = log(sp[["muc"]]))
+}
+
+test_that("multiphase shape fit reproduces the SAS shape fit", {
+  env <- .bhdead_setup()
+  sp <- env$fix$shape$specified
+  cv <- env$fix$shape$converged
+
+  # hz.dead fixes only M; THALF and NU are estimated. noconserve -> conserve = FALSE.
+  fit <- hazard(
+    survival::Surv(iv_dead, dead) ~ 1, data = env$caa, dist = "multiphase",
+    phases  = .bhdead_phases(sp, fixed = "m"),
+    theta   = .bhdead_theta(sp),
+    control = list(conserve = FALSE),
+    fit     = TRUE
+  )
+  expect_true(isTRUE(fit$fit$converged))
+
+  th <- coef(fit)
+  expect_equal(exp(th[["early.log_t_half"]]), cv[["thalf"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+  expect_equal(th[["early.nu"]], cv[["nu"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+  expect_equal(exp(th[["early.log_mu"]]), cv[["mue"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+  expect_equal(exp(th[["constant.log_mu"]]), cv[["muc"]],
+               tolerance = .bhdead_tolerance$shape_rel)
+})
+
+test_that("every SAS candidate exists in the data", {
+  env <- .bhdead_setup()
+  expect_identical(
+    setdiff(.hzr_bhdead_candidates(env$fix), names(env$caa)),
+    character(0)
+  )
+})
+
+test_that("bootstrap screen wiring: fixture scope -> hzr_bootstrap -> summary", {
+  env <- .bhdead_setup()
+  sp <- env$fix$shape$specified
+
+  # The full 92-variable SAS candidate pool costs ~25 minutes per bootstrap
+  # replicate (hzr_stepwise refits once per candidate per step), so a
+  # SAS-scale run belongs in the analysis notebook, not the test suite. See
+  # inst/dev/BHDEAD-SAS-PARITY-DESIGN.md, "Deferred: score-test selection".
+  # Here we slice to the first 3 candidates and n_boot = 1 -- enough to
+  # exercise fixture scope -> hzr_bootstrap -> summary wiring without the
+  # runtime cost.
+  scope_vars <- head(.hzr_bhdead_candidates(env$fix), 3)
+
+  # bh.dead fixes nu and m; THALF stays free.
+  base_fit <- hazard(
+    survival::Surv(iv_dead, dead) ~ 1, data = env$caa, dist = "multiphase",
+    phases  = .bhdead_phases(sp, fixed = c("nu", "m")),
+    theta   = .bhdead_theta(sp),
+    control = list(conserve = FALSE),
+    fit     = TRUE
+  )
+
+  bs <- hzr_bootstrap(
+    base_fit, n_boot = 1, seed = 123,
+    scope   = list(early = stats::reformulate(scope_vars),
+                   constant = stats::reformulate(scope_vars)),
+    slentry = env$fix$meta$sle, slstay = env$fix$meta$sls,
+    control = list(n_starts = 1, conserve = FALSE)
+  )
+
+  expect_s3_class(bs, "hzr_bootstrap")
+  expect_gt(bs$n_success, 0)
+  expect_gt(nrow(bs$summary), 0)
+  # The intercepts are never dropped by stepwise, so they appear in every
+  # successful replicate.
+  intercepts <- bs$summary[bs$summary$parameter %in%
+                             c("early.log_mu", "constant.log_mu"), ]
+  expect_true(all(intercepts$n == bs$n_success))
+})

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -775,6 +775,25 @@ test_that("hzr_bootstrap uses stored data frame when the original symbol is out 
   expect_equal(bs$n_failed, 0)
 })
 
+test_that("hzr_bootstrap resolves call arguments passed by symbol from a function", {
+  # Regression: hzr_bootstrap re-evaluated the stored call in its own frame, so
+  # arguments passed by symbol (theta here) resolved against the package
+  # namespace -> globalenv and were invisible when the fit was built inside a
+  # function. Every replicate threw, the tryCatch swallowed it, and n_success
+  # was silently 0. Building the fit in a helper is what triggers it.
+  data(avc, package = "TemporalHazard")
+  avc <- stats::na.omit(avc)
+  build <- function(d) {
+    th <- c(mu = 0.01, nu = 0.5) # passed by SYMBOL, not inline
+    hazard(survival::Surv(int_dead, dead) ~ 1, data = d, dist = "weibull",
+           theta = th, fit = TRUE)
+  }
+  fit <- build(avc)
+  bs <- hzr_bootstrap(fit, n_boot = 3, seed = 42)
+  expect_gt(bs$n_success, 0)
+  expect_equal(bs$n_failed, 0)
+})
+
 test_that("hzr_bootstrap scope = NULL reports mode = refit and is unaffected", {
   set.seed(42)
   fit <- .fit_avc_weibull()

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -816,6 +816,29 @@ test_that("hazard() captures only the symbols its call references", {
   expect_false(exists("unrelated_local", envir = fit$call_env, inherits = TRUE))
 })
 
+test_that("hazard() does not capture package or base closures", {
+  # Regression: call_env captured any symbol all.names() found, including
+  # `hazard` itself and base functions. R serialises a closure's environment by
+  # reference but its BODY by value, so saveRDS(fit) froze a copy of hazard()'s
+  # body into every fit. A fit saved under one version and bootstrapped after an
+  # upgrade runs that stale body against the new namespace; it throws inside the
+  # replicate, hzr_bootstrap()'s tryCatch swallows it, and the user gets a
+  # silent n_success = 0. Package and base functions must resolve through
+  # call_env's parent (globalenv()) instead of being copied.
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  build <- function(d) {
+    # `c` is referenced BY the call, so all.names() finds it.
+    hazard(survival::Surv(int_dead, dead) ~ 1, data = d, dist = "weibull",
+           theta = c(mu = 0.01, nu = 0.5), fit = TRUE)
+  }
+  fit <- build(avc)
+  expect_false(exists("hazard", envir = fit$call_env, inherits = FALSE))
+  expect_false(exists("c", envir = fit$call_env, inherits = FALSE))
+  # ... but both must still RESOLVE, through call_env's parent.
+  expect_true(exists("hazard", envir = fit$call_env, inherits = TRUE))
+})
+
 test_that("hzr_bootstrap resolves a call that invokes user-defined helpers", {
   # Regression: call_env selected symbols with all.vars(), which omits FUNCTION
   # names. A user whose call builds theta/phases via their own helper left those

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -794,6 +794,28 @@ test_that("hzr_bootstrap resolves call arguments passed by symbol from a functio
   expect_equal(bs$n_failed, 0)
 })
 
+test_that("hazard() captures only the symbols its call references", {
+  # Regression: call_env was parent.frame(), pinning the caller's whole frame
+  # to every fit (measured ~1400x saveRDS bloat) and dragging unrelated data --
+  # including other cohorts -- into any saved model.
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  build <- function(d) {
+    unrelated_local <- matrix(0, nrow = 100, ncol = 100)
+    th <- c(mu = 0.01, nu = 0.5)
+    hazard(survival::Surv(int_dead, dead) ~ 1, data = d, dist = "weibull",
+           theta = th, fit = TRUE)
+  }
+  fit <- build(avc)
+  # `th` and `d` ARE referenced by the call and must be captured.
+  expect_true(exists("th", envir = fit$call_env, inherits = FALSE))
+  expect_true(exists("d", envir = fit$call_env, inherits = FALSE))
+  # `unrelated_local` is NOT referenced and must not be reachable at all --
+  # including through the parent chain, which is why call_env parents to
+  # globalenv() rather than the caller.
+  expect_false(exists("unrelated_local", envir = fit$call_env, inherits = TRUE))
+})
+
 test_that("hzr_bootstrap scope = NULL reports mode = refit and is unaffected", {
   set.seed(42)
   fit <- .fit_avc_weibull()

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -816,6 +816,26 @@ test_that("hazard() captures only the symbols its call references", {
   expect_false(exists("unrelated_local", envir = fit$call_env, inherits = TRUE))
 })
 
+test_that("hzr_bootstrap resolves a call that invokes user-defined helpers", {
+  # Regression: call_env selected symbols with all.vars(), which omits FUNCTION
+  # names. A user whose call builds theta/phases via their own helper left those
+  # helpers uncaptured; call_env parents to globalenv(), where a local helper
+  # does not live, so every replicate threw and n_success silently returned 0 --
+  # the bug d9f38ee fixed. all.names() includes function names.
+  data(avc, package = "TemporalHazard")
+  avc <- na.omit(avc)
+  build <- function(d) {
+    make_theta <- function() c(mu = 0.01, nu = 0.5) # user-defined helper
+    hazard(survival::Surv(int_dead, dead) ~ 1, data = d, dist = "weibull",
+           theta = make_theta(), fit = TRUE)
+  }
+  fit <- build(avc)
+  expect_true(exists("make_theta", envir = fit$call_env, inherits = FALSE))
+  bs <- hzr_bootstrap(fit, n_boot = 3, seed = 42)
+  expect_gt(bs$n_success, 0)
+  expect_equal(bs$n_failed, 0)
+})
+
 test_that("hzr_bootstrap scope = NULL reports mode = refit and is unaffected", {
   set.seed(42)
   fit <- .fit_avc_weibull()


### PR DESCRIPTION
Builds a development-only harness comparing the multiphase fit and
`hzr_bootstrap(scope=)` against the SAS/C HAZARD originals (`%HAZARD`,
`%HAZBOOT`) for a clinical analysis held on a secure volume.

**It stopped being just a harness:** while building it, the harness found a real,
silent bug in unreleased 1.2.0 code. That fix is the most important thing here.

## The bug (`R/hazard_api.R`, `R/diagnostics.R`)

`hazard()` stored its call but not the environment that call was written in.
`hzr_bootstrap()` re-ran it per replicate via `eval(cl)` with no `envir`, so it
evaluated in `hzr_bootstrap()`'s own frame — symbol lookup went up the *package
namespace* to `globalenv()` and never reached the caller's locals. Any argument
passed **by symbol** (`theta`, `phases`, `control`) was unresolvable.

The failure was silent. The replicate's `tryCatch(error = function(e) NULL)`
swallowed `object not found`, so a model fitted **inside a function** returned
`n_success = 0`, `n_failed = n_boot`, **no error and no warning**. At top level
it appeared to work, by lexical fallthrough to `globalenv()`. Affects **both**
refit and select modes — i.e. most real analyses, which wrap their model in a
function.

Existing tests missed it because they pass every argument except `data` as an
inline literal, so no symbol ever needed resolving. `data`/`weights` had already
been worked around individually by reading them off the fitted object — the same
bug class, patched for two arguments rather than generally.

`hazard()` now stores a minimal `call_env`; each replicate evaluates in a child
of it carrying `boot_data`/`boot_weights`. Objects fitted before this change fall
back to `parent.frame()`.

The fix took three iterations, and the intermediate states are instructive:

| Attempt | Result |
|---|---|
| `call_env = parent.frame()` | Fixed the bug, but pinned the caller's whole frame: `saveRDS(fit)` **0.01 MB → 14.66 MB**, and would silently serialize patient data sitting in the analysis frame |
| narrow via `all.vars()` | Bloat gone — but `all.vars()` **omits function names**, so calls using the user's own helpers silently regressed to `n_success = 0` |
| `all.names()` + stop the scope walk at namespaces | Both properties hold |

The final review also caught that capturing package/base closures freezes their
**bodies** by value into every saved fit (R serializes a closure's env by
reference, its body by value) — a fit saved under 1.2.0 and bootstrapped after an
upgrade would run stale code, throw, and be swallowed into `n_success = 0` again.
The capture now walks only the caller's own scope chain.

## The harness (`inst/dev/bhdead-parity/`, dev-only)

Parses the two SAS listings into a fixture, refits both SAS specifications in R,
and asserts the deterministic shape fit tightly. It found three fidelity defects
in the draft analysis notebook, all confirmed against SAS's actual output:

- It screened **19** candidates; SAS screened **92**. `hist_ad`/`grade`/`resm1`/`lvi`
  were **never in SAS's pool** — killed by a nested-comment trap (`/* */` doesn't
  nest, so the block ends at the first `*/`). Selection frequency depends on the
  candidate pool, so the two were never comparable.
- `fixed = "shapes"` matched neither SAS run (the shape fit fixes only `M`; the
  bootstrap base fixes `nu` and `m`).
- It omitted `noconserve`, running Conservation of Events where SAS does not.

With those corrected, **R reproduces SAS's shape fit to 3.4e-04** (max relative
error, all parameters < 1e-3).

## Data governance

This repository is **public**, and `.Rbuildignore` excludes from the CRAN tarball
but does nothing about git. So:

- Neither the patient-level data nor the study's aggregate results enter the repo.
  The fixture lives beside the data on the secure volume, resolved via
  `TEMPORALHAZARD_BHBLT` / `TEMPORALHAZARD_BHDEAD_FIXTURE` (no default path — a
  study-identifying directory must not be committed).
- Committed code carries **no study values**; every expectation is read from the
  fixture at run time. Unit-test fixtures reproduce the SAS listing *format* with
  invented numbers.
- The parity test skips unless the data **and** fixture are readable, so it never
  runs on CRAN or CI.

## Deferred: `criterion = "score"`

Profiling found **99.77%** of one stepwise inside `.hzr_refit_with_scope()`. The
cause is algorithmic: R's forward step refits **once per candidate per step**
(92 vars × 2 phases = 184 optimizations/step), while SAS scores entry candidates
with Q-statistics at the current model and does not refit. Measured **~25 min per
replicate**, so SAS's `resampl=1000` is **~17 days**.

Consequently the bootstrap half of the parity test is a **wiring smoke check**,
and the statistical assertions (rank correlation, top-N recovery) are **deliberately
absent** — at a feasible `n_boot` the selection frequency is restricted to
{0,20,40,60,80,100}, so any floor would encode noise while reading as verified
parity. Documented in `inst/dev/BHDEAD-SAS-PARITY-DESIGN.md`.

## Verification

- `R CMD check --as-cran` with manual: **Status: OK** (0/0/0), **7m36s** (CRAN budget ~10 min)
- Full suite: **FAIL 0 | PASS 1847**
- Parity test vs real data: **10/10**; with the volume absent: **3 clean SKIPs** (what CRAN/CI sees)
- Installed-tarball run: both unit-test files skip cleanly, 0 errors (they *errored* before the final-review fix — `system.file()` returns `""` for `.Rbuildignore`d `inst/dev`, and `devtools::test()` hid it via pkgload's shim)
- Branch diff and all commit messages: free of study values and study-identifying paths

No version bump — this lands under the existing unreleased 1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)