### PR TITLE
fix: hzr_bootstrap() now resamples vector-interface fits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,21 @@ selects.
 
 ## Bug fixes
 
+* `hzr_bootstrap()` now resamples fits built with the **vector interface**
+  (`time =` / `status =` rather than a formula plus `data`). Previously it
+  resampled `data` only, but a vector-interface call stores `time = d$col` as
+  an *expression*, so every replicate re-evaluated it against the original
+  data and returned the original fit. The result was `n_success = n_boot`,
+  `n_failed = 0`, no warning, and `n_boot` **identical** replicates -- a
+  summary table that looked complete and contained nothing, with `sd` exactly
+  0 on every parameter. The evaluated `time`, `status`, `time_lower` and
+  `time_upper` vectors are already stored on the fitted object, so they are
+  now resampled by the same index as the rows and rewired into each
+  replicate's call, exactly as `data` and `weights` already were. Both
+  interfaces now produce identical bootstrap replicates for the same model,
+  data and seed. Found running a 500-replicate production bagging job that
+  completed in 9.5 minutes and produced no usable output.
+
 * A fit that cannot compute a Hessian now says so. The analytic Hessian
   declines for left- and interval-censored rows by design, the optimizer falls
   back to `numDeriv::hessian()`, and `numDeriv` is a `Suggests` -- so on a

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1457,6 +1457,39 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     )
   }
 
+  # VECTOR-INTERFACE FITS.
+  #
+  # hazard() accepts either a formula plus `data`, or bare `time`/`status`
+  # vectors. Resampling `data` alone is enough for the formula interface, but
+  # NOT for the vector one: the stored call holds `time = d$col` as an
+  # *expression*, so each replicate re-evaluates it against the ORIGINAL data
+  # and returns the original fit. That produced n_success = n_boot, n_failed
+  # = 0, no warning, and n_boot identical replicates -- a bootstrap summary
+  # that looks complete and contains nothing.
+  #
+  # The evaluated vectors are already stored on the object, so they can be
+  # resampled by the same index and rewired the same way `data` and `weights`
+  # are. `x` is excluded deliberately: a design matrix supplied that way is
+  # rebuilt from `data`/`scope` per replicate.
+  vector_interface <- is.null(cl$formula) && !is.null(cl$time)
+  vec_args <- c("time", "status", "time_lower", "time_upper")
+  vec_orig <- if (vector_interface) {
+    stats::setNames(lapply(vec_args, function(a) object$data[[a]]), vec_args)
+  } else {
+    NULL
+  }
+  if (vector_interface) {
+    have <- vapply(vec_orig, function(v) !is.null(v) && length(v) == n_obs, logical(1))
+    if (!any(have[c("time", "status")])) {
+      stop("hzr_bootstrap(): this fit was built with the vector interface ",
+           "(time=/status=), but the evaluated vectors are not stored on the ",
+           "object, so replicates cannot be resampled. Refit with the formula ",
+           "interface (Surv(...) ~ ., data = ...) and bootstrap that.",
+           call. = FALSE)
+    }
+    vec_orig <- vec_orig[have]
+  }
+
   # Parameter names from the fitted model. In fixed-refit mode every
   # replicate shares the same theta layout, so names are resolved once, up
   # front. In select-mode, each replicate can select a different variable
@@ -1492,6 +1525,12 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     rep_env <- new.env(parent = eval_env)
     assign("boot_data", boot_data, envir = rep_env)
     if (!is.null(orig_weights)) assign("boot_weights", boot_weights, envir = rep_env)
+    # Vector-interface arguments follow the same index as the rows.
+    if (vector_interface) {
+      for (a in names(vec_orig)) {
+        assign(paste0("boot_", a), vec_orig[[a]][idx], envir = rep_env)
+      }
+    }
 
     # Per-replicate fits routinely hit ill-conditioned Hessians and other
     # numerical warnings on individual resamples; these are not individually
