### PR TITLE
fix: resolve the stored formula in one place, not four

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -135,6 +135,22 @@ selects.
   fitting a production interval-censored study.
 
 
+* **`hzr_stepwise(scope = NULL)` still failed on a formula passed by
+  variable.** The fix for that defect reached `.hzr_refit_with_scope()` but
+  not three sibling sites, so the default-scope path still raised
+  `invalid formula "f": not a call` -- the very string the entry below says
+  no longer occurs. All four sites now resolve the stored formula through one
+  internal helper, so a fifth cannot drift: `match.call()` records `formula`
+  unevaluated, and `deparse(quote(f))` is `"f"`, which `as.formula()` rejects.
+
+  Two consequences of that path becoming reachable, both fixed here.
+  `scope = NULL` now skips non-numeric columns instead of erroring on them:
+  under an explicit scope the caller named the column, so an error is right,
+  but under `scope = NULL` the package enumerates the candidates itself and a
+  column it cannot model is its own choice to make better. Any data frame
+  carrying a character or factor column -- which is most of them -- was
+  otherwise unusable with the default scope.
+
 * `hzr_bootstrap()` no longer returns a silent `n_success = 0` (and
   `n_failed = n_boot`, with no error and no warning) when the model was fitted
   inside a function. `hazard()` stored its call but not the environment that

--- a/NEWS.md
+++ b/NEWS.md
@@ -144,7 +144,10 @@ selects.
   unevaluated, and `deparse(quote(f))` is `"f"`, which `as.formula()` rejects.
 
   Two consequences of that path becoming reachable, both fixed here.
-  `scope = NULL` now skips non-numeric columns instead of erroring on them:
+  `scope = NULL` now skips columns it cannot model instead of erroring on
+  them -- numeric and logical columns are kept, since whether a 0/1 field
+  arrives logical or numeric depends on the reader that built the frame
+  rather than on the variable:
   under an explicit scope the caller named the column, so an error is right,
   but under `scope = NULL` the package enumerates the candidates itself and a
   column it cannot model is its own choice to make better. Any data frame

--- a/R/stepwise-formula.R
+++ b/R/stepwise-formula.R
@@ -176,16 +176,11 @@
     if (!is.null(phase)) {
       stop("`phase` is only meaningful for multiphase models.", call. = FALSE)
     }
-    f <- fit$call$formula
+    f <- .hzr_stored_formula(fit)
     if (is.null(f)) {
       # Non-formula fit (time/x interface); infer from design matrix names.
       xcols <- colnames(fit$data$x)
       return(if (is.null(xcols)) character() else xcols)
-    }
-    # `match.call()` captures `formula` as an unevaluated `call` rather
-    # than a real `formula` object; coerce before term extraction.
-    if (!inherits(f, "formula")) {
-      f <- stats::as.formula(deparse(f))
     }
     return(.hzr_formula_rhs_terms(f))
   }
@@ -249,4 +244,53 @@
     FALSE
   }
   .walk(rhs)
+}
+
+#' Resolve the model formula a fit stored in its call
+#'
+#' `match.call()` stores the `formula` argument unevaluated, so it arrives as
+#' a `call` when the caller wrote it out at the `hazard()` call and as a
+#' *symbol* when they passed a variable holding it. Evaluating in the
+#' recorded calling environment covers both; deparsing does not, because
+#' `deparse(quote(f))` is `"f"`, which `as.formula()` rejects as "not a call".
+#'
+#' Every site that needs the stored formula goes through here. Three did it
+#' independently once, and two of them were still deparsing after the third
+#' was fixed.
+#'
+#' @param fit A fitted `hazard` object.
+#' @param what Character label for the object in error messages.
+#' @return The formula, or `NULL` when the fit carries none (the vector
+#'   interface). Errors when a stored formula cannot be resolved.
+#' @keywords internal
+#' @noRd
+.hzr_stored_formula <- function(fit, what = "`fit`") {
+  raw <- fit$call$formula
+  if (is.null(raw)) {
+    return(NULL)
+  }
+  if (inherits(raw, "formula")) {
+    return(raw)
+  }
+  # Evaluating can fail outright when the formula was passed by variable and
+  # that binding is gone -- after saveRDS()/readRDS() in a new session, say.
+  # Bare, the error reads "object 'f' not found", which names neither the fit
+  # at fault nor the remedy.
+  out <- tryCatch(
+    eval(raw, envir = fit$call_env %||% parent.frame(2L)),
+    error = function(e) {
+      stop(what, "'s stored model formula (", deparse(raw),
+           ") could not be resolved: ", conditionMessage(e),
+           ". The formula was passed to `hazard()` by variable and that ",
+           "binding is no longer reachable -- for example after saving and ",
+           "reloading the fit in a new session. Refit the base model with ",
+           "the formula written at the `hazard()` call.", call. = FALSE)
+    }
+  )
+  if (!inherits(out, "formula")) {
+    stop(what, "'s stored model formula (", deparse(raw),
+         ") did not resolve to a formula. Refit the base model with the ",
+         "formula written at the `hazard()` call.", call. = FALSE)
+  }
+  out
 }

