### PR TITLE
release: TemporalHazard 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.0
+Version: 2.0.0
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
 BugReports: https://github.com/ehrlinger/temporal_hazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TemporalHazard 1.2.0
+# TemporalHazard 2.0.0
 
 ## Breaking changes
 

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -72,7 +72,7 @@
 #'     are scored from a refit that adds the candidate (so its new coefficient
 #'     can be tested); drop candidates are scored from the *current* model's
 #'     Wald p-values without a per-candidate refit, and a single refit is run
-#'     only after a drop is chosen.  This was the default before version 1.2.0.
+#'     only after a drop is chosen.  This was the default before version 2.0.0.
 #'     It differs algorithmically from C/SAS HAZARD, so the two criteria can
 #'     take different step paths --- and select different variable sets ---
 #'     even when they converge to a similar final model.}

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,54 +1,99 @@
-# CRAN submission comments -- TemporalHazard 1.2.0
+# CRAN submission comments -- TemporalHazard 2.0.0
 
 ## Summary
 
-This is an update to TemporalHazard 1.1.0 (accepted 2026-06-12).
-No reviewer feedback to address. New version adds embedded stepwise
-variable selection to `hzr_bootstrap()`.
+This is an update to TemporalHazard 1.1.0 (accepted 2026-06-12). There is no
+reviewer feedback to address.
+
+The major version bump reflects one breaking change: `hzr_stepwise()` now
+defaults to a different selection criterion, so re-running an existing stepwise
+analysis can select a different set of variables. Everything else in this
+release is additive or a bug fix, and the previous behaviour remains available
+exactly, through a documented argument.
 
 ## Changes since 1.1.0
 
-* **`hzr_bootstrap()` gains a `scope` argument for embedded stepwise
-  variable selection.** This is the R equivalent of SAS's `%HAZBOOT`
-  procedure: each bootstrap replicate runs a fresh `hzr_stepwise()`
-  selection (starting from a fixed-shape refit of the base model) instead
-  of a plain refit, so `summary$pct` reports the variable's selection
-  frequency across resamples and `summary$mean`/`sd`/`ci_*` describe the
-  coefficient distribution conditional on selection. `scope = NULL`
-  (the default) preserves the original fixed-formula bootstrap unchanged.
+### Breaking
+
+* **`hzr_stepwise()` now defaults to `criterion = "score"`.** This reproduces
+  the `SELECTION` statistic of the original C/SAS HAZARD program, which this
+  package exists to reproduce. The previous default, `"wald"`, refit the model
+  once per candidate variable and tested the refit's Wald chi-square -- a
+  deviation from the reference implementation. Because the score and Wald paths
+  take different step sequences, re-running an existing analysis can now select
+  a different variable set. `criterion = "wald"` restores the old behaviour
+  exactly. Both the change and the escape hatch are documented in
+  `?hzr_stepwise` and in the "Breaking changes" section of `NEWS.md`.
+
+  Removing the per-candidate refit also removed the dominant runtime cost: a
+  92-variable two-phase screen fell from roughly 25 minutes per bootstrap
+  replicate to seconds.
+
+### New features
+
+* `hzr_bootstrap()` gains a `scope` argument for embedded stepwise variable
+  selection within each bootstrap replicate -- the R equivalent of SAS's
+  `%HAZBOOT` procedure. `scope = NULL` (the default) preserves the original
+  fixed-formula bootstrap unchanged.
+* `hzr_bootstrap(verbose = TRUE)` shows a text progress bar via
+  `utils::txtProgressBar()` instead of an every-50-replicates message.
+
+### Bug fixes
+
+* `hzr_bootstrap()` no longer fails silently (returning `n_success = 0` with no
+  error and no warning) when the model was fitted inside a function. `hazard()`
+  now records the environment its call was written in, so each replicate's refit
+  resolves arguments passed by symbol against the caller's locals rather than
+  against the package namespace.
+* Multiphase models whose shape sits exactly at the `m = 0` or `nu = 0`
+  limiting-case boundary no longer lose their analytic Hessian and fall back
+  silently to a numerical one, or to `NA` standard errors.
+* Multiphase fits with a single free parameter now use the analytic Hessian for
+  standard errors, instead of falling back to a numerical one because a 1x1
+  matrix had been dropped to a scalar.
+* `hzr_bootstrap(scope = ..., trace = ...)` no longer errors with "formal
+  argument matched by multiple actual arguments".
+* `hzr_bootstrap()` no longer floods the console with per-replicate numerical
+  warnings. Structural problems still surface once, up front.
+
+`NEWS.md` carries the full detail for each item.
 
 ## Test environments
 
 * **Local:** R 4.6.0 on macOS (aarch64-apple-darwin23).
