### PR TITLE
fix: score the candidates on a censoring the analytic Hessian declines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,28 @@ selects.
   diagnostics are still `NA` -- but the reason is now stated. Found while
   fitting a production interval-censored study.
 
+* **The score criterion could not test a single candidate on an interval- or
+  left-censored multiphase fit.** The analytic multiphase Hessian declines by
+  design for `status` in `{-1, 2}`, and the score path had no fallback on that
+  branch -- the single-distribution branch has had one all along. The `NULL`
+  propagated into the step's reusable nuisance block, every candidate scored
+  `NA`, and `hzr_stepwise()` stopped having tested nothing, reporting it in the
+  language of a degenerate candidate. Both halves became reachable in this
+  release and only together: the `Surv()` translation fix above made left- and
+  interval-censored rows expressible through the formula interface, and
+  `criterion = "score"` became the default. No test exercised the two at once.
+
+  The observed information is now computed numerically where the analytic form
+  declines, as the single-distribution path already did. It agrees with the
+  analytic Hessian to 1e-4 on the equivalent right-censored fit, which is what
+  licenses using it in place of one. The cost is a numeric Hessian per
+  candidate -- the per-candidate work the score criterion exists to avoid --
+  but it is paid only where there would otherwise be no information matrix at
+  all, and slower is the right trade against selecting nothing. `numDeriv` is a
+  `Suggests` here as elsewhere: when it is absent this now stops and names both
+  it and `criterion = "wald"`, rather than returning a screen that tested
+  nothing.
+
 
 * `hzr_bootstrap()` no longer returns a silent `n_success = 0` (and
   `n_failed = n_boot`, with no error and no warning) when the model was fitted

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -220,6 +220,54 @@
   h
 }
 
+#' Numeric observed information for a multiphase fit
+#'
+#' `.hzr_hessian_multiphase()` declines by design when any row is left- or
+#' interval-censored (`status` in `{-1, 2}`): the analytic second derivative
+#' is not defined for those contributions. Before this fallback existed the
+#' `NULL` propagated to `nuisance$ok = FALSE` and every candidate scored `NA`,
+#' so the screen stopped having tested nothing -- and said so in the language
+#' of a degenerate column, which is a different fault entirely.
+#'
+#' This costs a numeric Hessian per candidate, which is the per-candidate work
+#' the score criterion exists to avoid. It fires only where the analytic form
+#' is unavailable, and slower is the correct trade against selecting nothing.
+#'
+#' @noRd
+.hzr_score_multiphase_hessian <- function(current, theta, phases,
+                                           covariate_counts, x_list) {
+  if (!requireNamespace("numDeriv", quietly = TRUE)) {
+    # Returning NULL here would NA every candidate and make stepwise report
+    # nothing significant -- a plausible-looking wrong answer.
+    stop(
+      "The score criterion needs the 'numDeriv' package for a multiphase fit ",
+      "with left- or interval-censored rows: the analytic observed ",
+      "information is not defined there, so it must be computed numerically. ",
+      "Install 'numDeriv', or select with the Wald criterion.",
+      call. = FALSE
+    )
+  }
+  d <- current$data
+  nll <- function(par) {
+    -.hzr_logl_multiphase(
+      par, time = d$time, status = d$status,
+      time_lower = d$time_lower, time_upper = d$time_upper,
+      x = d$x, weights = d$weights, phases = phases,
+      covariate_counts = covariate_counts, x_list = x_list
+    )
+  }
+  h <- tryCatch(numDeriv::hessian(nll, theta), error = function(e) NULL)
+  if (is.null(h) || !is.matrix(h) || nrow(h) != length(theta) ||
+        !all(is.finite(h))) {
+    return(NULL)
+  }
+  # Mirror .hzr_hessian_multiphase(), which names from `theta`, so the two are
+  # interchangeable to a caller. `theta` is unnamed on an expanded model, and
+  # this then yields NULL dimnames there -- as the analytic path also does.
+  dimnames(h) <- list(names(theta), names(theta))
+  h
+}
+
 #' Observed information (Hessian of the negative log-likelihood)
 #'
 #' @noRd
@@ -228,16 +276,23 @@
   if (current$spec$dist != "multiphase") {
     return(.hzr_score_single_hessian(current, d$x, theta))
   }
-  tryCatch(
+  phases <- .hzr_score_phases(current)
+  h <- tryCatch(
     .hzr_hessian_multiphase(
       theta, time = d$time, status = d$status,
       time_lower = d$time_lower, time_upper = d$time_upper,
       x = d$x, weights = d$weights,
-      phases = .hzr_score_phases(current),
+      phases = phases,
       covariate_counts = current$fit$covariate_counts,
       x_list = current$fit$x_list
     ),
     error = function(e) NULL
+  )
+  if (!is.null(h)) {
+    return(h)
+  }
+  .hzr_score_multiphase_hessian(
+    current, theta, phases, current$fit$covariate_counts, current$fit$x_list
   )
 }
 
@@ -467,10 +522,12 @@
     ),
     error = function(e) NULL
   )
