### PR TITLE
ci: one in-flight run per workflow per ref (main's eight workflows)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,10 +10,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main, master, dev]
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/check-manual.yaml
+++ b/.github/workflows/check-manual.yaml
@@ -13,6 +13,15 @@ on:
 
 name: Check manual
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/check-manual.yaml
+++ b/.github/workflows/check-manual.yaml
@@ -17,10 +17,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 permissions:
   contents: read

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -14,10 +14,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 permissions:
   contents: read

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -10,6 +10,15 @@ on:
 
 name: CRAN release check
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/house-style.yaml
+++ b/.github/workflows/house-style.yaml
@@ -9,6 +9,15 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/house-style.yaml
+++ b/.github/workflows/house-style.yaml
@@ -13,10 +13,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main, master, dev]
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
 
   lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,10 +10,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 jobs:
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,6 +7,15 @@ on:
     branches: [main, master, dev]
   workflow_dispatch:
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,10 +11,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -13,10 +13,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 permissions:
   contents: read

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -9,6 +9,15 @@ on:
 
 name: spelling
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main, master, dev]
 
+concurrency:
+  # One in-flight run per workflow per ref. Without this every push starts a
+  # fresh run while the superseded one keeps holding a runner, and the queue
+  # grows faster than it drains -- one run sat queued for 410 minutes on
+  # 2026-08-17 behind work that had already been replaced. main is exempt so a
+  # release run is never cancelled mid-flight.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -10,10 +10,10 @@ concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
-  # 2026-08-17 behind work that had already been replaced. main is exempt so a
-  # release run is never cancelled mid-flight.
+  # 2026-08-17 behind work that had already been replaced. Protected branches
+  # are exempt, so a release run is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !github.ref_protected }}
 
 jobs:
   test-coverage:


### PR DESCRIPTION
No workflow declared a `concurrency` group, so every push started a fresh run while the superseded one kept holding a runner. The queue grew faster than it drained.

Measured on 2026-08-17: **20 runs in flight at once**, and one run had sat **queued for 410 minutes** behind work already replaced by newer commits.

That is why CI looked slow while the local gate ran in 3m44s. Nothing was running slowly — most of it was not running at all. macOS makes it worse, being the scarcest tier, which is why its job finished while five cheaper Linux jobs were still queued behind other runs.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

`main` is exempt from cancellation so a release run is never killed mid-flight.

Paired with the sibling PR so the two branches stay consistent: the four shared workflows get a byte-identical block on both sides, so the eventual `dev → main` release merge sees the same change rather than a conflict.

No package code touched.
Covers all eight workflows on `main`, including the four `dev` does not have — `check-manual`, `check-release`, `house-style`, `spelling` — which are the release-gating ones.