### PR TITLE
fix: three blind spots in stepwise/bootstrap variable selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -114,6 +114,30 @@ selects.
   replicate is evaluated in a child of it that carries the resampled data and
   weights. Affects both `refit` and `select` modes.
 
+* **`hzr_bootstrap(scope = ...)` selected nothing when the base fit's formula
+  was passed by symbol.** `hazard()` records its call with `match.call()`, so a
+  formula assigned to a variable first (`f <- Surv(t, d) ~ 1; hazard(f, ...)`)
+  is stored as a *symbol* rather than a call. The scope-mutating refit
+  recovered it with `as.formula(deparse(...))`, which turns that symbol into
+  the string `"f"` and errors with `invalid formula "f": not a call`. Every
+  post-entry refit therefore failed, no candidate ever entered, and the run
+  reported `n_success = n_boot`, `n_failed = 0`, no error and no warning --
+  with a summary holding only the base model's parameters. The stored formula
+  is now evaluated in the fit's recorded calling environment, which handles
+  the literal and by-symbol forms alike, and a stored formula that fails to
+  resolve raises an error naming the problem instead of degrading to an empty
+  screen. The same defect affected `hzr_stepwise()` directly. (#114)
+
+* **A select-mode `hzr_bootstrap()` run that selects no covariate now warns.**
+  The base model's own parameters appear in every replicate by construction,
+  so they fill the summary at `pct = 100` and an empty screen reads as a set
+  of perfectly reliable variables; nothing in the output prompted the reader
+  to compare the parameter names against `names(coef(object))`. The warning
+  names the likely causes: an entry criterion stricter than intended, a
+  `scope` naming columns absent from the data, or a base fit whose stored call
+  cannot be rewritten. Legitimate empty screens warn too -- an entry criterion
+  no candidate can clear is also worth reporting. (#115)
+
 * `hzr_bootstrap()` no longer floods the console with per-replicate numerical
   warnings (e.g. ill-conditioned-Hessian notes from unstable resamples), which
   are not individually actionable when the bootstrap aggregates over replicates.

--- a/NEWS.md
+++ b/NEWS.md
@@ -138,6 +138,33 @@ selects.
   cannot be rewritten. Legitimate empty screens warn too -- an entry criterion
   no candidate can clear is also worth reporting. (#115)
 
+* **A stepwise screen that could not score anything now says so, instead of
+  looking like one that finished.** Under `criterion = "score"` a candidate
+  whose Q statistic cannot be computed -- a degenerate or collinear column,
+  or an information matrix that will not invert on this data -- yields `NA`
+  and is dropped from consideration. When that happened to every remaining
+  candidate the step returned exactly what a legitimate "no candidate met
+  `slentry`" stop returns, so a screen that stopped because it was *unable
+  to test* its candidates was indistinguishable from one that tested them
+  and found nothing. The per-step diagnostic existed on the returned object
+  the whole time and had no readers.
+
+  `hzr_stepwise()` now warns when a run stops this way and reports
+  `$criteria$n_uncomputable_scores`. Because `hzr_bootstrap()` runs each
+  replicate under `suppressWarnings()` -- deliberately, so per-replicate
+  numerical noise does not swamp the console -- that warning cannot surface
+  in the mode where it matters most, so the count is aggregated instead:
+  `hzr_bootstrap()` gains `$n_uncomputable_replicates` and warns once when it
+  is non-zero. A replicate that scored nothing still counts toward
+  `n_success` while contributing no selections, so it silently depresses
+  every reported selection frequency -- which is the whole deliverable of a
+  bootstrap screen.
+
+  Found by a pre-release review pass, not by a failing test: the package's
+  own `print.hzr_bootstrap` test runs a five-replicate screen in which four
+  replicates cannot score a candidate and none selects anything, and it
+  passed throughout because it only ever asserted the printed label.
+
 * `hzr_bootstrap()` no longer floods the console with per-replicate numerical
   warnings (e.g. ill-conditioned-Hessian notes from unstable resamples), which
   are not individually actionable when the bootstrap aggregates over replicates.

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1295,6 +1295,12 @@ print.hzr_nelson <- function(x, digits = 4, ...) {
 #'     and the other statistics are conditional on selection.}
 #'   \item{n_success}{Number of successfully converged replicates.}
 #'   \item{n_failed}{Number of replicates that failed to converge.}
+#'   \item{n_uncomputable_replicates}{Select mode only: number of otherwise
+#'     successful replicates whose screen stopped because no remaining
+#'     candidate's score statistic could be computed, rather than because no
+#'     candidate met `slentry`. Such replicates contribute no selections, so
+#'     a non-zero count means every reported selection frequency is
+#'     depressed. Always `0` in refit mode.}
 #'   \item{mode}{`"refit"` (fixed-formula bootstrap) or `"select"`
 #'     (embedded stepwise selection).}
 #'   \item{scope}{Only present when `mode == "select"`: the candidate
@@ -1518,6 +1524,11 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   rep_list <- vector("list", n_boot)
   n_success <- 0L
   n_failed <- 0L
+  # Replicates whose stepwise screen stopped because no candidate's score
+  # could be computed.  Each replicate runs under suppressWarnings(), so the
+  # step-level warning never reaches the user here; the count has to be read
+  # off the returned objects and reported in aggregate.
+  n_uncomputable_reps <- 0L
 
   # Progress bar over replicates (verbose only). Closed after the loop.
   pb <- if (verbose) utils::txtProgressBar(min = 0, max = n_boot, style = 3)
@@ -1600,6 +1611,10 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
 
     if (!is.null(boot_fit) && is.finite(boot_fit$fit$objective)) {
       n_success <- n_success + 1L
+      if (select_mode &&
+            isTRUE(boot_fit$criteria$stopped_uncomputable)) {
+        n_uncomputable_reps <- n_uncomputable_reps + 1L
+      }
       theta_b <- boot_fit$fit$theta
       names_b <- if (select_mode) {
         .hzr_bootstrap_param_names(boot_fit)
@@ -1684,11 +1699,22 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     }
   }
 
+  if (n_uncomputable_reps > 0L) {
+    warning(n_uncomputable_reps, " of ", n_success, " successful replicates ",
+            "stopped because the score statistic could not be computed for ",
+            "any remaining candidate, rather than because no candidate met ",
+            "`slentry`. Those replicates contribute no selections, so every ",
+            "reported selection frequency is depressed by them. Usual causes ",
+            "are a degenerate or collinear candidate column and resamples on ",
+            "which the information matrix is not invertible.", call. = FALSE)
+  }
+
   result <- list(
     replicates = replicates,
     summary    = summary_df,
     n_success  = n_success,
     n_failed   = n_failed,
+    n_uncomputable_replicates = n_uncomputable_reps,
     mode       = if (select_mode) "select" else "refit"
   )
   if (select_mode) result$scope <- scope

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1666,6 +1666,24 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
                               stringsAsFactors = FALSE)
   }
 
+  # A selection frequency is the whole deliverable of a select-mode run, so a
+  # screen that never selected anything is the result being empty rather than
+  # a quiet edge case.  It cannot be read off the object either: the base
+  # model's own parameters appear in every replicate by construction, so they
+  # fill the summary at pct = 100 and the table looks like a set of perfectly
+  # reliable variables.
+  if (select_mode && n_success > 0L) {
+    selected <- setdiff(unique(replicates$parameter), names(coef(object)))
+    if (length(selected) == 0L) {
+      warning("Bootstrap selection selected no covariate in any of the ",
+              n_success, " successful replicates. The summary holds only the ",
+              "base model's parameters, each at pct = 100. Common causes: ",
+              "`slentry` stricter than intended; a `scope` naming columns ",
+              "absent from the data; or a base fit whose stored call cannot ",
+              "be rewritten for the refit.", call. = FALSE)
+    }
+  }
+
   result <- list(
     replicates = replicates,
     summary    = summary_df,

--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -83,8 +83,12 @@
   extra_args <- user_args[!names(user_args) %in%
                             c("weights", "time_windows")]
 
-  # Recover the original formula.  match.call() stores the formula arg
-  # as an unevaluated `call`; coerce to a real formula.
+  # Recover the original formula.  match.call() stores the `formula` arg
+  # unevaluated, so it arrives as a `call` when the caller wrote it out at
+  # the hazard() call and as a *symbol* when they passed a variable holding
+  # it.  Evaluating in the recorded calling environment covers both;
+  # deparsing does not, because deparse(quote(f)) is "f", which as.formula()
+  # rejects as "not a call".
   raw_formula <- current$call$formula
   if (is.null(raw_formula)) {
     stop("`current` was not built via the formula interface; refit ",
@@ -93,7 +97,12 @@
   current_formula <- if (inherits(raw_formula, "formula")) {
     raw_formula
   } else {
-    stats::as.formula(deparse(raw_formula))
+    eval(raw_formula, envir = current$call_env %||% parent.frame())
+  }
+  if (!inherits(current_formula, "formula")) {
+    stop("`current`'s stored model formula (", deparse(raw_formula),
+         ") did not resolve to a formula. Refit the base model with the ",
+         "formula written at the `hazard()` call.", call. = FALSE)
   }
 
   if (dist == "multiphase") {

--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -97,7 +97,23 @@
   current_formula <- if (inherits(raw_formula, "formula")) {
     raw_formula
   } else {
-    eval(raw_formula, envir = current$call_env %||% parent.frame())
+    # Evaluating can fail outright when the formula was passed by variable
+    # and that binding is gone -- after saveRDS()/readRDS() in a new
+    # session, say.  Bare, the error reads "object 'f' not found", which
+    # names neither the fit at fault nor the remedy, and callers that wrap
+    # candidate refits in tryCatch() reduce it to a generic failure.
+    tryCatch(
+      eval(raw_formula, envir = current$call_env %||% parent.frame()),
+      error = function(e) {
+        stop("`current`'s stored model formula (", deparse(raw_formula),
+             ") could not be resolved: ", conditionMessage(e),
+             ". The formula was passed to `hazard()` by variable and that ",
+             "binding is no longer reachable -- for example after saving ",
+             "and reloading the fit in a new session. Refit the base model ",
+             "with the formula written at the `hazard()` call.",
+             call. = FALSE)
+      }
+    )
   }
   if (!inherits(current_formula, "formula")) {
     stop("`current`'s stored model formula (", deparse(raw_formula),

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -366,9 +366,22 @@
   all_scores <- do.call(rbind, rows)
 
   valid <- which(!is.na(all_scores$score))
+
+  # A candidate whose Q could not be computed (degenerate or collinear
+  # column, uninvertible nuisance block) scores NA and drops out of `valid`
+  # silently.  Count them so the caller can tell a screen that finished from
+  # one that could not run: both otherwise return the same empty step.
+  n_uncomputable <- sum(is.na(all_scores$score))
+
   if (length(valid) == 0L) {
     out <- null_result()
-    out$all_scores <- all_scores
+    out$all_scores     <- all_scores
+    out$n_uncomputable <- n_uncomputable
+    out$stop_reason    <- if (n_uncomputable > 0L) {
+      "scores_uncomputable"
+    } else {
+      "no_candidates"
+    }
     return(out)
   }
 
@@ -377,7 +390,9 @@
 
   if (!(best$score < slentry)) {
     out <- null_result()
-    out$all_scores <- all_scores
+    out$all_scores     <- all_scores
+    out$n_uncomputable <- n_uncomputable
+    out$stop_reason    <- "no_candidate_met_slentry"
     return(out)
   }
 
@@ -404,6 +419,8 @@
     out <- null_result()
     out$all_scores     <- all_scores
     out$refit_failures <- failure_token
+    out$n_uncomputable <- n_uncomputable
+    out$stop_reason    <- "refit_failed"
     return(out)
   }
 
@@ -418,7 +435,9 @@
     stat      = best$stat,
     df        = best$df,
     all_scores = all_scores,
-    refit_failures = character()
+    refit_failures = character(),
+    n_uncomputable = n_uncomputable,
+    stop_reason    = "accepted"
   )
 }
 

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -257,6 +257,12 @@ hzr_stepwise <- function(fit,
   current <- fit
   step_no <- 0L
   stopped_by_max_steps <- FALSE
+  # Candidates whose score statistic could not be computed, summed over
+  # steps.  Tracked so a screen that stopped because nothing was
+  # computable is distinguishable from one that stopped because nothing
+  # was good enough -- the two produce identical empty steps otherwise.
+  n_uncomputable_scores <- 0L
+  stopped_uncomputable  <- FALSE
 
   # `crit` is the criterion actually applied to THIS step, which is not always
   # the run's `criterion`: score is entry-only, so its drops are decided by
@@ -357,6 +363,12 @@ hzr_stepwise <- function(fit,
         force_out = effective_force_out
       ), extra_args))
 
+      n_uncomputable_scores <- n_uncomputable_scores +
+        (fwd$n_uncomputable %||% 0L)
+      if (identical(fwd$stop_reason, "scores_uncomputable")) {
+        stopped_uncomputable <- TRUE
+      }
+
       if (fwd$accepted) {
         current <- fwd$fit
         record_step("enter", fwd)
@@ -429,8 +441,20 @@ hzr_stepwise <- function(fit,
     slstay    = slstay,
     max_steps = max_steps,
     max_move  = max_move,
-    hit_max_steps = stopped_by_max_steps
+    hit_max_steps = stopped_by_max_steps,
+    n_uncomputable_scores = n_uncomputable_scores,
+    stopped_uncomputable  = stopped_uncomputable
   )
+
+  if (stopped_uncomputable) {
+    warning("Stepwise selection stopped because the score statistic ",
+            "could not be computed for any remaining candidate (",
+            n_uncomputable_scores, " candidate score(s) were NA across the ",
+            "run). This is not the same as no candidate meeting `slentry`: ",
+            "the screen stopped without being able to test them. Usual ",
+            "causes are a degenerate or collinear candidate column and an ",
+            "uninvertible information matrix on this data.", call. = FALSE)
+  }
   result$trace_msg  <- trace_msg
   result$elapsed    <- elapsed
   result$final_call <- call

--- a/man/hzr_bootstrap.Rd
+++ b/man/hzr_bootstrap.Rd
@@ -90,6 +90,12 @@ parameter. In \code{mode = "select"}, \code{pct} is the selection frequency
 and the other statistics are conditional on selection.}
 \item{n_success}{Number of successfully converged replicates.}
 \item{n_failed}{Number of replicates that failed to converge.}
+\item{n_uncomputable_replicates}{Select mode only: number of otherwise
+successful replicates whose screen stopped because no remaining
+candidate's score statistic could be computed, rather than because no
+candidate met \code{slentry}. Such replicates contribute no selections, so
+a non-zero count means every reported selection frequency is
+depressed. Always \code{0} in refit mode.}
 \item{mode}{\code{"refit"} (fixed-formula bootstrap) or \code{"select"}
 (embedded stepwise selection).}
 \item{scope}{Only present when \code{mode == "select"}: the candidate

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -966,13 +966,19 @@ test_that("hzr_bootstrap suppresses per-replicate fit warnings", {
     ),
     fit = TRUE
   )
-  expect_no_warning(
+  # Assert the contract this test exists for -- no *per-replicate numerical*
+  # warning escapes -- rather than "no warning at all". The aggregate
+  # uncomputable-score summary is emitted once after the loop, not per
+  # replicate, so a blanket expect_no_warning() here would forbid a
+  # diagnostic this test was never meant to cover.
+  w <- testthat::capture_warnings(
     hzr_bootstrap(base, n_boot = 5, seed = 7,
                   scope = list(early    = ~ age + mal + com_iv,
                                constant = ~ age + mal + com_iv),
                   slentry = 0.3, slstay = 0.2,
                   control = list(n_starts = 1))
   )
+  expect_false(any(grepl("ill-conditioned|rcond|Hessian", w)))
 })
 
 test_that("hzr_bootstrap scope raises immediately on a structurally invalid scope", {
@@ -1071,9 +1077,17 @@ test_that("print.hzr_bootstrap reports the mode", {
     theta = c(mu = 0.01, nu = 0.5),
     fit   = TRUE
   )
-  bs_sel <- hzr_bootstrap(base, n_boot = 5, seed = 42, scope = ~ age + mal,
-                           control = list(n_starts = 1))
+  # This screen selects nothing in all five replicates, and four of the five
+  # cannot even score a candidate -- surfaced by the uncomputable-score
+  # warning added alongside this comment. The test only ever asserted the
+  # print label, so it passed throughout. Kept as-is because the print
+  # contract is what it covers; the empty screen is tracked separately.
+  bs_sel <- suppressWarnings(
+    hzr_bootstrap(base, n_boot = 5, seed = 42, scope = ~ age + mal,
+                  control = list(n_starts = 1))
+  )
   expect_output(print(bs_sel), "stepwise selection")
+  expect_gt(bs_sel$n_uncomputable_replicates, 0L)
 })
 
 
@@ -1201,4 +1215,52 @@ test_that("hzr_bootstrap does not warn when a screen does select covariates", {
   )
   expect_gt(length(setdiff(unique(boot$replicates$parameter),
                            names(coef(fit)))), 0L)
+})
+
+
+test_that("hzr_bootstrap reports replicates whose scores were uncomputable", {
+  # hzr_bootstrap() deliberately wraps each replicate in suppressWarnings(),
+  # so the step-level warning is invisible here -- exactly the mode where a
+  # silently-unscoreable candidate matters most, since a replicate that
+  # could not test anything still counts toward n_success and drags every
+  # selection frequency down.  The count therefore has to be aggregated off
+  # the returned objects rather than left to a warning.
+  data(avc)
+  avc$constcol <- 1.0     # numeric, present, and degenerate -> Q is NA
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  fit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+                phases = phases, fit = TRUE,
+                control = list(n_starts = 1L, maxit = 400L))
+
+  w <- testthat::capture_warnings(
+    boot <- hzr_bootstrap(fit, n_boot = 3, seed = 1,
+                          scope = list(early = ~ constcol),
+                          criterion = "score", direction = "forward",
+                          slentry = 0.5, slstay = 0.5)
+  )
+
+  expect_true(any(grepl("score statistic", w)))
+  expect_equal(boot$n_uncomputable_replicates, boot$n_success)
+  expect_gt(boot$n_uncomputable_replicates, 0L)
+})
+
+test_that("a healthy screen reports zero uncomputable replicates", {
+  data(avc)
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  fit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+                phases = phases, fit = TRUE,
+                control = list(n_starts = 1L, maxit = 400L))
+
+  boot <- hzr_bootstrap(fit, n_boot = 3, seed = 1,
+                        scope = list(early = ~ age, constant = ~ age),
+                        criterion = "score", direction = "forward",
+                        slentry = 0.5, slstay = 0.5)
+
+  expect_equal(boot$n_uncomputable_replicates, 0L)
 })

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -1149,3 +1149,56 @@ test_that("print.hzr_competing_risks runs without error", {
   cr <- hzr_competing_risks(time_cr, event_cr)
   expect_output(print(cr), "Competing risks")
 })
+
+
+# Select-mode screens that select nothing -----------------------------------
+
+test_that("hzr_bootstrap warns when a select-mode screen picks no covariate", {
+  # A selection frequency is the whole deliverable of a screen, so "nothing
+  # was ever selected" is the result being empty, not a quiet edge case.
+  # The base model's own parameters appear in every replicate by
+  # construction, so they fill the summary at pct = 100 and the table reads
+  # as a set of perfectly reliable variables.
+  data(avc)
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  fit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+                phases = phases, fit = TRUE,
+                control = list(n_starts = 1L, maxit = 500L))
+
+  # An entry criterion no candidate can clear -> a legitimately empty screen.
+  expect_warning(
+    boot <- hzr_bootstrap(fit, n_boot = 3, seed = 1,
+                          scope = list(early = ~ age, constant = ~ age),
+                          criterion = "score", direction = "forward",
+                          slentry = 1e-12, slstay = 1e-12),
+    "no covariate"
+  )
+
+  # The empty screen still reports as fully successful, which is exactly why
+  # the warning has to carry the news.
+  expect_equal(boot$n_failed, 0L)
+  expect_length(setdiff(unique(boot$replicates$parameter), names(coef(fit))), 0L)
+})
+
+test_that("hzr_bootstrap does not warn when a screen does select covariates", {
+  data(avc)
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  fit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+                phases = phases, fit = TRUE,
+                control = list(n_starts = 1L, maxit = 500L))
+
+  expect_no_warning(
+    boot <- hzr_bootstrap(fit, n_boot = 3, seed = 1,
+                          scope = list(early = ~ age, constant = ~ age),
+                          criterion = "score", direction = "forward",
+                          slentry = 0.5, slstay = 0.5)
+  )
+  expect_gt(length(setdiff(unique(boot$replicates$parameter),
+                           names(coef(fit)))), 0L)
+})

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -186,10 +186,13 @@ test_that("scope refit works when the base fit's formula is a symbol", {
 
 test_that("stepwise selects identically whether the formula was literal", {
   data(avc)
-  phases <- function() list(
-    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
-    constant = hzr_phase("constant")
-  )
+  phases <- function() {
+    list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    )
+  }
   ctl   <- list(n_starts = 1L, maxit = 500L)
   scope <- list(early = ~ age, constant = ~ age)
 

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -152,3 +152,62 @@ test_that("one bad candidate does not prevent others from entering", {
   expect_identical(step$variable, "x1")
   expect_identical(step$refit_failures, "nonexistent")
 })
+
+
+# Base fit whose formula was passed by symbol -------------------------------
+#
+# `hazard()` stores its call via match.call(), so a formula written into a
+# variable first is stored as a *symbol*, not a formula.  Everything that
+# rebuilds the call for a refit has to resolve it.
+
+test_that("scope refit works when the base fit's formula is a symbol", {
+  data(avc)
+  set.seed(1L)
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+
+  f   <- Surv(int_dead, dead) ~ 1
+  fit <- hazard(f, data = avc, dist = "multiphase", phases = phases,
+                fit = TRUE, control = list(n_starts = 1L, maxit = 500L))
+
+  # The premise of the test: the call really does hold a symbol.
+  expect_true(is.symbol(fit$call$formula))
+
+  refit <- .hzr_refit_with_scope(fit, action = "add", var = "age",
+                                 phase = "early", data = avc,
+                                 control = list(n_starts = 1L, maxit = 500L))
+
+  expect_s3_class(refit, "hazard")
+  expect_true("age" %in% names(coef(refit)) ||
+                any(grepl("age", names(coef(refit)))))
+})
+
+test_that("stepwise selects identically whether the formula was literal", {
+  data(avc)
+  phases <- function() list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  ctl   <- list(n_starts = 1L, maxit = 500L)
+  scope <- list(early = ~ age, constant = ~ age)
+
+  set.seed(2L)
+  lit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+                phases = phases(), fit = TRUE, control = ctl)
+  sw_lit <- hzr_stepwise(lit, scope = scope, data = avc, direction = "forward",
+                         slentry = 0.2, trace = FALSE)
+
+  set.seed(2L)
+  f   <- Surv(int_dead, dead) ~ 1
+  sym <- hazard(f, data = avc, dist = "multiphase",
+                phases = phases(), fit = TRUE, control = ctl)
+  sw_sym <- hzr_stepwise(sym, scope = scope, data = avc, direction = "forward",
+                         slentry = 0.2, trace = FALSE)
+
+  # Guard against both screens being empty, which would compare equal while
+  # testing nothing.
+  expect_gt(length(names(coef(sw_lit))), length(names(coef(lit))))
+  expect_equal(names(coef(sw_sym)), names(coef(sw_lit)))
+})

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -242,3 +242,64 @@ test_that("an unresolvable stored formula errors clearly, not obscurely", {
     "could not be resolved"
   )
 })
+
+
+# Uncomputable scores are not the same as "nothing met slentry" -------------
+#
+# Under criterion = "score", a candidate whose Q statistic cannot be computed
+# (degenerate or collinear column, uninvertible nuisance block) yields NA and
+# is dropped from `valid`.  When that happens to every candidate the step
+# returns the same shape as a legitimate "no candidate cleared slentry" stop,
+# so a broken screen and a finished one are indistinguishable.
+
+.uncomputable_fixture <- function() {
+  data(avc)
+  avc$constcol <- 1.0        # degenerate: Q is NA, but the column is numeric
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  fit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+                phases = phases, fit = TRUE,
+                control = list(n_starts = 1L, maxit = 400L))
+  list(fit = fit, data = avc)
+}
+
+test_that("a step whose scores are all uncomputable says so", {
+  fx <- .uncomputable_fixture()
+
+  step <- .hzr_stepwise_forward_step(
+    fx$fit, scope = list(early = ~ constcol), data = fx$data,
+    criterion = "score", slentry = 0.5
+  )
+
+  expect_false(step$accepted)
+  expect_identical(step$stop_reason, "scores_uncomputable")
+  expect_equal(step$n_uncomputable, 1L)
+})
+
+test_that("a step that simply found nothing good enough is distinguishable", {
+  fx <- .uncomputable_fixture()
+
+  # `age` scores fine (p ~ 1e-4) but cannot clear an impossible slentry.
+  step <- .hzr_stepwise_forward_step(
+    fx$fit, scope = list(early = ~ age), data = fx$data,
+    criterion = "score", slentry = 1e-12
+  )
+
+  expect_false(step$accepted)
+  expect_identical(step$stop_reason, "no_candidate_met_slentry")
+  expect_equal(step$n_uncomputable, 0L)
+})
+
+test_that("hzr_stepwise warns when a screen stops on uncomputable scores", {
+  fx <- .uncomputable_fixture()
+
+  expect_warning(
+    sw <- hzr_stepwise(fx$fit, scope = list(early = ~ constcol),
+                       data = fx$data, direction = "forward",
+                       criterion = "score", slentry = 0.5, trace = FALSE),
+    "could not be computed"
+  )
+  expect_gt(sw$criteria$n_uncomputable_scores, 0L)
+})

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -214,3 +214,31 @@ test_that("stepwise selects identically whether the formula was literal", {
   expect_gt(length(names(coef(sw_lit))), length(names(coef(lit))))
   expect_equal(names(coef(sw_sym)), names(coef(sw_lit)))
 })
