### PR TITLE
fix: qualify stats::coef() to clear an R CMD check NOTE

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1715,7 +1715,8 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   # fill the summary at pct = 100 and the table looks like a set of perfectly
   # reliable variables.
   if (select_mode && n_success > 0L) {
-    selected <- setdiff(unique(replicates$parameter), names(coef(object)))
+    selected <- setdiff(unique(replicates$parameter),
+                        names(stats::coef(object)))
     if (length(selected) == 0L) {
       warning("Bootstrap selection selected no covariate in any of the ",
               n_success, " successful replicates. The summary holds only the ",


### PR DESCRIPTION
Caught by the pre-release gate: a clean `git archive` export built and run through `R CMD check --as-cran` **with the PDF manual** returned `Status: 1 NOTE`, where the 2.0.0-era gate had been 0/0/0.

```
hzr_bootstrap: no visible global function definition for 'coef'
Undefined global functions or variables:
  coef
Consider adding
  importFrom("stats", "coef")
to your NAMESPACE file.
```

**The NOTE is mine.** The empty-screen guard added in #117 (issue #115) calls `coef()` unqualified — it was the only bare `coef(` in `R/`. The package registers `S3method(coef, hazard)` but does not import the generic, and nothing had called it unqualified from inside the package before.

Qualified to `stats::coef()` rather than extending the `importFrom(stats, ...)` block: `R/diagnostics.R` already uses `stats::` in ten other places, so this matches the file's own style and needs no NAMESPACE change.

Verified on a clean export after committing: `checking R code for possible problems ... OK`, `Status: OK`. Full check with tests, vignettes and manual running.

Worth recording that the first re-check still showed the NOTE because `git archive HEAD` exports the committed tree and the fix was still uncommitted — the export is the right way to build a release tarball, but it silently tests the wrong thing if you forget to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)