### PR TITLE
ci: lint on hard dependencies only

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,20 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # Hard dependencies only. Resolving Suggests as well pulled pkgdown,
+          # rmarkdown, knitr, quarto, haven and ggplot2, and with them 18 apt
+          # system packages -- the ragg / systemfonts / textshaping graphics
+          # chain plus pandoc. Those are not cached by anything, so they cost
+          # about 8 minutes on every run, to lint for 18 seconds.
+          #
+          # Nothing here needs them. `Imports:` is `survival` alone, and no
+          # enabled linter loads the package namespace: `object_usage_linter`
+          # is the only default that does and `.lintr` sets it to NULL, while
+          # `namespace_linter` is not a default at all. If a future linter
+          # does need the namespace, `local::.` still installs the package --
+          # only Suggests are dropped.
           extra-packages: any::lintr, local::.
+          dependencies: '"hard"'
           needs: lint
 
       - name: Lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,7 +44,7 @@ jobs:
           # does need the namespace, `local::.` still installs the package --
           # only Suggests are dropped.
           extra-packages: any::lintr, local::.
-          dependencies: '"hard"'
+          dependencies: hard
           needs: lint
 
       - name: Lint


### PR DESCRIPTION
The lint job spent **8.4 minutes installing dependencies to lint for 18 seconds.**

## Measured, not guessed

Run [32274413708](https://github.com/ehrlinger/temporal_hazard/actions/runs/32274413708) (`dev`, success), per-step:

| step | time |
|---|---|
| setup-r | 3.0 min |
| **setup-r-dependencies** | **8.4 min** |
| **Lint** | **0.3 min** |

The R package cache was **hit** — 62 MB restored in 2 seconds — so caching was not the problem. The cost was **18 apt system packages**, which no cache covers:

```
libfreetype6-dev, libharfbuzz-dev, libfribidi-dev, libpng-dev, libjpeg-dev,
libtiff-dev, libwebp-dev, libfontconfig1-dev   → ragg, systemfonts, textshaping
pandoc                                          → knitr, pkgdown, rmarkdown
cmake, libuv1-dev, libcurl4-openssl-dev, ...    → fs, curl, openssl, haven, sass
```

They arrive because `local::.` resolves **Suggests** as well as Imports, and Suggests carries `pkgdown`, `rmarkdown`, `knitr`, `quarto`, `haven`, `ggplot2` — the whole documentation toolchain, built to run a parser.

## Why dropping them is safe

- `Imports:` is **`survival`** alone.
- No enabled linter loads the package namespace. `object_usage_linter` is the only default that does, and `.lintr` sets it to `NULL`; `namespace_linter` is not a default at all.
- `local::.` is **kept**, so a future linter that does need the namespace still works — only Suggests are dropped.

## Verification

The check that matters is CI reporting **0 lints** on this run, since the change is to what gets *installed*, not to what lintr does. `lintr::lint_package()` confirmed 0 locally beforehand.

## Scope of the win

Honest accounting: wall-clock saving on a PR is small, because lint is not the long pole — `R-CMD-check` is. What it buys is a runner slot returned ~9 minutes sooner, which matters while every job on both open PRs is sitting `queued` rather than `running`.

Deliberately **not** included: trimming the `R-CMD-check` platform matrix on PRs. That is the obvious speedup and the wrong one here — Linux-vs-macOS divergence caught two real defects this week (#132's sign-vs-magnitude bug and #135's fixture flake), both invisible on macOS alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)