### PR TITLE
fix(stepwise): a zero-step screen now says why it is empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -194,6 +194,19 @@
 
 ## Bug fixes
 
+* `hzr_stepwise()` can no longer return a zero-step result that is silently
+  empty. Every accepted move goes through a refit, and a refit that failed was
+  downgraded to a warning and then dropped: the returned object carried no
+  record of it, so a screen that could not fit a single candidate looked
+  exactly like one that tested them all and liked none. `$criteria` now carries
+  `refit_failures`, `n_refit_failures` and `stopped_refit_failed`; a run that
+  ends on an iteration with failed refits warns that its candidates were never
+  tested; and the trace names the cause instead of claiming "no further
+  action". A base fit built with the vector interface (`time =` / `status =`)
+  stores no formula for the refit to mutate, so every candidate would fail --
+  `hzr_stepwise()` now rejects it up front with one message naming the remedy,
+  through the same predicate the refit itself uses.
+
 * A multiphase fit is now reproducible. `hazard(dist = "multiphase")` offsets
   the starting values for every optimization start after the first, and those
   offsets were drawn from the ambient RNG stream. The identical call run twice

--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -29,6 +29,34 @@
 # directly should pre-expand factors and splines into explicit main
 # effects.
 
+#' Why a fit cannot be refit with a mutated scope
+#'
+#' Single decision point for "can `.hzr_refit_with_scope()` handle this
+#' fit at all". `hzr_stepwise()` asks the same question up front so that a
+#' base fit no candidate could ever be refit from is rejected once, with a
+#' message that names the remedy, rather than failing candidate-by-candidate
+#' into N warnings and an empty screen that looks like an honest null result
+#' (#159). Both callers read this one function so the two answers cannot
+#' drift apart.
+#'
+#' @param fit A fitted `hazard` object.
+#' @return `NULL` when the fit can be refit, otherwise a character scalar
+#'   naming the obstruction, phrased to follow "... because".
+#'
+#' @keywords internal
+#' @noRd
+.hzr_refit_blocker <- function(fit) {
+  if (is.null(fit$call$formula)) {
+    return(paste0(
+      "it was built via the vector interface (`time =` / `status =`) ",
+      "rather than the formula interface, so it stores no model formula ",
+      "to mutate"
+    ))
+  }
+  NULL
+}
+
+
 #' Refit a hazard model with a single scope mutation applied
 #'
 #' @param current A fitted `hazard` object that was built via the
@@ -83,13 +111,12 @@
   extra_args <- user_args[!names(user_args) %in%
                             c("weights", "time_windows")]
 
+  blocker <- .hzr_refit_blocker(current)
+  if (!is.null(blocker)) {
+    stop("`current` cannot be refit because ", blocker, ".", call. = FALSE)
+  }
   # Recover the original formula; see .hzr_stored_formula() for why this
   # cannot be a deparse.
