### PR TITLE
fix: the multiphase derivatives disagreed with the likelihood on entry times

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
 BugReports: https://github.com/ehrlinger/temporal_hazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TemporalHazard 1.2.0
+# TemporalHazard 1.2.1
 
 ## Breaking changes
 
@@ -86,6 +86,33 @@ selects.
   log-likelihood is not among them; that still comes from the `.lst`.
 
 ## Bug fixes
+
+* **The multiphase gradient and Hessian disagreed with the log-likelihood on
+  left-truncated data.** For a row with `status` in `{0, 1}` the log-likelihood
+  subtracts `H(time_lower)` unconditionally, but the analytic derivatives
+  defined the entry time with an extra `time_lower < time` filter. A subject
+  entering the risk set at its own event or censoring time was therefore
+  differentiated as though it had no entry time, while its weight was still
+  applied -- so the derivative was taken of a different function from the one
+  being evaluated, and the optimizer left any sensible region immediately.
+  Measured on `avc` at fixed parameters, the analytic gradient was out by 382
+  where every row entered at its exit time, and by 126 where only *some* did
+  -- which is ordinary left-truncated data, not a pathological input. Both
+  derivatives now define the entry time exactly as the likelihood does, and
+  new tests assert agreement with `numDeriv` across five entry-time layouts
+  rather than the one the old filter happened to admit.
+
+* **`hazard()` documented `time_lower` incorrectly, and now warns when it is
+  self-defeating.** The argument was described only as the lower bound of a
+  censoring interval, "defaulting to `time` if NULL". For `status` in
+  `{0, 1}` it is in fact the counting-process **entry time**, and leaving it
+  `NULL` means entry at `0`, *not* at `time`. Read literally, the old wording
+  said that passing `time_lower = time` changes nothing; it in fact states
+  that every subject left the risk set at the instant it entered, which
+  removes every such row from the likelihood and leaves the objective
+  unbounded above. The documentation now gives both roles, and supplying
+  `time_lower >= time` on a `status` 0 or 1 row warns, naming the count and
+  the `NULL` default. Reported as issue #136.
 
 * **`hzr_stepwise()` now says *why* a candidate could not be scored, and warns
   when the reason is that the candidate looks strong.** Under

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -106,8 +106,18 @@ NULL
 #'
 #' @param time Numeric follow-up time vector.
 #' @param status Numeric or logical event indicator vector.
-#' @param time_lower Optional numeric lower bound vector for censoring intervals.
-#'   Used when `status == 2` (interval-censored); defaults to `time` if NULL.
+#' @param time_lower Optional numeric vector with two distinct roles, selected
+#'   by `status`. Supplying it explicitly is **not** a no-op.
+#'   * `status == 2` (interval-censored): the lower bound of the censoring
+#'     interval, defaulting to `time`.
+#'   * `status %in% c(0, 1)` (right-censored or event): the counting-process
+#'     **entry time**, so the row contributes `H(time) - H(time_lower)`.
+#'     Left `NULL`, the entry time is **`0`**, not `time`.
+#'
+#'   Passing `time_lower = time` therefore states that every subject entered
+#'   the risk set at the instant it left, which contributes nothing and
+#'   removes the row from the likelihood. That is a valid specification and
+#'   the fit will not converge to anything meaningful; it warns.
 #' @param time_upper Optional numeric upper bound vector for censoring intervals.
 #'   Used when `status %in% c(-1, 2)`; defaults to `time` if NULL.
 #' @param x Optional design matrix (or data frame coercible to matrix).
