### PR TITLE
fix(sas): EVENT, WEIGHT and RCENSOR are counts, not flags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -95,10 +95,23 @@
   Four censored individuals were therefore fitted as one observation. The
   censored branch of `weights` is now that variable, still unmultiplied by
   `WEIGHT`, and the both-fire guard now covers `EVENT` + `RCENSOR` and
-  `ICENSOR` + `RCENSOR` as well, since `readobs.c` drops a row only when
-  both counts of a pair are zero. Jobs whose `RCENSOR` variable is a `0/1`
-  flag -- which is every such job in the public corpus -- fit exactly as
-  before.
+  `ICENSOR` + `RCENSOR` as well: `readobs.c` deletes an all-zero row only
+  when `RCENSOR` is named *and* exactly one of the other two is, so a row
+  with two counts positive always survives to be summed.
+
+  A `0/1` `RCENSOR` flag that is exactly `1 - EVENT` -- which is what both
+  corpus jobs carry, and what the statement is usually used for -- fits
+  exactly as before. A `0/1` flag that is **not** its complement does not,
+  and both ways it can differ are deliberate: a row with the event and the
+  censoring flag both set now stops the document instead of being fitted as
+  an event alone, and a row with neither set now carries weight `0` instead
+  of a fabricated weight of `1`, matching the row SAS would have deleted.
+  An `RCENSOR` column that is negative or missing likewise stops the fit at
+  `hazard()`'s weight check rather than being silently dropped.
+
+  A job with an `RCENSOR` statement now emits an extra `status` chunk ahead
+  of its fit, where the guard lives; the emitted document format remains
+  experimental.
 
   Loading a fit from an external `INHAZ=` dataset returns a classed
   `hzr_outhaz` object with a `predict()` method (#151). That method takes

--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,18 @@
   cannot express, so the emitted status chunk now stops before the fit
   rather than picking the event branch and discarding the interval one.
 
+  `RCENSOR` is the third of those counts and was being ignored outright
+  (#162). It names `C2` -- "COUNT OF CENSORED INDIVIDUALS AT TIME=T" --
+  and when a job names it, `readc2.c` reads the column straight from the
+  data and skips the `C2 = 1` derivation that a job without `RCENSOR` gets.
+  Four censored individuals were therefore fitted as one observation. The
+  censored branch of `weights` is now that variable, still unmultiplied by
+  `WEIGHT`, and the both-fire guard now covers `EVENT` + `RCENSOR` and
+  `ICENSOR` + `RCENSOR` as well, since `readobs.c` drops a row only when
+  both counts of a pair are zero. Jobs whose `RCENSOR` variable is a `0/1`
+  flag -- which is every such job in the public corpus -- fit exactly as
+  before.
+
   Loading a fit from an external `INHAZ=` dataset returns a classed
   `hzr_outhaz` object with a `predict()` method (#151). That method takes
   the same arguments in the same order as `predict.hazard()` --

--- a/NEWS.md
+++ b/NEWS.md
@@ -106,12 +106,23 @@
   censoring flag both set now stops the document instead of being fitted as
   an event alone, and a row with neither set now carries weight `0` instead
   of a fabricated weight of `1`, matching the row SAS would have deleted.
-  An `RCENSOR` column that is negative or missing likewise stops the fit at
-  `hazard()`'s weight check rather than being silently dropped.
+  A count column that is **negative or missing** on any row now stops the
+  document with a message naming the variable, rather than being folded into
+  the censored branch or propagating `NA` into `weights` until `hazard()`
+  refused it as "non-negative and finite". `readc1.c`, `readc2.c` and
+  `readc3.c` apply the same rule to every count the job names -- a missing
+  value sets `mdel`, a negative one sets `del` -- and `readobs.c` then skips
+  `setobs()` for that row and subtracts it from `Nobs`. Such a row
+  contributes nothing at all, so translating it as a right-censored
+  observation of weight `1` adds survival mass at a time SAS had removed.
+  This is the one case where a missing count is **not** interchangeable with
+  a zero one: a zero count is kept and contributes, a missing one is deleted.
+  The translator cannot drop rows without changing `n` behind the reader's
+  back, so it stops and says to filter them.
 
-  A job with an `RCENSOR` statement now emits an extra `status` chunk ahead
-  of its fit, where the guard lives; the emitted document format remains
-  experimental.
+  Every translated job now emits a `status` chunk ahead of its fit, where
+  these guards live -- previously only jobs with `ICENSOR` or more than one
+  named count did. The emitted document format remains experimental.
 
   Loading a fit from an external `INHAZ=` dataset returns a classed
   `hzr_outhaz` object with a `predict()` method (#151). That method takes

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,8 +72,21 @@
   step). The trailing element is now read from the job's own `DO` statement
   and emitted as the grid's last point; a trailing element this cannot
   resolve to the loop's own bound is refused with an `UNTRANSLATED` row.
-  An `ICENSOR` event count now reaches the fit as `weights` instead of being
-  discarded (#154).
+  `EVENT`, `ICENSOR` and `WEIGHT` are **counts** in the reference
+  implementation, not flags, and `setlik.c` combines one record's
+  contribution as `c1c2c3 = c1w + c2 + c3w` with `c1w = C1 * WT` and
+  `c3w = C3 * WT`. All three now reach the fit that way. An `ICENSOR` event
+  count is no longer discarded (#154); an `EVENT` count carries into
+  `weights` and `status` derives from `EVENT > 0`, where `EVENT = 2` used to
+  map straight onto `status = 2` and be fitted as **interval-censored** --
+  a different likelihood branch, not an under-count (#157); and a `WEIGHT`
+  variable no longer weights right-censored rows, because `c2` is the one
+  term entering that sum unweighted and `readc2.c` sets it to `1` on exactly
+  those rows -- a `WEIGHT` that was `0` there previously deleted them from
+  the fit silently (#158). A row where the `EVENT` and `ICENSOR` counts both
+  fire is two contributions at once, which one `status` and one `weight`
+  cannot express, so the emitted status chunk now stops before the fit
+  rather than picking the event branch and discarding the interval one.
 
   Loading a fit from an external `INHAZ=` dataset returns a classed
   `hzr_outhaz` object with a `predict()` method (#151). That method takes

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -36,28 +36,60 @@
 #' everywhere, overridden to `2` where `C3 > 0`. A job specifying neither is
 #' rejected with an error, mirroring HAZARD's own termination.
 #'
-#' Because `C3` is a count, it also carries a *weight*. `setlik.c` multiplies
-#' the whole log-likelihood contribution of an interval row by it
-#' (`c3w = c3 * weight`, then both `-(c1w + c2 + c3w) * (cumhaz - cumhst)` and
-#' `+= c3w * lct`), which is exactly what [hazard()]'s `weights` argument does
-#' per row. So `weights_expr` is emitted as
-#' `ifelse(<status> == 2, C3, 1)` whenever `ICENSOR` is present. Two details
-#' there are not negotiable. Passing the bare `C3` instead would give every
-#' event and right-censored row a weight of *zero* -- `C3` is 0 on those rows
-#' -- deleting them from the likelihood without a word; `readc2.c` sets
-#' `C2 = 1` on exactly those rows when no `RCENSOR` statement is given, so
-#' their weight is 1. And the gate is on `status`, not on `C3 > 0`, so that a
-#' row where `EVENT` and `C3` both fire keeps the event's weight, matching the
-#' status mapping directly below.
+#' **`EVENT`, `ICENSOR` and `WEIGHT` are all counts**, and `setlik.c` combines
+#' them for one OBS record as `c1c2c3 = c1w + c2 + c3w` (with `c1w = C1 * WT`
+#' and `c3w = C3 * WT`), then
+#' `llike = -(c1c2c3) * (CH(T) - CH(ST)) + c1w * log h(T) + c3w * lct`. That
+#' decomposes into at most three independent contributions, each of which
+#' [hazard()] expresses as one row's status and weight:
+#' * `C1 > 0` -- an event row of weight `C1 * WT` (status `1`);
+#' * `C2 > 0` -- a right-censored row of weight `C2` (status `0`);
+#' * `C3 > 0` -- an interval row of weight `C3 * WT` (status `2`).
 #'
-#' A `WEIGHT` statement, if also present, multiplies that expression, since
-#' `c3w` is the product of the two.
+#' `C2` is the one **not** multiplied by `WT`, and that is not an oversight in
+#' the reference: `readc2.c` sets `C2 = ONE` on exactly the rows where neither
+#' `C1` nor `C3` fires, so SAS weights a right-censored row `1` whatever the
+#' `WEIGHT` variable says. Emitting a bare `WT` there instead over- or
+#' under-weights every censored row -- and a `WEIGHT` that happens to be `0`
+#' on censored rows deletes them from the fit outright, silently (#158).
 #'
-#' An event outranks interval censoring: a row that is an event is not
-#' interval-censored, so `ICENSOR` overrides only where `EVENT == 0`. Treating
-#' a malformed row where `EVENT` and `C3 > 0` both fire as an event is the
-#' conservative reading; this is an assumption of this translation, not
-#' something confirmed against a SAS reference run.
+#' So `weights_expr` is emitted whenever `EVENT` or `ICENSOR` is present --
+#' which is always, since a job with neither is rejected -- as
+#' `ifelse(EVENT > 0, EVENT * WT, ifelse(C3 > 0, C3 * WT, 1))`, dropping
+#' whichever branches the job does not have and dropping `* WT` when there is
+#' no `WEIGHT` statement. For the 0/1 `EVENT` and absent `WEIGHT` that most
+#' jobs carry this evaluates to exactly the unit weights those jobs already
+#' fitted with; it is the repeat-event and weighted rows that change.
+#'
+#' `status` therefore derives from `EVENT > 0`, never from `EVENT` itself
+#' (#157). This package codes status `-1` left, `0` right, `1` event, `2`
+#' interval, so a row recording two events (`EVENT = 2`) mapped straight onto
+#' `status` becomes *interval-censored* -- a different likelihood branch, not
+#' an under-count -- and `EVENT = 3` lands outside the coding altogether,
+#' which also disables Conservation of Events (`coe_supported_data`).
+#' `readc1.c` accepts any `C1 >= 0` and keeps a fractional count (`notintg`
+#' only raises a report flag), so `> 0` is the right test and a fractional
+#' count carries through as a fractional weight. A *negative* count SAS
+#' deletes (`c1del`, `del = 1`); this translator has no way to drop a row, so
+#' such a row arrives as right-censored with weight 1 rather than absent.
+#'
+#' **A row where `EVENT` and `ICENSOR` both fire is refused at fit time.**
+#' `setlik.c` *sums* the two contributions, so such a row is simultaneously an
+#' event of weight `C1 * WT` and an interval observation of weight `C3 * WT`;
+#' [hazard()] carries one status and one weight per row and cannot express
+#' both. Whether any row does this is a property of the *data*, not of the job
+#' text, so it cannot be refused at translation time the way `LCENSOR` +
+#' `ICENSOR` is; instead the hoisted status chunk opens with a guard that
+#' stops before the fit and names the by-hand remedy (split the row in two).
+#' Picking the event branch and discarding `c3w` -- what this translator did
+#' before -- converges and reports plausibly, which is the shape this package
+#' exists to refuse.
+#'
+#' `RCENSOR` names `C2` itself (`rcnsprc.c` sets `c2name` from statement field
+#' 13), which is likewise a *count*. This translator still ignores it and
+#' relies on `readc2.c`'s derived `C2 = 1`, which is exact for the 0/1
+#' `CENSORED` flags every corpus job uses but under-weights a genuine count
+#' above 1. That is a separate defect from #157/#158 and is not fixed here.
 #'
 #' `hazard()`'s `time_lower` carries a different meaning per row, selected by
 #' `status` (see `R/hazard_api.R`): for status 2 (interval) it is the
@@ -88,11 +120,12 @@
 #' studies use the combination. So the pair is recorded in `untranslated` and
 #' `refused` is set, and the caller emits a `stop()` in place of the fit.
 #'
-#' The `ifelse()` forms are gated on a `status_name` placeholder (`.hzr_status`)
-#' the caller assigns the `status_expr` to first -- never unconditionally,
-#' which would trip `hazard()`'s finite-value check off the interval subset
-#' and, where populated, silently redefine event/right-censored rows' risk-set
-#' entry times.
+#' The `time_lower` `ifelse()` is gated on a `status_name` placeholder
+#' (`.hzr_status`) the caller assigns the `status_expr` to first -- never
+#' unconditionally, which would trip `hazard()`'s finite-value check off the
+#' interval subset and, where populated, silently redefine event/right-censored
+#' rows' risk-set entry times. `weights_expr` gates on the count variables
+#' themselves, not on `status`, so it stays valid on the un-hoisted paths.
 #'
 #' @param statements Named list of SAS statement operands, e.g.
 #'   `list(EVENT = "DEAD", TIME = "T", ICENSOR = c("C3", "CTIME"))`.
@@ -105,10 +138,10 @@
 #'   a `bquote()`-built call, evaluable against an environment/list holding
 #'   the named SAS variables. `time_lower` and `weights_expr`, when
 #'   non-`NULL`, are `bquote()`-built calls; `status_name` is non-`NULL` only
-#'   when `ICENSOR` is present, since only then does anything need to gate on
-#'   it. `weights_expr` is likewise non-`NULL` only under `ICENSOR`, so a job
-#'   without one emits no `weights` argument at all and fits with the unit
-#'   weights it always did. `refused` is `TRUE` only for the `LCENSOR` +
+#'   when `ICENSOR` is present, since only then does `time_lower` need to gate
+#'   on it. `weights_expr` is non-`NULL` on every non-refused path, because
+#'   `EVENT` and `ICENSOR` are both counts and one of the two is always
+#'   present. `refused` is `TRUE` only for the `LCENSOR` +
 #'   `ICENSOR` combination described above, and every other element is `NULL`
 #'   when it is: there is nothing to emit. Both returns carry the same element
 #'   names, so a caller reading one never meets an unexpected missing field.
@@ -145,44 +178,73 @@
   }
 
   ev <- if (has_event) as.name(statements$EVENT)
-  expr <- if (has_event) ev else 0
+  c3 <- if (has_icensor) as.name(statements$ICENSOR[[1L]])
+  wt <- if (!is.null(statements$WEIGHT)) as.name(statements$WEIGHT)
 
-  # RCENSOR needs no branch: right-censoring is code 0, which is exactly what
-  # EVENT already carries when the event did not occur. This is deliberate,
-  # not an omission -- there is nothing for an RCENSOR flag to change.
+  # RCENSOR needs no status branch: right-censoring is code 0, which is what
+  # a zero EVENT count already yields. Its C2 *count* is a separate,
+  # unfixed gap -- see roxygen.
 
   # LCENSOR is left-truncation, not left-censoring (see roxygen): it never
   # touches status, only time_lower below.
 
-  if (has_icensor) {
-    c3 <- as.name(statements$ICENSOR[[1L]])
-    # C3 is an event count, not a 0/1 flag (see roxygen): a row is
-    # interval-censored where C3 > 0. Interval censoring only applies where
-    # the event did not occur; if it did, EVENT == 1 and the row stays coded
-    # as an event, not an interval.
-    expr <- if (has_event) {
-      bquote(ifelse(.(ev) == 0 & .(c3) > 0, 2, .(expr)))
-    } else {
-      bquote(ifelse(.(c3) > 0, 2, .(expr)))
-    }
+  # EVENT and C3 are counts, not flags (see roxygen). status comes from
+  # `> 0`, never from the count itself: EVENT = 2 read as a status is
+  # interval-censored, a different likelihood branch (#157).
+  expr <- if (has_event && has_icensor) {
+    bquote(ifelse(.(ev) > 0, 1, ifelse(.(c3) > 0, 2, 0)))
+  } else if (has_event) {
+    bquote(ifelse(.(ev) > 0, 1, 0))
+  } else {
+    bquote(ifelse(.(c3) > 0, 2, 0))
+  }
+
+  # setlik.c SUMS the two contributions (c1c2c3 = c1w + c2 + c3w), so a row
+  # with both counts non-zero is an event AND an interval observation at
+  # once. hazard() has one status and one weight per row and cannot say
+  # that. Whether any row does it is a property of the data, so the refusal
+  # has to happen at fit time rather than at translation time.
+  if (has_event && has_icensor) {
+    expr <- bquote({
+      if (any(.(ev) > 0 & .(c3) > 0, na.rm = TRUE)) {
+        stop(.(sprintf(paste(
+          "This job has rows where the EVENT count (%s) and the ICENSOR",
+          "count (%s) are both non-zero. SAS sums the two contributions",
+          "(setlik.c: c1c2c3 = c1w + c2 + c3w), so such a row is at once an",
+          "event of weight %s and an interval observation of weight %s.",
+          "hazard() carries one status and one weight per row and cannot",
+          "express both. Split each such row into two -- a status 1 row and",
+          "a status 2 row, same times, those two weights -- and fit by hand",
+          "(#157)."),
+          deparse(ev), deparse(c3),
+          deparse(if (is.null(wt)) ev else bquote(.(ev) * .(wt))),
+          deparse(if (is.null(wt)) c3 else bquote(.(c3) * .(wt))))),
+          call. = FALSE)
+      }
+      .(expr)
+    })
+  }
+
+  # The weight is the row's own count times the WEIGHT variable on event and
+  # interval rows (c1w = C1 * WT, c3w = C3 * WT), and exactly 1 on
+  # right-censored rows -- c2 enters the sum unweighted, and readc2.c sets it
+  # to ONE on precisely the rows where neither other count fires. Weighting a
+  # censored row by WT is #158; a WEIGHT that is 0 there deletes the row.
+  ev_w <- if (is.null(wt)) ev else bquote(.(ev) * .(wt))
+  c3_w <- if (is.null(wt)) c3 else bquote(.(c3) * .(wt))
+  weights_expr <- if (has_event && has_icensor) {
+    bquote(ifelse(.(ev) > 0, .(ev_w), ifelse(.(c3) > 0, .(c3_w), 1)))
+  } else if (has_event) {
+    bquote(ifelse(.(ev) > 0, .(ev_w), 1))
+  } else {
+    bquote(ifelse(.(c3) > 0, .(c3_w), 1))
   }
 
   status_name <- NULL
   time_lower <- NULL
-  weights_expr <- NULL
   if (has_icensor) {
     status_name <- as.name(".hzr_status")
     ctime <- as.name(statements$ICENSOR[[2L]])
-    # C3 is a count, and setlik.c multiplies the whole log-likelihood
-    # contribution by it -- c3w = c3 * weight, then both
-    # -(c1w + c2 + c3w) * (cumhaz - cumhst) and += c3w * lct. hazard()'s
-    # `weights` multiplies each row's contribution the same way, so the count
-    # belongs there; without it a row carrying 3 events is fitted as one
-    # observation (#154). Status-gated, and emphatically not the bare count:
-    # C3 is 0 on every non-interval row, and a weight of 0 deletes a row from
-    # the likelihood outright. readc2.c sets C2 = 1 on exactly those rows
-    # when no RCENSOR statement is given, so their weight is 1.
-    weights_expr <- bquote(ifelse(.(status_name) == 2, .(c3), 1))
     # Status-gated, not unconditional (see roxygen): interval rows get the
     # interval's lower bound (CTIME); every other row falls back to
     # hazard()'s own entry-time default (0). LCENSOR cannot be present here
@@ -413,19 +475,12 @@
     args$phases <- parms$phases
   }
   args$theta <- parms$theta
-  # Two independent sources of a row weight, and they multiply, exactly as
-  # setlik.c's c3w = c3 * weight does: the SAS WEIGHT statement's variable,
-  # and ICENSOR's event count on interval rows (see .hzr_censor_spec()).
-  wt_name <- if (!is.null(statements$WEIGHT)) as.name(statements$WEIGHT)
-  if (!is.null(cens$weights_expr)) {
-    args$weights <- if (is.null(wt_name)) {
-      cens$weights_expr
-    } else {
-      bquote(.(cens$weights_expr) * .(wt_name))
-    }
-  } else if (!is.null(wt_name)) {
-    args$weights <- wt_name
-  }
+  # One expression, built in .hzr_censor_spec() from all three counts at
+  # once: EVENT, ICENSOR's C3 and the WEIGHT variable. It cannot be composed
+  # by multiplying a WEIGHT variable onto a count-only expression, because
+  # setlik.c's c2 term -- the right-censored row -- enters the sum unweighted
+  # (#158).
+  if (!is.null(cens$weights_expr)) args$weights <- cens$weights_expr
 
   # Canonical control order, so the emitted call does not depend on the order
   # the options happened to appear in the SAS text.

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -83,13 +83,48 @@
 #' stops before the fit and names the by-hand remedy (split the row in two).
 #' Picking the event branch and discarding `c3w` -- what this translator did
 #' before -- converges and reports plausibly, which is the shape this package
-#' exists to refuse.
+#' exists to refuse. The same guard covers `EVENT` + `RCENSOR` and `ICENSOR`
+#' + `RCENSOR`; see the `RCENSOR` paragraph below.
 #'
-#' `RCENSOR` names `C2` itself (`rcnsprc.c` sets `c2name` from statement field
-#' 13), which is likewise a *count*. This translator still ignores it and
-#' relies on `readc2.c`'s derived `C2 = 1`, which is exact for the 0/1
-#' `CENSORED` flags every corpus job uses but under-weights a genuine count
-#' above 1. That is a separate defect from #157/#158 and is not fixed here.
+#' **`RCENSOR` names `C2` itself** (`hazard_y.y`:
+#' `rcensorstmt : RCENSOR NAME { setvar(13,$2); }`; `rcnsprc.c` sets `c2name`
+#' from statement field 13), and `C2` is likewise a *count* --
+#' "COUNT OF CENSORED INDIVIDUALS AT TIME=T" in `setlik.c`'s header, and
+#' `OBS(3)`, "NUMBER OF CENSORED OBSERVATIONS AT T". The two branches of
+#' `readc2.c` are what decides the translation: when `c2name` is non-blank
+#' `C2` is read straight from the data, and the `C2 = ONE` derivation is
+#' skipped *entirely*; only a blank `c2name` derives it. So the censored
+#' branch of `weights_expr` is the literal `1` for a job with no `RCENSOR`
+#' and the `C2` variable itself for a job with one (#162), and it is never
+#' multiplied by `WT` either way. Four censored individuals fitted as one
+#' observation is the same under-weighting as #154/#157, arriving by the
+#' third of the three counts.
+#'
+#' No corpus job exercises it: `hz.te123.OMC.sas` and `hz.tm123.OMC.sas` are
+#' the only two of the 110 with an `RCENSOR` statement, and both set a 0/1
+#' `CENSORED` that is mutually exclusive with `EVENT`, for which `C2` and the
+#' derived `1` agree on every row. That is why it went unseen, not evidence
+#' that it does not bite.
+#'
+#' Two edge cases follow from reading `C2` verbatim, and neither is silent.
+#' `readobs.c` deletes an all-zero row (`ic10 && ic20`, or `ic30 && ic20`);
+#' this translator has no way to drop a row, so such a row arrives with
+#' weight `0` -- no contribution to the likelihood, which is what deletion
+#' means for the fit, though it still counts toward `n`. A *negative* `C2`
+#' SAS also deletes (`c2del`); here it reaches [hazard()]'s non-negative
+#' check and stops the fit outright rather than vanishing from it.
+#'
+#' **A row where two named counts both fire is refused at fit time.** With
+#' `RCENSOR` present this is no longer only the `EVENT` + `ICENSOR` pair:
+#' `readobs.c` deletes a row only when *both* of a pair are zero, so
+#' `C1 > 0 & C2 > 0` and `C3 > 0 & C2 > 0` reach `setlik.c` too and are
+#' summed there. Each such row is two observations at once -- an event of
+#' weight `C1 * WT` *and* a right-censored observation of weight `C2`, say --
+#' and [hazard()] carries one status and one weight per row. A guard is
+#' emitted for every pair of counts the job named, and only for named ones: a
+#' *derived* `C2` fires on exactly the rows where no other count does, so it
+#' cannot collide. Any job carrying a guard has its status hoisted into its
+#' own chunk, so the guard runs, and is seen to run, before the fit.
 #'
 #' `hazard()`'s `time_lower` carries a different meaning per row, selected by
 #' `status` (see `R/hazard_api.R`): for status 2 (interval) it is the
@@ -137,9 +172,11 @@
 #'   untranslated = <data.frame>, refused = <logical>)`. `status_expr` is
 #'   a `bquote()`-built call, evaluable against an environment/list holding
 #'   the named SAS variables. `time_lower` and `weights_expr`, when
-#'   non-`NULL`, are `bquote()`-built calls; `status_name` is non-`NULL` only
-#'   when `ICENSOR` is present, since only then does `time_lower` need to gate
-#'   on it. `weights_expr` is non-`NULL` on every non-refused path, because
+#'   non-`NULL`, are `bquote()`-built calls; `status_name` is non-`NULL` when
+#'   `ICENSOR` is present, since only then does `time_lower` need to gate on
+#'   it, and whenever the job named more than one count, since the both-fire
+#'   guard then has to run in its own chunk ahead of the fit.
+#'   `weights_expr` is non-`NULL` on every non-refused path, because
 #'   `EVENT` and `ICENSOR` are both counts and one of the two is always
 #'   present. `refused` is `TRUE` only for the `LCENSOR` +
 #'   `ICENSOR` combination described above, and every other element is `NULL`
@@ -150,6 +187,7 @@
   has_event <- !is.null(statements$EVENT)
   has_icensor <- !is.null(statements$ICENSOR)
   has_lcensor <- !is.null(statements$LCENSOR)
+  has_rcensor <- !is.null(statements$RCENSOR)
 
   if (!has_event && !has_icensor) {
     stop("The EVENT or ICENSOR variable must be specified.", call. = FALSE)
@@ -179,18 +217,17 @@
 
   ev <- if (has_event) as.name(statements$EVENT)
   c3 <- if (has_icensor) as.name(statements$ICENSOR[[1L]])
+  c2 <- if (has_rcensor) as.name(statements$RCENSOR)
   wt <- if (!is.null(statements$WEIGHT)) as.name(statements$WEIGHT)
-
-  # RCENSOR needs no status branch: right-censoring is code 0, which is what
-  # a zero EVENT count already yields. Its C2 *count* is a separate,
-  # unfixed gap -- see roxygen.
 
   # LCENSOR is left-truncation, not left-censoring (see roxygen): it never
   # touches status, only time_lower below.
 
   # EVENT and C3 are counts, not flags (see roxygen). status comes from
   # `> 0`, never from the count itself: EVENT = 2 read as a status is
-  # interval-censored, a different likelihood branch (#157).
+  # interval-censored, a different likelihood branch (#157). RCENSOR adds no
+  # branch of its own -- C2 > 0 is right-censoring, code 0, which is already
+  # this expression's fallback. It changes the row's WEIGHT, not its status.
   expr <- if (has_event && has_icensor) {
     bquote(ifelse(.(ev) > 0, 1, ifelse(.(c3) > 0, 2, 0)))
   } else if (has_event) {
@@ -199,51 +236,83 @@
     bquote(ifelse(.(c3) > 0, 2, 0))
   }
 
-  # setlik.c SUMS the two contributions (c1c2c3 = c1w + c2 + c3w), so a row
-  # with both counts non-zero is an event AND an interval observation at
-  # once. hazard() has one status and one weight per row and cannot say
-  # that. Whether any row does it is a property of the data, so the refusal
-  # has to happen at fit time rather than at translation time.
-  if (has_event && has_icensor) {
-    expr <- bquote({
-      if (any(.(ev) > 0 & .(c3) > 0, na.rm = TRUE)) {
-        stop(.(sprintf(paste(
-          "This job has rows where the EVENT count (%s) and the ICENSOR",
-          "count (%s) are both non-zero. SAS sums the two contributions",
-          "(setlik.c: c1c2c3 = c1w + c2 + c3w), so such a row is at once an",
-          "event of weight %s and an interval observation of weight %s.",
-          "hazard() carries one status and one weight per row and cannot",
-          "express both. Split each such row into two -- a status 1 row and",
-          "a status 2 row, same times, those two weights -- and fit by hand",
-          "(#157)."),
-          deparse(ev), deparse(c3),
-          deparse(if (is.null(wt)) ev else bquote(.(ev) * .(wt))),
-          deparse(if (is.null(wt)) c3 else bquote(.(c3) * .(wt))))),
-          call. = FALSE)
-      }
-      .(expr)
-    })
-  }
-
   # The weight is the row's own count times the WEIGHT variable on event and
-  # interval rows (c1w = C1 * WT, c3w = C3 * WT), and exactly 1 on
-  # right-censored rows -- c2 enters the sum unweighted, and readc2.c sets it
-  # to ONE on precisely the rows where neither other count fires. Weighting a
-  # censored row by WT is #158; a WEIGHT that is 0 there deletes the row.
+  # interval rows (c1w = C1 * WT, c3w = C3 * WT). C2 is the term that enters
+  # the sum UNWEIGHTED (#158), and it is a count in its own right whenever
+  # RCENSOR named it: readc2.c reads c2name straight from the data and only
+  # DERIVES C2 = 1 -- on precisely the rows where neither other count fires
+  # -- when that name is blank (#162). So the censored branch is the literal
+  # 1 for a job with no RCENSOR and the C2 variable for a job with one.
   ev_w <- if (is.null(wt)) ev else bquote(.(ev) * .(wt))
   c3_w <- if (is.null(wt)) c3 else bquote(.(c3) * .(wt))
+  c2_w <- if (has_rcensor) c2 else 1
   weights_expr <- if (has_event && has_icensor) {
-    bquote(ifelse(.(ev) > 0, .(ev_w), ifelse(.(c3) > 0, .(c3_w), 1)))
+    bquote(ifelse(.(ev) > 0, .(ev_w), ifelse(.(c3) > 0, .(c3_w), .(c2_w))))
   } else if (has_event) {
-    bquote(ifelse(.(ev) > 0, .(ev_w), 1))
+    bquote(ifelse(.(ev) > 0, .(ev_w), .(c2_w)))
   } else {
-    bquote(ifelse(.(c3) > 0, .(c3_w), 1))
+    bquote(ifelse(.(c3) > 0, .(c3_w), .(c2_w)))
   }
 
-  status_name <- NULL
+  # Every count the job NAMED, with the status code and the weight setlik.c
+  # gives its contribution. A derived C2 is deliberately absent from this
+  # table: readc2.c sets it on exactly the rows where no other count fires,
+  # so it cannot collide with one. A named C2 can, and does (#162).
+  counts <- list()
+  if (has_event) {
+    counts$EVENT <- list(v = ev, w = ev_w, code = 1L, what = "an event")
+  }
+  if (has_rcensor) {
+    counts$RCENSOR <- list(v = c2, w = c2, code = 0L,
+                           what = "a right-censored observation")
+  }
+  if (has_icensor) {
+    counts$ICENSOR <- list(v = c3, w = c3_w, code = 2L,
+                           what = "an interval observation")
+  }
+
+  # setlik.c SUMS the contributions (c1c2c3 = c1w + c2 + c3w), so a row with
+  # two of these counts non-zero is two observations at once, and readobs.c
+  # deletes a row only when BOTH of a pair are zero -- so such a row does
+  # reach the fit. hazard() carries one status and one weight per row and
+  # cannot say that. Whether any row does it is a property of the DATA, not
+  # of the job text, so the refusal happens at fit time rather than at
+  # translation time, the way the LCENSOR + ICENSOR one does.
+  nms <- names(counts)
+  for (i in seq_along(nms)) {
+    for (j in seq_len(i - 1L)) {
+      a <- counts[[nms[[j]]]]
+      b <- counts[[nms[[i]]]]
+      expr <- bquote({
+        if (any(.(a$v) > 0 & .(b$v) > 0, na.rm = TRUE)) {
+          stop(.(sprintf(paste(
+            "This job has rows where the %s count (%s) and the %s count",
+            "(%s) are both non-zero. SAS sums the two contributions",
+            "(setlik.c: c1c2c3 = c1w + c2 + c3w), so such a row is at once",
+            "%s of weight %s and %s of weight %s. hazard() carries one",
+            "status and one weight per row and cannot express both. Split",
+            "each such row into two -- a status %d row and a status %d row,",
+            "same times, those two weights -- and fit by hand (%s)."),
+            nms[[j]], deparse(a$v), nms[[i]], deparse(b$v),
+            a$what, deparse(a$w), b$what, deparse(b$w), a$code, b$code,
+            if ("RCENSOR" %in% c(nms[[j]], nms[[i]])) "#162" else "#157")),
+            call. = FALSE)
+        }
+        .(expr)
+      })
+    }
+  }
+
+  # A job carrying a guard gets its status hoisted into a chunk of its own,
+  # not only the ICENSOR jobs whose time_lower has to gate on it: the guard
+  # must run and be seen to run BEFORE the fit, and one buried inside
+  # hazard(status = ...) is neither readable in the rendered document nor
+  # separable from the fit that follows it.
+  status_name <- if (has_icensor || length(counts) > 1L) {
+    as.name(".hzr_status")
+  }
   time_lower <- NULL
   if (has_icensor) {
-    status_name <- as.name(".hzr_status")
     ctime <- as.name(statements$ICENSOR[[2L]])
     # Status-gated, not unconditional (see roxygen): interval rows get the
     # interval's lower bound (CTIME); every other row falls back to

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -70,8 +70,13 @@
 #' `readc1.c` accepts any `C1 >= 0` and keeps a fractional count (`notintg`
 #' only raises a report flag), so `> 0` is the right test and a fractional
 #' count carries through as a fractional weight. A *negative* count SAS
-#' deletes (`c1del`, `del = 1`); this translator has no way to drop a row, so
-#' such a row arrives as right-censored with weight 1 rather than absent.
+#' deletes (`c1del`, `del = 1`) and a *missing* one likewise (`mc1del`,
+#' `mdel = 1`); `readobs.c` then skips `setobs()` and subtracts the row from
+#' `Nobs`, so it contributes nothing at all -- it is emphatically not a
+#' right-censored row of weight 1. This translator has no way to drop a row,
+#' and dropping one silently would change `n` behind the reader's back, so the
+#' hoisted status chunk opens with a guard per named count that stops and
+#' names the variable, the SAS rule and the remedy (filter the rows out).
 #'
 #' **A row where `EVENT` and `ICENSOR` both fire is refused at fit time.**
 #' `setlik.c` *sums* the two contributions, so such a row is simultaneously an
@@ -118,8 +123,10 @@
 #' likelihood, which is what deletion means for the fit and what the
 #' all-three case does anyway, though the row still counts toward `n`.
 #' A *negative* `C2` SAS deletes (`c2del`) and a *missing* one it deletes too
-#' (`mc2del`); both reach [hazard()]'s "non-negative and finite" check and
-#' stop the fit outright rather than vanishing from it.
+#' (`mc2del`) -- the same rule `readc1.c` and `readc3.c` apply to their own
+#' counts, guarded only by the name being non-blank -- so both are caught by
+#' the missing/negative guard above rather than by [hazard()]'s incidental
+#' "non-negative and finite" check.
 #'
 #' **A row where two named counts both fire is refused at fit time.** With
 #' `RCENSOR` present this is no longer only the `EVENT` + `ICENSOR` pair:
@@ -179,10 +186,10 @@
 #'   untranslated = <data.frame>, refused = <logical>)`. `status_expr` is
 #'   a `bquote()`-built call, evaluable against an environment/list holding
 #'   the named SAS variables. `time_lower` and `weights_expr`, when
-#'   non-`NULL`, are `bquote()`-built calls; `status_name` is non-`NULL` when
-#'   `ICENSOR` is present, since only then does `time_lower` need to gate on
-#'   it, and whenever the job named more than one count, since the both-fire
-#'   guard then has to run in its own chunk ahead of the fit.
+#'   non-`NULL`, are `bquote()`-built calls; `status_name` is non-`NULL` on
+#'   every non-refused path, because every such job names at least one count
+#'   and every named count carries a missing/negative guard that has to run in
+#'   its own chunk ahead of the fit.
 #'   `weights_expr` is non-`NULL` on every non-refused path, because
 #'   `EVENT` and `ICENSOR` are both counts and one of the two is always
 #'   present. `refused` is `TRUE` only for the `LCENSOR` +
@@ -267,14 +274,15 @@
   # so it cannot collide with one. A named C2 can, and does (#162).
   counts <- list()
   if (has_event) {
-    counts$EVENT <- list(v = ev, w = ev_w, code = 1L, what = "an event")
+    counts$EVENT <- list(v = ev, w = ev_w, code = 1L, readc = 1L,
+                         what = "an event")
   }
   if (has_rcensor) {
-    counts$RCENSOR <- list(v = c2, w = c2, code = 0L,
+    counts$RCENSOR <- list(v = c2, w = c2, code = 0L, readc = 2L,
                            what = "a right-censored observation")
   }
   if (has_icensor) {
-    counts$ICENSOR <- list(v = c3, w = c3_w, code = 2L,
+    counts$ICENSOR <- list(v = c3, w = c3_w, code = 2L, readc = 3L,
                            what = "an interval observation")
   }
 
@@ -310,14 +318,51 @@
     }
   }
 
-  # A job carrying a guard gets its status hoisted into a chunk of its own,
-  # not only the ICENSOR jobs whose time_lower has to gate on it: the guard
-  # must run and be seen to run BEFORE the fit, and one buried inside
-  # hazard(status = ...) is neither readable in the rendered document nor
-  # separable from the fit that follows it.
-  status_name <- if (has_icensor || length(counts) > 1L) {
-    as.name(".hzr_status")
+  # readc1.c, readc2.c and readc3.c apply one rule to every count the job
+  # NAMED, and it is the same rule in all three: a missing value sets mdel, a
+  # negative one sets del, and readobs.c then skips setobs() for that row and
+  # subtracts it from Nobs. A deleted row is NOT a right-censored observation
+  # of weight 1 -- it contributes nothing at all, and SAS reports the two
+  # tallies (mcNdel, cNdel) in its listing. `> 0` alone cannot say that: it
+  # folds a negative count into the censored fallback, and it propagates NA
+  # out of ifelse() into both status and weights, where hazard() rejects it
+  # with a message about weights that names neither the variable nor the
+  # cause. Deleting the rows here instead would change n silently, so stop
+  # and say which variable, what SAS does, and what to do about it.
+  # Reversed so the guards read EVENT, RCENSOR, ICENSOR top to bottom in the
+  # rendered document: each wrap goes outside the previous one.
+  for (nm in rev(names(counts))) {
+    a <- counts[[nm]]
+    expr <- bquote({
+      if (any(is.na(.(a$v)) | .(a$v) < 0)) {
+        stop(.(sprintf(paste(
+          "This job has rows where the %s count (%s) is missing or negative.",
+          "SAS deletes such rows outright: readc%d.c sets mdel on a missing",
+          "count and del on a negative one, and readobs.c then skips",
+          "setobs() and subtracts the row from Nobs, so it contributes",
+          "nothing to the likelihood -- it is not %s of weight 1. hazard()",
+          "has no equivalent, and translating the row as censored would",
+          "change the fit without saying so. Drop those rows before fitting",
+          "-- subset to !is.na(%s) & %s >= 0 -- and compare your row count",
+          "against the deletion tallies SAS prints for this job."),
+          nm, deparse(a$v), a$readc, a$what,
+          deparse(a$v), deparse(a$v))),
+          call. = FALSE)
+      }
+      .(expr)
+    })
   }
+
+  # Every job carrying a guard gets its status hoisted into a chunk of its
+  # own, not only the ICENSOR jobs whose time_lower has to gate on it: the
+  # guard must run and be seen to run BEFORE the fit, and one buried inside
+  # hazard(status = ...) is neither readable in the rendered document nor
+  # separable from the fit that follows it. Since every non-refused job names
+  # at least one count, and every named count carries the missing/negative
+  # guard above, that is now every job. It also settles the evaluation order:
+  # a missing count reaches the guard before it can reach hazard()'s
+  # `weights` check, so the explanatory message wins over the incidental one.
+  status_name <- as.name(".hzr_status")
   time_lower <- NULL
   if (has_icensor) {
     ctime <- as.name(statements$ICENSOR[[2L]])
@@ -504,46 +549,42 @@
   }
 
   # The status expression is hoisted into its own chunk, named .hzr_status so
-  # it cannot collide with a SAS variable, for two reasons: an ICENSOR job's
-  # time_lower has to gate on it, and a job that named more than one count
-  # carries a both-fire guard that must run, and be seen to run, ahead of the
-  # fit. A job with neither -- a plain EVENT job, or an LCENSOR-only one,
-  # whose entry time applies to every row unconditionally -- leaves status
-  # inline. See .hzr_censor_spec() roxygen. time_upper is never emitted: the
-  # ICENSOR interval's upper bound is TIME, and hazard()'s time_upper already
-  # defaults to TIME when left NULL (see .hzr_censor_spec() roxygen).
-  status_call <- NULL
+  # it cannot collide with a SAS variable, because every job carries at least
+  # one guard that must run, and be seen to run, ahead of the fit: the
+  # missing/negative guard on each named count, plus the both-fire guard when
+  # the job named more than one. ICENSOR jobs additionally need the name so
+  # time_lower can gate on it. See .hzr_censor_spec() roxygen. The refused
+  # path returned above, so status_name is non-NULL from here on.
+  # time_upper is never emitted: the ICENSOR interval's upper bound is TIME,
+  # and hazard()'s time_upper already defaults to TIME when left NULL (see
+  # .hzr_censor_spec() roxygen).
   args <- list()
   if (!is.null(data_name)) args$data <- as.name(data_name)
   args$time <- as.name(statements$TIME)
-  if (!is.null(cens$status_name)) {
-    # The status chunk is evaluated outside hazard(), so it has to resolve
-    # its own bare SAS column names. When the job reads a DATA= dataset the
-    # hoisted status is written back INTO that data frame rather than bound
-    # locally: hazard()'s vector path gives data columns precedence over the
-    # calling frame, so a local binding is shadowed by any column of the same
-    # name, and both `status =` and the `time_lower` gate would then read the
-    # user's column instead of the computed censoring classification -- a
-    # different censoring structure, from a fit that raises nothing but an
-    # ambiguity warning. Derived as a column, the mask resolves to the value
-    # this chunk just wrote, so it cannot be shadowed at all. `.hzr_` is this
-    # package's reserved prefix, so overwriting a column of that name is the
-    # intended consequence, not collateral damage. transform() masks exactly
-    # as with() did, so the expression's column names still resolve against
-    # the dataset. With no DATA= there is no data frame and no mask, so a
-    # plain local binding is already unshadowable.
-    status_call <- if (is.null(data_name)) {
-      call("<-", cens$status_name, cens$status_expr)
-    } else {
-      derive <- as.call(list(quote(transform), as.name(data_name),
-                             cens$status_expr))
-      names(derive) <- c("", "", as.character(cens$status_name))
-      call("<-", as.name(data_name), derive)
-    }
-    args$status <- cens$status_name
+  # The status chunk is evaluated outside hazard(), so it has to resolve
+  # its own bare SAS column names. When the job reads a DATA= dataset the
+  # hoisted status is written back INTO that data frame rather than bound
+  # locally: hazard()'s vector path gives data columns precedence over the
+  # calling frame, so a local binding is shadowed by any column of the same
+  # name, and both `status =` and the `time_lower` gate would then read the
+  # user's column instead of the computed censoring classification -- a
+  # different censoring structure, from a fit that raises nothing but an
+  # ambiguity warning. Derived as a column, the mask resolves to the value
+  # this chunk just wrote, so it cannot be shadowed at all. `.hzr_` is this
+  # package's reserved prefix, so overwriting a column of that name is the
+  # intended consequence, not collateral damage. transform() masks exactly
+  # as with() did, so the expression's column names still resolve against
+  # the dataset. With no DATA= there is no data frame and no mask, so a
+  # plain local binding is already unshadowable.
+  status_call <- if (is.null(data_name)) {
+    call("<-", cens$status_name, cens$status_expr)
   } else {
-    args$status <- cens$status_expr
+    derive <- as.call(list(quote(transform), as.name(data_name),
+                           cens$status_expr))
+    names(derive) <- c("", "", as.character(cens$status_name))
+    call("<-", as.name(data_name), derive)
   }
+  args$status <- cens$status_name
   if (!is.null(cens$time_lower)) args$time_lower <- cens$time_lower
   # Without fit = TRUE the emitted call returns an unfitted object: converged
   # is NA, objective is NA, and theta holds the SAS starting values, while

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -106,13 +106,20 @@
 #' derived `1` agree on every row. That is why it went unseen, not evidence
 #' that it does not bite.
 #'
-#' Two edge cases follow from reading `C2` verbatim, and neither is silent.
-#' `readobs.c` deletes an all-zero row (`ic10 && ic20`, or `ic30 && ic20`);
-#' this translator has no way to drop a row, so such a row arrives with
-#' weight `0` -- no contribution to the likelihood, which is what deletion
-#' means for the fit, though it still counts toward `n`. A *negative* `C2`
-#' SAS also deletes (`c2del`); here it reaches [hazard()]'s non-negative
-#' check and stops the fit outright rather than vanishing from it.
+#' Three edge cases follow from reading `C2` verbatim, and none is silent.
+#' `readobs.c`'s all-zero deletion is narrower than it first looks: both of
+#' its rules are guarded by a blank-name test, `ic10 && ic20` only when
+#' `c3name` is blank and `ic30 && ic20` only when `c1name` is blank. So a row
+#' with every count zero is deleted for `EVENT` + `RCENSOR` and for `ICENSOR`
+#' + `RCENSOR`, and *kept* -- contributing `c1c2c3 = 0` -- when all three are
+#' named. There is no such rule at all for `EVENT` + `ICENSOR`, which is
+#' exactly the pairing with no `c2name`. This translator has no way to drop a
+#' row, so an all-zero row arrives with weight `0`: no contribution to the
+#' likelihood, which is what deletion means for the fit and what the
+#' all-three case does anyway, though the row still counts toward `n`.
+#' A *negative* `C2` SAS deletes (`c2del`) and a *missing* one it deletes too
+#' (`mc2del`); both reach [hazard()]'s "non-negative and finite" check and
+#' stop the fit outright rather than vanishing from it.
 #'
 #' **A row where two named counts both fire is refused at fit time.** With
 #' `RCENSOR` present this is no longer only the `EVENT` + `ICENSOR` pair:
@@ -496,12 +503,14 @@
     ))
   }
 
-  # ICENSOR jobs get the status expression hoisted into its own chunk, named
-  # .hzr_status so it cannot collide with a SAS variable, so that time_lower
-  # can gate on it -- see .hzr_censor_spec() roxygen. LCENSOR-only jobs need
-  # no gating (LCENSOR's entry time applies to every row unconditionally), so
-  # status stays unhoisted there. time_upper is never emitted: the ICENSOR
-  # interval's upper bound is TIME, and hazard()'s time_upper already
+  # The status expression is hoisted into its own chunk, named .hzr_status so
+  # it cannot collide with a SAS variable, for two reasons: an ICENSOR job's
+  # time_lower has to gate on it, and a job that named more than one count
+  # carries a both-fire guard that must run, and be seen to run, ahead of the
+  # fit. A job with neither -- a plain EVENT job, or an LCENSOR-only one,
+  # whose entry time applies to every row unconditionally -- leaves status
+  # inline. See .hzr_censor_spec() roxygen. time_upper is never emitted: the
+  # ICENSOR interval's upper bound is TIME, and hazard()'s time_upper already
   # defaults to TIME when left NULL (see .hzr_censor_spec() roxygen).
   status_call <- NULL
   args <- list()
@@ -556,11 +565,12 @@
     args$phases <- parms$phases
   }
   args$theta <- parms$theta
-  # One expression, built in .hzr_censor_spec() from all three counts at
-  # once: EVENT, ICENSOR's C3 and the WEIGHT variable. It cannot be composed
-  # by multiplying a WEIGHT variable onto a count-only expression, because
-  # setlik.c's c2 term -- the right-censored row -- enters the sum unweighted
-  # (#158).
+  # One expression, built in .hzr_censor_spec() from every count the job
+  # named -- EVENT's C1, ICENSOR's C3, RCENSOR's C2 -- together with the
+  # WEIGHT variable, which is not a count but multiplies two of the three.
+  # It cannot be composed by multiplying a WEIGHT variable onto a count-only
+  # expression, because setlik.c's c2 term -- the right-censored row --
+  # enters the sum unweighted (#158, #162).
   if (!is.null(cens$weights_expr)) args$weights <- cens$weights_expr
 
   # Canonical control order, so the emitted call does not depend on the order

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -215,6 +215,7 @@ un
 unclassed
 underpredicts
 univariable
+unmultiplied
 unrecognisable
 unscored
 varphi

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -235,7 +235,7 @@ translator.
 | `LCENSOR <var>` | `time_lower = <var>` -- entry time, `status` unchanged |
 | `ICENSOR <c3> = <ctime>` | rows where `<c3> > 0`: `status = 2`, `time_lower = <ctime>` |
 | `RCENSOR <var>` | `status = 0`, no branch needed -- but `<var>` is `C2`, a *count*, so it is the censored rows' `weights` (#162) |
-| `EVENT <var>` | unchanged |
+| `EVENT <var>` | rows where `<var> > 0`: `status = 1` -- and `<var>` is `C1`, a *count*, so it is those rows' `weights` (#157) |
 
 It also touches known open work: the 2026-08-19 `preserve_root` parity run left a
 named residual where SAS maximises the interval-censored likelihood but *reports*

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -234,7 +234,7 @@ translator.
 |---|---|
 | `LCENSOR <var>` | `time_lower = <var>` -- entry time, `status` unchanged |
 | `ICENSOR <c3> = <ctime>` | rows where `<c3> > 0`: `status = 2`, `time_lower = <ctime>` |
-| `RCENSOR <var>` | unchanged: `status = 0`, no branch needed |
+| `RCENSOR <var>` | `status = 0`, no branch needed -- but `<var>` is `C2`, a *count*, so it is the censored rows' `weights` (#162) |
 | `EVENT <var>` | unchanged |
 
 It also touches known open work: the 2026-08-19 `preserve_root` parity run left a

--- a/tests/testthat/helper-render-sim.R
+++ b/tests/testthat/helper-render-sim.R
@@ -141,10 +141,22 @@ sas_synth_data <- function(job, n = 24L) {
       }
     }
     put(r$time, function(i) time_col)
-    # Distinct 0/1 patterns per status variable, so an ICENSOR job's EVENT
-    # and event-count columns do not coincide and the interval branch of the
-    # emitted ifelse() is actually reached.
-    put(r$status, function(i) as.numeric(seq_len(n) %% (i %% 3L + 2L) == 0L))
+    # One residue class per count variable, so no two of them ever fire on
+    # the same row and one class is left over where none does. EVENT,
+    # ICENSOR's C3 and RCENSOR's C2 are SEPARATE counts: a row where two
+    # fire is two observations at once, which the translator refuses at fit
+    # time (#157, #162). The patterns here used to be `%% (i %% 3L + 2L)`,
+    # which coincide at every common multiple -- that generates data the
+    # refusal is right to reject, and the rejection then reads as a
+    # rendering failure, testing this generator rather than the translation.
+    # Disjoint classes still reach every branch of the emitted ifelse(),
+    # which is what the old comment was after.
+    n_status <- length(r$status)
+    status_i <- 0L
+    put(r$status, function(i) {
+      status_i <<- status_i + 1L
+      as.numeric(seq_len(n) %% (n_status + 1L) == status_i - 1L)
+    })
     put(r$lower, function(i) time_col * 0.25)
     put(r$wt, function(i) rep(1, n))
     put(r$cov, covs)

--- a/tests/testthat/test-sas-censoring.R
+++ b/tests/testthat/test-sas-censoring.R
@@ -315,3 +315,146 @@ test_that("the refusal reaches both the untranslated callout and a stop() chunk"
   # No fit is emitted at all -- not a fit guarded by a warning.
   expect_false(grepl("fit <- hazard(", qmd, fixed = TRUE))
 })
+
+test_that("RCENSOR's C2 is a count: a censored row's weight is C2, not 1", {
+  # #162: RCENSOR names C2 itself (hazard_y.y `rcensorstmt : RCENSOR NAME
+  # { setvar(13,$2); }`; rcnsprc.c sets c2name from statement field 13), and
+  # C2 is "COUNT OF CENSORED INDIVIDUALS AT TIME=T" (setlik.c header). When
+  # c2name is non-blank readc2.c reads it straight from the data -- the
+  # `C2 = ONE` derivation applies only when it is BLANK. So a genuine count
+  # of 4 is four censored individuals, not one.
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T",
+                               RCENSOR = "NCENS"))
+  expect_equal(
+    eval(got$weights_expr, list(DEAD = c(0, 0, 2), NCENS = c(1, 4, 0))),
+    c(1, 4, 2)
+  )
+})
+
+test_that("C2 stays unweighted by WEIGHT, count or not", {
+  # c2 is the term setlik.c does NOT multiply by WT (c1c2c3 = c1w + c2 + c3w),
+  # and that does not change just because the job named C2 itself (#158).
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T",
+                               RCENSOR = "NCENS", WEIGHT = "WT"))
+  expect_equal(
+    eval(got$weights_expr,
+         list(DEAD = c(0, 2), NCENS = c(4, 0), WT = c(9, 3))),
+    c(4, 6)
+  )
+})
+
+test_that("an ICENSOR + RCENSOR job weights its censored rows by C2", {
+  got <- .hzr_censor_spec(list(TIME = "T", ICENSOR = c("C3", "CTIME"),
+                               RCENSOR = "NCENS"))
+  expect_equal(
+    eval(got$weights_expr, list(C3 = c(3, 0), NCENS = c(0, 5))),
+    c(3, 5)
+  )
+})
+
+test_that("RCENSOR still adds no status branch: C2 > 0 is right-censored, code 0", {
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T",
+                               RCENSOR = "NCENS"))
+  expect_equal(
+    eval(got$status_expr, list(DEAD = c(0, 0, 2), NCENS = c(1, 4, 0))),
+    c(0, 0, 1)
+  )
+})
+
+test_that("a row that is both an event and right-censored stops, rather than picking one", {
+  # readobs.c deletes a row only when BOTH counts are zero (ic10 && ic20), so
+  # a row with C1 > 0 AND C2 > 0 survives and setlik.c sums the two
+  # contributions: it is an event of weight C1*WT AND a right-censored
+  # observation of weight C2 at once. hazard() carries one status and one
+  # weight per row and cannot say that (#162).
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T",
+                               RCENSOR = "NCENS", WEIGHT = "WT"))
+  err <- tryCatch(
+    eval(got$status_expr, list(DEAD = 1, NCENS = 2, WT = 3)),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(err, "both non-zero")
+  # The message must name the two weights the split-out rows need, or the
+  # remedy it prescribes cannot be carried out.
+  expect_match(err, "DEAD \\* WT")
+  expect_match(err, "NCENS")
+  # Non-mixed rows are untouched: this is not a blanket refusal of the job.
+  expect_equal(
+    eval(got$status_expr,
+         list(DEAD = c(1, 0), NCENS = c(0, 2), WT = c(3, 3))),
+    c(1, 0)
+  )
+})
+
+test_that("a row that is both interval- and right-censored stops", {
+  # The C2 + C3 pairing has its own deletion rule in readobs.c (ic30 && ic20),
+  # so it too survives with both counts positive (#162).
+  got <- .hzr_censor_spec(list(TIME = "T", ICENSOR = c("C3", "CTIME"),
+                               RCENSOR = "NCENS"))
+  expect_error(
+    eval(got$status_expr, list(C3 = 1, NCENS = 2, CTIME = 4)),
+    "both non-zero"
+  )
+  expect_equal(
+    eval(got$status_expr,
+         list(C3 = c(1, 0), NCENS = c(0, 2), CTIME = c(4, 4))),
+    c(2, 0)
+  )
+})
+
+test_that("the guard is hoisted into its own chunk even with no ICENSOR", {
+  # The guard has to run BEFORE the fit, and a braced block buried in
+  # hazard(status = ...) is not something a reader of the rendered document
+  # can see fire. ICENSOR jobs already hoist; an EVENT + RCENSOR job needs
+  # the same treatment even though its time_lower gates on nothing.
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T",
+                               RCENSOR = "NCENS"))
+  expect_equal(got$status_name, as.name(".hzr_status"))
+  # And through the parser: the emitted status is the hoisted name, not the
+  # expression, and the assignment chunk carries the guard.
+  txt <- .hzr_sas_normalise(paste(
+    "%HAZARD( PROC HAZARD DATA=A CONDITION=14;",
+    "EVENT DEAD; TIME T; RCENSOR NCENS;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ))
+  parsed <- .hzr_parse_hazard(.hzr_sas_blocks(txt)[[1L]])
+  expect_equal(parsed$call[["status"]], as.name(".hzr_status"))
+  expect_false(is.null(parsed$status_call))
+  expect_error(
+    eval(parsed$status_call, list(A = data.frame(DEAD = 1, NCENS = 1))),
+    "both non-zero"
+  )
+})
+
+test_that("no RCENSOR statement leaves the censored weight the literal 1", {
+  # #154/#157/#158 non-regression. Without RCENSOR, c2name is blank and
+  # readc2.c DERIVES C2 = ONE on exactly the rows where no other count
+  # fires -- so 1 is right there, and no guard is possible either, because
+  # the derived C2 cannot collide with a count that fired.
+  for (st in list(list(EVENT = "DEAD", TIME = "T"),
+                  list(EVENT = "DEAD", TIME = "T", WEIGHT = "WT"),
+                  list(TIME = "T", ICENSOR = c("C3", "CTIME")))) {
+    got <- .hzr_censor_spec(st)
+    w <- eval(got$weights_expr,
+              list(DEAD = 0, C3 = 0, WT = 7, CTIME = 1))
+    expect_equal(w, 1)
+  }
+  plain <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T"))
+  expect_null(plain$status_name)
+  expect_equal(eval(plain$status_expr, list(DEAD = c(0, 1))), c(0, 1))
+})
+
+test_that("a 0/1 RCENSOR flag fits exactly as it did before #162", {
+  # hz.te123.OMC.sas and hz.tm123.OMC.sas -- the only two corpus jobs with an
+  # RCENSOR statement -- set CENSORED to 0/1, mutually exclusive with TE.
+  # Their weights must not move: the fix is for counts above 1, and a
+  # translator change that shifted the corpus would be the defect, not the
+  # fix.
+  got <- .hzr_censor_spec(list(EVENT = "TE", TIME = "INT_TE",
+                               LCENSOR = "STARTTME", RCENSOR = "CENSORED"))
+  env <- list(TE = c(1, 0, 1, 0), CENSORED = c(0, 1, 0, 1))
+  expect_equal(eval(got$weights_expr, env), c(1, 1, 1, 1))
+  expect_equal(eval(got$status_expr, env), c(1, 0, 1, 0))
+  # LCENSOR still supplies the entry time, unconditionally.
+  expect_equal(got$time_lower, as.name("STARTTME"))
+})

