### PR TITLE
fix: decline a candidate whose implied coefficient runs to infinity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,25 @@ selects.
 
 ## Bug fixes
 
+* **A score statistic could be finite, enormous and meaningless.** A
+  production screen accepted a candidate with `stat` = 92,211 on 1 df and
+  `p = 0.000`, after which the refit made the model worse. Neither existing
+  guard reached it: the adjusted variance stayed positive and well above the
+  collinearity floor, so the statistic was reported as evidence.
+
+  Near-collinearity alone does not do this — as a candidate approaches
+  collinearity its score shrinks along with its variance and `Q` stays small.
+  `Q` explodes when the model being scored against is *not at its optimum*,
+  because the reduced-model score is then no longer zero: the numerator is
+  inflated while the denominator stays small. That is the state a failed refit
+  leaves behind. `hzr_stepwise()` now declines a candidate whose implied
+  coefficient exceeds ±50, reporting `coefficient_diverging`, which is what
+  the SAS/C reference has always done (`dqstat.c` rejects `|QBETA| > 50` as
+  "the model is going to infinity"). Measured on the bundled `avc` data, a
+  model displaced 0.25 from its optimum produced `Q` = 6.5e7 with no reason
+  reported at all; a legitimate candidate reaches an implied coefficient of
+  about 14, so the threshold has real headroom. Reported as issue #134.
+
 * **The multiphase gradient and Hessian disagreed with the log-likelihood on
   left-truncated data.** For a row with `status` in `{0, 1}` the log-likelihood
   subtracts `H(time_lower)` unconditionally, but the analytic derivatives

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -665,6 +665,32 @@
     return(na_result("information_indefinite"))
   }
   stat <- (u_beta^2) / v_beta
+
+  # The coefficient this Q implies: one Newton step from beta = 0, with
+  # standard error 1 / sqrt(v_beta). SAS forms the same quantity and rejects
+  # the candidate when it is absurd -- `dqstat.c`:
+  #
+  #     *qz    = sqrt(q);
+  #     *qse   = -(*qz)/d1llad;
+  #     *qbeta = (*qz)*(*qse);          /* = u_beta / v_beta */
+  #     if (fabs(*qbeta) > 50.0e0) { *qflag = 4; return; }
+  #
+  # calling it "the model is going to infinity ... legitimate for a variable
+  # that is either positive or negative with respect to all the remaining
+  # events in its phase. However the model cannot manage this."
+  #
+  # This is the guard against a Q that is finite, enormous and meaningless.
+  # The other two guards do not reach it: v_beta stays positive and well
+  # above the collinearity floor. Measured on `avc` with a near-collinear
+  # candidate, scored against a model moved 0.25 off its optimum -- which is
+  # what a failed refit leaves behind -- Q was 6.5e7 with v_beta = 0.0076 and
+  # no reason reported at all. A legitimate candidate at the optimum reached
+  # |qbeta| of about 14 in the same setting, so 50 leaves real headroom.
+  q_beta <- u_beta / v_beta
+  if (!is.finite(q_beta) || abs(q_beta) > 50) {
+    return(na_result("coefficient_diverging"))
+  }
+
   list(stat = stat, df = 1L,
        p_value = stats::pchisq(stat, df = 1L, lower.tail = FALSE),
        reason = NA_character_)
@@ -692,6 +718,14 @@
       "adjustment for the current model. This is a different fault from",
       "collinearity: the candidate is a poor one in itself, or the fit it",
       "would be added to is not at a maximum"
+    ),
+    coefficient_diverging = paste(
+      "the coefficient the score implies exceeds +/-50, so the fit for this",
+      "candidate is running to infinity. That is legitimate for a variable",
+      "that separates the remaining events in its phase, and the model cannot",
+      "represent it; it is also what a candidate scored against a model that",
+      "is NOT at its optimum looks like, so check whether an earlier step's",
+      "refit failed"
     ),
     collinear = "the candidate was collinear with the current model",
     constant  = "the candidate column was constant",

