### PR TITLE
ci: move roxygen doc-currency check to a docs-current job in lint.yaml

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest, r: 'devel',    check_roxygen: false}
-          - {os: ubuntu-latest, r: 'release',  check_roxygen: true}
-          - {os: ubuntu-latest, r: 'oldrel-1', check_roxygen: false}
-          - {os: macos-latest,  r: 'release',  check_roxygen: false}
-          - {os: windows-latest, r: 'release', check_roxygen: false}
+          - {os: ubuntu-latest, r: 'devel'}
+          - {os: ubuntu-latest, r: 'release'}
+          - {os: ubuntu-latest, r: 'oldrel-1'}
+          - {os: macos-latest,  r: 'release'}
+          - {os: windows-latest, r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -36,19 +36,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::roxygen2@8.1.0, any::pkgload
+          extra-packages: any::rcmdcheck
           needs: check
-
-      - name: Ensure roxygen outputs are current
-        if: matrix.config.check_roxygen
-        shell: Rscript {0}
-        run: |
-          roxygen2::roxygenise(load_code = roxygen2::load_pkgload)
-          changed <- system("git status --porcelain", intern = TRUE)
-          if (length(changed) > 0) {
-            writeLines(changed)
-            stop("Roxygen outputs are not up to date. Run roxygen2::roxygenise() and commit changes.")
-          }
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,3 +34,32 @@ jobs:
         shell: Rscript {0}
         env:
           LINTR_ERROR_ON_LINT: true
+
+  docs-current:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          # roxygen2 is pinned to the version DESCRIPTION records in
+          # Config/roxygen2/version, so a roxygen upgrade arrives as a
+          # deliberate bump rather than masquerading as documentation drift.
+          # Bump the two together. This is the only place the pin lives.
+          # "hard" skips the Suggests tree -- roxygenise() only needs Imports
+          # loadable, and every Suggests use in R/ is behind requireNamespace().
+          extra-packages: any::roxygen2@8.1.0
+          dependencies: '"hard"'
+
+      - name: Documentation is current
+        run: |
+          Rscript -e 'roxygen2::roxygenise()'
+          git diff --exit-code man/ NAMESPACE DESCRIPTION

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,13 +29,16 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, any::roxygen2@8.1.0, any::pkgload
+          extra-packages: any::pkgdown
           needs: website
 
-      - name: Document and install package
+      # No roxygenise here: the site is built from the committed man/*.Rd, which
+      # is what the package actually ships. Regenerating first would rebuild the
+      # site over any drift instead of surfacing it -- lint.yaml's docs-current
+      # job is what fails on drift, and it does so before the merge.
+      - name: Install package
         shell: Rscript {0}
         run: |
-          roxygen2::roxygenise(load_code = roxygen2::load_pkgload)
           install.packages(".", repos = NULL, type = "source")
 
       - name: Build pkgdown site


### PR DESCRIPTION
Brings the roxygen2 doc-currency check into line with the house standard's **Continuous integration** section.

## What was wrong

The check itself was fine — it failed on drift rather than masking it, unlike the pattern removed from hvtiRutilities and hvtiRdatasets. It was *placed* wrong. It lived in `R-CMD-check.yaml`, whose five-cell matrix resolved `roxygen2` and `pkgload` on every platform to answer a platform-independent question on exactly one of them. And the same `@8.1.0` pin was written down a second time in `pkgdown.yaml`.

## What changed

**New `docs-current` job in `lint.yaml`** — `pull_request` only, ubuntu·release, exactly as the standard specifies:

```yaml
Rscript -e 'roxygen2::roxygenise()'
git diff --exit-code man/ NAMESPACE DESCRIPTION
```

**`R-CMD-check.yaml`** — roxygenise step gone, `any::roxygen2@8.1.0` and `any::pkgload` gone from `extra-packages`, and the now-dead `check_roxygen` matrix field removed from all five cells.

**`pkgdown.yaml`** — roxygenise gone, so its pin and `pkgload` go too.

## Three deliberate calls

**Dropping `load_code = roxygen2::load_pkgload` is safe.** It was redundant, not load-bearing. roxygen2 8.x already defaults to pkgload — confirmed against this package with `roxygen2::load_options(".")$load` → `"pkgload"`, and a bare `roxygenise()` prints pkgload's own `ℹ Loading TemporalHazard` banner when it runs. The standard's bare call loads identically.

**`dependencies: '"hard"'`.** All three preconditions the standard lists were checked: no `@eval`/`@evalRd` tags, no top-level `library()`/`require()` in `R/`, and the one Suggests package referenced in `R/` (`numDeriv`) appears only inside function bodies behind `requireNamespace()` — roxygen loads that code, it never runs it. The default `"all"` would fetch ggplot2, quarto and rmarkdown to support a check that takes seconds.

**pkgdown does *not* need to regenerate first** — so this is not a genuine second use, and the "one pin per repo" rule holds rather than yielding. `install.packages(".", repos = NULL, type = "source")` already builds the help database from the committed `man/*.Rd`, and pkgdown's reference index reads those same files off disk. The regeneration supplied nothing the site lacked; it *overwrote* the committed docs immediately before the build. If `man/` were ever stale, the published site would have looked correct while the repo stayed wrong — the same drift-masking shape the standard removed elsewhere. Failing loudly in `docs-current`, before the merge, is strictly better.

Net: the roxygen2 pin now appears exactly once in the repository, in the one job that runs it. `pkgload` is gone entirely.

## Verification

- Bare `roxygenise()` under roxygen2 8.1.0 leaves `man/`, `NAMESPACE` and `DESCRIPTION` clean on this base — `docs-current` passes here.
- `DESCRIPTION`'s `Config/roxygen2/version: 8.1.0` matches the pin, so a roxygen upgrade arrives as a deliberate bump rather than masquerading as drift.
- All seven workflows parse under `yaml.safe_load`.
- `dependencies` reads back as the string `"hard"` (doubled quoting intact), and no `#` comment text leaked into `extra-packages` — the comments sit at mapping level above a plain scalar, not inside a block scalar.

No version bump: this repo has no version-grep test, and the change is CI-only.

> **Note on the base.** This branch's worktree was created from `faa2447`, six commits behind `origin/main`. It was reset onto `ce4928c` before any edit — working from the stale base would have reverted `Config/roxygen2/version` to 8.0.0 and dropped `check-manual.yaml`, `check-release.yaml` and `spelling.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)