-  if (is.null(h) || !is.matrix(h) || nrow(h) != length(exp_$theta)) {
-    return(NULL)
+  if (!is.null(h) && is.matrix(h) && nrow(h) == length(exp_$theta)) {
+    return(h)
   }
-  h
+  .hzr_score_multiphase_hessian(
+    current, exp_$theta, exp_$phases, exp_$covariate_counts, exp_$x_list
+  )
 }
 
 #' Score statistic for one entry candidate

--- a/tests/testthat/test-score-test.R
+++ b/tests/testthat/test-score-test.R
@@ -405,3 +405,130 @@ test_that("score rejects a candidate already in the single-distribution model", 
                 dist = "weibull", theta = c(0.01, 0.5, 0), fit = TRUE)
   expect_null(.hzr_score_expand(fit, "age", phase = NULL, data = avc))
 })
+
+
+# The score criterion must work on the censoring the formula interface emits ---
+#
+# The multiphase analytic Hessian declines by design for status in {-1, 2}
+# (R/hessian-multiphase.R). .hzr_score_information() had no fallback on the
+# multiphase branch -- the single-distribution branch has one -- so NULL
+# propagated to nuisance$ok = FALSE and every candidate scored NA. The screen
+# then stopped having tested nothing, blaming a degenerate column.
+#
+# This became reachable in 1.2.0: the Surv() recoding fix made status -1 and 2
+# expressible through the formula interface, in the same release that made
+# criterion = "score" the default. No test exercised both.
+#
+# The fixture is run BOTH ways -- six rows interval-censored, and the same six
+# left as exact events -- because the claim is a parity one. Absolute
+# assertions on the interval fit alone would not distinguish "the fallback
+# works" from "the score criterion happens to like this data": the right-
+# censored arm is the control, and it exercises the analytic Hessian that the
+# fallback has to reproduce.
+#
+# beta_true is deliberately modest. The observed information at beta = 0 goes
+# indefinite for a strongly predictive candidate -- v_beta < 0, Q = NA -- on
+# right-censored data just as much as on interval-censored data, so a large
+# effect here would test that unrelated limitation instead of this fallback.
+
+.ic_multiphase_fixture <- function(interval = TRUE, beta_true = 0.2) {
+  set.seed(4242)
+  n <- 260
+  d <- data.frame(z = rnorm(n), w = rnorm(n))
+  tt <- rexp(n, 0.25 * exp(beta_true * d$z))
+  d$t <- pmin(tt, 12)
+  code <- ifelse(tt >= 12, 0L, 1L)
+  d$t2 <- NA_real_
+  if (interval) {
+    iv <- which(code == 1L)[1:6]
+    d$t[iv] <- pmax(d$t[iv] - 0.3, 1e-6)
+    d$t2[iv] <- d$t[iv] + 0.6
+    code[iv] <- 3L                    # Surv "interval" code
+  }
+  d$code <- code
+  ph <- list(early = hzr_phase("cdf", t_half = 1, nu = 1, m = 1,
+                               fixed = "shapes"),
+             const = hzr_phase("constant"))
+  f <- if (interval) {
+    survival::Surv(t, t2, code, type = "interval") ~ 1
+  } else {
+    survival::Surv(t, code) ~ 1
+  }
+  fit <- suppressWarnings(hazard(
+    f, data = d, dist = "multiphase", phases = ph, fit = TRUE,
+    control = list(n_starts = 1L, maxit = 800L)))
+  list(fit = fit, data = d)
+}
+
+test_that("observed information is available for interval-censored multiphase", {
+  skip_if_not_installed("numDeriv")
+  fx <- .ic_multiphase_fixture()
+  expect_true(any(fx$fit$data$status == 2L))
+
+  # The analytic Hessian declines here by design ...
+  expect_null(.hzr_hessian_multiphase(
+    fx$fit$fit$theta, time = fx$fit$data$time, status = fx$fit$data$status,
+    time_lower = fx$fit$data$time_lower, time_upper = fx$fit$data$time_upper,
+    x = fx$fit$data$x, weights = fx$fit$data$weights,
+    phases = .hzr_score_phases(fx$fit),
+    covariate_counts = fx$fit$fit$covariate_counts,
+    x_list = fx$fit$fit$x_list))
+
+  # ... so the information must come from somewhere else.
+  info <- .hzr_score_information(fx$fit, fx$fit$fit$theta)
+  expect_true(is.matrix(info))
+  expect_equal(dim(info), rep(length(fx$fit$fit$theta), 2L))
+  expect_true(all(is.finite(info)))
+  expect_equal(info, t(info), tolerance = 1e-6)
+})
+
+test_that("the numeric fallback reproduces the analytic observed information", {
+  skip_if_not_installed("numDeriv")
+  # Same model on right-censored data, where the analytic Hessian IS defined.
+  # The fallback must agree with it; agreeing is what licenses using it where
+  # the analytic form declines.
+  fx <- .ic_multiphase_fixture(interval = FALSE)
+  th <- fx$fit$fit$theta
+  analytic <- .hzr_hessian_multiphase(
+    th, time = fx$fit$data$time, status = fx$fit$data$status,
+    time_lower = fx$fit$data$time_lower, time_upper = fx$fit$data$time_upper,
+    x = fx$fit$data$x, weights = fx$fit$data$weights,
+    phases = .hzr_score_phases(fx$fit),
+    covariate_counts = fx$fit$fit$covariate_counts,
+    x_list = fx$fit$fit$x_list)
+  expect_true(is.matrix(analytic))
+
+  numeric_ <- .hzr_score_multiphase_hessian(
+    fx$fit, th, .hzr_score_phases(fx$fit),
+    fx$fit$fit$covariate_counts, fx$fit$fit$x_list)
+  expect_equal(numeric_, analytic, tolerance = 1e-4)
+})
+
+test_that("score selects on interval-censored multiphase, as it does without", {
+  skip_if_not_installed("numDeriv")
+  run <- function(interval, crit) {
+    fx <- .ic_multiphase_fixture(interval = interval)
+    r <- suppressWarnings(hzr_stepwise(
+      fx$fit, scope = list(early = ~ z + w, const = ~ z + w), data = fx$data,
+      direction = "forward", criterion = crit, slentry = 0.2, trace = FALSE,
+      control = list(n_starts = 1L)))
+    list(sel = setdiff(names(coef(r)), names(coef(fx$fit))),
+         nunc = r$criteria$n_uncomputable_scores %||% 0L)
+  }
+  ic <- run(TRUE, "score")
+  rc <- run(FALSE, "score")
+
+  # Not merely non-empty: the same variables the analytic path selects.
+  expect_gt(length(rc$sel), 0L)
+  expect_equal(ic$sel, rc$sel)
+
+  # No candidate went unscored for want of an information matrix.
+  expect_equal(ic$nunc, 0L)
+  expect_equal(rc$nunc, 0L)
+
+  # The wald path never needed the Hessian, so it is a check on the fixture
+  # rather than on the fallback: the data must carry signal either way. It is
+  # NOT asserted to select the same set -- 1.2.0's NEWS documents that score
+  # and wald can diverge, and here score enters early.z where wald does not.
+  expect_gt(length(run(TRUE, "wald")$sel), 0L)
+})