@@ -1509,6 +1548,9 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
           cl_base <- cl
           cl_base$data <- quote(boot_data)
           if (!is.null(orig_weights)) cl_base$weights <- quote(boot_weights)
+          for (a in names(vec_orig)) {
+            cl_base[[a]] <- as.name(paste0("boot_", a))
+          }
           cl_base$fit <- TRUE
           base_boot <- eval(cl_base, envir = rep_env)
           if (!is.finite(base_boot$fit$objective)) {
@@ -1536,6 +1578,9 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
           cl_boot <- cl
           cl_boot$data <- quote(boot_data)
           if (!is.null(orig_weights)) cl_boot$weights <- quote(boot_weights)
+          for (a in names(vec_orig)) {
+            cl_boot[[a]] <- as.name(paste0("boot_", a))
+          }
           cl_boot$fit <- TRUE
           eval(cl_boot, envir = rep_env)
         }),

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1479,15 +1479,25 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     NULL
   }
   if (vector_interface) {
-    have <- vapply(vec_orig, function(v) !is.null(v) && length(v) == n_obs, logical(1))
-    if (!any(have[c("time", "status")])) {
-      stop("hzr_bootstrap(): this fit was built with the vector interface ",
-           "(time=/status=), but the evaluated vectors are not stored on the ",
-           "object, so replicates cannot be resampled. Refit with the formula ",
-           "interface (Surv(...) ~ ., data = ...) and bootstrap that.",
-           call. = FALSE)
+    # EVERY vector argument the call actually passed must have a stored,
+    # correctly-sized copy. Rewiring only some of them is worse than rewiring
+    # none: the rewired arguments follow the resample while the rest still
+    # evaluate against the original data, so row i's time gets paired with
+    # row j's status or interval bound. That is silent corruption producing
+    # plausible numbers, not an error.
+    passed <- vec_args[vapply(vec_args, function(a) !is.null(cl[[a]]), logical(1))]
+    have   <- vapply(vec_orig, function(v) !is.null(v) && length(v) == n_obs,
+                     logical(1))
+    missing_vecs <- passed[!have[passed]]
+    if (length(missing_vecs)) {
+      stop("hzr_bootstrap(): this fit was built with the vector interface, ",
+           "but the evaluated vector(s) ",
+           paste(sQuote(missing_vecs), collapse = ", "),
+           " are not stored on the object, so replicates cannot be resampled ",
+           "consistently. Refit with the formula interface ",
+           "(Surv(...) ~ ., data = ...) and bootstrap that.", call. = FALSE)
     }
-    vec_orig <- vec_orig[have]
+    vec_orig <- vec_orig[passed]
   }
 
   # Parameter names from the fitted model. In fixed-refit mode every

--- a/tests/testthat/test-bootstrap-vector-interface.R
+++ b/tests/testthat/test-bootstrap-vector-interface.R
@@ -39,8 +39,9 @@ test_that("a vector-interface fit actually resamples", {
 })
 
 test_that("vector and formula interfaces bootstrap identically", {
-  # The strong form: same model, same data, same seed, so the replicates must
-  # agree. "It varies now" would also be satisfied by varying wrongly.
+  # The strong form, and it has to compare the REPLICATES, not a summary of
+  # them: two different sets of replicate estimates can share an SD, so
+  # comparing sd() alone would pass on outputs that differ.
   d <- fixture()
   fv <- suppressWarnings(hazard(
     time = d$int_dead, status = as.integer(d$dead), data = d,
@@ -51,7 +52,15 @@ test_that("vector and formula interfaces bootstrap identically", {
     dist = "multiphase", phases = phases_fixed(),
     fit = TRUE, control = list(n_starts = 1, maxit = 200)))
 
-  expect_equal(sd_log_mu(fv), sd_log_mu(ff), tolerance = 1e-8)
+  bv <- suppressWarnings(hzr_bootstrap(fv, n_boot = 20, seed = 1))
+  bf <- suppressWarnings(hzr_bootstrap(ff, n_boot = 20, seed = 1))
+
+  # Same model, same data, same seed: every replicate estimate must match.
+  expect_equal(bv$replicates, bf$replicates, tolerance = 1e-8)
+  expect_equal(bv$n_success, bf$n_success)
+  # And they must not be trivially equal by both being constant.
+  expect_gt(stats::sd(bv$replicates$estimate[
+    bv$replicates$parameter == "early.log_mu"]), 0)
 })
 
 test_that("time_lower and time_upper are resampled alongside time", {
@@ -71,4 +80,21 @@ test_that("time_lower and time_upper are resampled alongside time", {
     fit = TRUE, control = list(n_starts = 1, maxit = 200)))
 
   expect_gt(sd_log_mu(fit), 0)
+})
+
+test_that("a partially-stored vector-interface fit is refused, not half-rewired", {
+  # Rewiring some vector arguments and not others is worse than rewiring none:
+  # the rewired ones follow the resample while the rest evaluate against the
+  # original data, pairing row i's time with row j's status. Silent corruption
+  # producing plausible numbers.
+  d <- fixture()
+  fit <- suppressWarnings(hazard(
+    time = d$int_dead, status = as.integer(d$dead), data = d,
+    dist = "multiphase", phases = phases_fixed(),
+    fit = TRUE, control = list(n_starts = 1, maxit = 200)))
+
+  # Simulate an object fitted by an older version that did not store `status`.
+  fit$data$status <- NULL
+  expect_error(suppressWarnings(hzr_bootstrap(fit, n_boot = 5, seed = 1)),
+               "status")
 })

--- a/tests/testthat/test-bootstrap-vector-interface.R
+++ b/tests/testthat/test-bootstrap-vector-interface.R
@@ -1,0 +1,74 @@
+# hzr_bootstrap() must resample a fit built with the vector interface.
+#
+# hazard() accepts either a formula plus `data`, or bare time/status vectors.
+# Resampling `data` alone is enough for the formula interface; for the vector
+# one the stored call holds `time = d$col` as an EXPRESSION, so each replicate
+# re-evaluated it against the original data and returned the original fit --
+# n_success = n_boot, n_failed = 0, no warning, and n_boot identical
+# replicates. A bootstrap summary that looked complete and contained nothing.
+
+fixture <- function() {
+  e <- new.env()
+  utils::data("cabgkul", package = "TemporalHazard", envir = e)
+  e$cabgkul
+}
+
+phases_fixed <- function() {
+  list(
+    early = hzr_phase("cdf", t_half = 0.19, nu = 1.4, m = 1,
+                      fixed = c("t_half", "nu", "m")),
+    late  = hzr_phase("g3", tau = 1, gamma = 1, alpha = 1, eta = 1.7,
+                      fixed = c("tau", "gamma", "alpha", "eta"))
+  )
+}
+
+sd_log_mu <- function(fit, n_boot = 20, seed = 1) {
+  b <- suppressWarnings(hzr_bootstrap(fit, n_boot = n_boot, seed = seed))
+  stats::sd(b$replicates$estimate[b$replicates$parameter == "early.log_mu"])
+}
+
+test_that("a vector-interface fit actually resamples", {
+  d <- fixture()
+  fit <- suppressWarnings(hazard(
+    time = d$int_dead, status = as.integer(d$dead), data = d,
+    dist = "multiphase", phases = phases_fixed(),
+    fit = TRUE, control = list(n_starts = 1, maxit = 200)))
+
+  # The regression: this was exactly 0.
+  expect_gt(sd_log_mu(fit), 0)
+})
+
+test_that("vector and formula interfaces bootstrap identically", {
+  # The strong form: same model, same data, same seed, so the replicates must
+  # agree. "It varies now" would also be satisfied by varying wrongly.
+  d <- fixture()
+  fv <- suppressWarnings(hazard(
+    time = d$int_dead, status = as.integer(d$dead), data = d,
+    dist = "multiphase", phases = phases_fixed(),
+    fit = TRUE, control = list(n_starts = 1, maxit = 200)))
+  ff <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = d,
+    dist = "multiphase", phases = phases_fixed(),
+    fit = TRUE, control = list(n_starts = 1, maxit = 200)))
+
+  expect_equal(sd_log_mu(fv), sd_log_mu(ff), tolerance = 1e-8)
+})
+
+test_that("time_lower and time_upper are resampled alongside time", {
+  # Interval-censored rows carry their bounds in separate vectors; resampling
+  # `time` but not the bounds would silently pair row i's time with row j's
+  # interval.
+  d <- fixture()
+  status <- as.integer(d$dead)
+  idx <- which(status == 0L)[1:20]
+  status[idx] <- 2L
+  lower <- pmax(d$int_dead - 0.1, 0)
+
+  fit <- suppressWarnings(hazard(
+    time = d$int_dead, status = status,
+    time_lower = lower, time_upper = d$int_dead, data = d,
+    dist = "multiphase", phases = phases_fixed(),
+    fit = TRUE, control = list(n_starts = 1, maxit = 200)))
+
+  expect_gt(sd_log_mu(fit), 0)
+})


### PR DESCRIPTION
`hazard()` accepts either a formula plus `data`, or bare `time` / `status` vectors. `hzr_bootstrap()` resampled **`data` only** — sufficient for the formula interface, and silently wrong for the vector one.

A vector-interface call stores `time = d$col` as an **expression**. Rewiring `data` to the resampled frame doesn't touch it, so every replicate re-evaluated it against the *original* data and returned the *original fit*.

Measured on the same model, data and seed:

| Interface | `sd(early.log_mu)` over 20 resamples |
|---|---|
| **vector** | **0** |
| formula | 0.0676 |

Both reported `n_success = n_boot`, `n_failed = 0`, and no warning.

## How it surfaced

A 500-replicate production bagging job (AVR / LV-function survival, the R equivalent of `%HAZBOOT`) completed in **9.5 minutes** and produced a summary table holding only the shape parameters, every one with `sd` exactly `0` and not a single covariate. Every signal said it had worked: full progress bar, 500 successes, zero failures, a populated summary. The only tell was that a bootstrap summary containing no covariates is strange.

## Change

The evaluated `time`, `status`, `time_lower` and `time_upper` vectors are **already stored on the fitted object**, so they are now resampled by the same index as the rows and rewired into the replicate call, exactly as `data` and `weights` already were. Applied at both call sites — refit mode and select mode.

`x` is deliberately excluded: a design matrix supplied that way is rebuilt per replicate from `data` / `scope`.

If a vector-interface fit somehow lacks the stored vectors (fitted by an older version), `hzr_bootstrap()` now **stops** and says to refit with the formula interface, rather than returning identical replicates.

## Tests

`tests/testthat/test-bootstrap-vector-interface.R` asserts the **strong** form, not just that it varies now:

- a vector-interface fit resamples at all (`sd > 0`) — the direct regression
- vector and formula interfaces produce **identical** replicates for the same model, data and seed. *Varying wrongly* would satisfy a weaker check; this pins the correct answer.
- `time_lower` / `time_upper` are resampled **alongside** `time` — resampling one and not the others would pair row *i*'s time with row *j*'s interval, which is a silent corruption rather than an error

Full suite: **1999 pass / 0 fail**. `lintr::lint_package()`: 0.

## Note

This is the third silent-failure fix in this family (#112 the Hessian, and the earlier `n_success = 0` call-environment bug). The shape recurs: a bootstrap that reports success and returns nothing usable. A caller cannot distinguish it from a real result without checking that the replicates actually vary — which is not an obvious thing to think to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)