-  raw_formula <- current$call$formula
-  if (is.null(raw_formula)) {
-    stop("`current` was not built via the formula interface; refit ",
-         "requires a formula-based base fit.", call. = FALSE)
-  }
   current_formula <- .hzr_stored_formula(current, "`current`")
 
   if (dist == "multiphase") {

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -227,8 +227,9 @@ hzr_stepwise <- function(fit,
     stop("`fit` cannot be used as a stepwise base model because ",
          refit_blocker, ". Every candidate would fail to refit, so the ",
          "screen could never enter or drop anything. Rebuild the base fit ",
-         "with the formula interface -- ",
-         "hazard(Surv(time, status) ~ ., data = df) -- and retry.",
+         "with the formula interface -- for a forward screen that usually ",
+         "means an intercept-only base, hazard(Surv(time, status) ~ 1, ",
+         "data = df, ...) -- and retry.",
          call. = FALSE)
   }
 

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -142,7 +142,13 @@
 #'       candidates whose effect is too large for the score test's
 #'       approximation at zero, which are typically the strongest variables
 #'       on offer rather than degenerate ones. `criterion = "wald"` tests
-#'       them.}
+#'       them.  For every criterion it also carries `refit_failures` (the
+#'       `"var"` / `"var@phase"` tokens of candidate moves whose refit
+#'       errored or failed to converge), `n_refit_failures`, and
+#'       `stopped_refit_failed` --- `TRUE` when the run ended on an iteration
+#'       in which refits failed, which is a screen that could not test its
+#'       candidates rather than one that tested them and liked none.  Check
+#'       it before reading a zero-row `steps` as an honest null result.}
 #'     \item{\code{trace_msg}}{Character vector of the trace lines,
 #'       captured regardless of the `trace` flag.}
 #'     \item{\code{elapsed}}{`difftime` from start to finish.}
@@ -206,6 +212,23 @@ hzr_stepwise <- function(fit,
   }
   if (missing(data) || !is.data.frame(data)) {
     stop("`data` must be a data frame (typically the frame used for the base fit).",
+         call. = FALSE)
+  }
+
+  # Every accepted step goes through .hzr_refit_with_scope(), so a base fit
+  # it cannot refit makes the entire screen a no-op.  Left to fail
+  # candidate-by-candidate that produces N warnings and a zero-step result
+  # indistinguishable from an honest "nothing met slentry" (#159).  Ask the
+  # refit's own predicate once, up front: one message, naming the remedy,
+  # before any fitting happens.  Sharing .hzr_refit_blocker() with the refit
+  # is what stops the two answers drifting apart.
+  refit_blocker <- .hzr_refit_blocker(fit)
+  if (!is.null(refit_blocker)) {
+    stop("`fit` cannot be used as a stepwise base model because ",
+         refit_blocker, ". Every candidate would fail to refit, so the ",
+         "screen could never enter or drop anything. Rebuild the base fit ",
+         "with the formula interface -- ",
+         "hazard(Surv(time, status) ~ ., data = df) -- and retry.",
          call. = FALSE)
   }
 
@@ -279,6 +302,14 @@ hzr_stepwise <- function(fit,
   n_uncomputable_scores <- 0L
   uncomputable_reasons  <- stats::setNames(integer(0), character(0))
   stopped_uncomputable  <- FALSE
+  # Candidates whose REFIT failed, summed over steps.  The per-candidate
+  # warning already fires inside the step, but nothing recorded it on the
+  # result, so a screen that could not fit any candidate returned the same
+  # empty object as one that fit them all and liked none (#159).  The step
+  # functions have returned `refit_failures` since v1; this is the caller
+  # finally reading it.
+  refit_failures       <- character()
+  stopped_refit_failed <- FALSE
 
   # `crit` is the criterion actually applied to THIS step, which is not always
   # the run's `criterion`: score is entry-only, so its drops are decided by
@@ -368,6 +399,10 @@ hzr_stepwise <- function(fit,
 
     add_happened  <- FALSE
     drop_happened <- FALSE
+    # Per-ITERATION, not per-run: what stopped the screen is what the last
+    # iteration did, and a failure three steps back is not why it ended.
+    iter_refit_failures <- character()
+    iter_uncomputable   <- FALSE
 
     effective_force_out <- unique(c(force_out, frozen))
     effective_force_in  <- unique(c(force_in,  frozen))
@@ -389,7 +424,10 @@ hzr_stepwise <- function(fit,
       )
       if (identical(fwd$stop_reason, "scores_uncomputable")) {
         stopped_uncomputable <- TRUE
+        iter_uncomputable    <- TRUE
       }
+      iter_refit_failures <- c(iter_refit_failures,
+                               fwd$refit_failures %||% character())
 
       if (fwd$accepted) {
         # Nested models: the entered model contains the current one, so at the
@@ -430,6 +468,9 @@ hzr_stepwise <- function(fit,
         force_in  = effective_force_in
       ), extra_args))
 
+      iter_refit_failures <- c(iter_refit_failures,
+                               bwd$refit_failures %||% character())
+
       if (bwd$accepted) {
         current <- bwd$fit
         record_step("drop", bwd, crit = drop_criterion)
@@ -438,9 +479,29 @@ hzr_stepwise <- function(fit,
       }
     }
 
+    refit_failures <- c(refit_failures, iter_refit_failures)
+
     if (!add_happened && !drop_happened) {
-      emit(sprintf("(no further action after %d step%s)",
-                   step_no, if (step_no == 1L) "" else "s"))
+      step_txt <- sprintf("%d step%s", step_no,
+                          if (step_no == 1L) "" else "s")
+      # "no further action" is a claim that candidates were tested and none
+      # was good enough.  Say that only when it is true.
+      if (length(iter_refit_failures) > 0L) {
+        stopped_refit_failed <- TRUE
+        emit(sprintf(
+          "(stopped after %s: %d candidate refit%s FAILED and could not be tested -- %s)",
+          step_txt, length(iter_refit_failures),
+          if (length(iter_refit_failures) == 1L) "" else "s",
+          paste(iter_refit_failures, collapse = ", ")
+        ))
+      } else if (iter_uncomputable) {
+        emit(sprintf(
+          "(stopped after %s: no candidate score could be COMPUTED -- none was tested)",
+          step_txt
+        ))
+      } else {
+        emit(sprintf("(no further action after %s)", step_txt))
+      }
       break
     }
   }
@@ -490,6 +551,9 @@ hzr_stepwise <- function(fit,
     n_uncomputable_scores = n_uncomputable_scores,
     uncomputable_reasons  = uncomputable_reasons,
     stopped_uncomputable  = stopped_uncomputable,
+    n_refit_failures      = length(refit_failures),
+    refit_failures        = refit_failures,
+    stopped_refit_failed  = stopped_refit_failed,
     n_nonmonotone_entries = n_nonmonotone_entries
   )
 
@@ -516,6 +580,16 @@ hzr_stepwise <- function(fit,
             "selected set may omit strong variables. Re-run with ",
             "`criterion = \"wald\"` to test them; see ",
             "`$criteria$uncomputable_reasons`.", call. = FALSE)
+  }
+  if (stopped_refit_failed) {
+    warning("Stepwise selection stopped after ", nrow(steps_df),
+            " accepted step(s), and the iteration it stopped on had ",
+            "candidate refit failure(s) (", length(refit_failures),
+            " across the run: ",
+            paste(unique(refit_failures), collapse = ", "),
+            "). Those candidates were never tested, so stopping here is ",
+            "NOT evidence that nothing met the entry or retention rule. ",
+            "See `$criteria$refit_failures`.", call. = FALSE)
   }
   result$trace_msg  <- trace_msg
   result$elapsed    <- elapsed

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -104,7 +104,13 @@ an unscored candidate as a bad one: \code{information_indefinite} marks
 candidates whose effect is too large for the score test's
 approximation at zero, which are typically the strongest variables
 on offer rather than degenerate ones. \code{criterion = "wald"} tests
