### PR TITLE
fix(sas): the unresolved-INHAZ remedy is R you can paste

### DIFF
--- a/R/sas-render-qmd.R
+++ b/R/sas-render-qmd.R
@@ -32,9 +32,12 @@
 
   if (!is.null(job$inhaz) && !isTRUE(job$inhaz_resolved)) {
     lib <- sub("[.].*$", "", job$inhaz)
+    # Quote the libref. A SAS libref is nearly always a syntactic R name, but
+    # one that collides with a reserved word (TRUE, if) would make the remedy
+    # invalid R, and the whole point of the line is that it can be pasted.
     msg <- paste0(
-      "unresolved INHAZ=", job$inhaz, " -- pass librefs = c(", lib,
-      ' = "<path>") to hzr_translate_sas()'
+      "unresolved INHAZ=", job$inhaz, ' -- pass librefs = c("', lib,
+      '" = "<path>") to hzr_translate_sas()'
     )
     stop_call <- bquote(stop(.(msg)))
     add("```{r}",

--- a/tests/testthat/test-sas-render-qmd.R
+++ b/tests/testthat/test-sas-render-qmd.R
@@ -57,6 +57,30 @@ test_that("an unresolved INHAZ with an apostrophe still emits parseable R", {
   expect_true(grepl("O'BRIEN.HZD", stop_line, fixed = TRUE))
 })
 
+test_that("the INHAZ remedy is pasteable R for a reserved-word libref", {
+  # The message advertises a `librefs = c(...)` call for the user to copy. The
+  # libref went in unquoted, so one colliding with an R reserved word made the
+  # advertised fragment a syntax error: the remedy could not be run as printed.
+  j <- .hzr_sas_job(
+    source = list(path = "hp.sas", checksum = "abc"),
+    calls = list(pred = quote(predict(fit, newdata = PREDICT))),
+    grid = NULL, inhaz = "TRUE.HZD", outhaz = NULL,
+    untranslated = .hzr_untranslated_frame(),
+    coverage = list(tokens_seen = 4L, tokens_mapped = 4L)
+  )
+  out <- .hzr_render_qmd(j)
+  stop_line <- out[grepl("^stop\\(", out)]
+  expect_length(stop_line, 1L)
+
+  # Run the remedy rather than matching its text: the claim is that it works,
+  # not that it looks right.
+  msg <- tryCatch(eval(parse(text = stop_line)), error = conditionMessage)
+  remedy <- sub(".*pass librefs = (c\\(.*?\\)) to .*", "\\1", msg)
+  expect_false(identical(remedy, msg))
+  v <- eval(parse(text = remedy))
+  expect_named(v, "TRUE")
+})
+
 test_that("a resolved INHAZ does not emit a stop()", {
   j <- .hzr_sas_job(
     source = list(path = "hp.sas", checksum = "abc"),

--- a/tests/testthat/test-sas-render-qmd.R
+++ b/tests/testthat/test-sas-render-qmd.R
@@ -75,7 +75,10 @@ test_that("the INHAZ remedy is pasteable R for a reserved-word libref", {
   # Run the remedy rather than matching its text: the claim is that it works,
   # not that it looks right.
   msg <- tryCatch(eval(parse(text = stop_line)), error = conditionMessage)
-  remedy <- sub(".*pass librefs = (c\\(.*?\\)) to .*", "\\1", msg)
+  # Stop at the first ")" rather than leaning on a non-greedy quantifier: the
+  # fragment has no nested parentheses, and this needs no regex-engine
+  # extension to mean what it says.
+  remedy <- sub(".*pass librefs = (c\\([^)]*\\)) to .*", "\\1", msg)
   expect_false(identical(remedy, msg))
   v <- eval(parse(text = remedy))
   expect_named(v, "TRUE")


### PR DESCRIPTION
Addresses the Copilot review item on #172. That PR is the `dev` → `main` release merge and takes no direct commits, so the fix lands here.

## The item, narrowed

`R/sas-render-qmd.R:38` built the remedy with the libref inserted bare:

```r
"unresolved INHAZ=", job$inhaz, " -- pass librefs = c(", lib,
' = "<path>") to hzr_translate_sas()'
```

Copilot framed this as "if the libref is not a syntactic R name". After reading the code that is wider than the real exposure: SAS librefs are letter-or-underscore initial, at most 8 alphanumerics, and `lib` has already had everything past the first `.` stripped — so a libref is almost always a syntactic R name and `c(EX = "<path>")` parses fine.

The case that does break is a libref colliding with an R **reserved word**. SAS accepts one named `TRUE`; `c(TRUE = "<path>")` is a syntax error. Narrow, but the line exists to be pasted, and quoting is unconditionally correct.

## The test runs the remedy

Rather than asserting the message's shape, the test executes what it advertises: render a job with `INHAZ=TRUE.HZD`, pull the `c(...)` fragment out of the emitted message, `parse()` and evaluate it, assert the result is named `TRUE`.

**Mutation-tested:** restoring the unquoted form fails it (1 FAIL).

That choice is deliberate. A string-matching assertion here would pass on `c(TRUE = "<path>")` — the exact broken output — because it *looks* right. The bug is only visible if you run it.

`test-sas-render-qmd.R:43` already covers a neighbouring case, an apostrophe in the libref breaking the *chunk*. This is the separate question of whether the remedy *inside* the message is runnable.

## Gate

`document()` clean · `lintr::lint_package()` **0** · `devtools::test()` **0 FAIL / 6 SKIP / 3190 PASS** (`NOT_CRAN=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)