### PR TITLE
docs: drop the dev branch, work one line on main

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,11 +9,11 @@ on:
   push:
     paths-ignore:
       - '.claude/**'
-    branches: [main, master, dev]
+    branches: [main, master]
   pull_request:
     paths-ignore:
       - '.claude/**'
-    branches: [main, master, dev]
+    branches: [main, master]
 
 concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: lint
 
 on:
   push:
-    branches: [main, master, dev]
+    branches: [main, master]
   pull_request:
-    branches: [main, master, dev]
+    branches: [main, master]
 
 concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -9,11 +9,11 @@ on:
   push:
     paths-ignore:
       - '.claude/**'
-    branches: [main, master, dev]
+    branches: [main, master]
   pull_request:
     paths-ignore:
       - '.claude/**'
-    branches: [main, master, dev]
+    branches: [main, master]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -9,11 +9,11 @@ on:
   push:
     paths-ignore:
       - '.claude/**'
-    branches: [main, master, dev]
+    branches: [main, master]
   pull_request:
     paths-ignore:
       - '.claude/**'
-    branches: [main, master, dev]
+    branches: [main, master]
 
 concurrency:
   # One in-flight run per workflow per ref. Without this every push starts a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ Before opening the PR, and whenever the change touches an exported function or t
 likelihood, run the `r-reviewer` agent (`.claude/agents/r-reviewer.md`) over the diff. It is
 advisory: verify each finding against the code rather than acting on it, and do not let a
 clean report stand in for the commands above. `RELEASE.md` step 5 runs the same agent over
-the accumulated `main...dev` diff at release time, because per-PR review never sees the
-release as a whole.
+the accumulated `v<previous>...main` diff at release time, because per-PR review never sees
+the release as a whole.
 
 Four details there are load bearing:
 
@@ -47,7 +47,7 @@ Four details there are load bearing:
   failures first.
 - **`R CMD check` does not run the whole suite.** It runs with `NOT_CRAN` false, so
   `skip_on_cran()` tests are skipped: 146 skips and 2339 passes under check, against 6 skips