--- a/tests/testthat/test-score-diverging-coefficient.R
+++ b/tests/testthat/test-score-diverging-coefficient.R
@@ -1,0 +1,106 @@
+# A finite, enormous, meaningless Q ------------------------------------------
+#
+# Defect A of issue #134: a production screen accepted a candidate with
+# `stat` = 92,211 on 1 df and `p = 0.000`, and the refit that followed made
+# the model worse. Neither existing guard reaches that case -- `v_beta` stays
+# positive and well above the collinearity floor -- so the statistic is
+# reported as evidence.
+#
+# The cause is not near-collinearity on its own. Measured on `avc`, as a
+# candidate approaches collinearity `u_beta` shrinks with `v_beta` and
+# Q stays around 1-2 before the collinear guard takes over. Q only explodes
+# when the model being scored against is NOT at its optimum: the reduced-model
+# score is then no longer zero, so `u_beta` is inflated while `v_beta` stays
+# small. That is exactly the state a failed refit leaves behind, which is why
+# #134 saw it at step 9 after steps 8 and 9 had lowered the log-likelihood.
+#
+# The reference guards this and TemporalHazard did not. `dqstat.c` forms the
+# implied coefficient and rejects it beyond +/-50:
+#
+#     *qbeta = (*qz)*(*qse);          /* = u_beta / v_beta */
+#     if (fabs(*qbeta) > 50.0e0) { *qflag = 4; return; }
+
+.diverge_case <- function(noise_sd = 0.01) {
+  data("avc", package = "TemporalHazard", envir = environment())
+  set.seed(1L)
+  fit0 <- hazard(
+    Surv(int_dead, dead) ~ 1, data = avc, dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")),
+    fit = TRUE, control = list(n_starts = 1L, maxit = 500L))
+  # `age` in the model, then a near-copy of it offered as a candidate.
+  with_age <- .hzr_refit_with_scope(
+    fit0, action = "add", var = "age", phase = "early",
+    data = avc, control = list(n_starts = 1L, maxit = 500L))
+  set.seed(99L)
+  d <- avc
+  d$agee <- d$age + stats::rnorm(nrow(avc), sd = noise_sd)
+  list(fit = with_age, data = d)
+}
+
+.moved_off_optimum <- function(fit, shift) {
+  fit$fit$theta[1] <- fit$fit$theta[1] + shift
+  fit
+}
+
+test_that("a candidate scored against a non-optimal model is declined", {
+  skip_if_not_installed("numDeriv")
+  o <- .diverge_case()
+
+  # At the optimum the same candidate scores normally. This is the control:
+  # without it the test could not tell the guard from the fixture.
+  at_opt <- .hzr_score_q(o$fit, "agee", phase = "early", data = o$data)
+  expect_false(is.na(at_opt$stat))
+  expect_true(is.na(at_opt$reason))
+
+  # Moved off the optimum -- what a failed refit leaves behind -- the score
+  # statistic runs to millions and is now refused rather than reported.
+  broken <- .moved_off_optimum(o$fit, 0.25)
+  q <- .hzr_score_q(broken, "agee", phase = "early", data = o$data)
+  expect_true(is.na(q$stat))
+  expect_identical(q$reason, "coefficient_diverging")
+})
+
+test_that("the guard fires on the implied coefficient, not on Q being large", {
+  skip_if_not_installed("numDeriv")
+  o <- .diverge_case()
+  broken <- .moved_off_optimum(o$fit, 0.25)
+
+  nui <- .hzr_score_nuisance(broken)
+  ex <- .hzr_score_expand(broken, "agee", phase = "early", data = o$data)
+  info <- .hzr_score_information_expanded(broken, ex)
+  grad <- .hzr_score_gradient(broken, ex)
+  b <- ex$beta_idx
+  t_idx <- ex$theta_idx[nui$idx]
+  i_bt <- info[b, t_idx, drop = FALSE]
+  v_beta <- info[b, b] - as.numeric(i_bt %*% nui$inv %*% t(i_bt))
+
+  # Neither existing guard reaches this: v_beta is positive and far above the
+  # collinearity floor. That is why the statistic was reportable.
+  expect_gt(v_beta, 0)
+  expect_gt(v_beta, info[b, b] * sqrt(.Machine$double.eps))
+  # It is the implied coefficient that is absurd.
+  expect_gt(abs(grad[b] / v_beta), 50)
+})
+
+test_that("a legitimate candidate is well inside the threshold", {
+  skip_if_not_installed("numDeriv")
+  # A guard that clipped ordinary candidates would be worse than none. With
+  # a mildly correlated candidate the implied coefficient is single digits,
+  # against a threshold of 50.
+  o <- .diverge_case(noise_sd = 0.1)
+  q <- .hzr_score_q(o$fit, "agee", phase = "early", data = o$data)
+  expect_false(is.na(q$stat))
+  expect_true(is.na(q$reason))
+})
+
+test_that("the diverging reason is distinct and points at the failed refit", {
+  txt <- .hzr_score_reason_text("coefficient_diverging")
+  expect_match(txt, "infinity")
+  # The actionable half: this is often a symptom of an earlier bad step.
+  expect_match(txt, "NOT at its optimum")
+  expect_false(identical(txt, .hzr_score_reason_text("collinear")))
+  expect_false(identical(txt, .hzr_score_reason_text("information_indefinite")))
+})