--- a/tests/testthat/test-sas-censoring.R
+++ b/tests/testthat/test-sas-censoring.R
@@ -15,7 +15,7 @@ test_that("ICENSOR produces interval code 2 and a status-gated time_lower", {
   # Assert the exact codes. `all(status %in% c(0,1,2,3))` cannot fail and is
   # the assertion shape that hid this class of bug for years.
   expect_equal(
-    eval(got$status_expr, list(DEAD = c(1, 0), C3 = c(1, 3), CTIME = c(2, 2))),
+    eval(got$status_expr, list(DEAD = c(1, 0), C3 = c(0, 3), CTIME = c(2, 2))),
     c(1, 2)
   )
 })
@@ -39,10 +39,14 @@ test_that("RCENSOR produces 0", {
                c(0, 1))
 })
 
-test_that("no censoring statement leaves status as the bare EVENT variable", {
+test_that("no censoring statement still derives status from EVENT > 0, not from EVENT", {
+  # EVENT is a COUNT (readc1.c keeps any C1 >= 0). Mapped straight onto
+  # status, DEAD = 2 reads as INTERVAL-CENSORED in this package's -1/0/1/2
+  # coding and DEAD = 3 falls outside it altogether (#157).
   st <- list(EVENT = "DEAD", TIME = "T")
   got <- .hzr_censor_spec(st)
-  expect_equal(got$status_expr, as.name("DEAD"))
+  expect_equal(eval(got$status_expr, list(DEAD = c(0, 1, 2, 3))),
+               c(0, 1, 1, 1))
   expect_null(got$time_lower)
   expect_null(got$time_upper)
 })
@@ -74,11 +78,38 @@ test_that("a job with neither EVENT nor ICENSOR is rejected", {
   expect_error(.hzr_censor_spec(list(TIME = "T")), "EVENT|ICENSOR")
 })
 
-test_that("an event outranks interval censoring", {
+test_that("a row that is both an event and interval-censored stops, rather than picking one", {
+  # setlik.c SUMS the contributions of one OBS record
+  # (c1c2c3 = c1w + c2 + c3w; llike gains c1w*log h AND c3w*lct), so such a
+  # row is an event of weight C1*WT and an interval observation of weight
+  # C3*WT at once. hazard() has one status and one weight per row and cannot
+  # say that. This translator used to pick the event branch and drop c3w --
+  # a fit that converges and reports plausibly over a model it is not.
   st <- list(EVENT = "DEAD", TIME = "T", ICENSOR = c("C3", "CTIME"))
   got <- .hzr_censor_spec(st)
-  expect_equal(eval(got$status_expr, list(DEAD = c(1, 0), C3 = c(1, 1), CTIME = c(2, 2))),
-               c(1, 2))
+  expect_error(
+    eval(got$status_expr,
+         list(DEAD = c(1, 0), C3 = c(1, 1), CTIME = c(2, 2))),
+    "both non-zero"
+  )
+  # Non-mixed rows are unaffected: the guard is not a blanket refusal of
+  # EVENT + ICENSOR jobs.
+  expect_equal(
+    eval(got$status_expr, list(DEAD = c(1, 0), C3 = c(0, 1), CTIME = c(2, 2))),
+    c(1, 2)
+  )
+})
+
+test_that("the both-fire guard names the two weights the split-out rows need", {
+  st <- list(EVENT = "DEAD", TIME = "T", ICENSOR = c("C3", "CTIME"),
+             WEIGHT = "WT")
+  got <- .hzr_censor_spec(st)
+  err <- tryCatch(
+    eval(got$status_expr, list(DEAD = 1, C3 = 1, WT = 2)),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(err, "DEAD \\* WT", fixed = FALSE)
+  expect_match(err, "C3 \\* WT", fixed = FALSE)
 })
 
 test_that("LCENSOR and ICENSOR together are refused, not translated", {
@@ -161,36 +192,43 @@ test_that("the refusal does not leak into LCENSOR-only or ICENSOR-only jobs", {
   }
 })
 
-test_that("ICENSOR's event count is carried as a status-gated weight", {
-  # setlik.c: C3 is a COUNT of interval-censored individuals at TIME, and it
-  # multiplies the log-likelihood contribution in BOTH terms
-  # (c3w = c3 * weight; llike = -(c1w + c2 + c3w) * (cumhaz - cumhst);
-  # if (c3 > ZERO) llike += c3w * lct). Discarding the magnitude fits a
-  # 3-event row as a single observation (#154).
+test_that("the weight is each row's own count, and 1 on right-censored rows", {
+  # setlik.c: c1c2c3 = c1w + c2 + c3w, with c1w = C1 * WT and c3w = C3 * WT.
+  # C2 -- which readc2.c sets to ONE on exactly the rows where neither other
+  # count fires -- is the ONE term not multiplied by the weight (#158).
+  # Discarding a magnitude fits a 3-event row as a single observation (#154,
+  # #157); emitting a bare count gives every other row a weight of ZERO,
+  # deleting it from the likelihood without a word.
   st <- list(EVENT = "DEAD", TIME = "T", ICENSOR = c("C3", "CTIME"))
   got <- .hzr_censor_spec(st)
-  # Gated on status, never the bare count. C3 is 0 on every non-interval row,
-  # and hazard() multiplies each row's log-likelihood contribution by its
-  # weight, so a bare C3 would delete every event and right-censored row from
-  # the fit outright. readc2.c sets C2 = 1 on exactly those rows when no
-  # RCENSOR statement is given, so their weight is 1.
-  env <- list(.hzr_status = c(1, 2, 0), C3 = c(0, 3, 0))
-  expect_equal(eval(got$weights_expr, env), c(1, 3, 1))
-  # An event outranks interval censoring, so a row that is both carries the
-  # event's weight of 1, not C3.
-  expect_equal(eval(got$weights_expr, list(.hzr_status = 1, C3 = 3)), 1)
+  env <- list(DEAD = c(2, 0, 0), C3 = c(0, 3, 0))
+  expect_equal(eval(got$weights_expr, env), c(2, 3, 1))
+  expect_false(any(eval(got$weights_expr, env) == 0))
 })
 
-test_that("a job with no ICENSOR emits no weights expression", {
-  expect_null(.hzr_censor_spec(list(EVENT = "DEAD", TIME = "T"))$weights_expr)
-  expect_null(
-    .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T",
-                          LCENSOR = "STARTTME"))$weights_expr
-  )
-  expect_null(
-    .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T",
-                          RCENSOR = "RFLAG"))$weights_expr
-  )
+test_that("EVENT's count is carried as a weight even with no ICENSOR", {
+  # #157: c1w = C1 * weight, so the event COUNT weights the row's whole
+  # contribution whether or not the job has an ICENSOR statement.
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T"))
+  expect_equal(eval(got$weights_expr, list(DEAD = c(0, 1, 2, 3))),
+               c(1, 1, 2, 3))
+})
+
+test_that("WEIGHT multiplies the event count but leaves censored rows at 1", {
+  # c1w = C1 * WT, but c2 enters the sum unweighted (#158). A WEIGHT that is
+  # 0 on censored rows -- the shape of hz.tm123.OMC.sas's WEIGHT MORBID --
+  # deletes them from the fit outright when emitted bare.
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T", WEIGHT = "WT"))
+  w <- eval(got$weights_expr, list(DEAD = c(1, 0, 2), WT = c(4, 0, 3)))
+  expect_equal(w, c(4, 1, 6))
+  expect_false(any(w == 0))
+})
+
+test_that("an ICENSOR-only job weights interval rows by C3 * WT and the rest by 1", {
+  got <- .hzr_censor_spec(list(TIME = "T", ICENSOR = c("C3", "CTIME"),
+                               WEIGHT = "WT"))
+  expect_equal(eval(got$weights_expr, list(C3 = c(3, 0), WT = c(2, 5))),
+               c(6, 1))
 })
 
 test_that("the emitted call carries ICENSOR's count as weights", {
@@ -201,12 +239,12 @@ test_that("the emitted call carries ICENSOR's count as weights", {
   ))
   got <- .hzr_parse_hazard(.hzr_sas_blocks(txt)[[1L]])
   expect_equal(
-    eval(got$call[["weights"]], list(.hzr_status = c(2, 0), C3 = c(3, 0))),
+    eval(got$call[["weights"]], list(DEAD = c(0, 0), C3 = c(3, 0))),
     c(3, 1)
   )
 })
 
-test_that("ICENSOR and WEIGHT together multiply, as c3w = c3 * weight does", {
+test_that("ICENSOR and WEIGHT multiply on interval rows, as c3w = c3 * weight does", {
   txt <- .hzr_sas_normalise(paste(
     "%HAZARD( PROC HAZARD DATA=A CONDITION=14;",
     "EVENT DEAD; TIME T; ICENSOR C3 = CT; WEIGHT WT;",
@@ -215,29 +253,48 @@ test_that("ICENSOR and WEIGHT together multiply, as c3w = c3 * weight does", {
   got <- .hzr_parse_hazard(.hzr_sas_blocks(txt)[[1L]])
   expect_equal(
     eval(got$call[["weights"]],
-         list(.hzr_status = c(2, 0), C3 = c(3, 0), WT = c(2, 2))),
-    c(6, 2)
+         list(DEAD = c(0, 0), C3 = c(3, 0), WT = c(2, 2))),
+    c(6, 1)
   )
 })
 
-test_that("a job with no ICENSOR emits no weights argument at all", {
-  # The non-ICENSOR path must be untouched by #154: no weights argument, so
-  # hazard() uses unit weights exactly as it did before.
+test_that("a WEIGHT job's censored rows are not weighted by the WEIGHT variable", {
+  # #158's decisive shape at the emitted-call level: the translator used to
+  # emit a bare WT here, which over-weights every censored row and deletes
+  # them entirely when WT is 0 there.
+  txt <- .hzr_sas_normalise(paste(
+    "%HAZARD( PROC HAZARD DATA=A CONDITION=14;",
+    "EVENT DEAD; TIME T; WEIGHT WT;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ))
+  got <- .hzr_parse_hazard(.hzr_sas_blocks(txt)[[1L]])
+  expect_equal(
+    eval(got$call[["weights"]], list(DEAD = c(1, 0), WT = c(4, 0))),
+    c(4, 1)
+  )
+})
+
+test_that("a plain 0/1 EVENT job's emitted weights are unit weights, as before", {
+  # #154 non-regression: nothing about a job whose counts are all 0/1 may
+  # change. Asserted on the evaluated weights, not on the call's shape.
   txt <- .hzr_sas_normalise(paste(
     "%HAZARD( PROC HAZARD DATA=A CONDITION=14;",
     "EVENT DEAD; TIME T;",
     "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
   ))
   got <- .hzr_parse_hazard(.hzr_sas_blocks(txt)[[1L]])
-  expect_false("weights" %in% names(as.list(got$call)))
-  # A WEIGHT statement without ICENSOR still emits the bare weight variable.
+  expect_equal(eval(got$call[["weights"]], list(DEAD = c(1, 0, 1))),
+               c(1, 1, 1))
+  # And an ICENSOR job with a 0/1 EVENT and no WEIGHT still weights interval
+  # rows by C3 and everything else by 1 -- what #154 shipped.
   txt2 <- .hzr_sas_normalise(paste(
     "%HAZARD( PROC HAZARD DATA=A CONDITION=14;",
-    "EVENT DEAD; TIME T; WEIGHT WT;",
+    "EVENT DEAD; TIME T; ICENSOR C3 = CT;",
     "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
   ))
   got2 <- .hzr_parse_hazard(.hzr_sas_blocks(txt2)[[1L]])
-  expect_equal(got2$call[["weights"]], as.name("WT"))
+  env <- list(DEAD = c(1, 0, 0), C3 = c(0, 3, 0))
+  expect_equal(eval(got2$call[["weights"]], env), c(1, 3, 1))
 })
 
 test_that("the refusal reaches both the untranslated callout and a stop() chunk", {

--- a/tests/testthat/test-sas-censoring.R
+++ b/tests/testthat/test-sas-censoring.R
@@ -376,8 +376,12 @@ test_that("a row that is both an event and right-censored stops, rather than pic
   expect_match(err, "both non-zero")
   # The message must name the two weights the split-out rows need, or the
   # remedy it prescribes cannot be carried out.
-  expect_match(err, "DEAD \\* WT")
-  expect_match(err, "NCENS")
+  expect_match(err, "of weight DEAD \\* WT")
+  # "NCENS" alone also matches "NCENS * WT", so it cannot catch c2 being
+  # weighted here -- #158 re-introduced inside the remedy this very message
+  # prescribes. Assert the weight C2 actually needs, and that it is bare.
+  expect_match(err, "of weight NCENS\\.")
+  expect_false(grepl("NCENS * WT", err, fixed = TRUE))
   # Non-mixed rows are untouched: this is not a blanket refusal of the job.
   expect_equal(
     eval(got$status_expr,

--- a/tests/testthat/test-sas-censoring.R
+++ b/tests/testthat/test-sas-censoring.R
@@ -26,7 +26,7 @@ test_that("LCENSOR is left-truncation: status is untouched, time_lower is the en
   # status = -1 must never be produced by this translator.
   st <- list(EVENT = "DEAD", TIME = "T", LCENSOR = "STARTTME")
   got <- .hzr_censor_spec(st)
-  expect_null(got$status_name)
+  expect_equal(got$status_name, as.name(".hzr_status"))
   expect_equal(eval(got$status_expr, list(DEAD = c(1, 0))), c(1, 0))
   expect_equal(got$time_lower, as.name("STARTTME"))
   expect_null(got$time_upper)
@@ -444,7 +444,9 @@ test_that("no RCENSOR statement leaves the censored weight the literal 1", {
     expect_equal(w, 1)
   }
   plain <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T"))
-  expect_null(plain$status_name)
+  # Hoisted even here: the missing/negative guard on EVENT has to run ahead
+  # of the fit, and every non-refused job names at least one count.
+  expect_equal(plain$status_name, as.name(".hzr_status"))
   expect_equal(eval(plain$status_expr, list(DEAD = c(0, 1))), c(0, 1))
 })
 
@@ -461,4 +463,77 @@ test_that("a 0/1 RCENSOR flag fits exactly as it did before #162", {
   expect_equal(eval(got$status_expr, env), c(1, 0, 1, 0))
   # LCENSOR still supplies the entry time, unconditionally.
   expect_equal(got$time_lower, as.name("STARTTME"))
+})
+
+test_that("a missing or negative count stops instead of fitting as censored", {
+  # readc1.c/readc2.c/readc3.c apply ONE rule to every count the job names,
+  # guarded only by the name being non-blank: ISMISS sets mdel, < ZERO sets
+  # del, and readobs.c then skips setobs() and subtracts the row from Nobs.
+  # A deleted row contributes nothing -- it is NOT a right-censored row of
+  # weight 1, which is what `ifelse(count > 0, ...)` alone makes of a
+  # negative count, and NA is what it makes of a missing one. Both change
+  # the likelihood against SAS, so both stop.
+  cases <- list(
+    list(st = list(EVENT = "DEAD", TIME = "T"),
+         var = "DEAD", ok = list(DEAD = c(0, 1, 2)),
+         bad = list(list(DEAD = c(0, 1, NA)), list(DEAD = c(0, 1, -1)))),
+    list(st = list(EVENT = "DEAD", TIME = "T", RCENSOR = "NCENS"),
+         var = "NCENS", ok = list(DEAD = c(0, 1), NCENS = c(3, 0)),
+         bad = list(list(DEAD = c(0, 1), NCENS = c(NA, 0)),
+                    list(DEAD = c(0, 1), NCENS = c(-2, 0)))),
+    list(st = list(TIME = "T", ICENSOR = c("C3", "CTIME")),
+         var = "C3", ok = list(C3 = c(0, 4)),
+         bad = list(list(C3 = c(0, NA)), list(C3 = c(0, -4))))
+  )
+  for (case in cases) {
+    got <- .hzr_censor_spec(case$st)
+    # The guard must be capable of NOT firing: a clean count still returns a
+    # status vector, so a red result below is the guard, not a broken chunk.
+    expect_type(eval(got$status_expr, case$ok), "double")
+    for (env in case$bad) {
+      expect_error(eval(got$status_expr, env), case$var, fixed = TRUE)
+      expect_error(eval(got$status_expr, env), "missing or negative")
+      expect_error(eval(got$status_expr, env), "deletes such rows")
+    }
+  }
+})
+
+test_that("a missing count is NOT treated as a zero count", {
+  # Zero and missing are opposite in SAS: a zero count is KEPT (readobs.c
+  # deletes an all-zero row only under its two blank-name-guarded rules, and
+  # never when all three counts are named), while a missing one is always
+  # deleted. Treating NA as non-firing would land the row in the fit as
+  # right-censored of weight 1 -- a row SAS removed, contributing survival
+  # mass at its time. Pin the asymmetry: zero flows through, NA stops.
+  got <- .hzr_censor_spec(list(EVENT = "DEAD", TIME = "T"))
+  expect_equal(eval(got$status_expr, list(DEAD = c(0, 1))), c(0, 1))
+  expect_equal(eval(got$weights_expr, list(DEAD = c(0, 1))), c(1, 1))
+  expect_error(eval(got$status_expr, list(DEAD = c(0, NA))),
+               "missing or negative")
+})
+
+test_that("a missing count stops before hazard()'s weights check", {
+  # The reported reproduction (PR #164 review): with the count NA, the
+  # emitted weights ifelse() yields NA and hazard() aborts with "'weights'
+  # must be non-negative and finite" -- a message that names neither the
+  # variable nor the cause. The hoisted status chunk runs first and says
+  # both, so that incidental message is never what the reader sees.
+  txt <- .hzr_sas_normalise(paste(
+    "%HAZARD( PROC HAZARD DATA=A CONDITION=14;",
+    "EVENT DEAD; TIME T;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ))
+  parsed <- .hzr_parse_hazard(.hzr_sas_blocks(txt)[[1L]])
+  expect_equal(parsed$call[["status"]], as.name(".hzr_status"))
+  a <- data.frame(DEAD = c(1, 0, 1, 0), T = c(1, 2, 3, 4))
+  a$DEAD[3] <- NA
+  env <- new.env()
+  assign("A", a, envir = env)
+  err <- expect_error(eval(parsed$status_call, env), "DEAD", fixed = TRUE)
+  expect_no_match(conditionMessage(err), "non-negative and finite")
+  # Same job, same data, count repaired: the chunk runs and the fit follows.
+  a$DEAD[3] <- 1
+  assign("A", a, envir = env)
+  expect_silent(eval(parsed$status_call, env))
+  expect_equal(get("A", envir = env)$.hzr_status, c(1, 0, 1, 0))
 })

--- a/tests/testthat/test-sas-render-sim.R
+++ b/tests/testthat/test-sas-render-sim.R
@@ -50,7 +50,7 @@ test_that("a censoring job's status chunk renders", {
   n <- 120
   AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
                      DEAD = rep(c(1, 0, 0), length.out = n))
-  AVCS$C3FLAG <- as.numeric(seq_len(n) %% 5 == 0)
+  AVCS$C3FLAG <- as.numeric(seq_len(n) %% 5 == 0 & AVCS$DEAD == 0)
   AVCS$ICTIME <- ifelse(AVCS$C3FLAG > 0, AVCS$INT_DEAD * 0.5, NA)
   f <- withr::local_tempfile(fileext = ".sas")
   writeLines(paste(
@@ -90,7 +90,7 @@ test_that("the ICENSOR count reaches the fitted object as weights", {
   n <- 120
   AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
                      DEAD = rep(c(1, 0, 0), length.out = n))
-  AVCS$C3FLAG <- ifelse(seq_len(n) %% 5 == 0, 3, 0)
+  AVCS$C3FLAG <- ifelse(seq_len(n) %% 5 == 0 & AVCS$DEAD == 0, 3, 0)
   AVCS$ICTIME <- ifelse(AVCS$C3FLAG > 0, AVCS$INT_DEAD * 0.5, NA)
   f <- withr::local_tempfile(fileext = ".sas")
   writeLines(paste(
@@ -105,8 +105,11 @@ test_that("the ICENSOR count reaches the fitted object as weights", {
   # The decisive check: a count of 3 must not arrive as a weight of 1 -- and
   # a count of 0 on a non-interval row must not arrive as a weight of 0,
   # which would delete that row from the likelihood.
-  status <- ifelse(AVCS$DEAD == 0 & AVCS$C3FLAG > 0, 2, AVCS$DEAD)
-  expect_equal(got$env$fit$data$weights, ifelse(status == 2, AVCS$C3FLAG, 1))
+  status <- ifelse(AVCS$DEAD > 0, 1, ifelse(AVCS$C3FLAG > 0, 2, 0))
+  expect_equal(got$env$fit$data$status, status)
+  expect_equal(got$env$fit$data$weights,
+               ifelse(AVCS$DEAD > 0, AVCS$DEAD,
+                      ifelse(AVCS$C3FLAG > 0, AVCS$C3FLAG, 1)))
   expect_true(any(got$env$fit$data$weights == 3))
   expect_false(any(got$env$fit$data$weights == 0))
 })
@@ -126,5 +129,101 @@ test_that("a job with no ICENSOR fits with unit weights, unchanged", {
   got <- render_sim(job, data = list(AVCS = AVCS))
   expect_true(got$ok, info = paste(names(got$results), got$results,
                                    collapse = " | "))
-  expect_null(got$env$fit$data$weights)
+  # EVENT is a count, so a weights argument is always emitted now (#157).
+  # For the 0/1 DEAD this job carries it must evaluate to unit weights on
+  # every row -- the same fit the job got before, asserted on the fitted
+  # object rather than on the presence or absence of an argument.
+  expect_equal(got$env$fit$data$weights, rep(1, 200))
+  expect_equal(got$env$fit$data$status, AVCS$DEAD)
+})
+
+test_that("a repeat-event count reaches the fitted object as weight and status 1", {
+  # #157: EVENT is a COUNT (readc1.c keeps any C1 >= 0; setlik.c weights the
+  # row's whole contribution by c1w = C1 * WT). Mapped straight onto status,
+  # DEAD = 2 becomes INTERVAL-CENSORED in this package's coding -- a
+  # different likelihood branch -- and DEAD = 3 falls outside the coding
+  # entirely, which also disables Conservation of Events.
+  skip_on_cran()
+  set.seed(11)
+  n <- 120
+  AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
+                     DEAD = rep(c(0, 1, 2, 3), length.out = n))
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste(
+    "%HAZARD( PROC HAZARD DATA=AVCS CONDITION=14;",
+    "EVENT DEAD; TIME INT_DEAD;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+  got <- render_sim(job, data = list(AVCS = AVCS))
+  expect_true(got$ok, info = paste(names(got$results), got$results,
+                                   collapse = " | "))
+  # Every count > 0 is an event, never an interval or an out-of-range code.
+  expect_equal(got$env$fit$data$status, as.numeric(AVCS$DEAD > 0))
+  expect_false(any(got$env$fit$data$status == 2))
+  # The magnitude survives as the weight, and no row is deleted by a zero.
+  expect_equal(got$env$fit$data$weights, ifelse(AVCS$DEAD > 0, AVCS$DEAD, 1))
+  expect_equal(sort(unique(got$env$fit$data$weights)), c(1, 2, 3))
+})
+
+test_that("WEIGHT leaves right-censored rows at 1, as c2 enters setlik.c unweighted", {
+  # #158: setlik.c accumulates c1c2c3 = c1w + c2 + c3w, and c2 -- which
+  # readc2.c sets to ONE on exactly the rows where neither other count fires
+  # -- is the term NOT multiplied by the weight. A bare WT on censored rows
+  # over-weights them, and a WT of 0 there deletes them from the likelihood
+  # silently.
+  skip_on_cran()
+  set.seed(12)
+  n <- 120
+  AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
+                     DEAD = rep(c(1, 0, 0), length.out = n))
+  # MORBID is 0 on censored rows -- the shape of hz.tm123.OMC.sas's WEIGHT
+  # MORBID, and the case that silently deletes rows.
+  AVCS$MORBID <- ifelse(AVCS$DEAD > 0, rep(c(2, 4), length.out = n), 0)
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste(
+    "%HAZARD( PROC HAZARD DATA=AVCS CONDITION=14;",
+    "EVENT DEAD; TIME INT_DEAD; WEIGHT MORBID;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+  got <- render_sim(job, data = list(AVCS = AVCS))
+  expect_true(got$ok, info = paste(names(got$results), got$results,
+                                   collapse = " | "))
+  w <- got$env$fit$data$weights
+  expect_equal(w, ifelse(AVCS$DEAD > 0, AVCS$MORBID, 1))
+  # The decisive one: not a single censored row was deleted by a zero
+  # weight, and there are as many weight-1 rows as there are censored rows.
+  expect_equal(sum(w == 0), 0L)
+  expect_equal(sum(w == 1), sum(AVCS$DEAD == 0))
+  expect_equal(got$env$fit$data$status, as.numeric(AVCS$DEAD > 0))
+})
+
+test_that("a row that is both an event and interval-censored is refused, not guessed", {
+  # setlik.c SUMS the contributions (c1c2c3 = c1w + c2 + c3w), so such a row
+  # is an event of weight C1*WT AND an interval observation of weight C3*WT
+  # at once. hazard() has one status and one weight per row. Picking the
+  # event branch converges and reports plausibly, which is the shape this
+  # package exists to refuse.
+  skip_on_cran()
+  set.seed(13)
+  n <- 60
+  AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
+                     DEAD = rep(c(1, 0, 0), length.out = n))
+  AVCS$C3FLAG <- ifelse(seq_len(n) %% 5 == 0, 2, 0)
+  AVCS$ICTIME <- ifelse(AVCS$C3FLAG > 0, AVCS$INT_DEAD * 0.5, NA)
+  expect_true(any(AVCS$DEAD > 0 & AVCS$C3FLAG > 0))
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste(
+    "%HAZARD( PROC HAZARD DATA=AVCS CONDITION=14;",
+    "EVENT DEAD; TIME INT_DEAD; ICENSOR C3FLAG = ICTIME;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+  got <- render_sim(job, data = list(AVCS = AVCS))
+  expect_false(got$ok)
+  expect_match(got$results[["status"]], "both non-zero")
+  # And no fit was produced: a refusal that still leaves a fitted object
+  # behind is not a refusal.
+  expect_null(got$env$fit)
 })

--- a/tests/testthat/test-sas-render-sim.R
+++ b/tests/testthat/test-sas-render-sim.R
@@ -227,3 +227,134 @@ test_that("a row that is both an event and interval-censored is refused, not gue
   # behind is not a refusal.
   expect_null(got$env$fit)
 })
+
+test_that("the RCENSOR count reaches the fitted object as weights", {
+  # #162: RCENSOR names C2 (hazard_y.y; rcnsprc.c sets c2name from statement
+  # field 13), and C2 is a COUNT of censored individuals at T (setlik.c
+  # header). With c2name non-blank readc2.c reads it straight from the data
+  # -- the `C2 = ONE` derivation is skipped entirely -- so four censored
+  # individuals must arrive as weight 4, not as one observation.
+  skip_on_cran()
+  set.seed(21)
+  n <- 120
+  AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
+                     DEAD = rep(c(1, 0, 0), length.out = n))
+  # A genuine count above 1, and only on rows where DEAD does not fire --
+  # the both-fire case is refused, and is tested separately below.
+  AVCS$NCENS <- ifelse(AVCS$DEAD > 0, 0, rep(c(1, 4), length.out = n))
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste(
+    "%HAZARD( PROC HAZARD DATA=AVCS CONDITION=14;",
+    "EVENT DEAD; TIME INT_DEAD; RCENSOR NCENS;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+  got <- render_sim(job, data = list(AVCS = AVCS))
+  expect_true(got$ok, info = paste(names(got$results), got$results,
+                                   collapse = " | "))
+  # The decisive check, on the fitted object: a count of 4 must not arrive
+  # as a weight of 1, and the event rows keep their own count.
+  expect_equal(got$env$fit$data$weights,
+               ifelse(AVCS$DEAD > 0, AVCS$DEAD, AVCS$NCENS))
+  expect_true(any(got$env$fit$data$weights == 4))
+  # C2 changes the weight, never the status: it is right-censoring, code 0.
+  expect_equal(got$env$fit$data$status, as.numeric(AVCS$DEAD > 0))
+  expect_false(any(got$env$fit$data$status == 2))
+  # And the counts really are being read -- a fit whose weights are all 1
+  # would satisfy a weaker assertion while ignoring RCENSOR entirely.
+  expect_gt(sum(got$env$fit$data$weights), n)
+})
+
+test_that("a WEIGHT variable never multiplies the RCENSOR count", {
+  # c2 is the one term setlik.c leaves out of the WT product
+  # (c1c2c3 = c1w + c2 + c3w). Naming C2 explicitly does not change that.
+  skip_on_cran()
+  set.seed(22)
+  n <- 90
+  AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
+                     DEAD = rep(c(1, 0, 0), length.out = n))
+  AVCS$NCENS <- ifelse(AVCS$DEAD > 0, 0, 3)
+  # MORBID is 0 on censored rows, the hz.tm123.OMC.sas shape: multiplied in,
+  # it would delete every censored row from the likelihood.
+  AVCS$MORBID <- ifelse(AVCS$DEAD > 0, 2, 0)
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste(
+    "%HAZARD( PROC HAZARD DATA=AVCS CONDITION=14;",
+    "EVENT DEAD; TIME INT_DEAD; RCENSOR NCENS; WEIGHT MORBID;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+  got <- render_sim(job, data = list(AVCS = AVCS))
+  expect_true(got$ok, info = paste(names(got$results), got$results,
+                                   collapse = " | "))
+  expect_equal(got$env$fit$data$weights,
+               ifelse(AVCS$DEAD > 0, AVCS$DEAD * AVCS$MORBID, AVCS$NCENS))
+  expect_equal(sum(got$env$fit$data$weights == 0), 0L)
+})
+
+test_that("a row that is both an event and right-censored is refused, not guessed", {
+  # readobs.c deletes a row only when BOTH ic10 and ic20 fire, so a row with
+  # C1 > 0 AND C2 > 0 reaches setlik.c and contributes c1w + c2 -- an event
+  # of weight C1*WT and a right-censored observation of weight C2 at once.
+  # Fitting it as an event alone converges and reports plausibly (#162).
+  skip_on_cran()
+  set.seed(23)
+  n <- 60
+  AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
+                     DEAD = rep(c(1, 0, 0), length.out = n))
+  AVCS$NCENS <- ifelse(seq_len(n) %% 5 == 0, 2, 0)
+  expect_true(any(AVCS$DEAD > 0 & AVCS$NCENS > 0))
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste(
+    "%HAZARD( PROC HAZARD DATA=AVCS CONDITION=14;",
+    "EVENT DEAD; TIME INT_DEAD; RCENSOR NCENS;",
+    "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  ), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+  got <- render_sim(job, data = list(AVCS = AVCS))
+  expect_false(got$ok)
+  expect_match(got$results[["status"]], "both non-zero")
+  # A refusal that still leaves a fitted object behind is not a refusal.
+  expect_null(got$env$fit)
+})
+
+test_that("a 0/1 RCENSOR flag fits identically with and without the statement", {
+  # The two corpus jobs that carry RCENSOR (hz.te123.OMC.sas,
+  # hz.tm123.OMC.sas) set a mutually-exclusive 0/1 CENSORED. Their fits must
+  # be bit-for-bit what they were: this fix is for counts above 1. Compared
+  # as two real fits, not as two call shapes.
+  skip_on_cran()
+  set.seed(24)
+  n <- 150
+  AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
+                     TE = rep(c(1, 0, 0), length.out = n))
+  AVCS$CENSORED <- 1 - AVCS$TE
+  head <- "%HAZARD( PROC HAZARD DATA=AVCS CONDITION=14; EVENT TE; TIME INT_DEAD;"
+  tail <- "PARMS MUE=0.2 THALF=0.15 NU=1 MUC=0.0005; );"
+  fits <- lapply(c("", " RCENSOR CENSORED;"), function(stmt) {
+    f <- withr::local_tempfile(fileext = ".sas")
+    writeLines(paste0(head, stmt, " ", tail), f)
+    job <- suppressWarnings(hzr_translate_sas(f))
+    # .hzr_optim_multiphase()'s random restart draws from the global RNG
+    # stream (R/likelihood-multiphase.R), so the SAME call twice returns
+    # different theta. Seed each fit identically or this comparison tests
+    # the RNG, not the translation.
+    set.seed(99)
+    got <- render_sim(job, data = list(AVCS = AVCS))
+    expect_true(got$ok, info = paste(names(got$results), got$results,
+                                     collapse = " | "))
+    got$env$fit
+  })
+  expect_equal(fits[[2L]]$data$weights, fits[[1L]]$data$weights)
+  expect_equal(fits[[2L]]$data$status, fits[[1L]]$data$status)
+  expect_equal(fits[[2L]]$fit$theta, fits[[1L]]$fit$theta)
+  expect_equal(fits[[2L]]$fit$objective, fits[[1L]]$fit$objective)
+  # Guard against the comparison being vacuous. The fitted parameters live
+  # under fit$fit, not fit -- `fits[[1L]]$theta` is NULL, and every
+  # all()/is.finite() assertion over NULL passes while comparing nothing.
+  expect_equal(length(fits[[1L]]$data$weights), n)
+  expect_true(is.finite(fits[[1L]]$fit$objective))
+  expect_true(all(is.finite(fits[[1L]]$fit$theta)))
+  expect_gt(length(fits[[1L]]$fit$theta), 0L)
+  expect_equal(fits[[1L]]$data$weights, rep(1, n))
+})

--- a/tests/testthat/test-sas-render-sim.R
+++ b/tests/testthat/test-sas-render-sim.R
@@ -367,7 +367,13 @@ test_that("a data column named .hzr_status cannot change the fitted status", {
   n <- 120
   AVCS <- data.frame(INT_DEAD = stats::rexp(n, 0.2),
                      DEAD = rep(c(1, 0, 0), length.out = n))
-  AVCS$C3FLAG <- as.numeric(seq_len(n) %% 5 == 0)
+  # Conditioned on DEAD, as every neighbouring fixture is: a row where the
+  # EVENT and ICENSOR counts BOTH fire is two contributions at once, which
+  # the status chunk refuses at fit time (#157). Unconditioned, every fifth
+  # row collided and the refusal fired before any of the assertions below
+  # could reach a fit -- this test would then be measuring the guard, not
+  # the column-masking it exists for.
+  AVCS$C3FLAG <- as.numeric(seq_len(n) %% 5 == 0 & AVCS$DEAD == 0)
   AVCS$ICTIME <- ifelse(AVCS$C3FLAG > 0, AVCS$INT_DEAD * 0.5, NA)
   # The hostile column: every row an exact event, which is a different
   # censoring structure from the one the job specifies. `.hzr_status` is

--- a/tests/testthat/test-sas-translate-fits.R
+++ b/tests/testthat/test-sas-translate-fits.R
@@ -18,7 +18,11 @@ test_that("an ICENSOR job's emitted call actually fits", {
   # time variable that is the interval's LOWER bound (the interval runs
   # ctime -> TIME). C3FLAG is a count (any positive value fires), not
   # NA-gated; CTIME must precede INT_DEAD to be a valid lower bound.
-  AVCS$C3FLAG <- as.numeric(seq_len(n) %% 5 == 0)
+  # Gated on DEAD == 0: a row where EVENT and C3 both fire is refused at
+  # fit time (setlik.c sums the two contributions and hazard() carries one
+  # status per row), so a fixture that mixes them tests the refusal, not
+  # the fit.
+  AVCS$C3FLAG <- as.numeric(seq_len(n) %% 5 == 0 & AVCS$DEAD == 0)
   AVCS$ICTIME <- ifelse(AVCS$C3FLAG > 0, AVCS$INT_DEAD * 0.5, NA)
 
   f <- withr::local_tempfile(fileext = ".sas")

--- a/tests/testthat/test-sas-translate-fits.R
+++ b/tests/testthat/test-sas-translate-fits.R
@@ -128,7 +128,10 @@ test_that("a plain EVENT/TIME job's emitted call fits with no time_lower/time_up
   ), f)
 
   job <- suppressWarnings(hzr_translate_sas(f))
-  expect_equal(names(job$calls), c("data", "fit"))
+  # The status chunk is emitted for every job now, not only ICENSOR or
+  # multi-count ones: it carries the missing/negative guard on EVENT, which
+  # has to run and be seen to run ahead of the fit.
+  expect_equal(names(job$calls), c("data", "status", "fit"))
   # job$calls$fit is now `fit <- hazard(...)`; index into the hazard() call.
   expect_null(job$calls$fit[[3L]][["time_lower"]])
   expect_null(job$calls$fit[[3L]][["time_upper"]])


### PR DESCRIPTION
Completes the count-vs-flag family. `ICENSOR` was fixed in #161; this handles the other three — `EVENT`, `WEIGHT` and `RCENSOR`.

## The pattern

SAS's `HAZARD` stores per-observation **counts**, not flags. `setlik.c` accumulates one record's contribution as

```c
c1c2c3 = c1w + c2 + c3w;          /* c1w = c1*weight, c3w = c3*weight */
llike  = -(c1c2c3) * (cumhaz - cumhst);
if (c3 > ZERO) llike += (c3w * lct);
```

The translator treated all four operands as 0/1 flags. A count whose observed values happen to be 0 and 1 is indistinguishable from a flag, so this is invisible on every dataset without repeat events — and wrong on exactly the data where it matters.

| Operand | Was | Now |
|---|---|---|
| `EVENT` (#157) | mapped straight onto `status`, so `EVENT = 2` became **interval-censored** | `status = EVENT > 0`, count carried into `weights` |
| `WEIGHT` (#158) | applied to every row | applied to event and interval rows only — `c2` enters `setlik.c` **unweighted** |
| `RCENSOR` (#162) | operand ignored entirely | parsed and carried as the censored row's weight |

`EVENT = 2` was the worst of the three: it did not under-count an event row, it silently reclassified it as interval-censored, with `time_lower`/`time_upper` read as bounds the data never had. `EVENT >= 3` produced a status outside this package's `{-1, 0, 1, 2}` coding altogether.

## What is emitted now

```r
# EVENT + ICENSOR + RCENSOR + WEIGHT
weights = ifelse(DEAD > 0, DEAD * WT, ifelse(C3 > 0, C3 * WT, C2))
```

Note the censored branch is bare `C2`, not `C2 * WT` — that asymmetry is `setlik.c`'s, not ours.

## Rows SAS can express and `hazard()` cannot

One OBS record can carry `C1`, `C2` and `C3` simultaneously, and SAS **sums** their contributions. `hazard()` carries one status and one weight per row, so such a row cannot be represented at all.

Whether any row actually mixes them is a property of the **data**, not the job text, so a job-level refusal would reject every legitimate `EVENT` + `ICENSOR` job. Instead the guard is emitted *into* the status chunk and stops before the fit, naming the remedy: split the row into two — a status-1 row of weight `C1*WT` and a status-2 row of weight `C3*WT` — which sum to `setlik.c` identically. All three pairwise combinations are guarded.

## Divergence worth knowing

`readc1.c` **deletes** rows with a negative or missing count (`c1del`/`mc1del`). This package cannot drop rows during translation, so such a row now lands as right-censored with weight 1. Previously a negative `EVENT` became `status = -1` — read as *left-censored*. Documented in the roxygen.

Fractional counts SAS **keeps** (`notintg` only raises a report flag), so they carry through as fractional weights.

## Verification

Every decision cites the reference C rather than inference — the first attempted `ICENSOR` fix in #161 emitted a bare count, which would have given weight 0 to every event and right-censored row: 96 of 120 rows silently deleted, converging, no warning. That is why these are read from source.

Mutations tried and killed: `status <- EVENT` directly; `WT` applied to censored rows; bare count as weight; guard removed; `* WT` dropped from the event branch; `C3` dropped from the interval weight. Each was verified to turn tests red.

## Gate

- `R CMD check --as-cran` from a clean `git archive`, with the manual: **Status: OK**, 206s, tarball 2.94 MB, no developer files, `build/vignette.rds` present
- `devtools::test()`: **FAIL 0 | PASS 2892**
- `lintr::lint_package()`: 0 lints
- `spelling::spell_check_package()`: clean

**One observation, not a claim of cleanliness:** the very first suite run after merging `dev` reported `FAIL 3 | WARN 521 | PASS 2888`. Four subsequent runs are byte-identical at `FAIL 0 | WARN 520 | PASS 2892`. I could not capture the failing run's identity. One extra warning and four fewer passes is consistent with a fit taking a different convergence path on this package's multimodal multiphase likelihood, and it reproduced neither on repeat nor under `R CMD check`. Flagging it rather than reporting five-for-five.

Closes #157, #158, #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
