### PR TITLE
fix(hazard): $se keeps the standard errors it can compute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -203,10 +203,14 @@
   the vector [1]".
 
   A scalar `NA` now carries the meaning it already has for `vcov()`, that there
-  is no variance matrix at all. Where a matrix is present, `$se` is sized to it.
-  `summary()` was never affected, since it builds its coefficient table from
-  the variance matrix directly, so this was a quiet inconsistency on the fit
-  object rather than a visible break.
+  is no variance matrix at all. Where a matrix is present, `$se` is computed
+  element by element: a parameter held fixed carries an NA variance row and
+  earns an `NA` standard error, while every parameter whose variance *was*
+  computed keeps its own. Sizing the vector to the matrix is not enough on its
+  own -- filling it with `NA` throughout would leave `$se` conformable and
+  empty, and contradicting `summary()`, which reads the same matrix and reports
+  those standard errors. `summary()` was never affected either way, so this was
+  a quiet inconsistency on the fit object rather than a visible break.
 
 * `hzr_decompos()` no longer returns a wrong value for large `|m|`. The three
   branches with a nonzero `m` all formed `2^m` and the terms built from it

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -657,6 +657,9 @@ hazard <- function(formula = NULL,
     # discarded standard errors that summary() reports from the same matrix,
     # leaving `$se` the right length and empty of everything it should carry.
     out <- rep(NA_real_, length(d))
+    # rep() starts unnamed; carry over whatever diag() gave us so a named vcov
+    # still yields a named `$se`, as the old sqrt(d) path did.
+    names(out) <- names(d)
     ok <- is.finite(d) & d >= 0
     out[ok] <- sqrt(d[ok])
     out

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -649,15 +649,17 @@ hazard <- function(formula = NULL,
     if (is.null(vcov_mat) || !is.matrix(vcov_mat)) {
       return(NA)
     }
-    if (anyNA(vcov_mat)) {
-      return(rep(NA_real_, ncol(vcov_mat)))
-    }
     d <- diag(vcov_mat)
-    # Guard against small negative/invalid variances from numerical Hessians.
-    if (!all(is.finite(d)) || any(d < 0)) {
-      return(rep(NA_real_, length(d)))
-    }
-    sqrt(d)
+    # Element by element, never all-or-nothing. A parameter held fixed carries
+    # an NA variance row and earns an NA standard error; every parameter whose
+    # variance *was* computed keeps its own. Collapsing the whole vector on the
+    # first NA -- or on one small negative variance from a numerical Hessian --
+    # discarded standard errors that summary() reports from the same matrix,
+    # leaving `$se` the right length and empty of everything it should carry.
+    out <- rep(NA_real_, length(d))
+    ok <- is.finite(d) & d >= 0
+    out[ok] <- sqrt(d[ok])
+    out
   }
 
   # Distribution dispatch -- select the distribution-specific optimizer and fit.

--- a/tests/testthat/test-hazard-api.R
+++ b/tests/testthat/test-hazard-api.R
@@ -181,6 +181,11 @@ test_that("fit$se is conformable with fit$par whether or not vcov has NA rows", 
   expect_equal(unname(fit_mp$fit$se[computable]), unname(sqrt(d_mp[computable])))
   expect_true(all(is.na(fit_mp$fit$se[!computable])))
 
+  # `$se` carries the variance matrix's names when it has them. No fitted path
+  # currently produces a named `fit$fit$vcov`, so this guards against the two
+  # diverging later rather than reproducing a fault seen today.
+  expect_equal(names(fit_mp$fit$se), names(diag(fit_mp$fit$vcov)))
+
   # `$se` and summary() derive from the same matrix, so they cannot disagree.
   # They did: summary() reported real standard errors where `$se` was all NA.
   expect_equal(unname(fit_mp$fit$se),

--- a/tests/testthat/test-hazard-api.R
+++ b/tests/testthat/test-hazard-api.R
@@ -169,6 +169,22 @@ test_that("fit$se is conformable with fit$par whether or not vcov has NA rows", 
   # Naming the SEs against the parameters is what the old shape broke.
   expect_named(stats::setNames(fit_mp$fit$se, names(fit_mp$fit$par)),
                names(fit_mp$fit$par))
+
+  # Length and naming alone cannot fail on a vector of NA, which is exactly
+  # what the first fix returned: one NA per parameter, conformable and empty.
+  # Assert first that this fixture reaches both branches, then that the SEs
+  # that were computable actually survive.
+  d_mp <- diag(fit_mp$fit$vcov)
+  computable <- is.finite(d_mp) & d_mp >= 0
+  expect_true(any(computable))
+  expect_true(any(!computable))
+  expect_equal(unname(fit_mp$fit$se[computable]), unname(sqrt(d_mp[computable])))
+  expect_true(all(is.na(fit_mp$fit$se[!computable])))
+
+  # `$se` and summary() derive from the same matrix, so they cannot disagree.
+  # They did: summary() reported real standard errors where `$se` was all NA.
+  expect_equal(unname(fit_mp$fit$se),
+               unname(summary(fit_mp)$coefficients$std_error))
 })
 test_that("vcov.hazard returns a named matrix and preserves NA rows", {
   # A multiphase fit legitimately has NA variance rows: parameters held fixed


### PR DESCRIPTION
Follow-up to #170, found by the `RELEASE.md` step 5 review of the accumulated 1.2.2 diff (posted on #172).

## What #170 missed

#170 made `$se` conformable with `$par` and stopped there — any `NA` anywhere in the variance matrix returned one `NA` per parameter:

```r
if (anyNA(vcov_mat)) {
  return(rep(NA_real_, ncol(vcov_mat)))
}
```

A multiphase fit holding a shape fixed carries `NA` variance rows **by design** — that is the case #170 was written for — so in practice this returned a vector of the right length and empty of everything it should carry. Measured on an `avc` two-phase fit with `m` fixed:

```
$se        : NA  NA  NA  NA  NA
diag(vcov) : 0.02238  0.4367  0.1914  NA  0.2985
summary SE : 0.1496  0.6609  0.4375  NA  0.5464
```

Four computable standard errors discarded because one entry was `NA`, and `$se` contradicting `summary()` on the same object. That is the hollow-object shape in `AGENTS.md`'s table: right length, nothing inside, defeats both `is.null()` and a length check.

## The fix

`.hzr_safe_se_from_vcov()` computes element by element. A parameter whose variance is missing or invalid gets `NA`; every other parameter keeps its own standard error.

This also removes the `any(d < 0)` guard, which had the identical all-or-nothing flaw — one small negative variance from a numerical Hessian discarded every good one beside it. A scalar `NA` still means there is no variance matrix at all, the contract `vcov.hazard()` keeps.

Nothing internal consumes `$se` (`wald.R` and `predict-cl.R` go to `vcov` directly), so the blast radius is the fit object's own field.

## The test was the real problem

The #170 regression test asserted only `expect_length()` and `expect_named()` — and `rep(NA_real_, 5)` satisfies both. It passed for the entire life of the bug. Strengthened in place rather than duplicated:

- assert the fixture reaches **both** branches before comparing anything (`any(computable)` and `any(!computable)`) — coverage first, per `AGENTS.md`;
- assert the computable standard errors survive and equal `sqrt` of their variances;
- assert `$se` equals `summary()`'s `std_error`, which is the invariant that actually broke.

**Mutation-tested:** reinstating the `anyNA` early return fails 2 assertions.

## NEWS

The 1.2.2 entry claimed "one standard error per parameter, whatever the variance matrix looks like", which was true only in the sizing sense. Corrected to describe the elementwise behaviour, and to say why sizing alone is not enough. `cran-comments.md` carried the same overstatement and is corrected in #171.

## Gate

`document()` clean (no `man/` churn) · `lintr::lint_package()` **0** · `devtools::test()` **0 FAIL / 6 SKIP / 3192 PASS** (`NOT_CRAN=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)