-  `R CMD check --as-cran` (with PDF manual) returns 0 errors, 0 warnings,
-  0 notes.
-* **GitHub Actions matrix:** ubuntu-latest (R-devel / R-release /
-  R-oldrel-1), macos-latest (R-release), windows-latest (R-release).
-  All checks passed (0 errors / 0 warnings).
+  `R CMD check --as-cran` on the built tarball, **with the PDF manual**,
+  returns 0 errors, 0 warnings, 0 notes. Overall check time is approximately
+  2.5 minutes; the source tarball is 2.7 MB.
+* **GitHub Actions matrix:** ubuntu-latest (R-devel / R-release / R-oldrel-1),
+  macos-latest (R-release), windows-latest (R-release).
 * **Reverse-dependency check:** `tools::package_dependencies(reverse = TRUE)`
-  returns 0.
-* **`urlchecker::url_check()`:** all URLs correct.
+  returns 0 reverse dependencies.
+* **`urlchecker::url_check()`:** all 19 URLs correct.
 
 ## NOTE disposition
 
-`R CMD check --as-cran` on the release tarball is clean (0/0/0).
-CRAN's incoming-feasibility / aspell check may report:
+`R CMD check --as-cran` on the release tarball is clean (0/0/0) locally. The
+CRAN incoming-feasibility aspell check is expected to report:
 
 * **Possibly misspelled words in DESCRIPTION:** `Naftel`, `Rajeswaran`
-  (cited authors with `<doi:...>` references), `UAB` (acronym), `et`,
-  `al` ("et al." citation), `multiphase` (the core domain term). None are
-  misspellings. `inst/WORDLIST` lists these for the `spelling` unit test;
-  the CRAN aspell check has no package-level suppression mechanism, so
-  this NOTE recurs by design on every submission.
+  (cited authors, each with an accompanying `<doi:...>` reference), `UAB`
+  (an acronym), `et`, `al` (from the "et al." citation), and `multiphase`
+  (the core domain term, standard in the literature this package
+  implements). None are misspellings.
+
+  `inst/WORDLIST` records these for `devtools::spell_check()`. It has no
+  effect on the CRAN aspell check, which offers no package-level suppression
+  mechanism, so this NOTE recurs by design on every submission.
 
 ## Background
 
-* Package contains five clinical reference datasets (~120 KB compressed)
-  used in vignettes and parity tests against the original C/SAS HAZARD
+* The package contains five clinical reference datasets (~120 KB compressed)
+  used in vignettes and in parity tests against the original C/SAS HAZARD
   program.
 * Vignettes use Quarto (`VignetteBuilder: quarto`).
-* A subset of tests (SAS parity, multi-start multiphase fits, OMC
-  raw-file derivation) are guarded with `skip_on_cran()` to stay within
-  CRAN runtime budgets; the full suite runs on GitHub Actions.
-* DOI URLs in vignettes (doi.org) may return HTTP 403 to automated
-  checkers but resolve correctly in browsers.
+* A subset of tests -- SAS parity, multi-start multiphase fits, OMC raw-file
+  derivation -- is guarded with `skip_on_cran()` to stay within CRAN runtime
+  budgets. The full suite, including the SAS parity gate, runs on GitHub
+  Actions.
+* DOI URLs in vignettes (doi.org) may return HTTP 403 to automated checkers
+  but resolve correctly in browsers.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -62,8 +62,8 @@ exactly, through a documented argument.
 
 * **Local:** R 4.6.0 on macOS (aarch64-apple-darwin23).
   `R CMD check --as-cran` on the built tarball, **with the PDF manual**,
