### PR TITLE
docs: link AGENTS.md from the CLAUDE.md shim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 # Claude Code specifics
 
-`AGENTS.md`, imported above, is the operational contract and applies in full. It is written to
+[`AGENTS.md`](AGENTS.md), imported above, is the operational contract and applies in full. It is written to
 be tool-neutral so that Codex and other agents read the same rules. Only the Claude Code
 affordances live here.
 


### PR DESCRIPTION
One-token change, completing the sweep across all twelve family repositories.

`@AGENTS.md` on line 1 is Claude Code's import directive and **renders as plain text on GitHub**, so a human reader has no way to click through to the contract. This linkifies the existing prose mention:

```markdown
[`AGENTS.md`](AGENTS.md), imported above, is the operational contract and applies in full.
```

Chosen over adding a line after the directive so the shim stays byte-comparable across the family, and line 1 is untouched.

**Based on `dev`, not `main`** — the AGENTS.md split (`d26cbaa`) is on `dev` and has not reached `main`, where `CLAUDE.md` is still the old 42-line generic file. A PR against `main` would have had nothing to change.

Raised in review on [hvtiPropensityScores#14](https://github.com/ehrlinger/hvtiPropensityScores/pull/14). Docs only, no version bump. Made in an isolated worktree so the active `feat/sas-job-translator` checkout was never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)