### PR TITLE
docs(news): record the start_seed values that are now rejected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -219,6 +219,17 @@
   `objective` values. See the note on `starts` below for how to read two
   objectives that differ, which is not always a pair of rival optima.
 
+  `start_seed` takes any whole number within integer range, negatives included
+  -- `set.seed(-1)` is perfectly valid and deterministic, so restricting to
+  non-negative values would discard half the seed space for no reason. A
+  fractional value is rejected rather than truncated: `set.seed()` truncates,
+  so `3.9` and `3` would select the same ensemble, and a sweep over
+  `3.1 / 3.5 / 3.9` would report three fits having tried one set of starts.
+  Coercing quietly would keep that aliasing and merely move it. A value out of
+  integer range is rejected too, because `set.seed()` would otherwise fail with
+  "supplied seed is not a valid integer" and name neither the argument nor the
+  fit it came from.
+
   `hzr_bootstrap()` draws its own resample before each refit, so replicates are
   still distinct. Its numbers do shift, because the refits no longer advance
   the stream between resamples, and a run with `seed=` is now reproducible end


### PR DESCRIPTION
## What this is

`NEWS.md` only. No code change.

8796659, merged in #163, made `control$start_seed` reject fractional and out-of-range values — `start_seed = 3.5` errors where it previously ran. That is user-visible behaviour in an unreleased 1.2.2 and it had no `NEWS.md` entry. `?hazard` already documents it; only the changelog was missing it.

## Where it went

Folded into the entry that introduces `control$start_seed` rather than added as a separate bullet, so a reader meets the constraint where they meet the argument.

It carries the reasoning, because "rejected rather than coerced" looks arbitrary without it: `set.seed()` truncates, so `3.9` and `3` select the same ensemble, and a sweep over `3.1 / 3.5 / 3.9` would report three fits having tried one set of starts. Coercing quietly keeps that aliasing and merely moves it. Negatives stay legal because `set.seed(-1)` is valid and deterministic, and restricting to non-negative values would discard half the seed space for no reason.

## Verified against the code, not the commit message

```
3        -> accepted
-1       -> accepted
3.5      -> rejected: 'control$start_seed' must be a single whole number no larger in magnitude than 2147483647.
3e+09    -> rejected: (same)
NA       -> rejected: (same)
```

## Gate

`lintr` 0 · `devtools::spell_check()` clean · `R CMD check --as-cran` from a clean `git archive` with manual and vignettes: **Status OK**.
