### PR TITLE
docs: mark hzr_translate_sas() experimental and stop overclaiming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,35 @@
 ## New features
 
 * `hzr_translate_sas()` translates a SAS `PROC HAZARD` / `PROC HAZPRED` job
-  into a Quarto document that reproduces the analysis with [hazard()] and
-  [predict.hazard()]. It parses the SAS statements, builds the equivalent R
-  calls, and renders them into `.qmd` chunks -- the model state is stored as
-  unevaluated calls, so rendering is `deparse()`, not string templating.
+  into a Quarto document of equivalent R calls. It parses the SAS statements,
+  builds the calls, and renders them into `.qmd` chunks -- the model state is
+  stored as unevaluated calls, so rendering is `deparse()`, not string
+  templating.
+
+  **This function is experimental, and the emitted document does not render
+  as-is.** It is a translation aid, not a turnkey reproduction: the emitted
+  chunks currently need hand-editing before they run. Known gaps, all
+  tracked: the fitted model is not bound to a name and `fit = TRUE` is not
+  emitted, so the `predict()` chunks have nothing to predict from and the
+  `hazard()` call stops at the SAS starting values (#151); a resolved
+  prediction grid is named after the SAS `DO` variable rather than the `time`
+  column `predict.hazard()` requires (#151); `hzr_read_outhaz()` returns an
+  unclassed list, so the external-`INHAZ=` path has no `predict()` method
+  (#151); a `SELECTION` statement emits an `hzr_stepwise()` call that is
+  missing `fit` and `scope` (#152); and the log prediction grid uses a step
+  that diverges from SAS's by up to ~9.6% at the last point (#153). Two
+  translation gaps affect the likelihood rather than the document: an
+  `ICENSOR` event count is discarded (#154), and `LCENSOR` combined with
+  `ICENSOR` drops left truncation on interval rows (#155).
+
+  Treat the coverage figures below, and `job$coverage`, as a measure of
+  *parsing* -- tokens recognised -- not of whether the result runs. The
+  parameter translation itself is verified: refitting the `hz.death.AVC.sas`
+  job's parameters through `hazard()` directly reproduces the SAS
+  log-likelihood to six significant figures.
+
+  The API of this function, the `hzr_sas_job` field layout and the emitted
+  document format are all expected to change as those gaps close.
 
   The keyword grammar behind the parser -- 117 keyword rules mapped to R
   targets -- is **generated from the reference `HAZARD`/`HAZPRED` C

--- a/R/read-outhaz.R
+++ b/R/read-outhaz.R
@@ -10,9 +10,19 @@
 #'
 #' @param path Path to a `.sas7bdat` written by `outhaz=`, or to an `.rds`
 #'   holding the same data frame.
-#' @return A list with `estimates` (named numeric), `status` (named integer,
-#'   1 free / 0 fixed), `vcov` (matrix over free parameters, dimnames set) and
-#'   `flags` (named numeric of model-structure flags).
+#' @return A plain list -- **not** a `hazard` object -- with `estimates`
+#'   (named numeric), `status` (named integer, 1 free / 0 fixed), `vcov`
+#'   (matrix over free parameters, dimnames set) and `flags` (named numeric of
+#'   model-structure flags). When no parameter is free, `vcov` is a 0x0 matrix
+#'   rather than `NULL`, so check its dimensions rather than `is.null()`.
+#'
+#' @section Experimental:
+#' This function is experimental and its return shape is expected to change.
+#' Because the result is an unclassed list, it has no `predict()` method: the
+#' `hzr_translate_sas(librefs = )` path emits `predict()` against it, which
+#' does not work today (#151). The `_STATUS_` coding is asserted against a
+#' synthetic fixture, so a real `OUTHAZ=` file using a different convention
+#' would yield an empty `vcov` alongside a fully populated `estimates`.
 #' @export
 #' @examples
 #' f <- system.file("extdata", "outhaz-fixture.rds", package = "TemporalHazard")

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -38,8 +38,12 @@
 #' Translate a SAS HAZARD job into a Quarto document
 #'
 #' Reads a SAS program containing `PROC HAZARD` and/or `PROC HAZPRED` blocks and
-#' emits a Quarto document that reproduces the analysis with [hazard()] and
-#' [predict.hazard()].
+#' emits a Quarto document of the equivalent [hazard()] and [predict.hazard()]
+#' calls.
+#'
+#' **Experimental, and the emitted document does not render as-is:** it is a
+#' translation aid whose chunks need hand-editing before they run. See the
+#' Experimental section below.
 #'
 #' Constructs the translator does not cover are recorded on the returned object
 #' and rendered as visible callouts, never dropped. A `PROC HAZPRED` job whose

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -72,7 +72,21 @@
 #'   that already ends in `.rds` or `.sas7bdat` (a specific file, not a
 #'   directory) to name an already-converted fit directly, e.g.
 #'   `c(EX = "estimates/hzdeath.rds")`.
-#' @return An `hzr_sas_job` object, invisibly.
+#' @return An `hzr_sas_job` object, invisibly. `$calls` holds the emitted
+#'   calls keyed by chunk label, `$grid` the last prediction grid seen and
+#'   `$inhaz` the first unresolved `INHAZ=` (not all of each, when a job has
+#'   several), `$untranslated` the recorded gaps and `$coverage` the token
+#'   counts.
+#'
+#' @section Experimental:
+#' This function is experimental and **the emitted document does not render
+#' as-is** -- it is a translation aid whose chunks currently need hand-editing
+#' before they run. `$coverage` counts tokens the parser recognised; it is not
+#' evidence that the emitted calls execute, and a job can report full coverage
+#' with an empty `$untranslated` while its document still errors on render.
+#' See the 1.2.2 `NEWS.md` entry for the tracked gaps. The function's API, the
+#' `hzr_sas_job` field layout and the emitted document format are all expected
+#' to change.
 #' @examples
 #' \donttest{
 #' job <- hzr_translate_sas(

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -182,6 +182,7 @@ prerelease
 pval
 qquad
 recognise
+recognised
 recomputation
 reimplementation
 reimplementing
@@ -209,6 +210,7 @@ th
 thromboembolic
 tᵢ
 un
+unclassed
 underpredicts
 univariable
 unrecognisable

--- a/man/hzr_read_outhaz.Rd
+++ b/man/hzr_read_outhaz.Rd
@@ -11,9 +11,11 @@ hzr_read_outhaz(path)
 holding the same data frame.}
 }
 \value{
-A list with \code{estimates} (named numeric), \code{status} (named integer,
-1 free / 0 fixed), \code{vcov} (matrix over free parameters, dimnames set) and
-\code{flags} (named numeric of model-structure flags).
+A plain list -- \strong{not} a \code{hazard} object -- with \code{estimates}
+(named numeric), \code{status} (named integer, 1 free / 0 fixed), \code{vcov}
+(matrix over free parameters, dimnames set) and \code{flags} (named numeric of
+model-structure flags). When no parameter is free, \code{vcov} is a 0x0 matrix
+rather than \code{NULL}, so check its dimensions rather than \code{is.null()}.
 }
 \description{
 \verb{PROC HAZARD}'s \verb{outhaz=} dataset stores the converged estimates and the
@@ -25,6 +27,16 @@ being the binding constraint and optimizer convergence takes over.
 \details{
 The log-likelihood is \emph{not} stored here; take it from the \code{.lst}.
 }
+\section{Experimental}{
+
+This function is experimental and its return shape is expected to change.
+Because the result is an unclassed list, it has no \code{predict()} method: the
+\code{hzr_translate_sas(librefs = )} path emits \code{predict()} against it, which
+does not work today (#151). The \verb{_STATUS_} coding is asserted against a
+synthetic fixture, so a real \verb{OUTHAZ=} file using a different convention
+would yield an empty \code{vcov} alongside a fully populated \code{estimates}.
+}
+
 \examples{
 f <- system.file("extdata", "outhaz-fixture.rds", package = "TemporalHazard")
 if (nzchar(f)) str(hzr_read_outhaz(f))

--- a/man/hzr_translate_sas.Rd
+++ b/man/hzr_translate_sas.Rd
@@ -20,7 +20,11 @@ directory) to name an already-converted fit directly, e.g.
 \code{c(EX = "estimates/hzdeath.rds")}.}
 }
 \value{
-An \code{hzr_sas_job} object, invisibly.
+An \code{hzr_sas_job} object, invisibly. \verb{$calls} holds the emitted
+calls keyed by chunk label, \verb{$grid} the last prediction grid seen and
+\verb{$inhaz} the first unresolved \verb{INHAZ=} (not all of each, when a job has
+several), \verb{$untranslated} the recorded gaps and \verb{$coverage} the token
+counts.
 }
 \description{
 Reads a SAS program containing \verb{PROC HAZARD} and/or \verb{PROC HAZPRED} blocks and
@@ -49,6 +53,18 @@ resolves and the job holds more than one local fit, which fit a
 back to referencing \code{fit} and the ambiguity is recorded in
 \code{untranslated}, never guessed at silently.
 }
+\section{Experimental}{
+
+This function is experimental and \strong{the emitted document does not render
+as-is} -- it is a translation aid whose chunks currently need hand-editing
+before they run. \verb{$coverage} counts tokens the parser recognised; it is not
+evidence that the emitted calls execute, and a job can report full coverage
+with an empty \verb{$untranslated} while its document still errors on render.
+See the 1.2.2 \code{NEWS.md} entry for the tracked gaps. The function's API, the
+\code{hzr_sas_job} field layout and the emitted document format are all expected
+to change.
+}
+
 \examples{
 \donttest{
 job <- hzr_translate_sas(

--- a/man/hzr_translate_sas.Rd
+++ b/man/hzr_translate_sas.Rd
@@ -28,10 +28,14 @@ counts.
 }
 \description{
 Reads a SAS program containing \verb{PROC HAZARD} and/or \verb{PROC HAZPRED} blocks and
-emits a Quarto document that reproduces the analysis with \code{\link[=hazard]{hazard()}} and
-\code{\link[=predict.hazard]{predict.hazard()}}.
+emits a Quarto document of the equivalent \code{\link[=hazard]{hazard()}} and \code{\link[=predict.hazard]{predict.hazard()}}
+calls.
 }
 \details{
+\strong{Experimental, and the emitted document does not render as-is:} it is a
+translation aid whose chunks need hand-editing before they run. See the
+Experimental section below.
+
 Constructs the translator does not cover are recorded on the returned object
 and rendered as visible callouts, never dropped. A \verb{PROC HAZPRED} job whose
 \verb{INHAZ=} fitted model cannot be located emits a \code{stop()}, so the document

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -505,6 +505,23 @@ blocks describe. It is the same statement-by-statement mapping this
 vignette documents, run by the parser instead of by you -- useful
 for a one-off job, and essential for migrating a corpus of hundreds.
 
+::: {.callout-warning}
+## Experimental: the emitted document does not render as-is
+
+`hzr_translate_sas()` is a translation aid, not a turnkey reproduction.
+It gets you the calls; it does not yet get you a runnable document. The
+emitted chunks need hand-editing first -- most importantly the fitted
+model is not bound to a name and `fit = TRUE` is not emitted, so the
+`hazard()` chunk stops at the SAS starting values and the `predict()`
+chunks have nothing to predict from.
+
+Read the coverage figures below, and `job$coverage`, as a measure of how
+much of the SAS job the *parser recognised* -- not of whether the result
+runs. A job can report full coverage with nothing in `$untranslated` and
+still error on render. The tracked gaps are listed in the 1.2.2 entry of
+`NEWS.md`; the API and the emitted format will change as they close.
+:::
+
 Take the `PROC HAZARD` block shipped as
 `system.file("extdata", "hz-example.sas", package = "TemporalHazard")`
 (de-identified from the public `hazard` examples):


### PR DESCRIPTION
Documentation only -- no code changes. Prepares 1.2.2 for release by making the translator's documentation match what the translator actually does.

## Why

RELEASE.md step 5 (adversarial review of the accumulated `main...dev` diff) found that `hzr_translate_sas()` emits documents that cannot render, while reporting full coverage and an empty `$untranslated`. I reproduced it directly -- evaluating the emitted chunks of a two-block job in a clean environment holding only the input data frame:

```
coverage: 10 / 10 tokens mapped        untranslated rows: 0

  data     ok
  fit      ERROR: object 'INT_DEAD' not found
  grid     ok
  pred     ERROR: object 'fit' not found
  pred_haz ERROR: object 'fit' not found
```

Three of five chunks error, `fit` is never bound, and the job object reports a clean translation. That is the pattern at the top of the AGENTS.md table -- a populated summary over nothing -- in the release's headline feature.

Neither `R CMD check` (0/0/0) nor the 2528-test suite sees it, because the tests were written from the same assumptions as the emitter: `test-sas-translate-fits.R` builds `env <- list2env(as.list(AVCS)); env$AVCS <- AVCS`, manufacturing exactly the bindings the emitted document lacks.

Gaps are tracked in #151 (the emitted-document cluster), #152 (`SELECTION` emits an uncallable `hzr_stepwise()`), #153 (log grid step diverges from SAS by up to ~9.6%), #154 (`ICENSOR` event count discarded), #155 (`LCENSOR`+`ICENSOR` drops left truncation).

## The decision

Ship 1.2.2 with the feature marked experimental rather than hold the release. The core package is sound -- the reviewer separately confirmed the censoring translation, the `Surv` recoding, the gradient/Hessian `epoch_idx` fix and the score statistic's guard ordering all check out -- and `main` needs to be current for downstream installs. What changes here is that the documentation stops claiming something the code does not do.

## Changes

- **`NEWS.md`** -- "a Quarto document that reproduces the analysis" becomes "a Quarto document of equivalent R calls", plus an explicit experimental note listing every tracked gap and stating that coverage measures *parsing*, not runnability.

  The measured-parity claim is **kept**, because it holds: it was obtained by refitting the job's parameters through `hazard()` directly, not by rendering a translated document.

- **`R/translate-sas.R`** -- `@return` now documents what the fields actually hold, including two things that were never written down: `$grid` keeps only the **last** grid seen and `$inhaz` only the **first** unresolved one. An `@section Experimental` states that full coverage with an empty `$untranslated` is not evidence the document runs.

- **`R/read-outhaz.R`** -- `@return` says plainly this is a plain list, **not** a `hazard` object, so it has no `predict()` method; and that an all-fixed parameter set yields a **0x0** `vcov` rather than `NULL` -- a hollow value defeating both `is.null()` and a length check.

- **`vignettes/sas-to-r-migration.qmd`** -- a `callout-warning` at the head of the translator section, so the reader meets the limitation before the walkthrough rather than after.

- **`inst/WORDLIST`** -- +2 for the new prose (`recognised`, `unclassed`).

## Gate

- `devtools::document()` -- clean
- `lintr::lint_package()` -- 0 lints
- `spelling::spell_check_package(use_wordlist = TRUE)` -- clean
- `devtools::test()` -- **FAIL 0 | PASS 2528**

`R CMD check --as-cran` with the manual was **Status: OK, 0/0/0** on the pre-change tree (3m06s, 2.8 MB tarball); this PR changes only roxygen, NEWS, a vignette callout and WORDLIST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
