### PR TITLE
docs: make the release-ops commands pasteable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ one persona at a time, not a blend.
   not assert it.
 - **`.Rbuildignore` must exclude `^\.claude$`, `^CLAUDE\.md$` and `^AGENTS\.md$`.** These are
   developer files and have no business in a CRAN tarball. Confirm with
-  `tar tzf <tarball> | grep -iE 'CLAUDE|AGENTS'` after building.
+  `tar tzf TemporalHazard_X.Y.Z.tar.gz | grep -iE 'CLAUDE|AGENTS'` after building.
 - The CRAN incoming aspell check is **not** run by a local `--as-cran` unless `aspell` is
   installed, so local checks under-report it. `devtools::check_win_devel()` is the source of
   truth for that NOTE, and `inst/WORDLIST` feeds only `devtools::spell_check()` — it has no

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -191,6 +191,10 @@ keep the two in agreement.
    section as the body, marked as the latest release:
 
    ```sh
+   # The body is this version's NEWS.md section, so write it out first.
+   awk '/^# TemporalHazard X\.Y\.Z$/{f=1;next} /^# TemporalHazard /{f=0} f' \
+     NEWS.md > news-section.md
+
    gh release create vX.Y.Z --verify-tag --latest \
      --title "TemporalHazard X.Y.Z" --notes-file news-section.md
    ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -180,7 +180,7 @@ keep the two in agreement.
    `main` (the released line):
 
    ```sh
-   git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z — accepted & published on CRAN <date>" <main-HEAD>
+   git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z — accepted & published on CRAN YYYY-MM-DD" main
    git push origin vX.Y.Z
    ```
 
@@ -192,7 +192,7 @@ keep the two in agreement.
 
    ```sh
    gh release create vX.Y.Z --verify-tag --latest \
-     --title "TemporalHazard X.Y.Z" --notes-file <news-section.md>
+     --title "TemporalHazard X.Y.Z" --notes-file news-section.md
    ```
 
 3. **Nothing to bump at this step.** `main` stays at `X.Y.Z`, the number that


### PR DESCRIPTION
Follow-up to the Copilot item on #177, which fixed the release-diff command. These are the remaining instances of the same defect — the ones you would actually paste on your next CRAN acceptance, so they would bite at the worst moment.

## What was broken

Angle brackets are shell redirection operators. Tested each form in isolation, since a `>` anywhere in a script breaks parsing of the whole file:

| Form | Result |
|---|---|
| `git tag ... <main-HEAD>` | **`parse error near '\n'`** |
| `gh release create ... --notes-file <news-section.md>` | **`parse error near '\n'`** |
| `"... on CRAN <date>"` (inside double quotes) | prints fine — **already safe** |

Both failures are *parse* errors from the dangling `>` with no redirect target, so the command never runs. Worth noting precisely: **nothing is written to disk** either, because the shell aborts before performing any redirection. The risk is a command that silently doesn't run, not a clobbered file.

## What changed

```diff
-git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z — accepted & published on CRAN <date>" <main-HEAD>
+git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z — accepted & published on CRAN YYYY-MM-DD" main

-  --title "TemporalHazard X.Y.Z" --notes-file <news-section.md>
+  --title "TemporalHazard X.Y.Z" --notes-file news-section.md
```

`<main-HEAD>` becomes a literal **`main`** rather than another placeholder. Under the one-line model the tag goes on `main`'s HEAD, so that argument is no longer something the reader substitutes — the command is correct as written.

`<date>` was already safe inside the quotes; it becomes `YYYY-MM-DD` only so the three read consistently.

## One more, in the sibling contract

Found while sweeping: `AGENTS.md:238` had `tar tzf <tarball> | grep -iE 'CLAUDE|AGENTS'`, the same defect in the file that tells you to run it. Now `tar tzf TemporalHazard_X.Y.Z.tar.gz | ...`.

**Deliberately left:** `AGENTS.md:84`'s `expect_true(all(status %in% <every possible value>))`. That is R pseudo-code in prose illustrating an assertion that cannot fail — not a shell command, and not a paste hazard.

## Verification

Every fixed command syntax-checked with `zsh -n`:

```
a.sh (git tag + push)      parses OK
b.sh (gh release create)   parses OK
c.sh (git diff v1.2.2...main, from #177)  parses OK
d.sh (tar tzf ...)         parses OK
```

`grep -n '<[A-Za-z][^>]*>'` now returns nothing in `RELEASE.md`, and only the R pseudo-code line in `AGENTS.md`.

`lintr::lint_package()` **0**. No R code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)