+
+test_that("an unresolvable stored formula errors clearly, not obscurely", {
+  # A fit saved with saveRDS() and reloaded in a fresh session loses the
+  # binding its `formula` symbol pointed at, so evaluating the stored call
+  # raises "object 'f' not found" -- which says nothing about which fit is
+  # at fault or what to do.  Inside hzr_stepwise()/hzr_bootstrap() the
+  # per-candidate tryCatch() then swallows it into a generic "candidate
+  # refit failed" and an empty screen.  Blanking `call_env` reproduces that
+  # state without a second R session.
+  data(avc)
+  set.seed(3L)
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  f   <- Surv(int_dead, dead) ~ 1
+  fit <- hazard(f, data = avc, dist = "multiphase", phases = phases,
+                fit = TRUE, control = list(n_starts = 1L, maxit = 400L))
+
+  fit$call_env <- new.env(parent = emptyenv())
+
+  expect_error(
+    .hzr_refit_with_scope(fit, action = "add", var = "age", phase = "early",
+                          data = avc,
+                          control = list(n_starts = 1L, maxit = 400L)),
+    "could not be resolved"
+  )
+})


### PR DESCRIPTION
Closes #114. Closes #115.

## #114 — the formula arrives as a symbol

`hazard()` records its call with `match.call()`, so the `formula` argument is stored **unevaluated**. Written literally it is a `call`; assigned to a variable first it is a **symbol**:

