### PR TITLE
fix: translate Surv() status codes instead of passing them through

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,32 @@ selects.
   data and seed. Found running a 500-replicate production bagging job that
   completed in 9.5 minutes and produced no usable output.
 
+* **The formula interface mistranslated left- and interval-censored
+  `Surv()` objects.** `survival::Surv()` and this package use different
+  integer codings for censoring status, and the parser passed `Surv()`'s
+  through unchanged. `Surv(time, event, type = "left")` codes a left-censored
+  row as `0`, which this package reads as *right*-censored: a wrong answer
+  with no error, warning, or other outward sign. Under
+  `type = "interval"` / `"interval2"`, `Surv()` codes rows `0`/`1`/`2`/`3`
+  for right / event / left / interval against this package's `0`/`1`/`-1`/`2`,
+  so left-censored rows were read as interval-censored and interval rows
+  carried a status the likelihood does not recognise at all.
+
+  Two related faults in the same branch: `Surv()` stores the status in its
+  `time2` column for every non-interval row, and the parser read that
+  sentinel as an upper bound; and it set `time_lower` for every row, which
+  the likelihood treats as a counting-process *entry* time when status is
+  `0` or `1`, cancelling each exact-event and right-censored row out of the
+  likelihood. Together these made an interval-censored formula fit return
+  the optimizer's failure sentinel rather than a fit.
+
+  Status codes are now translated, an upper bound is taken only from a
+  genuine interval row, and `time_lower` left-truncates only interval rows.
+  A regression test asserts that a `Surv(type = "interval")` fit reproduces
+  the equivalent vector-interface fit to 1e-8 in log-likelihood.
+  Found when a production study's three interval-censored records could only
+  be expressed through the vector interface.
+
 * A fit that cannot compute a Hessian now says so. The analytic Hessian
   declines for left- and interval-censored rows by design, the optimizer falls
   back to `numDeriv::hessian()`, and `numDeriv` is a `Suggests` -- so on a

--- a/R/formula-helpers.R
+++ b/R/formula-helpers.R
@@ -9,6 +9,20 @@
 #' The start times are returned as `time_lower` and stop times as `time`,
 #' enabling the likelihood to compute `H(stop) - H(start)` per epoch.
 #'
+#' `Surv()` and this package code censoring status differently, so the
+#' returned `status` is translated, not passed through:
+#'
+#' | Meaning   | TemporalHazard | `Surv` "left" | `Surv` "interval" |
+#' | --------- | -------------- | ------------- | ----------------- |
+#' | left      | `-1`           | `0`           | `2`               |
+#' | right     | `0`            | --            | `0`               |
+#' | event     | `1`            | `1`           | `1`               |
+#' | interval  | `2`            | --            | `3`               |
+#'
+#' Under `type = "interval"`, `Surv()` reuses the `time2` column to hold the
+#' status of any non-interval row, so an upper bound is read only where the
+#' row is genuinely interval-censored.
+#'
 #' @param formula A formula object with Surv() on the LHS.
 #' @param data A data frame containing variables referenced in the formula.
 #' @return A list with elements: time, status, time_lower, time_upper, x
