### PR TITLE
release: fold dev into 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 2.0.0
+Version: 1.2.0
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
 BugReports: https://github.com/ehrlinger/temporal_hazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
-# TemporalHazard 2.0.0
+# TemporalHazard 1.2.0
 
 ## Breaking changes
+
+This release contains a breaking change but ships as a minor version. The
+`1.x` line is the run-up to a first production release; the major digit is
+reserved for that milestone rather than spent on a single changed default.
+The change below is also closer to a correction than a redesign — the previous
+default deviated from the SAS/C reference this package exists to reproduce.
+Read the entry regardless: it can change which variables a stepwise run
+selects.
 
 * `hzr_stepwise()` now defaults to `criterion = "score"`, reproducing SAS/C
   HAZARD's `SELECTION` statistic. Previously it defaulted to `"wald"`, which

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -72,7 +72,7 @@
 #'     are scored from a refit that adds the candidate (so its new coefficient
 #'     can be tested); drop candidates are scored from the *current* model's
 #'     Wald p-values without a per-candidate refit, and a single refit is run
-#'     only after a drop is chosen.  This was the default before version 2.0.0.
+#'     only after a drop is chosen.  This was the default before version 1.2.0.
 #'     It differs algorithmically from C/SAS HAZARD, so the two criteria can
 #'     take different step paths --- and select different variable sets ---
 #'     even when they converge to a similar final model.}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,23 @@ Maintainer checklist for TemporalHazard. Not shipped (`.Rbuildignore`d).
   breaking API → major, back-compatible features → minor, fixes only → patch.
   Then strip `.9000` and set that number. You never submit a `.9000` version
   to CRAN.
+- **The major digit is reserved for a deliberate product milestone**, and this
+  overrides the mechanical rule above. A breaking change does **not** by itself
+  force a major bump while the package is still working toward its first
+  production release — the whole `1.x` line is the run-up to that milestone,
+  and spending the major digit on a single default flip mid-run-up leaves
+  nothing to mark the milestone with.
+
+  This is not hypothetical. On 2026-08-04 the mechanical reading took `dev` to
+  `2.0.0` for one changed default in `hzr_stepwise()` (`criterion = "wald"` →
+  `"score"`). That work was folded back into `1.2.0`, where it belonged: the
+  old default deviated from the SAS/C reference this package exists to
+  reproduce, so the change is closer to a correction than to a redesign, and
+  the `1.x` line had not yet reached production.
+
+  When a breaking change ships in a minor for this reason, say so plainly in
+  NEWS under a **Breaking changes** heading. The version number is a release
+  decision; the warning to users is not negotiable and is not softened by it.
 
 So the per-release cycle is:
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-# CRAN submission comments -- TemporalHazard 2.0.0
+# CRAN submission comments -- TemporalHazard 1.2.0
 
 ## Summary
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,11 +5,20 @@
 This is an update to TemporalHazard 1.1.0 (accepted 2026-06-12). There is no
 reviewer feedback to address.
 
-The major version bump reflects one breaking change: `hzr_stepwise()` now
-defaults to a different selection criterion, so re-running an existing stepwise
-analysis can select a different set of variables. Everything else in this
-release is additive or a bug fix, and the previous behaviour remains available
-exactly, through a documented argument.
+This is a minor-version release that nonetheless contains one breaking change:
+`hzr_stepwise()` now defaults to a different selection criterion, so re-running
+an existing stepwise analysis can select a different set of variables. It is
+numbered as a minor rather than a major deliberately. The previous default
+deviated from the C/SAS HAZARD reference this package exists to reproduce, so
+the change restores intended behaviour rather than redesigning the interface;
+the signature is unchanged and the old behaviour remains available exactly,
+through a documented argument. The `1.x` line is the run-up to a first
+production release, and the major digit is reserved for that milestone.
+
+Everything else in this release is additive or a bug fix. The breaking change
+is flagged under a "Breaking changes" heading in `NEWS.md` and in
+`?hzr_stepwise`, so users encounter the warning regardless of the version
+number.
 
 ## Changes since 1.1.0
 

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -190,7 +190,7 @@ a term is dropped if its p-value rises above \code{slstay}.  Entry candidates
 are scored from a refit that adds the candidate (so its new coefficient
 can be tested); drop candidates are scored from the \emph{current} model's
 Wald p-values without a per-candidate refit, and a single refit is run
-only after a drop is chosen.  This was the default before version 2.0.0.
+only after a drop is chosen.  This was the default before version 1.2.0.
 It differs algorithmically from C/SAS HAZARD, so the two criteria can
 take different step paths --- and select different variable sets ---
 even when they converge to a similar final model.}


### PR DESCRIPTION
Renumbers `dev` **2.0.0 → 1.2.0**.

## Nothing is affected downstream

Nothing above **1.1.0** has ever shipped:

| | |
|---|---|
| Latest tag | `v1.1.0` |
| Latest GitHub release | TemporalHazard 1.1.0 (2026-06-12) |
| `CRAN-SUBMISSION` | Version 1.1.0 |

There is no `v1.2.0` or `v2.0.0` tag, release, or submission. No user holds a package claiming either number, so this renumbering is invisible outside the repo.

## Why

The `1.x` line is the run-up to a first production release. **The major digit is reserved for that milestone**, not spent mid-run-up on a single changed default.

The 2026-08-04 stamp (5b11176) applied `RELEASE.md`'s mechanical rule — *"breaking API → major"* — which conflicts with that principle. This PR folds the work back where it belongs and amends `RELEASE.md` so the conflict does not recur.

This is the same shape as #88, where 1.1.0 was frozen on `main`, never shipped, and the following cycle folded **into** it rather than succeeding it.

The change is also closer to a correction than a redesign. The old `hzr_stepwise()` default — `criterion = "wald"`, refitting once per candidate — deviated from the SAS/C HAZARD `SELECTION` statistic this package exists to reproduce. #77 documented the resulting divergence as unfixable by construction; `criterion = "score"` removes the cause.

## Changes

| File | |
|---|---|
| `DESCRIPTION` | `2.0.0` → `1.2.0` |
| `NEWS.md` | heading → 1.2.0; **Breaking changes section kept**, with a preamble stating plainly that a breaking change is shipping in a minor and why |
| `R/stepwise.R` + `man/hzr_stepwise.Rd` | "before version 2.0.0" → 1.2.0 |
| `cran-comments.md` | title → 1.2.0 |
| `RELEASE.md` | reserved-major principle encoded as an explicit override of the mechanical rule, with this episode as the worked example |

The two remaining `2.0.0` strings in `RELEASE.md` are generic illustrations of the decide-at-release choice and of a next-major line — not references to this release — so they stay.

## Verification

- `DESCRIPTION` and `NEWS.md` agree at 1.2.0
- roxygen outputs current
- `lintr::lint_package()` → 0
- Full suite: **1435 pass / 0 fail** (50 warn, 96 skip — all pre-existing)
- `dev`'s NEWS section is a **strict superset** of `main`'s 1.2.0 section, checked entry by entry, so folding drops nothing

## What is deliberately unchanged

The user-facing warning. `hzr_stepwise()` can still select a different variable set on a re-run, and NEWS still says so under **Breaking changes**. The version number is a release decision; the warning is not softened by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)