### PR TITLE
docs: correct stale claims in the SAS migration vignette

### DIFF
--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -510,8 +510,10 @@ tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md` and
 - **Not yet supported:** FAST-screening (Lawless-Singhal approximate
   Wald updates).  Much of what it exists to save is already gone, though:
   the default `criterion = "score"` tests each candidate at the current
-  estimates and never refits to do it.  `criterion = "wald"` is the path
-  that still fits every candidate before testing it.
+  estimates and never refits to do it.  `criterion = "wald"` still refits
+  once per *entry* candidate.  Removals never did, under either criterion:
+  a drop is tested on the current model's Wald p-value against `slstay`,
+  which is what SAS does, and only the accepted drop is refitted.
 
 ### Per-phase time-varying windows
 

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -498,7 +498,7 @@ hazard contributions instead of just the total.
 ## Known limitations vs. SAS HAZARD
 
 A SAS HAZARD veteran migrating to `TemporalHazard` should be aware of
-the following scope limits as of v0.9.8.  Detailed status per feature is
+the following scope limits as of v1.2.0.  Detailed status per feature is
 tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md` and
 `inst/dev/DEVELOPMENT-PLAN.md`.
 
@@ -508,8 +508,10 @@ tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md` and
   two-way stepwise with SAS-style SLENTRY / SLSTAY thresholds,
   per-phase entry for multiphase, and a MOVE oscillation guard.
 - **Not yet supported:** FAST-screening (Lawless-Singhal approximate
-  Wald updates).  Every candidate currently gets a full refit, which
-  is slower but always correct.
+  Wald updates).  Much of what it exists to save is already gone, though:
+  the default `criterion = "score"` tests each candidate at the current
+  estimates and never refits to do it.  `criterion = "wald"` is the path
+  that still fits every candidate before testing it.
 
 ### Per-phase time-varying windows
 


### PR DESCRIPTION
Pre-release documentation sweep. Independent of #116 and #117 — different file, no conflict.

## The vignette contradicted itself

`sas-to-r-migration.qmd` says two incompatible things about stepwise, forty lines apart:

> §Stepwise variable selection — "It now defaults to `criterion = "score"` … a score test at the current estimates, with no per-candidate refit"

> §Known limitations — "Every candidate currently gets a full refit, which is slower but always correct."

The second was written when Wald was the only path and was left behind when the score criterion landed. It also contradicts this release's headline change, where removing the per-candidate refit took a 92-variable screen from ~25 minutes per bootstrap replicate to seconds.

Rewritten to say what is genuinely still missing — FAST-screening itself — rather than a cost 1.2.0 already removed.

## "as of v0.9.8"

The section header claimed to describe v0.9.8. Bumping that to v1.2.0 is a claim that everything under it is still true, so I checked each entry against the code rather than only editing the number:

| Claim | Verified |
|---|---|
| No per-phase `time_windows` | `hzr_phase()` formals are `type, t_half, nu, m, tau, gamma, alpha, eta, formula, fixed` — no `time_windows` |
| `predict.hazard()` has no density/quantile type | `type = c("hazard", "linear_predictor", "survival", "cumulative_hazard")` |
| No `OUTEST=`/`OUTVCOV=` equivalent | no export function; `coef()`/`vcov()` only |
| "currently pure R" | no `src/`, no `LinkingTo` |

All four hold, so the version bump is honest.

Prose follows the repo's writing harness, persona (c) — the bilingual SAS-to-R migrant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)