```r
a <- hazard(Surv(t, d) ~ 1, data = df, ...)   # class(a$call$formula) == "call"
f <- Surv(t, d) ~ 1
b <- hazard(f, data = df, ...)                # class(b$call$formula) == "name"
```

`.hzr_refit_with_scope()` recovered it with `as.formula(deparse(raw_formula))`. For a symbol, `deparse()` yields the string `"f"`, and:

```
Error in formula.character(object, env = baseenv()) : invalid formula "f": not a call
```

Every post-entry refit threw, so no candidate ever entered. The run reported `n_success = n_boot`, `n_failed = 0`, no error, no warning — and a summary holding only the base model's parameters.

**Fix:** evaluate the stored formula in the fit's recorded `call_env`, which handles both forms. A stored formula that fails to resolve now errors naming the problem rather than degrading to an empty screen.

`hzr_stepwise()` was affected directly by the same code path, not only through `hzr_bootstrap()`.

## #115 — an empty screen looked like a successful one

A selection frequency is the entire deliverable of a select-mode run, so "nothing was selected" is the result being empty. It cannot be read off the object: the base model's parameters appear in every replicate by construction, so they occupy the summary at `pct = 100` and the table reads as a set of perfectly reliable variables.

`hzr_bootstrap()` now warns when a select-mode run selects no covariate, naming the likely causes. Legitimate empty screens warn too — an entry criterion no candidate can clear is also worth reporting.

## Verification

Both fixes were written test-first and watched fail.

- #114 RED: `Error ... invalid formula "f": not a call`, and the screen comparison showed the literal run selecting `early.age` while the symbol run selected nothing.
- #115 RED: `Expected ... to throw a warning.` A companion test asserts a *populated* screen stays warning-free, so the guard cannot fire indiscriminately.
- The issue's own reproduction now gives **6 new covariates for both** interfaces, against 6 vs 0 before.

Full suite: **0 failures, 96 documented `skip_on_cran`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)