@@ -51,17 +65,31 @@
     time_lower <- NULL
     time_upper <- NULL
   } else if (surv_type == "left") {
-    # Format: [time, status]
+    # Format: [time, status], where Surv codes 1 = event, 0 = left-censored.
+    # TemporalHazard codes left-censoring as -1; passing 0 through would
+    # silently read these rows as right-censored.
     time <- surv_mat[, 1L]
-    status <- surv_mat[, 2L]
+    status <- ifelse(surv_mat[, 2L] == 0, -1, 1)
     time_lower <- NULL
     time_upper <- surv_mat[, 1L]
   } else if (surv_type == "interval") {
-    # Format: [time1, time2, status]
-    time_lower <- surv_mat[, 1L]
+    # Format: [time1, time2, status], where Surv codes
+    #   0 = right-censored, 1 = event, 2 = left-censored, 3 = interval.
+    # Map onto TemporalHazard's 0 / 1 / -1 / 2.
+    surv_status <- surv_mat[, 3L]
+    status <- c(0, 1, -1, 2)[surv_status + 1L]
     time <- surv_mat[, 1L]
-    time_upper <- surv_mat[, 2L]
-    status <- surv_mat[, 3L]
+
+    # Surv stores the status in `time2` for every non-interval row, so that
+    # column is a sentinel except where surv_status == 3.
+    is_interval <- surv_status == 3
+    time_upper <- ifelse(is_interval, surv_mat[, 2L], time)
+
+    # `time_lower` doubles as the counting-process entry time for status
+    # 0 and 1, where the likelihood forms H(stop) - H(start).  Surv
+    # "interval" carries no left truncation, so entry time is 0 outside the
+    # interval rows; using `time` there would cancel those rows out.
+    time_lower <- ifelse(is_interval, surv_mat[, 1L], 0)
   } else if (surv_type == "counting") {
     # Start-stop (counting process) format: Surv(start, stop, event)
     # Used for repeating events / epoch-decomposed longitudinal data.

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -111,7 +111,14 @@ NULL
 #' @param time_upper Optional numeric upper bound vector for censoring intervals.
 #'   Used when `status %in% c(-1, 2)`; defaults to `time` if NULL.
 #' @param x Optional design matrix (or data frame coercible to matrix).
-#' @param formula Optional formula of the form `Surv(time, status) ~ predictors`.
+#' @param formula Optional formula with a `Surv()` object on the left.
+#'   Right-censored (`Surv(time, status)`), left-censored
+#'   (`Surv(time, event, type = "left")`), interval-censored
+#'   (`type = "interval"` or `"interval2"`) and counting-process
+#'   (`Surv(start, stop, event)`) forms are all accepted. `Surv()` codes
+#'   censoring status with different integers than this package does; the
+#'   formula path translates them, so write `Surv()`'s codes here and this
+#'   package's codes when passing `status` directly.
 #'   When provided, overrides direct time/status/x arguments and extracts from data.
 #'   Example: `hazard(Surv(time, status) ~ x1 + x2, data = df, dist = "weibull", fit = TRUE)`.
 #' @param data Optional data frame containing variables referenced in formula.

--- a/man/dot-hzr_parse_formula.Rd
+++ b/man/dot-hzr_parse_formula.Rd
@@ -24,5 +24,19 @@ counting-process (start-stop) data.
 For counting-process (start-stop) data, use \code{Surv(start, stop, event)}.
 The start times are returned as \code{time_lower} and stop times as \code{time},
 enabling the likelihood to compute \code{H(stop) - H(start)} per epoch.
+
+\code{Surv()} and this package code censoring status differently, so the
+returned \code{status} is translated, not passed through:\tabular{llll}{
+   Meaning \tab TemporalHazard \tab \code{Surv} "left" \tab \code{Surv} "interval" \cr
+   left \tab \code{-1} \tab \code{0} \tab \code{2} \cr
+   right \tab \code{0} \tab -- \tab \code{0} \cr
+   event \tab \code{1} \tab \code{1} \tab \code{1} \cr
+   interval \tab \code{2} \tab -- \tab \code{3} \cr
+}
+
+
+Under \code{type = "interval"}, \code{Surv()} reuses the \code{time2} column to hold the
+status of any non-interval row, so an upper bound is read only where the
+row is genuinely interval-censored.
 }
 \keyword{internal}

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -23,7 +23,14 @@ hazard(
 )
 }
 \arguments{
-\item{formula}{Optional formula of the form \code{Surv(time, status) ~ predictors}.
+\item{formula}{Optional formula with a \code{Surv()} object on the left.
+Right-censored (\code{Surv(time, status)}), left-censored
+(\code{Surv(time, event, type = "left")}), interval-censored
+(\code{type = "interval"} or \code{"interval2"}) and counting-process
+(\code{Surv(start, stop, event)}) forms are all accepted. \code{Surv()} codes
+censoring status with different integers than this package does; the
+formula path translates them, so write \code{Surv()}'s codes here and this
+package's codes when passing \code{status} directly.
 When provided, overrides direct time/status/x arguments and extracts from data.
 Example: \code{hazard(Surv(time, status) ~ x1 + x2, data = df, dist = "weibull", fit = TRUE)}.}
 

--- a/tests/testthat/test-formula-helpers.R
+++ b/tests/testthat/test-formula-helpers.R
@@ -43,7 +43,7 @@ test_that("left-censored Surv sets time_upper but not time_lower", {
   )
 
   expect_equal(out$time,       df$t)
-  expect_equal(out$status,     df$d)
+  expect_equal(out$status,     c(1, -1, 1))   # Surv 0 = left-censored -> -1
   expect_null(out$time_lower)
   expect_equal(out$time_upper, df$t)
   expect_null(out$x)
@@ -64,12 +64,80 @@ test_that("interval-censored Surv extracts time_lower + time_upper + status", {
     data = df
   )
 
-  # interval status codes coming out of Surv are 0/1/2/3; the parser
-  # keeps them as-is, just routes lower/upper columns.
+  # Surv codes every row here as 3 (interval); the parser recodes to
+  # TemporalHazard's 2.  Asserting the value matters -- an earlier version
+  # of this test checked `status %in% c(0, 1, 2, 3)`, which is the full set
+  # of codes Surv can emit and so could never fail.
   expect_length(out$time, 3)
   expect_equal(out$time_lower, df$lo)
   expect_equal(out$time_upper, df$hi)
-  expect_true(all(out$status %in% c(0, 1, 2, 3)))
+  expect_equal(out$status, rep(2, 3))
+})
+
+# ---------------------------------------------------------------------------
+# Surv() status codes are not TemporalHazard status codes
+#
+# survival::Surv() and this package disagree on the integer coding, so the
+# parser has to translate rather than pass through:
+#
+#   TemporalHazard   -1 left   0 right   1 event   2 interval
+#   Surv "left"                0 left    1 event
+#   Surv "interval"            0 right   1 event   2 left   3 interval
+#
+# For a non-interval row, Surv stores the status in the `time2` column, so
+# `time2` is a sentinel there and must never be read as an upper bound.
+# ---------------------------------------------------------------------------
+
+test_that("left-censored Surv recodes status 0 to TemporalHazard's -1", {
+  df <- data.frame(
+    t = c(1, 2, 3),
+    d = c(1, 0, 1)   # Surv "left": 1 = event, 0 = left-censored
+  )
+  out <- parse(survival::Surv(t, d, type = "left") ~ 1, data = df)
+
+  expect_equal(out$status, c(1, -1, 1))
+})
+
+test_that("interval Surv recodes all four status codes", {
+  df <- data.frame(
+    lo = c(1, 2, 3, 4),
+    hi = c(NA, NA, NA, 6),
+    ev = c(1, 0, 2, 3)   # event, right-censored, left-censored, interval
+  )
+  out <- parse(survival::Surv(lo, hi, ev, type = "interval") ~ 1, data = df)
+
+  expect_equal(out$status, c(1, 0, -1, 2))
+})
+
+test_that("interval Surv never reads an upper bound from the time2 sentinel", {
+  # Surv writes 1 into time2 for every non-interval row.  Only the genuine
+  # interval row (4, 6) has an upper bound; the rest must fall back to `time`.
+  df <- data.frame(
+    lo = c(1, 2, 3, 4),
+    hi = c(NA, NA, NA, 6),
+    ev = c(1, 0, 2, 3)
+  )
+  out <- parse(survival::Surv(lo, hi, ev, type = "interval") ~ 1, data = df)
+
+  expect_equal(out$time,       c(1, 2, 3, 4))
+  expect_equal(out$time_upper, c(1, 2, 3, 6))
+})
+
+test_that("interval Surv does not left-truncate non-interval rows", {
+  # `time_lower` is overloaded: the interval lower bound when status == 2,
+  # but the counting-process entry time when status is 0 or 1, where the
+  # likelihood forms H(stop) - H(start).  Surv "interval" carries no
+  # truncation, so entry time is 0 for every non-interval row -- setting it
+  # to the observed time instead would cancel those rows out of the
+  # likelihood entirely.
+  df <- data.frame(
+    lo = c(1, 2, 3, 4),
+    hi = c(NA, NA, NA, 6),
+    ev = c(1, 0, 2, 3)
+  )
+  out <- parse(survival::Surv(lo, hi, ev, type = "interval") ~ 1, data = df)
+
+  expect_equal(out$time_lower, c(0, 0, 0, 4))
 })
 
 # ---------------------------------------------------------------------------

--- a/tests/testthat/test-interval-censoring-multiphase.R
+++ b/tests/testthat/test-interval-censoring-multiphase.R
@@ -139,3 +139,59 @@ test_that("multiphase fit converges on an interval-censored sample", {
   # Two intercepts estimated (early + constant), shapes held fixed.
   expect_length(fit$fit$theta, 5L)
 })
+
+# ---------------------------------------------------------------------------
+# Formula interface parity
+#
+# The production job that surfaced this could not express its three
+# interval-censored records through the formula interface -- the fit returned
+# the optimizer's failure sentinel -- and fell back to the vector interface,
+# which in turn could not be bootstrapped.  The two interfaces must describe
+# the same data.
+# ---------------------------------------------------------------------------
+
+test_that("Surv(type = 'interval') fits identically to the vector interface", {
+  set.seed(20260817)
+  n  <- 400
+  df <- data.frame(x = rnorm(n))
+  t  <- rexp(n, rate = 0.25 * exp(0.6 * df$x))
+
+  # Statuses: right-censored at 6, exact event, or observed in an interval.
+  ev <- ifelse(t >= 6, 0L, 1L)
+  t  <- pmin(t, 6)
+  iv <- which(ev == 1L)[1:40]        # 40 events known only within a window
+  lo <- t
+  hi <- rep(NA_real_, n)
+  lo[iv] <- pmax(t[iv] - 0.4, 1e-6)
+  hi[iv] <- t[iv] + 0.4
+  ev[iv] <- 3L                        # Surv "interval" code
+
+  ph  <- mp_ic_phases()
+  ctl <- list(n_starts = 1, maxit = 2000)
+
+  df$lo <- lo; df$hi <- hi; df$ev <- ev
+  fit_formula <- hazard(survival::Surv(lo, hi, ev, type = "interval") ~ x,
+                        data = df, dist = "multiphase", phases = ph,
+                        fit = TRUE, control = ctl)
+
+  # Same data spelled out in TemporalHazard's own coding.
+  fit_vector <- hazard(
+    time        = lo,
+    status      = ifelse(ev == 3L, 2, ev),
+    time_lower  = ifelse(ev == 3L, lo, 0),
+    time_upper  = ifelse(ev == 3L, hi, lo),
+    x           = as.matrix(df["x"]),
+    dist = "multiphase", phases = ph, fit = TRUE, control = ctl)
+
+  # Assert both fits produced a real number before comparing them -- two
+  # absent objectives compare equal and would report parity that was never
+  # tested.
+  expect_true(is.finite(fit_formula$fit$objective))
+  expect_true(is.finite(fit_vector$fit$objective))
+  expect_length(coef(fit_formula), length(coef(fit_vector)))
+
+  expect_equal(fit_formula$fit$objective, fit_vector$fit$objective,
+               tolerance = 1e-8)
+  expect_equal(unname(coef(fit_formula)), unname(coef(fit_vector)),
+               tolerance = 1e-6)
+})

--- a/tests/testthat/test-interval-censoring-multiphase.R
+++ b/tests/testthat/test-interval-censoring-multiphase.R
@@ -169,7 +169,9 @@ test_that("Surv(type = 'interval') fits identically to the vector interface", {
   ph  <- mp_ic_phases()
   ctl <- list(n_starts = 1, maxit = 2000)
 
-  df$lo <- lo; df$hi <- hi; df$ev <- ev
+  df$lo <- lo
+  df$hi <- hi
+  df$ev <- ev
   fit_formula <- hazard(survival::Surv(lo, hi, ev, type = "interval") ~ x,
                         data = df, dist = "multiphase", phases = ph,
                         fit = TRUE, control = ctl)

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -355,10 +355,21 @@ The package encodes censoring type in the `status` vector:
 | `2` | Interval-censored | Event occurred in `(time_lower, time_upper)` |
 | `-1` | Left-censored | Event occurred before `time` (upper bound) |
 
-For interval-censored rows, supply both `time_lower` and `time_upper`
-directly to `hazard()`.  The formula interface handles `Surv(time, status)`
-for right-censored data and `Surv(start, stop, event)` for counting-process
-(repeating-event) data; interval censoring is passed via the direct arguments.
+For interval-censored rows, supply both `time_lower` and `time_upper`.  You
+can pass them as direct arguments to `hazard()`, or hand it a `Surv()`
+object instead: `Surv(lower, upper, event, type = "interval")` and
+`Surv(lower, upper, type = "interval2")` both work, as do
+`Surv(time, event, type = "left")` for left censoring and
+`Surv(start, stop, event)` for counting-process (repeating-event) data.
+
+One thing to watch, because the two interfaces do not use the same numbers.
+The table above is this package's coding, and it is what you pass to the
+`status` argument.  `Surv()` has its own scheme --- under
+`type = "interval"` it reads `0` as right-censored, `1` as an exact event,
+`2` as left-censored and `3` as interval-censored --- and `hazard()`
+translates it for you when it parses the formula.  So use whichever coding
+belongs to the interface you are writing in, and don't carry one set of
+codes across to the other.
 
 ### Mixed censoring example
 


### PR DESCRIPTION
## Summary

`survival::Surv()` and this package use **different integer codings for censoring status**, and `.hzr_parse_formula()` passed `Surv()`'s through unchanged.

| Meaning | TemporalHazard | `Surv` `"left"` | `Surv` `"interval"` |
|---|---|---|---|
| left | `-1` | `0` | `2` |
| right | `0` | — | `0` |
| event | `1` | `1` | `1` |
| interval | `2` | — | `3` |

Three defects follow, in ascending order of how hard they are to notice:

1. **`type = "interval"` rows arrive as status `3`**, which the likelihood recognises in no branch.
2. **`Surv` left-censored rows arrive as TemporalHazard "interval"**, with a garbage upper bound — `Surv` reuses its `time2` column to hold the status of every non-interval row, and the parser read that sentinel as a bound.
3. **`Surv(t, e, type = "left")` silently reads left-censored rows as right-censored.** No error, no warning, no sentinel — just a wrong answer.

A fourth fault sits in the same branch and is independent of the status codes: `time_lower` was set for *every* row. The likelihood treats `time_lower` as the counting-process **entry time** when status is `0` or `1`, forming `H(stop) - H(start)`. With `time_lower == time`, every exact-event and right-censored row contributed nothing. `Surv` `"interval"` carries no left truncation, so entry time is now `0` outside genuine interval rows.

## Why it surfaced now

The AVR / LV-function production job has three interval-censored records among 1032 events. `Surv(l, u, ev, type = "interval")` returned the optimizer's `-1e10` failure sentinel, so the job fell back to the vector interface — which, until #113, could not then be bootstrapped. Stage 4 still carries a written concession treating those three records as right-censored. This removes the reason for it.

## Two existing tests asserted the defect

- `test-formula-helpers.R:46` expected the `type = "left"` status to pass through, i.e. asserted that left-censored rows come out as right-censored.
- The interval test asserted `all(out$status %in% c(0, 1, 2, 3))` — the complete set of codes `Surv` can emit. **That assertion could never fail.**

Both now assert the translated values.

## Verification

Watched all five new tests fail before fixing. The integration test is the load-bearing one — with the parser reverted it reports:

```
Expected `fit_formula$fit$objective` to equal `fit_vector$fit$objective`.
  `actual`: 186201.6
`expected`:   -666.9
```

After the fix a `Surv(type = "interval")` fit reproduces the equivalent vector-interface fit to 1e-8 in log-likelihood and 1e-6 in coefficients.

Full suite: **0 failures, 1514 passing, 96 documented `skip_on_cran`.**

## Note for review

`time_lower` is genuinely overloaded — interval lower bound when `status == 2`, counting-process entry time when `status` is `0`/`1`. Splitting it into two arguments would be the cleaner design, but that is a breaking API change and this is days from a CRAN submission, so it is handled inside the parser here. Worth revisiting after 1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)