### PR TITLE
fix: a forward step that lowers the log-likelihood is a failed refit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,25 @@ selects.
 
 ## Bug fixes
 
+* **`hzr_stepwise()` never checked that an accepted step improved the fit.**
+  A forward step enters a model that *contains* the one it started from, so at
+  the optimum the log-likelihood cannot fall. It was written into `$steps` at
+  every step and compared at none, so a step whose refit failed to converge
+  entered anyway and every later step was then scored against a model that was
+  not at its own optimum. In the production screen that surfaced this, three of
+  ten steps lowered the log-likelihood and the run still reported convergence,
+  ten entries and `p = 0.000` throughout; the final 19-coefficient model fitted
+  57 units worse than the nested 16-coefficient model from three steps earlier,
+  which cannot happen at a maximum.
+
+  `$steps` now carries `delta_logLik`, a forward step that lowers the objective
+  warns and is counted in `$criteria$n_nonmonotone_entries`, and
+  `hzr_bootstrap(scope = )` reports `$n_nonmonotone_replicates` — a replicate
+  whose path went backwards still contributes its selections to the pooled
+  frequencies, and each replicate runs under `suppressWarnings()` so the
+  step-level warning cannot reach the user. The comparison carries a small
+  tolerance so optimizer noise does not fire it. Reported as issue #134.
+
 * **The multiphase gradient and Hessian disagreed with the log-likelihood on
   left-truncated data.** For a row with `status` in `{0, 1}` the log-likelihood
   subtracts `H(time_lower)` unconditionally, but the analytic derivatives

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1334,6 +1334,12 @@ print.hzr_nelson <- function(x, digits = 4, ...) {
 #'     candidates whose effect is too large for the score test's approximation
 #'     at zero -- typically strong variables that were passed over rather than
 #'     tested, understating their selection frequency. Empty in refit mode.}
+#'   \item{n_nonmonotone_replicates}{Select mode only: number of otherwise
+#'     successful replicates in which a forward step *lowered* the
+#'     log-likelihood. Entered models are nested, so this cannot occur at the
+#'     optimum; such a replicate continued from a refit that did not converge,
+#'     and its later selections are pooled on the same footing as any other.
+#'     Always `0` in refit mode.}
 #'   \item{mode}{`"refit"` (fixed-formula bootstrap) or `"select"`
 #'     (embedded stepwise selection).}
 #'   \item{scope}{Only present when `mode == "select"`: the candidate
@@ -1568,6 +1574,11 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   # see, and each replicate runs under suppressWarnings() so its own warning
   # never reaches the user.
   uncomputable_reasons <- stats::setNames(integer(0), character(0))
+  # Replicates whose selection path went BACKWARDS. Each still contributes its
+  # selected variables to the pooled frequencies, indistinguishable from a
+  # replicate that converged, and every replicate runs under
+  # suppressWarnings() so the step-level warning cannot reach the user.
+  n_nonmonotone_reps <- 0L
 
   # Progress bar over replicates (verbose only). Closed after the loop.
   pb <- if (verbose) utils::txtProgressBar(min = 0, max = n_boot, style = 3)
@@ -1657,6 +1668,9 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
         uncomputable_reasons <- .hzr_merge_reasons(
           uncomputable_reasons, boot_fit$criteria$uncomputable_reasons
         )
+        if (isTRUE((boot_fit$criteria$n_nonmonotone_entries %||% 0L) > 0L)) {
+          n_nonmonotone_reps <- n_nonmonotone_reps + 1L
+        }
       }
       theta_b <- boot_fit$fit$theta
       names_b <- if (select_mode) {
@@ -1766,6 +1780,16 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
             "`$uncomputable_reasons`.", call. = FALSE)
   }
 