-  and **3193** passes locally (both measured 2026-08-23 on `dev` at `c9f6c28`,
+  and **3193** passes locally (both measured 2026-08-23 at `c9f6c28`,
   with no environment variables set; the local figure needs the SAS fixture checkouts
   present under `~/Documents/GitHub/hazard`). A green check is **not**
   evidence that those tests pass; only the local `devtools::test()` line is.
@@ -158,7 +158,7 @@ Note the registry name is `TemporalHazard` while the directory is `temporal_haza
 ### Where the check's time actually goes
 
 Overall `R CMD check --as-cran` with the manual: **3m 29s**, tarball **2.8 MB** (measured
-2026-08-23 on `dev` at `c9f6c28`). CRAN's ceiling is about 10 minutes and it
+2026-08-23 at `c9f6c28`). CRAN's ceiling is about 10 minutes and it
 rejects on that even at 0/0/0 — that is what got ggRandomForests archived in June 2026.
 
 | Component | Time |
@@ -195,8 +195,9 @@ A new dependency is a CRAN cost. Ask first.
 
 ## Git and versioning
 
-- **Never push to `main` or `dev` directly.** Branch, commit, push the branch, open a PR, then
-  stop. The maintainer merges.
+- **Never push to `main` directly.** Branch, commit, push the branch, open a PR, then stop.
+  The maintainer merges. `main` is the only long-lived branch: there is no `dev`, and every
+  kind of change takes the same route (see `RELEASE.md`, "Branch model").
 - **Never roll the MINOR or MAJOR digit.** That is the maintainer's call, made when a feature
   set is consolidated into a release. Patch bumps are fine for incremental work; say so when
   you make one.
@@ -205,9 +206,10 @@ A new dependency is a CRAN cost. Ask first.
 - ⚠️ **Unlike ggRandomForests, there is no test here that greps `NEWS.md` for the `DESCRIPTION`
   version.** Nothing will catch a mismatch. Keep `DESCRIPTION` `Version:` and the `NEWS.md`
   top heading in sync **by hand** on every bump.
-- ⚠️ **`Closes #123` does not fire on this repo's normal flow.** GitHub auto-closes only on
-  merge into the *default* branch, and routine work merges to `dev`. Close the issue manually
-  after the merge, or it stays open silently.
+- **`Closes #123` fires on the normal flow.** GitHub auto-closes only on merge into the
+  *default* branch, and routine work now merges to `main`, which is it. This inverted on
+  2026-08-24 when the `dev` branch was dropped; before that the keyword silently did nothing
+  and issues had to be closed by hand.
 
 ## Prose
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ Before opening the PR, and whenever the change touches an exported function or t
 likelihood, run the `r-reviewer` agent (`.claude/agents/r-reviewer.md`) over the diff. It is
 advisory: verify each finding against the code rather than acting on it, and do not let a
 clean report stand in for the commands above. `RELEASE.md` step 5 runs the same agent over
-the accumulated `v<previous>...main` diff at release time, because per-PR review never sees
-the release as a whole.
+the accumulated diff from the previous release tag to `main` (`git diff v1.2.2...main` at
+the time of writing) at release time, because per-PR review never sees the release as a
+whole.
 
 Four details there are load bearing:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ Maintainer checklist for TemporalHazard. Not shipped (`.Rbuildignore`d).
 - **Every version is a straight three-part number**: `1.1.0`, `1.2.0`, `1.2.1`.
   Never a fourth component, and never a `.9000` dev suffix — not for dev
   snapshots, not to satisfy a version-grep test, not anywhere.
-- **Acceptance itself never bumps the version.** `dev` stays at the number
+- **Acceptance itself never bumps the version.** `main` stays at the number
   that shipped; there is no placeholder to strip later and no bump to
   remember. The version moves only when work moves it, per the next two
   bullets.
@@ -39,48 +39,57 @@ Maintainer checklist for TemporalHazard. Not shipped (`.Rbuildignore`d).
 So the per-release cycle is:
 
 ```
-1.1.0 (released)  ->  dev stays 1.1.0  ->  accumulate work, patch-bumping
-                                            as fixes land (1.1.1, 1.1.2 ...)
+1.1.0 (released)  ->  main stays 1.1.0  ->  accumulate work, patch-bumping
+                                             as fixes land (1.1.1, 1.1.2 ...)
   ->  at release, decide from NEWS: 1.1.3 | 1.2.0 | 2.0.0  ->  submit
-  ->  accepted  ->  dev stays at that number until work moves it ...
+  ->  accepted  ->  main stays at that number until work moves it ...
 ```
 
-**Do not pre-stamp a future release number into the version.** Labelling `dev`
-with the number you expect to ship silently commits a decision that should be
-made last, from the evidence. That is the mistake behind the 2026-06 version
-confusion, when `dev` was labelled for a minor release before `1.1.0` had even
-shipped and before the work existed to justify it.
+**Do not pre-stamp a future release number into the version.** Labelling the
+working line with the number you expect to ship silently commits a decision
+that should be made last, from the evidence. That is the mistake behind the
+2026-06 version confusion, when the line was labelled for a minor release
+before `1.1.0` had even shipped and before the work existed to justify it. It
+recurred on `main` in 2026-08, via `chore(release): target 1.2.0 for the next
+CRAN drop`, which left `main` naming a release that never went out.
 
-## Branch model (default: single line)
+## Branch model (one line: `main`)
 
 | Branch | Version | Role |
 |--------|---------|------|
-| `main` | the clean CRAN release (e.g. `1.1.0`) | the released/stable line; always == the latest version on CRAN. Tagged at each release. |
-| `dev`  | the same three-part number as `main`, patch-bumped as fixes land | the working line; accumulates the next release. Carries no dev marker. |
+| `main` | a clean three-part number, patch-bumped as fixes land | the only long-lived branch. Feature branches merge in; releases are cut from it and tagged. |
 
-Both branches carry a clean three-part version. A README/badge tweak on `main`
-at the same version number is normal and fine — it does not need a version
-marker. (Historically `main` carried a fourth `.9000` component; that was
-dropped after `1.1.0`, and the convention was dropped entirely in 2026-08.)
+`main` carries a clean three-part version at all times, and it is **not** pinned
+to whatever is on CRAN: work accumulates and the patch digit moves as fixes
+land. A README or badge tweak at the same version number is normal and needs no
+version marker. (Historically `main` carried a fourth `.9000` component; that
+was dropped after `1.1.0`, and the convention was dropped entirely in 2026-08.)
 
-**Routing:**
+**Routing: there is one route.** Branch off `main`, PR to `main`, the maintainer
+merges. That covers R code, `man/`, vignettes, tests, docs, cosmetic fixes and
+hotfixes alike — no second destination to choose between, and no back-merge to
+forget.
 
-- **Routine work** (R code, `man/`, vignettes, tests, docs) — branch off `dev`,
-  PR to `dev`. It reaches `main` only via a release.
-- **Urgent patch / hotfix** to the released line — branch off `main`, fix, set
-  `DESCRIPTION` to the next *patch* (`X.Y.(Z+1)`), PR to `main`, release it,
-  then merge `main -> dev` so the fix flows into the dev line. (This is the
-  "bug fixes go to `main`" path: ship a patch without dragging in `dev`'s
-  unfinished features.)
-- **Cosmetic / GitHub-facing fixes** (README prose, badges, figures, pkgdown
-  config) — branch off `main`, PR to `main`. No version change; `main` stays at
-  the released number.
-- **Release ops** (tag, GitHub Release) — directly on `main` (the documented
-  exception to the branch+PR rule).
+**Release ops** (tag, GitHub Release) go directly on `main`, the documented
+exception to the branch + PR rule.
 
-**Keep them in sync:** after any `main`-side fix, merge `main -> dev` so it
-flows into the dev line. Skipping this is what produces the "same fix, two
-parallel PRs" situation.
+Two things follow from having one line, both worth knowing:
+
+- **`Closes #123` works now.** GitHub auto-closes an issue only on merge into
+  the *default* branch. Under the old split, routine work merged to `dev`, so
+  the keyword silently did nothing and every issue had to be closed by hand.
+- **There is no release PR, and no trap inside it.** With "Automatically delete
+  head branches" enabled, merging a `dev -> main` release PR deletes `dev`,
+  because `dev` is that PR's head branch. That happened on the 1.2.2 release
+  (2026-08-24); nothing was lost, since `main` already contained every commit,
+  but `dev` had to be pushed back from `main`.
+
+**Adopted 2026-08-24**, replacing a `main` + `dev` split. A second long-lived
+branch earns its keep only when a stable line must keep shipping patches while a
+diverged line runs in parallel. TemporalHazard has no such parallel line, so the
+split bought nothing and cost a back-merge after every `main`-side fix.
+(ggRandomForests *does* have that constraint, for the greenfield RHF work, and
+keeps its feature branch. The two repos differ here on purpose.)
 
 ### When to diverge into a two-branch model
 
@@ -94,12 +103,12 @@ it as the default — it is not worth that tax for ordinary incremental cycles.
 **Release flow (default single line):**
 
 ```
-dev (X.Y.Z) accumulates, patch-bumping as fixes land
+main (X.Y.Z) accumulates, patch-bumping as fixes land
   -> at release, decide the next number N from NEWS scope
-  -> set DESCRIPTION + NEWS top heading to N on dev
+  -> set DESCRIPTION + NEWS top heading to N on main (via a PR)
   -> run the pre-submission gate (below), submit to CRAN
-  -> on acceptance: merge dev -> main (main = N), tag vN, GitHub Release
-  -> dev stays at N; it moves again only when work lands (N patch-bumped)
+  -> on acceptance: tag vN on main, GitHub Release
+  -> main stays at N; it moves again only when work lands (N patch-bumped)
 ```
 
 ## Pre-submission checklist
@@ -112,8 +121,10 @@ dev (X.Y.Z) accumulates, patch-bumping as fixes land
 4. `devtools::document()` is clean and `man/` is in sync.
 5. **Adversarial review of the accumulated release diff.** Every PR is reviewed
    on its own; nobody reviews the release as a whole, and by submission time
-   `dev` is typically dozens of commits ahead of `main`. Run the `r-reviewer`
-   agent (`.claude/agents/r-reviewer.md`) over `git diff main...dev`.
+   `main` is typically dozens of commits past the last release. Run the
+   `r-reviewer` agent (`.claude/agents/r-reviewer.md`) over
+   `git diff v<previous>...main` — the previous release tag is the anchor now
+   that there is no `dev` to diff against.
 
    This step is **advisory**, unlike the rest of this checklist. It returns
    findings to triage, not a pass/fail. Verify each one against the code before
@@ -144,9 +155,8 @@ dev (X.Y.Z) accumulates, patch-bumping as fixes land
    (revdeps must be handled; currently 0). doi.org links may 403 to automated
    checkers but resolve in browsers — note, don't chase.
 9. Submit: `devtools::submit_cran()` (writes `CRAN-SUBMISSION`). Submit from a
-   checkout of the release tree (normally `dev` at the release number, or
-   `main` once merged) — the shipped tarball content is what matters, not which
-   branch the working tree was on.
+   checkout of `main` at the release number — the shipped tarball content is
+   what matters, not which branch the working tree was on.
 
 ### Known benign NOTE
 
@@ -172,9 +182,8 @@ keep the two in agreement.
    git push origin vX.Y.Z
    ```
 
-   `CRAN-SUBMISSION`'s `SHA:` records the tree `submit_cran()` ran from; if you
-   submitted from `dev`, the shipped content still matches `main` HEAD (they
-   differ only in `.Rbuildignore`'d files), so tag `main`.
+   `CRAN-SUBMISSION`'s `SHA:` records the tree `submit_cran()` ran from, which
+   is `main` HEAD.
 
 2. Publish a GitHub Release from the tag, using that version's `NEWS.md`
    section as the body, marked as the latest release:
@@ -184,7 +193,7 @@ keep the two in agreement.
      --title "TemporalHazard X.Y.Z" --notes-file <news-section.md>
    ```
 
-3. **Nothing to bump at this step.** `dev` stays at `X.Y.Z`, the number that
+3. **Nothing to bump at this step.** `main` stays at `X.Y.Z`, the number that
    just shipped. Do not run `usethis::use_dev_version()` — it writes a fourth
    `.9000` component, which this package does not use. The version moves later,
    when work moves it: the patch digit once a fix actually lands.
@@ -197,7 +206,7 @@ pkgdown) was aligned at the first CRAN release (`1.0.3`) and the manual
 version-badge CI (`update-version-badge.yaml`) retired then — no badge work on
 subsequent releases.
 
