### PR TITLE
ci: one in-flight run per workflow per ref

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main, master, dev]
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main, master, dev]
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
 
   lint:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,6 +7,15 @@ on:
     branches: [main, master, dev]
   workflow_dispatch:
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main, master, dev]
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
No workflow declared a `concurrency` group, so every push started a fresh run while the superseded one kept holding a runner. The queue grew faster than it drained.

Measured on 2026-08-17: **20 runs in flight at once**, and one run had sat **queued for 410 minutes** behind work already replaced by newer commits.

That is why CI looked slow while the local gate ran in 3m44s. Nothing was running slowly — most of it was not running at all. macOS makes it worse, being the scarcest tier, which is why its job finished while five cheaper Linux jobs were still queued behind other runs.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

`main` is exempt from cancellation so a release run is never killed mid-flight.

Paired with the sibling PR so the two branches stay consistent: the four shared workflows get a byte-identical block on both sides, so the eventual `dev → main` release merge sees the same change rather than a conflict.

No package code touched.
Covers dev's four workflows. Sibling PR covers main's eight.