-them.}
+them.  For every criterion it also carries \code{refit_failures} (the
+\code{"var"} / \code{"var@phase"} tokens of candidate moves whose refit
+errored or failed to converge), \code{n_refit_failures}, and
+\code{stopped_refit_failed} --- \code{TRUE} when the run ended on an iteration
+in which refits failed, which is a screen that could not test its
+candidates rather than one that tested them and liked none.  Check
+it before reading a zero-row \code{steps} as an honest null result.}
 \item{\code{trace_msg}}{Character vector of the trace lines,
 captured regardless of the \code{trace} flag.}
 \item{\code{elapsed}}{\code{difftime} from start to finish.}

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -362,3 +362,143 @@ test_that("scope = NULL keeps logical columns and drops unmodellable ones", {
   expect_equal(.hzr_modellable_vars(d, c("num", "flag", "chr")),
                c("num", "flag"))
 })
+
+
+# A zero-step screen must say WHY it is empty (#159) -------------------------
+#
+# The refit-failure counterpart of the uncomputable-score tests above.  Every
+# accepted step goes through .hzr_refit_with_scope(); when the refit fails the
+# forward/backward step downgrades it to a warning and returns nothing.  The
+# step functions have always reported `refit_failures`, but hzr_stepwise()
+# never read it, so a screen that could not fit a single candidate returned
+# the same zero-row `steps` as one that fit them all and liked none.
+
+test_that("hzr_stepwise rejects a vector-interface base fit up front", {
+  # The reproduction from #159: `.hzr_refit_with_scope()` cannot rebuild a
+  # call that has no stored formula, so EVERY candidate refit fails.  Before
+  # the fix this ran to completion and returned a zero-step result with
+  # nothing on the object to distinguish it from an honest empty screen.
+  data(avc)
+  avc <- na.omit(avc)
+  vecfit <- hazard(time = avc$int_dead, status = avc$dead, dist = "weibull",
+                   fit = TRUE, theta = c(mu = 0.01, nu = 0.5))
+  # Premise of the test: the call really does lack a formula.
+  expect_null(vecfit$call$formula)
+
+  expect_error(
+    hzr_stepwise(vecfit, scope = ~ age + mal, data = avc,
+                 direction = "forward", trace = FALSE),
+    "vector interface"
+  )
+})
+
+test_that(".hzr_refit_blocker is the single answer both callers read", {
+  data(avc)
+  avc <- na.omit(avc)
+  vecfit <- hazard(time = avc$int_dead, status = avc$dead, dist = "weibull",
+                   fit = TRUE, theta = c(mu = 0.01, nu = 0.5))
+  frmfit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "weibull",
+                   fit = TRUE, theta = c(mu = 0.01, nu = 0.5))
+
+  expect_null(.hzr_refit_blocker(frmfit))
+  expect_match(.hzr_refit_blocker(vecfit), "vector interface")
+})
+
+# Fixture: an intercept-only formula fit whose only candidate names a column
+# that is not in `data`, so hazard() errors inside the candidate tryCatch.
+.refit_failure_fixture <- function() {
+  data(avc)
+  avc <- na.omit(avc)
+  fit <- hazard(Surv(int_dead, dead) ~ 1, data = avc, dist = "weibull",
+                fit = TRUE, theta = c(mu = 0.01, nu = 0.5))
+  list(fit = fit, data = avc)
+}
+
+test_that("a screen emptied by refit failures records that on the object", {
+  fx <- .refit_failure_fixture()
+
+  warns <- character()
+  sw <- withCallingHandlers(
+    hzr_stepwise(fx$fit, scope = c("nonexistent"), data = fx$data,
+                 direction = "forward", criterion = "wald",
+                 trace = FALSE, control = list(n_starts = 1L)),
+    warning = function(w) {
+      warns <<- c(warns, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  # The run must say out loud that the empty screen is not a null result.
+  expect_true(any(grepl("never tested", warns, fixed = TRUE)))
+
+  # Assert on the OBJECT, not on printed output: this is what a caller has.
+  expect_equal(nrow(sw$steps), 0L)
+  expect_true(sw$criteria$stopped_refit_failed)
+  expect_equal(sw$criteria$n_refit_failures, 1L)
+  expect_identical(sw$criteria$refit_failures, "nonexistent")
+})
+
+test_that("an honest empty screen records no refit failure", {
+  # The discriminating negative control: same zero-row `steps`, but nothing
+  # failed -- the candidate was tested and simply did not clear slentry.
+  fx <- .refit_failure_fixture()
+
+  sw <- hzr_stepwise(fx$fit, scope = ~ age, data = fx$data,
+                     direction = "forward", criterion = "score",
+                     slentry = 1e-12, trace = FALSE,
+                     control = list(n_starts = 1L))
+
+  expect_equal(nrow(sw$steps), 0L)
+  expect_false(sw$criteria$stopped_refit_failed)
+  expect_equal(sw$criteria$n_refit_failures, 0L)
+  expect_identical(sw$criteria$refit_failures, character())
+})
+
+test_that("the trace does not claim 'no further action' when nothing was fit", {
+  fx <- .refit_failure_fixture()
+
+  sw <- suppressWarnings(
+    hzr_stepwise(fx$fit, scope = c("nonexistent"), data = fx$data,
+                 direction = "forward", criterion = "wald",
+                 trace = FALSE, control = list(n_starts = 1L))
+  )
+  trace <- stepwise_trace(sw)
+
+  expect_false(any(grepl("no further action", trace, fixed = TRUE)))
+  expect_true(any(grepl("refit FAILED", trace, fixed = TRUE)))
+  expect_true(any(grepl("nonexistent", trace, fixed = TRUE)))
+
+  # print() shows exactly the trace, so the reader sees the same thing.
+  expect_output(print(sw), "refit FAILED")
+})
+
+test_that("a score screen stopped on uncomputable scores says so in the trace", {
+  fx <- .uncomputable_fixture()
+
+  sw <- suppressWarnings(
+    hzr_stepwise(fx$fit, scope = list(early = ~ constcol), data = fx$data,
+                 direction = "forward", criterion = "score", slentry = 0.5,
+                 trace = FALSE)
+  )
+  trace <- stepwise_trace(sw)
+
+  expect_false(any(grepl("no further action", trace, fixed = TRUE)))
+  expect_true(any(grepl("could be COMPUTED", trace, fixed = TRUE)))
+})
+
+test_that("partial refit failure keeps the steps it did accept", {
+  # Partial failure is not total failure: one candidate is unfittable, the
+  # other enters.  Erroring out here would discard a real accepted step, so
+  # the run continues and records the failure instead.
+  fx <- .refit_failure_fixture()
+
+  sw <- suppressWarnings(
+    hzr_stepwise(fx$fit, scope = c("age", "nonexistent"), data = fx$data,
+                 direction = "forward", criterion = "wald", trace = FALSE,
+                 control = list(n_starts = 1L))
+  )
+
+  expect_equal(nrow(sw$steps), 1L)
+  expect_identical(sw$steps$variable, "age")
+  expect_gt(sw$criteria$n_refit_failures, 0L)
+  expect_true(all(sw$criteria$refit_failures == "nonexistent"))
+})


### PR DESCRIPTION
`hzr_stepwise()` could return a zero-step result that was indistinguishable from an honest empty screen, even when nothing had actually been evaluated.

## The defect

`AGENTS.md` already lists this shape in its table of shipped defects:

> A stepwise screen that stopped cleanly — it could not *score* any candidate, which is indistinguishable from finding none good enough.

That reasoning had been applied to the **score** side (`information_indefinite`, `uncomputable_reasons`, `stopped_uncomputable`) but not to the **refit** side. Reproduced on `dev` with a vector-interface base fit, which `.hzr_refit_with_scope()` cannot refit:

```
(no further action after 0 steps)
Final model: 0 covariates, logLik = -182.90, AIC = 369.81

  steps rows: 0
  fields mentioning failure:     <-- nothing
```

The reader concludes no covariate met the entry criterion. In fact nothing was ever tested.

Notably this was **not a missing diagnostic** — `.hzr_stepwise_forward_step()` already collected failures and returned them as `refit_failures`, with roxygen documenting the field. The driver simply never read it: `refit_failures` appeared **zero times** in `R/stepwise.R`. The signal was produced correctly and discarded at the layer boundary.

## What changed

`$criteria` gains `refit_failures` (the `"var"` / `"var@phase"` tokens), `n_refit_failures`, and `stopped_refit_failed`, mirroring the score side's vocabulary rather than inventing a parallel one. An honest empty screen reports `0` / `character()` / `FALSE`; a screen that stopped because a refit failed does not.

**Total failure is split in two**, because the two cases are genuinely different:

- **A broken call** — a vector-interface base fit, which can never be refit — now `stop()`s up front with an actionable message, instead of failing one candidate at a time.
- **A runtime refit failure** warns prominently, records the state, and **keeps the steps already accepted**. Erroring mid-run would discard real work over a data fact.

The up-front check reads a shared predicate, `.hzr_refit_blocker()`, consulted by both `hzr_stepwise()` and `.hzr_refit_with_scope()` — so the two cannot drift apart about what is refittable, which was the main objection to checking early.

## A correction to the issue's framing

#159 assumed every candidate refit fails, giving N warnings. Under the **default** `criterion = "score"` only the winner is refit, so exactly **one** refit fails. The outcome is equally invisible, but a fix keyed on "all candidates failed" would have read `FALSE` in precisely the case that motivated the issue. The recorded state keys on "the run stopped and refits failed" instead.

## Also fixed

The trace printed `"(no further action after N steps)"` even when candidates had never been tested. That line now appears only when candidates really were evaluated; otherwise it names the cause. The same lie was being printed for the uncomputable-**score** case, which recorded its flag correctly but still printed the misleading line — fixed too.

## Verification

Six mutations, all confirmed red and restored:

| | |
|---|---|
| M1 | delete the up-front `stop()` |
| M2 | make the blocker always `NULL` |
| M3 | never accumulate failures — 9 assertions |
| M4 | always emit "no further action" — 8 assertions |
| M5 | remove the stop warning |
| M6 | set `stopped_refit_failed <- TRUE` unconditionally |

M6 matters most: it proves the honest-empty **negative control** can fail, so the tests distinguish the two outcomes rather than merely detecting the broken one.

`FAIL 0 | WARN 543 | SKIP 6 | PASS 2969` (baseline 540 / 2946), lint 0, spelling clean.

Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