-All subsequent development happens at `X.Y.Z` on `dev`, patch-bumping as
+All subsequent development happens at `X.Y.Z` on `main`, patch-bumping as
 fixes land, until the next release decides the number to submit.
 
 ## Historical note
@@ -212,6 +221,9 @@ fixes land, until the next release decides the number to submit.
   model documented above, after the `dev = 1.2.0.9000` mislabel (a minor bump
   pre-stamped before the work existed, while `1.1.0` was frozen on `main` but
   never shipped). `1.1.0` folded that work in and was accepted & published on
-  CRAN 2026-06-12; `main` stays at the released number, and since 2026-08-17
-  so does `dev`.
+  CRAN 2026-06-12.
+- **2026-08-24:** dropped the `main` + `dev` split entirely for the one-line
+  model above. 1.2.0 and 1.2.1 were both numbered and never submitted, and
+  1.2.2 was tagged as a GitHub release without a CRAN submission, so the
+  premise that `main` tracks CRAN had already stopped holding.
 - Existing tags: `v0.1.0`, `v0.9.3`, `v1.0.0`, `v1.0.1`, `v1.0.3`, `v1.1.0`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -122,9 +122,11 @@ main (X.Y.Z) accumulates, patch-bumping as fixes land
 5. **Adversarial review of the accumulated release diff.** Every PR is reviewed
    on its own; nobody reviews the release as a whole, and by submission time
    `main` is typically dozens of commits past the last release. Run the