--- a/R/stepwise-formula.R
+++ b/R/stepwise-formula.R
@@ -246,7 +246,7 @@
   .walk(rhs)
 }
 
-#' Resolve the model formula a fit stored in its call
+#' Resolve the model formula stored in a fit's call
 #'
 #' `match.call()` stores the `formula` argument unevaluated, so it arrives as
 #' a `call` when the caller wrote it out at the `hazard()` call and as a
@@ -260,11 +260,16 @@
 #'
 #' @param fit A fitted `hazard` object.
 #' @param what Character label for the object in error messages.
+#' @param envir Environment to resolve in when the fit carries no recorded
+#'   `call_env` (objects serialised before it was stored). Defaults to the
+#'   caller's frame; passing it explicitly is preferable to relying on the
+#'   default, which is only correct because it is evaluated lazily.
 #' @return The formula, or `NULL` when the fit carries none (the vector
 #'   interface). Errors when a stored formula cannot be resolved.
 #' @keywords internal
 #' @noRd
-.hzr_stored_formula <- function(fit, what = "`fit`") {
+.hzr_stored_formula <- function(fit, what = "`fit`",
+                                envir = parent.frame()) {
   raw <- fit$call$formula
   if (is.null(raw)) {
     return(NULL)
@@ -277,7 +282,7 @@
   # Bare, the error reads "object 'f' not found", which names neither the fit
   # at fault nor the remedy.
   out <- tryCatch(
-    eval(raw, envir = fit$call_env %||% parent.frame(2L)),
+    eval(raw, envir = fit$call_env %||% envir),
     error = function(e) {
       stop(what, "'s stored model formula (", deparse(raw),
            ") could not be resolved: ", conditionMessage(e),
@@ -293,4 +298,26 @@
          "formula written at the `hazard()` call.", call. = FALSE)
   }
   out
+}
+
+#' Columns the package may offer itself as candidates
+#'
+#' Under `scope = NULL` the *package* enumerates candidates from the data, so a
+#' column it cannot model is its own bad choice rather than the caller's, and
+#' dropping it beats erroring on it. An explicit `scope` still errors, because
+#' there the caller named the column.
+#'
+#' Logical columns count: they are ordinary 0/1 predictors, and whether a
+#' 0/1 field arrives logical or numeric depends on the reader that produced
+#' the frame rather than on anything about the variable.
+#'
+#' @keywords internal
+#' @noRd
+.hzr_modellable_vars <- function(data, vars) {
+  keep <- vapply(
+    data[vars],
+    function(col) is.numeric(col) || is.logical(col),
+    logical(1L)
+  )
+  vars[keep]
 }

--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -83,43 +83,14 @@
   extra_args <- user_args[!names(user_args) %in%
                             c("weights", "time_windows")]
 
-  # Recover the original formula.  match.call() stores the `formula` arg
-  # unevaluated, so it arrives as a `call` when the caller wrote it out at
-  # the hazard() call and as a *symbol* when they passed a variable holding
-  # it.  Evaluating in the recorded calling environment covers both;
-  # deparsing does not, because deparse(quote(f)) is "f", which as.formula()
-  # rejects as "not a call".
+  # Recover the original formula; see .hzr_stored_formula() for why this
+  # cannot be a deparse.
   raw_formula <- current$call$formula
   if (is.null(raw_formula)) {
     stop("`current` was not built via the formula interface; refit ",
          "requires a formula-based base fit.", call. = FALSE)
   }
-  current_formula <- if (inherits(raw_formula, "formula")) {
-    raw_formula
-  } else {
-    # Evaluating can fail outright when the formula was passed by variable
-    # and that binding is gone -- after saveRDS()/readRDS() in a new
-    # session, say.  Bare, the error reads "object 'f' not found", which
-    # names neither the fit at fault nor the remedy, and callers that wrap
-    # candidate refits in tryCatch() reduce it to a generic failure.
-    tryCatch(
-      eval(raw_formula, envir = current$call_env %||% parent.frame()),
-      error = function(e) {
-        stop("`current`'s stored model formula (", deparse(raw_formula),
-             ") could not be resolved: ", conditionMessage(e),
-             ". The formula was passed to `hazard()` by variable and that ",
-             "binding is no longer reachable -- for example after saving ",
-             "and reloading the fit in a new session. Refit the base model ",
-             "with the formula written at the `hazard()` call.",
-             call. = FALSE)
-      }
-    )
-  }
-  if (!inherits(current_formula, "formula")) {
-    stop("`current`'s stored model formula (", deparse(raw_formula),
-         ") did not resolve to a formula. Refit the base model with the ",
-         "formula written at the `hazard()` call.", call. = FALSE)
-  }
+  current_formula <- .hzr_stored_formula(current, "`current`")
 
   if (dist == "multiphase") {
     if (is.null(phase)) {

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -39,11 +39,7 @@
       stored <- .hzr_stored_formula(fit)
       lhs_vars <- if (is.null(stored)) character() else all.vars(stored[[2L]])
       data_vars <- setdiff(colnames(data), c(lhs_vars, force_out))
-      # Under scope = NULL the *package* picks the candidates, so a column
-      # it cannot model is its own bad choice, not the caller's. Drop the
-      # non-numeric ones rather than erroring on them. An explicit scope
-      # still errors, because there the caller named the column.
-      data_vars <- data_vars[vapply(data[data_vars], is.numeric, logical(1L))]
+      data_vars <- .hzr_modellable_vars(data, data_vars)
       scope <- setNames(
         lapply(phase_names, function(p) {
           rhs_syms <- data_vars
@@ -86,11 +82,7 @@
     f <- .hzr_stored_formula(fit)
     lhs_vars <- if (is.null(f)) character() else all.vars(f[[2L]])
     data_vars <- setdiff(colnames(data), c(lhs_vars, force_out))
-      # Under scope = NULL the *package* picks the candidates, so a column
-      # it cannot model is its own bad choice, not the caller's. Drop the
-      # non-numeric ones rather than erroring on them. An explicit scope
-      # still errors, because there the caller named the column.
-      data_vars <- data_vars[vapply(data[data_vars], is.numeric, logical(1L))]
+    data_vars <- .hzr_modellable_vars(data, data_vars)
   } else {
     if (inherits(scope, "formula")) {
       data_vars <- .hzr_formula_rhs_terms(scope)

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -36,10 +36,14 @@
     if (is.null(scope)) {
       # Default: all data-frame vars (excluding Surv components and
       # force_out) are candidates for every phase.
-      lhs_vars <- all.vars(stats::as.formula(
-        deparse(fit$call$formula)
-      )[[2L]])
+      stored <- .hzr_stored_formula(fit)
+      lhs_vars <- if (is.null(stored)) character() else all.vars(stored[[2L]])
       data_vars <- setdiff(colnames(data), c(lhs_vars, force_out))
+      # Under scope = NULL the *package* picks the candidates, so a column
+      # it cannot model is its own bad choice, not the caller's. Drop the
+      # non-numeric ones rather than erroring on them. An explicit scope
+      # still errors, because there the caller named the column.
+      data_vars <- data_vars[vapply(data[data_vars], is.numeric, logical(1L))]
       scope <- setNames(
         lapply(phase_names, function(p) {
           rhs_syms <- data_vars
@@ -79,12 +83,14 @@
 
   # Single-distribution
   if (is.null(scope)) {
-    f <- fit$call$formula
-    if (!is.null(f) && !inherits(f, "formula")) {
-      f <- stats::as.formula(deparse(f))
-    }
+    f <- .hzr_stored_formula(fit)
     lhs_vars <- if (is.null(f)) character() else all.vars(f[[2L]])
     data_vars <- setdiff(colnames(data), c(lhs_vars, force_out))
+      # Under scope = NULL the *package* picks the candidates, so a column
+      # it cannot model is its own bad choice, not the caller's. Drop the
+      # non-numeric ones rather than erroring on them. An explicit scope
+      # still errors, because there the caller named the column.
+      data_vars <- data_vars[vapply(data[data_vars], is.numeric, logical(1L))]
   } else {
     if (inherits(scope, "formula")) {
       data_vars <- .hzr_formula_rhs_terms(scope)

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -346,3 +346,19 @@ test_that("scope = NULL works by variable for multiphase too", {
   expect_false(any(vapply(cands, function(c) c$var, character(1L)) %in%
                      c("int_dead", "dead")))
 })
+
+test_that("scope = NULL keeps logical columns and drops unmodellable ones", {
+  # Whether a 0/1 field arrives logical or numeric depends on the reader that
+  # built the frame, not on the variable. Dropping logicals would make the
+  # default scope silently narrower for one of two equivalent read paths.
+  d <- data.frame(
+    t    = c(2, 4, 6, 8, 10, 12, 14, 16),
+    ev   = c(1L, 0L, 1L, 1L, 0L, 1L, 1L, 0L),
+    num  = c(1, 2, 3, 4, 5, 6, 7, 8),
+    flag = c(TRUE, FALSE, TRUE, TRUE, FALSE, TRUE, FALSE, TRUE),
+    chr  = letters[1:8],
+    stringsAsFactors = FALSE
+  )
+  expect_equal(.hzr_modellable_vars(d, c("num", "flag", "chr")),
+               c("num", "flag"))
+})

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -303,3 +303,46 @@ test_that("hzr_stepwise warns when a screen stops on uncomputable scores", {
   )
   expect_gt(sw$criteria$n_uncomputable_scores, 0L)
 })
+
+
+# A formula passed by variable must work everywhere, not just in the refit ----
+#
+# #117 fixed .hzr_refit_with_scope(), and NEWS said the by-symbol defect
+# "also affected hzr_stepwise() directly" and was fixed. Two sibling sites in
+# .hzr_stepwise_candidates() still deparsed the stored call, so the default
+# scope = NULL path raised `invalid formula "f": not a call` -- verbatim the
+# string NEWS claims no longer occurs. Both distributions reach it.
+
+test_that("scope = NULL works when the base formula was passed by variable", {
+  data(avc)
+  avc <- na.omit(avc)
+
+  f    <- Surv(int_dead, dead) ~ age
+  base <- hazard(f, data = avc, dist = "weibull", fit = TRUE,
+                 theta = c(mu = 0.01, nu = 0.5, 0))
+  expect_true(is.symbol(base$call$formula))
+
+  sw <- hzr_stepwise(base, scope = NULL, data = avc, direction = "forward",
+                     slentry = 0.05, trace = FALSE)
+  expect_s3_class(sw, "hazard")
+  # The Surv() response columns must not be offered as candidates.
+  expect_false(any(c("int_dead", "dead") %in% sw$steps$variable))
+})
+
+test_that("scope = NULL works by variable for multiphase too", {
+  data(avc)
+  avc <- na.omit(avc)
+
+  g   <- Surv(int_dead, dead) ~ 1
+  ph  <- list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                                fixed = "shapes"),
+              constant = hzr_phase("constant"))
+  fit <- hazard(g, data = avc, dist = "multiphase", phases = ph, fit = TRUE,
+                control = list(n_starts = 1L, maxit = 400L))
+  expect_true(is.symbol(fit$call$formula))
+
+  cands <- .hzr_stepwise_candidates(fit, scope = NULL, data = avc)
+  expect_gt(length(cands), 0L)
+  expect_false(any(vapply(cands, function(c) c$var, character(1L)) %in%
+                     c("int_dead", "dead")))
+})


### PR DESCRIPTION
First of the two HIGH defects from the release-diff review (step 5 of the pre-submission checklist).

## The claim was wrong

#117 fixed the by-symbol formula defect in `.hzr_refit_with_scope()`, and `NEWS.md` recorded it as *also* fixing `hzr_stepwise()` directly. It did not. **Three sibling sites still deparsed the stored call:**

| Site | Path |
|---|---|
| `R/stepwise-step.R:39` | multiphase, `scope = NULL` |
| `R/stepwise-step.R:83` | single-distribution, `scope = NULL` |
| `R/stepwise-formula.R:188` | `.hzr_scope_current_vars()` |

Reproduced on a clean `origin/dev` export before touching anything:

```r
f    <- Surv(int_dead, dead) ~ age
base <- hazard(f, data = avc, dist = "weibull", fit = TRUE, theta = c(mu=.01, nu=.5, 0))
hzr_stepwise(base, scope = NULL, data = avc, direction = "forward")
#> Error: invalid formula "f": not a call
```

That is verbatim the string NEWS says no longer occurs.

## One helper, not four copies

Four independent implementations of the same resolution is *why* fixing one left three broken. All four now call `.hzr_stored_formula()`, so a fifth cannot drift.

## A second defect, exposed by the first being fixed

Making `scope = NULL` reachable surfaced this immediately: it enumerates candidates from `colnames(data)` and then errored on any non-numeric column. `avc` carries a character column (`study`), so the default scope was unusable on **the package's own example data**.

The fix draws a distinction worth stating: under an explicit scope the caller named the column, so an error is correct. Under `scope = NULL` the *package* enumerated the candidates, and a column it cannot model is its own choice to make better — so it now skips non-numeric columns.

## Verification

Both defects have regression tests, watched failing first. Suite **1544 pass / 0 fail**, `lintr::lint_package()` clean.

The NEWS entry for #114 is corrected rather than left overstating what landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)