@@ -395,6 +405,28 @@ hazard <- function(formula = NULL,
   if (!is.null(time_upper)) {
     if (!is.numeric(time_upper) || length(time_upper) != n || any(!is.finite(time_upper)) || any(time_upper < 0)) {
       stop("'time_upper' must be a numeric vector of finite non-negative values matching length(time).", call. = FALSE)
+    }
+  }
+
+  # For status 0/1 rows `time_lower` is the counting-process ENTRY time, not a
+  # censoring bound, so `time_lower >= time` says the subject left the risk set
+  # at or before it entered.  Such a row contributes H(time) - H(time_lower),
+  # which is zero or negative: it drops out of the likelihood, or worse.  With
+  # every row like that the objective is unbounded above and the optimizer
+  # returns a large positive "log-likelihood", converged = TRUE and rcond = 0,
+  # with nothing naming the cause.  Reported as issue #136, where the argument
+  # had been supplied in the belief that it was a no-op.
+  if (!is.null(time_lower)) {
+    degenerate <- status %in% c(0, 1) & time_lower >= time
+    if (any(degenerate)) {
+      warning(sum(degenerate), " of ", n, " row(s) have 'time_lower' >= 'time' ",
+              "with status 0 or 1. For those rows 'time_lower' is the ",
+              "counting-process entry time, so they enter the risk set at or ",
+              "after they leave it and contribute nothing to the likelihood ",
+              "(it is not a censoring bound outside status 2). If you meant ",
+              "the default -- entry at time 0 -- leave 'time_lower' as NULL; ",
+              "passing 'time_lower = time' is not the same thing.",
+              call. = FALSE)
     }
   }
 

--- a/R/hessian-multiphase.R
+++ b/R/hessian-multiphase.R
@@ -376,11 +376,20 @@ NULL
   n_e       <- length(idx_event)
 
   # Counting-process start-time handling (mirrors gradient)
+  # The start time must be defined EXACTLY as the log-likelihood defines it:
+  # `.hzr_logl_multiphase()` subtracts H(time_lower) from every status 0/1 row
+  # whenever `time_lower` is supplied, with no further condition. An earlier
+  # `time_lower < time` filter here excluded rows entering at their own event
+  # or censoring time, so the derivative was taken of a different function from
+  # the one being evaluated -- the optimizer then walked off a cliff. The
+  # `> 0` test is only a skip: H(0) = 0, so those rows contribute nothing
+  # either way, and it must match `has_start` below or the term is weighted in
+  # while its derivative is left at zero.
   need_start <- !is.null(time_lower) &&
-                any(time_lower > 0 & time_lower < time & status %in% c(0L, 1L))
+                any(time_lower > 0 & status %in% c(0L, 1L))
   start_vec <- if (need_start) {
     sv <- rep(0, n)
-    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    epoch_idx <- status %in% c(0L, 1L)
     sv[epoch_idx] <- time_lower[epoch_idx]
     sv
   } else {

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -613,17 +613,20 @@
   phase_deriv      <- vector("list", n_phases)  # derivative list at time
   phase_Phi_start  <- vector("list", n_phases)  # Phi_j(start_i), if needed
   phase_deriv_start <- vector("list", n_phases) # derivative list at start
-  # Whether to actually compute start-time quantities for the gradient.
-  # Without any counting-process rows (time_lower = NULL or all zeros with
-  # status in {0, 1}) these additions are identically zero and we can skip.
-  # Only genuine epoch rows (status 0/1 with time_lower < time) get a
-  # non-zero start.  Interval-censored rows (status 2) are handled through
-  # their own lower/upper cumhaz terms and must not contribute to H(start).
+  # The start time must be defined EXACTLY as the log-likelihood defines it:
+  # `.hzr_logl_multiphase()` subtracts H(time_lower) from every status 0/1 row
+  # whenever `time_lower` is supplied, with no further condition. An earlier
+  # `time_lower < time` filter here excluded rows entering at their own event
+  # or censoring time, so the derivative was taken of a different function from
+  # the one being evaluated -- the optimizer then walked off a cliff. The
+  # `> 0` test is only a skip: H(0) = 0, so those rows contribute nothing
+  # either way, and it must match `has_start` below or the term is weighted in
+  # while its derivative is left at zero.
   need_start <- !is.null(time_lower) &&
-                any(time_lower > 0 & time_lower < time & status %in% c(0L, 1L))
+                any(time_lower > 0 & status %in% c(0L, 1L))
   start_vec <- if (need_start) {
     sv <- rep(0, n)
-    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    epoch_idx <- status %in% c(0L, 1L)
     sv[epoch_idx] <- time_lower[epoch_idx]
     sv
   } else {

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -618,7 +618,9 @@
   # whenever `time_lower` is supplied, with no further condition. An earlier
   # `time_lower < time` filter here excluded rows entering at their own event
   # or censoring time, so the derivative was taken of a different function from
-  # the one being evaluated -- the optimizer then walked off a cliff. The
+  # the one being evaluated: the reported gradient pointed somewhere the
+  # objective did not, and the optimizer followed it out of the region where
+  # the fit means anything. The
   # `> 0` test is only a skip: H(0) = 0, so those rows contribute nothing
   # either way, and it must match `has_start` below or the term is weighted in
   # while its derivative is left at zero.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-# CRAN submission comments -- TemporalHazard 1.2.0
+# CRAN submission comments -- TemporalHazard 1.2.1
 
 ## Summary
 

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -40,8 +40,20 @@ Example: \code{hazard(Surv(time, status) ~ x1 + x2, data = df, dist = "weibull",
 
 \item{status}{Numeric or logical event indicator vector.}
 
-\item{time_lower}{Optional numeric lower bound vector for censoring intervals.
-Used when \code{status == 2} (interval-censored); defaults to \code{time} if NULL.}
+\item{time_lower}{Optional numeric vector with two distinct roles, selected
+by \code{status}. Supplying it explicitly is \strong{not} a no-op.
+\itemize{
+\item \code{status == 2} (interval-censored): the lower bound of the censoring
+interval, defaulting to \code{time}.
+\item \code{status \%in\% c(0, 1)} (right-censored or event): the counting-process
+\strong{entry time}, so the row contributes \code{H(time) - H(time_lower)}.
+Left \code{NULL}, the entry time is \strong{\code{0}}, not \code{time}.
+}
+
+Passing \code{time_lower = time} therefore states that every subject entered
+the risk set at the instant it left, which contributes nothing and
+removes the row from the likelihood. That is a valid specification and
+the fit will not converge to anything meaningful; it warns.}
 
 \item{time_upper}{Optional numeric upper bound vector for censoring intervals.
 Used when \code{status \%in\% c(-1, 2)}; defaults to \code{time} if NULL.}

--- a/tests/testthat/test-time-lower-entry.R
+++ b/tests/testthat/test-time-lower-entry.R
@@ -1,0 +1,111 @@
+# `time_lower` as a counting-process entry time -------------------------------
+#
+# For status 0/1 rows the log-likelihood subtracts H(time_lower) from every
+# row, unconditionally, whenever `time_lower` is supplied. The gradient and
+# the Hessian used to define "start" differently -- they filtered on
+# `time_lower < time` -- so a row entering the risk set at its own event or
+# censoring time was differentiated as though it had no entry time at all,
+# while its weight was still applied.
+#
+# The derivative was therefore taken of a different function from the one
+# being evaluated. Measured on `avc` at fixed theta, the analytic gradient was
+# out by 382 with time_lower = time, and by 126 on data where only SOME rows
+# entered at their exit time -- which is ordinary left-truncated data, not a
+# pathological input. Issue #136.
+#
+# The invariant is the guard: analytic derivatives must agree with numDeriv
+# for EVERY arrangement of entry times, not merely the ones the old filter
+# happened to admit.
+
+.entry_case <- function() {
+  data("avc", package = "TemporalHazard", envir = environment())
+  ph <- list(early = hzr_phase("cdf", t_half = 0.19, nu = 1.44, m = 1,
+                               fixed = "m"),
+             constant = hzr_phase("constant"))
+  list(
+    time = avc$int_dead, status = avc$dead,
+    theta = c(log(0.35), log(0.19), 1.44, 1, log(0.03)),
+    phases = ph,
+    weights = rep(1, nrow(avc)),
+    counts = c(early = 0L, constant = 0L),
+    x_list = list(early = NULL, constant = NULL)
+  )
+}
+
+.entry_variants <- function(k) {
+  mixed <- k$time
+  half <- seq_len(floor(length(mixed) / 2))
+  mixed[half] <- pmax(k$time[half] - 0.5, 0)     # some enter early, rest at exit
+  list(
+    "no entry times"      = NULL,
+    "entry at zero"       = rep(0, length(k$time)),
+    "entry at exit"       = k$time,
+    "genuine truncation"  = pmax(k$time - 0.5, 0),
+    "mixed entry times"   = mixed
+  )
+}
+
+test_that("the multiphase gradient matches numDeriv for every entry-time layout", {
+  skip_if_not_installed("numDeriv")
+  k <- .entry_case()
+  for (nm in names(.entry_variants(k))) {
+    tl <- .entry_variants(k)[[nm]]
+    f <- function(p) {
+      .hzr_logl_multiphase(p, time = k$time, status = k$status, time_lower = tl,
+                           time_upper = NULL, x = NULL, weights = k$weights,
+                           phases = k$phases, covariate_counts = k$counts,
+                           x_list = k$x_list)
+    }
+    analytic <- .hzr_gradient_multiphase(
+      k$theta, time = k$time, status = k$status, time_lower = tl,
+      time_upper = NULL, x = NULL, weights = k$weights, phases = k$phases,
+      covariate_counts = k$counts, x_list = k$x_list)
+    numeric_ <- numDeriv::grad(f, k$theta)
+    expect_equal(analytic, numeric_, tolerance = 1e-5, info = nm)
+  }
+})
+
+test_that("the multiphase Hessian matches numDeriv for every entry-time layout", {
+  skip_if_not_installed("numDeriv")
+  k <- .entry_case()
+  for (nm in names(.entry_variants(k))) {
+    tl <- .entry_variants(k)[[nm]]
+    nll <- function(p) {
+      -.hzr_logl_multiphase(p, time = k$time, status = k$status, time_lower = tl,
+                            time_upper = NULL, x = NULL, weights = k$weights,
+                            phases = k$phases, covariate_counts = k$counts,
+                            x_list = k$x_list)
+    }
+    analytic <- .hzr_hessian_multiphase(
+      k$theta, time = k$time, status = k$status, time_lower = tl,
+      time_upper = NULL, x = NULL, weights = k$weights, phases = k$phases,
+      covariate_counts = k$counts, x_list = k$x_list)
+    expect_false(is.null(analytic), info = nm)
+    expect_equal(unname(analytic), numDeriv::hessian(nll, k$theta),
+                 tolerance = 1e-4, info = nm)
+  }
+})
+
+test_that("entry at or after exit warns, and names the NULL default", {
+  k <- .entry_case()
+  fit_with <- function(tl) {
+    suppressMessages(hazard(
+      time = k$time, status = k$status, time_lower = tl,
+      dist = "multiphase", phases = k$phases, theta = k$theta, fit = FALSE))
+  }
+  w <- capture_warnings(fit_with(k$time))
+  expect_match(w, "counting-process entry time", all = FALSE)
+  expect_match(w, "310 of 310", all = FALSE)
+  # The remedy has to be in the message: NULL is not the same as `time`.
+  expect_match(w, "leave 'time_lower' as NULL", all = FALSE)
+})
+
+test_that("genuine left truncation does not warn", {
+  k <- .entry_case()
+  # Every row enters strictly before it leaves: an ordinary counting-process
+  # dataset, which must stay silent or the warning is noise.
+  w <- capture_warnings(suppressMessages(hazard(
+    time = k$time, status = k$status, time_lower = pmax(k$time - 0.5, 0),
+    dist = "multiphase", phases = k$phases, theta = k$theta, fit = FALSE)))
+  expect_false(any(grepl("counting-process entry time", w)))
+})

--- a/tests/testthat/test-time-lower-entry.R
+++ b/tests/testthat/test-time-lower-entry.R
@@ -48,8 +48,9 @@
 test_that("the multiphase gradient matches numDeriv for every entry-time layout", {
   skip_if_not_installed("numDeriv")
   k <- .entry_case()
-  for (nm in names(.entry_variants(k))) {
-    tl <- .entry_variants(k)[[nm]]
+  variants <- .entry_variants(k)
+  for (nm in names(variants)) {
+    tl <- variants[[nm]]
     f <- function(p) {
       .hzr_logl_multiphase(p, time = k$time, status = k$status, time_lower = tl,
                            time_upper = NULL, x = NULL, weights = k$weights,
@@ -68,8 +69,9 @@ test_that("the multiphase gradient matches numDeriv for every entry-time layout"
 test_that("the multiphase Hessian matches numDeriv for every entry-time layout", {
   skip_if_not_installed("numDeriv")
   k <- .entry_case()
-  for (nm in names(.entry_variants(k))) {
-    tl <- .entry_variants(k)[[nm]]
+  variants <- .entry_variants(k)
+  for (nm in names(variants)) {
+    tl <- variants[[nm]]
     nll <- function(p) {
       -.hzr_logl_multiphase(p, time = k$time, status = k$status, time_lower = tl,
                             time_upper = NULL, x = NULL, weights = k$weights,
@@ -93,9 +95,12 @@ test_that("entry at or after exit warns, and names the NULL default", {
       time = k$time, status = k$status, time_lower = tl,
       dist = "multiphase", phases = k$phases, theta = k$theta, fit = FALSE))
   }
+  n <- length(k$time)
   w <- capture_warnings(fit_with(k$time))
   expect_match(w, "counting-process entry time", all = FALSE)
-  expect_match(w, "310 of 310", all = FALSE)
+  # Derived, not hard-coded: the assertion is that the warning counts EVERY
+  # row, which stays true if `avc` ever changes size.
+  expect_match(w, paste0(n, " of ", n), all = FALSE)
   # The remedy has to be in the message: NULL is not the same as `time`.
   expect_match(w, "leave 'time_lower' as NULL", all = FALSE)
 })


### PR DESCRIPTION
Closes #136 — though not in the way the report frames it. It found something worse than what it describes, and the thing it expected is not a defect.

## The real bug: the derivative was of a different function from the objective

For a `status` 0/1 row the log-likelihood subtracts `H(time_lower)` **unconditionally** whenever `time_lower` is supplied. The analytic gradient and Hessian defined the entry time with an extra `time_lower < time` filter, so a subject entering the risk set at its own event or censoring time was differentiated as though it had no entry time — while `has_start` still applied its weight. Three conditions for one concept, across two files.

Measured on `avc` at fixed θ, `max |analytic − numeric|`:

| `time_lower` | before | after |
|---|---|---|
| `NULL` | 3.5e−08 | 3.5e−08 |
| `= time` | **382** | 3.9e−09 |
| `= time − 0.5` (all rows) | 2.3e−09 | 2.3e−09 |
| **mixed** (some rows `== time`) | **126** | 3.0e−09 |

**The mixed row is the one that matters.** That is ordinary left-truncated data — some subjects enter at the moment they leave — not a pathological input, and it was silently wrong. Hessians likewise now agree to ~1e−6 across all five layouts.

## The reported expectation is wrong, and the docs are why

The report expects `b` (bounds `= time`) to equal `a` (no bounds). It should not, and it still does not after this fix. For `status` 0/1, `time_lower` is the counting-process **entry time**: setting it to `time` says every subject left the risk set at the instant it entered, so every such row drops out and the objective is unbounded above. The divergence is correct behaviour.

What produced the wrong expectation was the documentation:

> `time_lower` — Optional numeric lower bound vector for censoring intervals. Used when `status == 2` (interval-censored); **defaults to `time` if NULL.**

For `status` 0/1 the default entry time is **`0`**, not `time`. Read literally, the old wording says supplying `time_lower = time` changes nothing. Both roles are now documented, and `time_lower >= time` on a `status` 0/1 row warns with the count and the `NULL` default named:

```
310 of 310 row(s) have 'time_lower' >= 'time' with status 0 or 1. For those rows
'time_lower' is the counting-process entry time, so they enter the risk set at or
after they leave it and contribute nothing to the likelihood ... If you meant the
default -- entry at time 0 -- leave 'time_lower' as NULL; passing
'time_lower = time' is not the same thing.
```

Genuine left truncation stays silent — asserted, so the warning cannot become noise.

## On the issue's other suggestions

- *"Guard a converged fit whose objective is positive."* Not implemented. A log-likelihood of a continuous density can legitimately be positive, so a blanket sign test would false-positive. The invariant that actually catches this class is analytic-vs-`numDeriv`, which is now asserted.
- *`logLik()` has no `hazard` method.* True, and out of scope here — worth its own issue.

## Version

**1.2.1.** Nothing above 1.1.0 has shipped — no `v1.2.0` tag, no release — so this folds into the existing unreleased block rather than opening a NEWS section for a version nobody can install (the precedent from the 1.1.0 cycle). `DESCRIPTION`, `NEWS.md` and `cran-comments.md` headings all moved together.

## Verification

New `tests/testthat/test-time-lower-entry.R` asserts the analytic-vs-`numDeriv` invariant for gradient **and** Hessian across five entry-time layouts, rather than the one the old filter happened to admit. Watched failing: **7 of 19** against the parent commit.

`devtools::test()` **2107 pass / 0 fail**, `lintr::lint_package()` clean, `document()` regenerated `man/hazard.Rd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)