-   `r-reviewer` agent (`.claude/agents/r-reviewer.md`) over
-   `git diff v<previous>...main` — the previous release tag is the anchor now
-   that there is no `dev` to diff against.
+   `r-reviewer` agent (`.claude/agents/r-reviewer.md`) over the diff from the
+   previous release tag to `main` — `git diff v1.2.2...main` at the time of
+   writing. That tag is the anchor now that there is no `dev` to diff against,
+   and it is the better one: a tag records exactly what shipped, where `dev`'s
+   position depended on when you looked.
 
    This step is **advisory**, unlike the rest of this checklist. It returns
    findings to triage, not a pass/fail. Verify each one against the code before


### PR DESCRIPTION
Drops the `main` + `dev` split for a single line on `main`.

## Why

A second long-lived branch earns its keep when a stable line must keep shipping patches while a diverged line runs in parallel. TemporalHazard has no such line, so the split bought nothing and cost a back-merge after every `main`-side fix.

ggRandomForests **does** have that constraint — greenfield RHF work alongside a maintained CRAN release — and keeps its feature branch. The two repos differ here on purpose, and `RELEASE.md` now says so.

The premise the split rested on had also stopped holding. `RELEASE.md` claimed `main` "always == the latest version on CRAN". In fact 1.2.0 and 1.2.1 were both numbered and never submitted, and `v1.2.2` is tagged as a GitHub release with no CRAN submission behind it.