### PR DESCRIPTION
Second of the two HIGH defects from the release-diff review (step 5 of the pre-submission checklist). The first was #124.

## The score criterion tested nothing, and reported it as something else

`.hzr_hessian_multiphase()` returns `NULL` by design when any row is left- or interval-censored (`status` in `{-1, 2}`). The score path had **no fallback on the multiphase branch** — the single-distribution branch has had one all along. The `NULL` reached `nuisance$ok = FALSE`, every candidate scored `NA`, and `hzr_stepwise()` stopped having tested nothing — reporting it in the language of a degenerate candidate, which is a different fault entirely.

Reachable only as of this release, and only from **both** halves of it: #116 made left- and interval-censored rows expressible through the formula interface, and `criterion = "score"` became the default in the same release. No test crossed the two.

Watched failing on the corrected test, with the fix reverted:

```
Expected `ic$sel` to equal `rc$sel`.
`actual`:                            # interval-censored: selected nothing
`expected`: "early.z" "const.z"      # same data right-censored: selected both
Expected `ic$nunc` to equal 0L.  actual: 4      # 4 of 4 candidates unscorable
```

## The fallback, and the evidence for it

Same numeric Hessian the single-distribution path already uses. Measured against the analytic form on the equivalent right-censored fit, it agrees to **1e-4** — that agreement is what licenses substituting one for the other, and it is now a test. It also carries the analytic path's dimnames, so the two are interchangeable to a caller.

`numDeriv` is a `Suggests`, so its absence **stops** with a message naming it and `criterion = "wald"`, rather than returning a screen that tested nothing.

## The test is a parity test, deliberately

The fixture runs **both ways** — six rows interval-censored, and the same six left as exact events. Absolute assertions on the interval arm alone would not separate "the fallback works" from "the score criterion happens to like this data"; the right-censored arm is the control, and it exercises the analytic Hessian the fallback has to reproduce.

## One thing found on the way, filed separately

`beta_true` in the fixture is deliberately modest. The observed information at `beta = 0` goes **indefinite for a strongly predictive candidate** — `v_beta < 0`, `Q = NA` — and it does so on right-censored data just as much as on interval-censored data:

| true β | v_β | score Q | wald |
|---|---|---|---|
| 0.0 | 3.02 | 0.066 | — |
| 0.2 | 1.00 | 13.6 ✓ | selects |
| 0.4 | **−7.92** | **NA** | selects |
| 0.8 | **−23.30** | **NA** | selects |

That is pre-existing, unrelated to this branch, and filed on its own. A large effect in this fixture would have tested it instead of the fallback.

## Verification

`devtools::test()` **2049 pass / 0 fail**, `lintr::lint_package()` clean, `document()` no-op. The three new tests carry `skip_if_not_installed("numDeriv")` but **no** `skip_on_cran()`: the whole file runs in 4.2 s, and a regression guard that never runs on CRAN would not guard this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)