### PR TITLE
docs(vignette): the emitted-document example matches what the translator emits

### DIFF
--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -568,12 +568,15 @@ job <- hzr_translate_sas(
 )
 ```
 
-The emitted `.qmd` carries a `data` chunk and a `fit` chunk (reformatted
-here for width; the emitted document wraps at 60 columns like any
-`deparse()`d call). `DATA` step translation is out of scope, so the
-`data` chunk is a guard, not a re-implementation -- it checks that
-`AVCS` is already in scope and stops with a named error if not, rather
-than silently proceeding without data:
+The emitted `.qmd` carries three chunks past its `setup`: a `data`
+chunk, a `status` chunk, and a `fit` chunk (reformatted here for width;
+the emitted document wraps at 60 columns like any `deparse()`d call).
+`DATA` step translation is out of scope, so the `data` chunk is a
+guard, not a re-implementation. It checks that `AVCS` is already in
+scope and stops with a named error if not, rather than silently
+proceeding without data. The `status` chunk is where `EVENT DEAD`
+becomes something `hazard()` can take, and it is worth reading closely
+if you are checking a translation against the job it came from:
 
 ```{r}
 #| eval: false
@@ -584,8 +587,16 @@ if (!exists("AVCS")) {
        " before rendering.")
 }
 
+AVCS <- transform(AVCS, .hzr_status = {
+  if (any(is.na(DEAD) | DEAD < 0)) {
+    stop("This job has rows where the EVENT count (DEAD) is missing or ",
+         "negative. ...")   # message trimmed here; see below
+  }
+  ifelse(DEAD > 0, 1, 0)
+})
+
 fit <- hazard(
-  data = AVCS, time = INT_DEAD, status = DEAD, fit = TRUE,
+  data = AVCS, time = INT_DEAD, status = .hzr_status, fit = TRUE,
   dist = "multiphase",
   phases = list(
     hzr_phase("cdf", t_half = 0.1512095, nu = 1.438652, m = 1, fixed = "m"),
@@ -594,9 +605,33 @@ fit <- hazard(
   theta = c(
     log(0.2361727), log(0.1512095), 1.438652, 1, log(0.0005436977)
   ),
+  weights = ifelse(DEAD > 0, DEAD, 1),
   control = list(condition = 14, conserve = TRUE, method = "bfgs")
 )
 ```
+
+`EVENT DEAD` names a **count**, not a flag. In the reference program a
+row with `DEAD = 2` is two events, and `setlik.c` weights its
+contribution accordingly. `hazard()` takes a 0/1 status and a separate
+`weights` argument, so the one SAS statement translates into two: the
+status derives from `DEAD > 0`, and the count carries into `weights`.
+Read `status = .hzr_status` and `weights = ifelse(DEAD > 0, DEAD, 1)`
+as a pair and they are your `EVENT` statement, not two new modelling
+choices. If you have translated this job before version 1.2.2, note
+that `DEAD = 2` used to map straight onto `status = 2` and be fitted as
+interval-censored, which is a different likelihood branch rather than
+an under-count.
+
+The guard in front of it refuses the rows SAS would have deleted. A
+missing or negative count is dropped outright by the reference program:
+`readc1.c` sets `mdel` on a missing count and `del` on a negative one,
+and `readobs.c` then skips the row and subtracts it from `Nobs`, so it
+contributes nothing to the likelihood. `hazard()` has no equivalent of
+that deletion, and translating such a row as censored would change the
+fit without saying so, so the chunk stops instead and asks you to drop
+the rows yourself. When it fires, subset to `!is.na(DEAD) & DEAD >= 0`
+and check your row count against the deletion tallies SAS printed for
+the job.
 
 The fit is bound to `fit` and `fit = TRUE` is emitted, which is what
 makes the document runnable: a later `predict()` chunk from a

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -570,7 +570,9 @@ job <- hzr_translate_sas(
 
 The emitted `.qmd` carries three chunks past its `setup`: a `data`
 chunk, a `status` chunk, and a `fit` chunk (reformatted here for width;
-the emitted document wraps at 60 columns like any `deparse()`d call).
+the emitted document wraps at 60 columns like any `deparse()`d call,
+and the three are run together in one block below, each marked by a
+comment, rather than shown as the three separate chunks they are).
 `DATA` step translation is out of scope, so the `data` chunk is a
 guard, not a re-implementation. It checks that `AVCS` is already in
 scope and stops with a named error if not, rather than silently
@@ -581,12 +583,14 @@ if you are checking a translation against the job it came from:
 ```{r}
 #| eval: false
 #| label: translate-output
+# chunk: data
 if (!exists("AVCS")) {
   stop("This job read ", "AVCS", " from a SAS DATA step, which ",
        "hzr_translate_sas() does not translate. Assign ", "AVCS",
        " before rendering.")
 }
 
+# chunk: status
 AVCS <- transform(AVCS, .hzr_status = {
   if (any(is.na(DEAD) | DEAD < 0)) {
     stop("This job has rows where the EVENT count (DEAD) is missing or ",
@@ -595,6 +599,7 @@ AVCS <- transform(AVCS, .hzr_status = {
   ifelse(DEAD > 0, 1, 0)
 })
 
+# chunk: fit
 fit <- hazard(
   data = AVCS, time = INT_DEAD, status = .hzr_status, fit = TRUE,
   dist = "multiphase",


### PR DESCRIPTION
Found by the `RELEASE.md` step 5 review of the 1.2.2 diff (see #172). Verified by running the translator on `hz-example.sas`, the file the vignette itself cites.

## The drift

| `sas-to-r-migration.qmd` said | `hzr_translate_sas()` actually emits |
|---|---|
| "carries a `data` chunk and a `fit` chunk" | `setup`, `data`, **`status`**, `fit` |
| `status = DEAD` | `status = .hzr_status` |
| *(no `weights`)* | `weights = ifelse(DEAD > 0, DEAD, 1)` |

That contradicts this release's own changelog. `NEWS.md` states that "an `EVENT` count carries into `weights` and `status` derives from `EVENT > 0`", and `hz-example.sas` has `EVENT DEAD;`, so it takes exactly that path.

**No gate could have caught this.** Both blocks are `#| eval: false`, so the vignette rebuild renders them as literal text — `R CMD check` verifies the vignette *builds*, never that its displayed output matches what the code produces.

## Why it matters here

This vignette is written for the bilingual SAS-to-R migrant, the reader most likely to lift that emitted `hazard()` call as a template. Carrying `status = DEAD` into a real fit is not a cosmetic error: before 1.2.2, `DEAD = 2` mapped onto `status = 2` and was fitted as **interval-censored** — a different likelihood branch, not an under-count.

## What changed

- The narrative names all three chunks and points at `status` as the one to read closely.
- The shown output is what the translator emits, including the `status` chunk and `weights`.
- Two new paragraphs: why one SAS `EVENT` statement becomes a `status`/`weights` pair, and why the guard refuses rows SAS would have deleted (`readc1.c` sets `mdel` on a missing count and `del` on a negative one; `readobs.c` skips the row and subtracts it from `Nobs`, so it contributes nothing to the likelihood). Translating such a row as censored would move the fit without saying so.

The guard's full `stop()` text is trimmed in the displayed chunk, marked as trimmed, and explained in the prose beneath it.

## Gate

`lintr::lint_package()` **0** · `devtools::spell_check()` clean · `R CMD build` renders the vignette. No R code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)