### PR TITLE
docs: mark hzr_bootstrap() selection mode experimental

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,7 +62,14 @@ selects.
 
 * `hzr_bootstrap()` gains a `scope` argument for embedded stepwise variable
   selection during each bootstrap replicate -- the R equivalent of SAS's
-  `%HAZBOOT` procedure. Each replicate runs a fresh `hzr_stepwise()`
+  `%HAZBOOT` procedure. **This is experimental**: the selection arguments and
+  the shape of what they return may change in a future release, and
+  `?hzr_bootstrap` says why under "Selection mode is experimental". The
+  fixed-formula bootstrap (`scope = NULL`) is unaffected and unchanged.
+  The short version: the design is still being read off production runs, and
+  a screen large enough to matter runs for hours while this function writes
+  nothing until its last replicate, so splitting a run across processes is
+  currently the caller's job. Each replicate runs a fresh `hzr_stepwise()`
   selection (starting from a fixed-shape refit of the base model) instead
   of a plain refit, so `summary$pct` reports the variable's selection
   frequency across resamples and `summary$mean`/`sd`/`ci_*` describe the

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1257,8 +1257,11 @@ print.hzr_nelson <- function(x, digits = 4, ...) {
 #'   the advance during resampling.
 #' @param verbose Logical; if `TRUE`, display a text progress bar over the
 #'   `n_boot` replicates (via [utils::txtProgressBar()]).
-#' @param scope Candidate variable scope for embedded stepwise selection
-#'   during each bootstrap replicate. `NULL` (default) preserves the
+#' @param scope **Experimental.** Candidate variable scope for embedded
+#'   stepwise selection during each bootstrap replicate. The argument and the
+#'   shape of the object it returns may change in a future release; see the
+#'   "Selection mode is experimental" section below. `NULL` (default)
+#'   preserves the
 #'   original fixed-formula bootstrap: every replicate refits `object`'s
 #'   exact model, and `summary$pct` is always ~100. When supplied (a
 #'   one-sided formula, character vector, or -- for multiphase fits -- a
@@ -1284,6 +1287,30 @@ print.hzr_nelson <- function(x, digits = 4, ...) {
 #' @param ... Additional arguments forwarded to [hzr_stepwise()] (e.g.
 #'   `control = list(n_starts = 1)`) when `scope` is supplied; ignored
 #'   otherwise.
+#'
+#' @section Selection mode is experimental:
+#'
+#' Everything reached through `scope` -- the selection arguments, and the
+#' `summary$pct` selection frequencies they produce -- is new and should be
+#' treated as unstable. The fixed-formula bootstrap (`scope = NULL`) is not
+#' affected and has been stable since 0.9.3.
+#'
+#' Two reasons to expect change. The first is that the design is still being
+#' read off real runs rather than settled in advance: production screens have
+#' already moved the defaults once and turned up several ways a screen could
+#' report success while selecting nothing.
+#'
+#' The second is scale, and it is the one to plan around. A screen over a
+#' large candidate pool runs for hours, and this function writes nothing
+#' until its final replicate, so a run that dies late loses everything. There
+#' is no built-in way to split one screen across processes and combine the
+#' parts. If you are running at that scale, drive `hzr_bootstrap()` in chunks
+#' from your own script and pool the replicates yourself -- deriving each
+#' chunk's seed from its chunk number, offsetting replicate ids so a variable
+#' selected in two chunks is not counted once, and recomputing frequencies
+#' from the pooled replicates rather than averaging across chunks. Whatever
+#' eventually covers that inside the package may well change this function's
+#' interface.
 #'
 #' @return A list with class `"hzr_bootstrap"` containing:
 #' \describe{

--- a/man/hzr_bootstrap.Rd
+++ b/man/hzr_bootstrap.Rd
@@ -45,8 +45,11 @@ the advance during resampling.}
 \item{verbose}{Logical; if \code{TRUE}, display a text progress bar over the
 \code{n_boot} replicates (via \code{\link[utils:txtProgressBar]{utils::txtProgressBar()}}).}
 
-\item{scope}{Candidate variable scope for embedded stepwise selection
-during each bootstrap replicate. \code{NULL} (default) preserves the
+\item{scope}{\strong{Experimental.} Candidate variable scope for embedded
+stepwise selection during each bootstrap replicate. The argument and the
+shape of the object it returns may change in a future release; see the
+"Selection mode is experimental" section below. \code{NULL} (default)
+preserves the
 original fixed-formula bootstrap: every replicate refits \code{object}'s
 exact model, and \code{summary$pct} is always ~100. When supplied (a
 one-sided formula, character vector, or -- for multiphase fits -- a
@@ -118,6 +121,32 @@ they enter the model. \code{summary$pct} then reports the selection
 frequency across replicates, and \code{summary$mean}/\code{sd}/\verb{ci_*} describe the
 coefficient distribution conditional on selection.
 }
+\section{Selection mode is experimental}{
+
+
+Everything reached through \code{scope} -- the selection arguments, and the
+\code{summary$pct} selection frequencies they produce -- is new and should be
+treated as unstable. The fixed-formula bootstrap (\code{scope = NULL}) is not
+affected and has been stable since 0.9.3.
+
+Two reasons to expect change. The first is that the design is still being
+read off real runs rather than settled in advance: production screens have
+already moved the defaults once and turned up several ways a screen could
+report success while selecting nothing.
+
+The second is scale, and it is the one to plan around. A screen over a
+large candidate pool runs for hours, and this function writes nothing
+until its final replicate, so a run that dies late loses everything. There
+is no built-in way to split one screen across processes and combine the
+parts. If you are running at that scale, drive \code{hzr_bootstrap()} in chunks
+from your own script and pool the replicates yourself -- deriving each
+chunk's seed from its chunk number, offsetting replicate ids so a variable
+selected in two chunks is not counted once, and recomputing frequencies
+from the pooled replicates rather than averaging across chunks. Whatever
+eventually covers that inside the package may well change this function's
+interface.
+}
+
 \examples{
 \donttest{
 data(avc)


### PR DESCRIPTION
`scope=` — selection mode, the `%HAZBOOT` equivalent — ships to CRAN for the first time in 1.2.0. This marks it experimental rather than presenting it as settled API.

## Why

**The design is still being read off production runs.** `hvtiRbootstrap`'s spec defers its hazard fitter precisely because the variants "deserve reading before an API is fixed", and the AVR/LV-function screens are that reading. This release already carries three fixes to this exact path (#114, #115, and the uncomputable-score blind spot), all found by one study in one day.

**More concretely, the interface cannot do the job it is named for at production scale.** `hzr_bootstrap()` writes nothing until its last replicate and offers no way to split a screen across processes, while a screen over a real candidate pool runs for hours — one lost nine hours to a late failure. Every production run so far has wrapped it in an external chunked runner with pooling, chunk-derived seeds and replicate-id offsets. Whatever eventually covers that inside the package is likely to change this signature.

`scope = NULL` — the fixed-formula bootstrap — is untouched. It has been in the package since **0.9.3** and on CRAN since 1.0.x.

## Why mark rather than hold

Coupling was measured before deciding. Select mode rests almost entirely on the public API:

| Dependency | Kind |
|---|---|
| `hazard()`, `hzr_stepwise()`, `coef()` | exported |
| `$call`, `$call_env`, `$fit$theta`, `$data$x` | fitted-object fields |
| `.hzr_bootstrap_param_names()` | one internal, **22 lines**, pure naming logic |

`.hzr_safe_solve` appears only inside a comment, not a call. So moving selection mode to `hvtiRbootstrap` later is cheap, and an experimental note keeps that door open without holding back a release that is otherwise ready.

The production consumer installs from GitHub `@dev`, so CRAN publication of `scope=` is not what unblocks the study either way.

## Changes

- `?hzr_bootstrap` gains a **"Selection mode is experimental"** section, including the chunk-and-pool guidance callers need at scale.
- `@param scope` is flagged and points at it.
- The NEWS entry carries the caveat.

Docs regenerated; `lintr::lint_package()` clean. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)