-  returns 0 errors, 0 warnings, 0 notes. Overall check time is approximately
-  2.5 minutes; the source tarball is 2.7 MB.
+  returns 0 errors, 0 warnings, 0 notes. Overall check time is about two
+  minutes, well inside the reference budget; the source tarball is 2.7 MB.
 * **GitHub Actions matrix:** ubuntu-latest (R-devel / R-release / R-oldrel-1),
   macos-latest (R-release), windows-latest (R-release).
 * **Reverse-dependency check:** `tools::package_dependencies(reverse = TRUE)`

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -190,7 +190,7 @@ a term is dropped if its p-value rises above \code{slstay}.  Entry candidates
 are scored from a refit that adds the candidate (so its new coefficient
 can be tested); drop candidates are scored from the \emph{current} model's
 Wald p-values without a per-candidate refit, and a single refit is run
-only after a drop is chosen.  This was the default before version 1.2.0.
+only after a drop is chosen.  This was the default before version 2.0.0.
 It differs algorithmically from C/SAS HAZARD, so the two criteria can
 take different step paths --- and select different variable sets ---
 even when they converge to a similar final model.}


### PR DESCRIPTION
Sets the release number for the work accumulated on `dev` since 1.1.0, and brings `cran-comments.md` back in line with what is actually being shipped.

## Why 2.0.0 and not 1.2.0

`1.2.0` was stamped on both `main` and `dev` by #99 on 2026-07-15 but **never submitted** — there is no `v1.2.0` tag and no GitHub release past `v1.1.0`. Three PRs landed on `dev` afterwards (#100, #101, #102), and #102 added a **Breaking changes** section to the release notes that did not exist when the number was chosen: `hzr_stepwise()` now defaults to `criterion = "score"`, so re-running an existing stepwise analysis can select a different variable set.

`RELEASE.md` says breaking API → major. Version decision made by @ehrlinger.

## Changes

- `DESCRIPTION` and the `NEWS.md` top heading → `2.0.0`
- `?hzr_stepwise` now describes the `"wald"` default as pre-2.0.0 rather than pre-1.2.0, with the Rd regenerated
- `cran-comments.md` rewritten. It described only the `hzr_bootstrap(scope=)` feature from #98 and was silent on the breaking default flip, the SAS parity harness (#101) and the two Hessian fixes (#100). It also **claimed `inst/WORDLIST` feeds a "spelling unit test"** — no such test exists and `spelling` is not in `Suggests`, so that statement to CRAN was false. Now says what is true: the wordlist feeds `devtools::spell_check()` only.

## Release gate at 2.0.0

| Gate | Result |
|---|---|
| `R CMD check --as-cran`, built tarball, **with PDF manual** | **0 errors / 0 warnings / 0 notes** |
| Overall check time | **2.0 min** (CRAN budget ~10) |
| Tarball size | **2.7 MB** (limit 5) |
| `build/vignette.rds` present | yes |
| Tests | 1397 pass / 0 fail / 111 skip (documented `skip_on_cran` set) |
| Reverse dependencies | 0 |
| `urlchecker::url_check()` | all 19 URLs correct |
| `devtools::document()` drift | none |
| CRAN Cookbook audit | clean — `\value` coverage, no `\dontrun`, Suggests guarded by `requireNamespace()`, Title Case, quoted software names + space-free `<doi:>`, no parallelism, no global-state writes (the `<<-` in `stepwise.R` are closure-local accumulators), no `set.seed()`/`options()`/`par()` in bodies, console output gated on `trace`, non-ASCII properly `\enc{}`-wrapped |

## Not yet done before submission

- [ ] `devtools::check_win_devel()` — `RELEASE.md` names win-builder as the source of truth for the aspell NOTE; the local `--as-cran` under-reports it without `aspell` installed. The `## NOTE disposition` wording should be reconciled against the win-builder `00check.log`.
- [ ] CI green on this PR
- [ ] `devtools::submit_cran()`

Tag `v2.0.0`, the GitHub Release, the `dev → main` merge and the bump to `2.0.0.9000` all happen **after** CRAN acceptance, per `RELEASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)