## Two things this fixes outright

- **`Closes #123` now works.** GitHub auto-closes an issue only on merge into the *default* branch. Under the split, routine work merged to `dev`, so the keyword silently did nothing and every issue had to be closed by hand — `AGENTS.md` carried a ⚠️ warning about it. That warning is now inverted rather than deleted, so the history stays legible.
- **The release-PR trap is gone.** With "Automatically delete head branches" on, merging a `dev -> main` release PR deletes `dev`, because `dev` is that PR's head branch. That happened on #172 this morning. Nothing was lost — `main` already contained every commit — but `dev` had to be pushed back from `main`. With one line there is no release PR and no head branch to delete.

## Changes

| File | What |
|---|---|
| `RELEASE.md` | Branch model rewritten to one line. Release flow, versioning cycle, step 5 review diff, step 9 submit checkout, and the acceptance steps re-anchored on `main`. Dated entry added to the historical note. |
| `AGENTS.md` | "Never push to `main` or `dev`" → "Never push to `main`". `Closes #123` warning inverted. Two measurement stamps now cite `c9f6c28` rather than "`dev` at `c9f6c28`". |
| `.github/workflows/` | `dev` removed from push/pull_request triggers in `R-CMD-check`, `lint`, `pkgdown`, `test-coverage`. |

## One design decision worth flagging

`RELEASE.md` step 5 ran the adversarial release review over `git diff main...dev`. With `dev` gone it needs a new anchor, and it now uses **`git diff v<previous>...main`**.

That is arguably better than what it replaced: a tag is an immovable record of exactly what shipped, whereas `dev`'s position depended on when you looked at it.

## Verification

`lintr::lint_package()` **0**. All seven workflow files still parse, with triggers confirmed:

```
R-CMD-check   -> push [main, master]  pull_request [main, master]
lint          -> push [main, master]  pull_request [main, master]
pkgdown       -> push [main, master]  pull_request [main, master]
test-coverage -> push [main, master]  pull_request [main, master]
check-manual  -> push [main]  release  workflow_dispatch
check-release -> release  workflow_dispatch
spelling      -> push [main]  pull_request
```

`c9f6c28` was verified to be an ancestor of `main`, so the re-worded measurement stamps still resolve after `dev` goes away.

No R code changed.

## Not done here

The remote `dev` branch still exists. Deleting it is a separate, destructive step — I have left it for you to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)