### PR TITLE
ci: restore the quoting on the lint dependencies input

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,8 +43,13 @@ jobs:
           # `namespace_linter` is not a default at all. If a future linter
           # does need the namespace, `local::.` still installs the package --
           # only Suggests are dropped.
+          #
+          # The quoting is load-bearing and must stay: `dependencies` is
+          # documented by the action as "Must be an R expression. Note that it
+          # often needs to be quoted in YAML" and its own default is '"all"'.
+          # Bare `hard` is the R symbol `hard`, not the string "hard".
           extra-packages: any::lintr, local::.
-          dependencies: hard
+          dependencies: '"hard"'
           needs: lint
 
       - name: Lint


### PR DESCRIPTION
A Copilot Autofix committed to #138 before merge ([`7394dce`](https://github.com/ehrlinger/temporal_hazard/commit/7394dce)) changed:

```diff
-          dependencies: '"hard"'
+          dependencies: hard
```

## That input is an R expression, not a YAML string

From `r-lib/actions/setup-r-dependencies/action.yaml` itself:

> `dependencies`: **"Types of dependencies to install. Must be an R expression. Note that it often needs to be quoted in YAML, see the README for details."** — `default: '"all"'`

The action's own default is `'"all"'` — the same nested-quote shape. Bare `hard` is the R *symbol* `hard`, not the string `"hard"`.

## Why this one matters more than it looks

If the action errors, we find out immediately and it is merely noise. If it falls back to its default instead, the lint job silently goes back to resolving **Suggests** — reinstalling the 18 apt system packages #138 just removed — while still reporting `0 lints`. Nothing in the output would say so except the runtime, which is exactly the signal nobody reads.

That is the same shape as the defects this package keeps finding: the check still passes, so nothing looks wrong.

The `dev` lint run triggered by the #138 merge was still queued when I opened this, so the empirical answer is not in yet. The action's documented contract is enough to act on either way, and this PR's own lint job settles it: **2 system packages and `No lints found`** means the restriction is live.

A comment now marks the quoting as load-bearing, so the next autofix pass has something to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)