### PR DESCRIPTION
Defect **A** of #134, following #140 (defect B). Independent of it — either can merge first.

## The cause is not what the issue assumed, and measuring that changed the fix

#134 proposes expected rather than observed information. But the reference uses **observed** information too ([established on #130](https://github.com/ehrlinger/temporal_hazard/issues/130#issuecomment-5342289997)), so switching would break parity.

More importantly, **near-collinearity alone does not explode `Q`**. Measured on `avc`, sweeping a candidate toward collinearity: `u_beta` shrinks along with `v_beta`, `Q` stays around 1–2, and the existing collinear guard then takes over. It never reaches the thousands.

`Q` explodes when **the model being scored against is not at its optimum** — the reduced-model score is then no longer zero, so the numerator is inflated while the denominator stays small. That is precisely the state a failed refit leaves behind, which is why #134 saw it at step 9, *after* steps 8 and 9 had lowered the log-likelihood.

Near-collinear candidate on `avc`, model displaced from its optimum:

| θ shift | u_β | v_β | Q | implied β | reason **before** |
|---|---|---|---|---|---|
| 0 | 0.102 | 0.0059 | 1.77 | 17.3 | — |
| 0.05 | −126.6 | 0.0062 | **2.6e6** | −20,326 | **—** |
| 0.25 | −704.7 | 0.0076 | **6.5e7** | −92,381 | **—** |

The 0.25 row brackets the reported 92,211. **Nothing was declined** — `v_beta` is positive and far above the collinearity floor in every row.

## The reference has guarded this all along

We had implemented three of `dqstat.c`'s four checks. The fourth forms the **implied coefficient** — one Newton step from β=0, `u_beta / v_beta` — and rejects it:

```c
*qbeta = (*qz)*(*qse);                 /* = u_beta / v_beta */
if (fabs(*qbeta) > 50.0e0) { *qflag = 4; return; }
```

> "the model is going to infinity ... legitimate for a variable that is either positive or negative with respect to all the remaining events in its phase. However the model cannot manage this."

A legitimate candidate reaches `|qbeta|` of about **14** in the same setting, so 50 has real headroom rather than clipping ordinary work. The new reason `coefficient_diverging` says both halves: the fit is running to infinity, *and* to check whether an earlier step's refit failed.

## Verification

Tested from the **real fixture**, not a stub, with the at-optimum case as the control — without it the test could not distinguish the guard from the fixture. A third test asserts the failure is specifically in the implied coefficient, not in `Q` being large: `v_beta > 0` and above the floor, while `|u/v| > 50`.

Watched failing: **4 of 13**. `devtools::test()` **2129 pass / 0 fail**, `lintr::lint_package()` clean, `document()` a no-op.

## Relationship to #140

Complementary rather than overlapping. #140 detects the failed refit *after* the step and warns; this declines the bad candidate *before* it is accepted. Since A's trigger is the state B detects, running both means a screen that hits this reports the cause twice — once as a diverging candidate, once as a step that lowered the log-likelihood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)