+  if (n_nonmonotone_reps > 0L) {
+    warning(n_nonmonotone_reps, " of ", n_success, " successful replicates ",
+            "had a forward step LOWER the log-likelihood. Entered models are ",
+            "nested, so that cannot happen at the optimum -- those replicates ",
+            "continued from a refit that did not converge, and the variables ",
+            "they selected afterwards are in the pooled frequencies on the ",
+            "same footing as everything else. See ",
+            "`$n_nonmonotone_replicates`.", call. = FALSE)
+  }
+
   result <- list(
     replicates = replicates,
     summary    = summary_df,
@@ -1773,6 +1797,7 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     n_failed   = n_failed,
     n_uncomputable_replicates = n_uncomputable_reps,
     uncomputable_reasons      = uncomputable_reasons,
+    n_nonmonotone_replicates  = n_nonmonotone_reps,
     mode       = if (select_mode) "select" else "refit"
   )
   if (select_mode) result$scope <- scope

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -264,6 +264,13 @@ hzr_stepwise <- function(fit,
 
   current <- fit
   step_no <- 0L
+  # The log-likelihood the next step starts from. A forward step produces a
+  # model that CONTAINS the current one, so at the optimum the objective
+  # cannot fall. When it does, the refit did not converge -- provable in one
+  # comparison, which nothing was doing: the objective was written at every
+  # step and read at none.
+  prev_objective <- current$fit$objective %||% NA_real_
+  n_nonmonotone_entries <- 0L
   stopped_by_max_steps <- FALSE
   # Candidates whose score statistic could not be computed, summed over
   # steps.  Tracked so a screen that stopped because nothing was
@@ -290,10 +297,12 @@ hzr_stepwise <- function(fit,
       p_value   = out$p_value,
       delta_aic = out$delta_aic,
       logLik    = current$fit$objective   %||% NA_real_,
+      delta_logLik = (current$fit$objective %||% NA_real_) - prev_objective,
       aic       = .hzr_aic(current),
       n_coef    = length(current$fit$theta),
       stringsAsFactors = FALSE
     )
+    prev_objective <<- current$fit$objective %||% NA_real_
     steps[[length(steps) + 1L]] <<- row
 
     score_fmt <- if (criterion == "aic") {
@@ -328,6 +337,7 @@ hzr_stepwise <- function(fit,
       p_value   = NA_real_,
       delta_aic = NA_real_,
       logLik    = current$fit$objective   %||% NA_real_,
+      delta_logLik = 0,   # freezing changes no parameter
       aic       = .hzr_aic(current),
       n_coef    = length(current$fit$theta),
       stringsAsFactors = FALSE
@@ -382,6 +392,28 @@ hzr_stepwise <- function(fit,
       }
 
       if (fwd$accepted) {
+        # Nested models: the entered model contains the current one, so at the
+        # optimum objective_new >= objective_old. A violation is not a
+        # statistical result, it is proof the refit failed -- and every later
+        # step is then scored against a model that is not at its own optimum.
+        # The tolerance keeps optimizer noise from firing this; the cases that
+        # matter are whole log-likelihood units, not 1e-10.
+        entered_objective <- fwd$fit$fit$objective %||% NA_real_
+        obj_tol <- 1e-8 * max(1, abs(prev_objective))
+        if (is.finite(entered_objective) && is.finite(prev_objective) &&
+              entered_objective < prev_objective - obj_tol) {
+          n_nonmonotone_entries <- n_nonmonotone_entries + 1L
+          warning("Stepwise forward step ", step_no + 1L, " entered ",
+                  fwd$variable,
+                  if (!is.na(fwd$phase)) paste0(" (", fwd$phase, ")") else "",
+                  " and the log-likelihood FELL, ", format(prev_objective),
+                  " -> ", format(entered_objective), " (",
+                  format(entered_objective - prev_objective), "). The entered ",
+                  "model contains the current one, so this cannot happen at ",
+                  "the optimum: the refit did not converge, and every later ",
+                  "step is scored against a model that is not at its optimum. ",
+                  "See `$steps$delta_logLik`.", call. = FALSE)
+        }
         current <- fwd$fit
         record_step("enter", fwd)
         bump_move(fwd$variable)
@@ -456,7 +488,8 @@ hzr_stepwise <- function(fit,
     hit_max_steps = stopped_by_max_steps,
     n_uncomputable_scores = n_uncomputable_scores,
     uncomputable_reasons  = uncomputable_reasons,
-    stopped_uncomputable  = stopped_uncomputable
+    stopped_uncomputable  = stopped_uncomputable,
+    n_nonmonotone_entries = n_nonmonotone_entries
   )
 
   n_indefinite <- unname(uncomputable_reasons["information_indefinite"])

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -463,7 +463,8 @@ hzr_stepwise <- function(fit,
       criterion = character(), score = numeric(),
       stat = numeric(), df = integer(),
       p_value = numeric(), delta_aic = numeric(),
-      logLik = numeric(), aic = numeric(), n_coef = integer(),
+      logLik = numeric(), delta_logLik = numeric(),
+      aic = numeric(), n_coef = integer(),
       stringsAsFactors = FALSE
     )
   } else {

--- a/man/hzr_bootstrap.Rd
+++ b/man/hzr_bootstrap.Rd
@@ -105,6 +105,12 @@ replicate. \code{information_indefinite} is the one to read first: it marks
 candidates whose effect is too large for the score test's approximation
 at zero -- typically strong variables that were passed over rather than
 tested, understating their selection frequency. Empty in refit mode.}
+\item{n_nonmonotone_replicates}{Select mode only: number of otherwise
+successful replicates in which a forward step \emph{lowered} the
+log-likelihood. Entered models are nested, so this cannot occur at the
+optimum; such a replicate continued from a refit that did not converge,
+and its later selections are pooled on the same footing as any other.
+Always \code{0} in refit mode.}
 \item{mode}{\code{"refit"} (fixed-formula bootstrap) or \code{"select"}
 (embedded stepwise selection).}
 \item{scope}{Only present when \code{mode == "select"}: the candidate

--- a/tests/testthat/test-stepwise-monotonicity.R
+++ b/tests/testthat/test-stepwise-monotonicity.R
@@ -107,3 +107,29 @@ test_that("the tolerance does not fire on optimizer noise", {
     max_steps = 1L, control = list(n_starts = 1L, maxit = 500L)))
   expect_identical(r$criteria$n_nonmonotone_entries, 0L)
 })
+
+test_that("$steps has the same schema whether or not a step was taken", {
+  # The empty fallback frame is built by hand, separately from record_step()
+  # and record_freeze(), so a column added to the rows can be missed there --
+  # and it was. `$steps` then had 13 columns on a run that did nothing and 14
+  # on a run that did something, so `r$steps$delta_logLik` was NULL for the
+  # first. Assert the whole schema, not the presence of one column, or the
+  # next added column repeats this.
+  o <- .mono_fit()
+  taken <- suppressWarnings(hzr_stepwise(
+    o$fit, scope = list(early = ~ age, constant = ~ age), data = o$data,
+    direction = "forward", criterion = "wald", slentry = 0.5, trace = FALSE,
+    max_steps = 1L, control = list(n_starts = 1L, maxit = 500L)))
+
+  # slentry = 0 admits nothing, so no step is taken and the fallback is used.
+  none <- suppressWarnings(hzr_stepwise(
+    o$fit, scope = list(early = ~ age, constant = ~ age), data = o$data,
+    direction = "forward", criterion = "wald", slentry = 0, trace = FALSE,
+    max_steps = 1L, control = list(n_starts = 1L, maxit = 500L)))
+
+  expect_identical(nrow(none$steps), 0L)
+  expect_gt(nrow(taken$steps), 0L)
+  expect_identical(names(none$steps), names(taken$steps))
+  expect_true("delta_logLik" %in% names(none$steps))
+  expect_type(none$steps$delta_logLik, "double")
+})

--- a/tests/testthat/test-stepwise-monotonicity.R
+++ b/tests/testthat/test-stepwise-monotonicity.R
@@ -1,0 +1,109 @@
+# A forward step must not lower the log-likelihood --------------------------
+#
+# The model a forward step enters CONTAINS the model it started from, so at
+# the optimum the objective cannot fall. When it does, the refit did not
+# converge, and every later step is scored against a model that is not at its
+# own optimum.
+#
+# `hzr_stepwise()` wrote the objective into `$steps` at every step and
+# compared it at none: `grep -n objective R/stepwise.R` returned three write
+# sites and no read. A production 2-phase screen (issue #134) accepted four
+# collinear forms of one covariate, three of which lowered the
+# log-likelihood, and finished reporting `converged`, ten entries and
+# `p = 0.000` throughout. The final 19-coefficient model fitted 57 units worse
+# than the nested 16-coefficient model from three steps earlier -- which is
+# arithmetically impossible at a maximum, and the only thing that noticed was
+# a monotonicity check written by hand downstream.
+
+.mono_fit <- function() {
+  data("avc", package = "TemporalHazard", envir = environment())
+  set.seed(1L)
+  fit <- hazard(
+    Surv(int_dead, dead) ~ 1, data = avc,
+    dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE, control = list(n_starts = 1L, maxit = 500L))
+  list(fit = fit, data = avc)
+}
+
+test_that("a healthy forward run records delta_logLik and reports none worse", {
+  o <- .mono_fit()
+  r <- suppressWarnings(hzr_stepwise(
+    o$fit, scope = list(early = ~ age, constant = ~ age), data = o$data,
+    direction = "forward", criterion = "wald", slentry = 0.5, trace = FALSE,
+    max_steps = 2L, control = list(n_starts = 1L, maxit = 500L)))
+
+  expect_true("delta_logLik" %in% names(r$steps))
+  entries <- r$steps[r$steps$action == "enter", ]
+  expect_gt(nrow(entries), 0L)
+  # Every entry gained: this is the invariant, not merely a recorded number.
+  expect_true(all(entries$delta_logLik >= 0))
+  expect_identical(r$criteria$n_nonmonotone_entries, 0L)
+})
+
+test_that("a forward step that lowers the log-likelihood warns and is counted", {
+  o <- .mono_fit()
+  # Force the reported failure: take the real accepted step and degrade its
+  # objective. Reproducing it from data needs a near-singular design and a
+  # refit that genuinely fails, which is neither quick nor stable across
+  # platforms -- and the branch under test is the comparison, not the cause.
+  # SET relative to the model being entered FROM, rather than subtracting from
+  # the entered value. The genuine step here gains ~14.6 units, so a fixed
+  # subtraction has to beat a number the fixture does not control -- an
+  # earlier draft subtracted 5, left the step 9.6 units ahead, and asserted
+  # nothing.
+  base_obj <- o$fit$fit$objective
+  orig <- .hzr_stepwise_forward_step
+  local_mocked_bindings(
+    .hzr_stepwise_forward_step = function(...) {
+      out <- orig(...)
+      if (isTRUE(out$accepted)) {
+        out$fit$fit$objective <- base_obj - 5
+      }
+      out
+    }
+  )
+
+  w <- capture_warnings(
+    r <- hzr_stepwise(
+      o$fit, scope = list(early = ~ age, constant = ~ age), data = o$data,
+      direction = "forward", criterion = "wald", slentry = 0.5, trace = FALSE,
+      max_steps = 1L, control = list(n_starts = 1L, maxit = 500L)))
+
+  expect_match(w, "log-likelihood FELL", all = FALSE)
+  # The message must say WHY it is impossible, not merely that it happened.
+  expect_match(w, "contains the current one", all = FALSE)
+  expect_gt(r$criteria$n_nonmonotone_entries, 0L)
+
+  entries <- r$steps[r$steps$action == "enter", ]
+  expect_true(any(entries$delta_logLik < 0))
+})
+
+test_that("the tolerance does not fire on optimizer noise", {
+  # A drop of 1e-12 is not evidence of a failed refit, and a check that
+  # cried wolf on rounding would be turned off rather than read.
+  o <- .mono_fit()
+  base_obj <- o$fit$fit$objective
+  orig <- .hzr_stepwise_forward_step
+  local_mocked_bindings(
+    .hzr_stepwise_forward_step = function(...) {
+      out <- orig(...)
+      if (isTRUE(out$accepted)) {
+        # Just below the starting objective, not below the entered one: the
+        # step must land inside the tolerance band to test it at all.
+        out$fit$fit$objective <- base_obj - 1e-12
+      }
+      out
+    }
+  )
+
+  r <- suppressWarnings(hzr_stepwise(
+    o$fit, scope = list(early = ~ age, constant = ~ age), data = o$data,
+    direction = "forward", criterion = "wald", slentry = 0.5, trace = FALSE,
+    max_steps = 1L, control = list(n_starts = 1L, maxit = 500L)))
+  expect_identical(r$criteria$n_nonmonotone_entries, 0L)
+})


### PR DESCRIPTION
Defect **B** of #134. Defect A (the unbounded score statistic) is not in this PR — see the note at the end.

## The objective was written at every step and compared at none

A forward step enters a model that **contains** the one it started from, so at the optimum the log-likelihood cannot fall. `grep -n objective R/stepwise.R` returned three write sites and no read.

In the production screen that surfaced this, three of ten steps lowered the log-likelihood while the run reported `converged`, ten entries and `p = 0.000` throughout. The final 19-coefficient model fitted **57 units worse** than the nested 16-coefficient model three steps earlier — arithmetically impossible at a maximum. The only thing that noticed was a monotonicity check written by hand downstream, which every other caller would have had to reinvent.

## What changed

- `$steps` gains **`delta_logLik`**.
- A forward step that lowers the objective **warns**, naming the step, the drop, and *why* it is impossible — then is counted in `$criteria$n_nonmonotone_entries`.
- `hzr_bootstrap(scope = )` aggregates **`$n_nonmonotone_replicates`**, for the reason #117 and #132 both needed: a replicate whose path went backwards still contributes its selections to the pooled frequencies, indistinguishable from one that converged, and every replicate runs under `suppressWarnings()` so a step-level warning cannot surface in the mode that matters.
- The comparison carries a relative tolerance, so optimizer noise cannot fire it. The real cases are whole log-likelihood units, not `1e-10`.

## ⚠️ Two of the three tests first passed for the wrong reason

Worth stating, because it is the failure mode this package keeps finding. The mocked fixture subtracted a fixed amount from the **entered** objective. The genuine step gains ~14.6 units, so subtracting 5 left it **9.6 ahead of where it started** — the assertion held while the branch never fired, and the tolerance test never entered the tolerance band at all.

Caught by probing whether the mock fired, not by reading the green result. Both fixtures now set the objective relative to the model being entered *from*, which is the quantity the check actually compares.

## Verification

Watched failing: **6 of 8** against the parent commit. `devtools::test()` **2125 pass / 0 fail**, `lintr::lint_package()` clean, `document()` regenerated `man/hzr_bootstrap.Rd`.

## Not included

**Defect A** — the score statistic being unbounded as `v_beta -> 0+` (a `stat` of 92,211 on 1 df). #134 suggests expected rather than observed information, but the reference uses observed too, so that would break parity. The reference does have a guard we never implemented: `dqstat.c` bounds the *implied coefficient*, `if (fabs(*qbeta) > 50.0) { *qflag = 4; }`, calling it "the model is going to infinity". R computes `stat` and never derives `qbeta`. That is the parity-grounded fix for A, and it is a separate change.

B is deliberately first because it is independent of the criterion: it catches A whether or not A is resolved, and it catches any other failed refit too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)