### PR TITLE
fix(stepwise): a logical candidate screens as the 0/1 predictor it is

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
 BugReports: https://github.com/ehrlinger/temporal_hazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,11 @@
   expands the same way (`varb`). A candidate that expands to more than one
   column is still refused, unchanged.
 
+  That makes `criterion = "wald"` a real answer for a two-level factor or
+  character column named in an explicit `scope`, which the score criterion
+  still cannot expand. Its refusal used to say switching criterion would not
+  help, and now points at it instead.
+
 # TemporalHazard 1.2.2
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# TemporalHazard 1.2.3
+
+## Bug fixes
+
+* A logical column no longer stops a stepwise screen dead. `hzr_stepwise(scope
+  = NULL)` enumerates its own candidates and counts logical columns among them,
+  on the grounds that a 0/1 field arriving logical rather than numeric is a
+  property of the reader that produced the frame, not of the variable. Both
+  criteria then refused what the package had offered: the score criterion
+  errored with "is not numeric (logical)", and the Wald criterion failed
+  looking up `phase.var` when `model.matrix()` had named the column
+  `phase.varTRUE`. Either way the screen stopped before its first step, on a
+  column nobody had chosen by hand.
+
+  A logical candidate is now modelled as the 0/1 predictor it is, and gives
+  the same screen as the identical numeric column: same variables entered, in
+  the same order, at the same p-values, with the same coefficients.
+
+  The coefficient-name half of this also fixes a two-level factor, which
+  expands the same way (`varb`). A candidate that expands to more than one
+  column is still refused, unchanged.
+
 # TemporalHazard 1.2.2
 
 ## New features

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -447,9 +447,8 @@
   }
 
   d <- current$data
-  xcand <- data[[var]]
-  if (is.null(xcand) || !is.numeric(xcand) ||
-        length(xcand) != length(d$time) || anyNA(xcand)) {
+  xcand <- .hzr_candidate_numeric(data[[var]])
+  if (is.null(xcand) || length(xcand) != length(d$time) || anyNA(xcand)) {
     return(NULL)
   }
 
@@ -567,8 +566,8 @@
     )
   }
 
-  xcand <- data[[var]]
-  if (is.null(xcand) || !is.numeric(xcand) || anyNA(xcand)) {
+  xcand <- .hzr_candidate_numeric(data[[var]])
+  if (is.null(xcand) || anyNA(xcand)) {
     return(na_result("non_numeric"))
   }
   s <- stats::sd(xcand)

--- a/R/stepwise-formula.R
+++ b/R/stepwise-formula.R
@@ -321,3 +321,21 @@
   )
   vars[keep]
 }
+
+#' Coerce a candidate column to the numeric vector the screen models
+#'
+#' Logical columns are ordinary 0/1 predictors, and `.hzr_modellable_vars()`
+#' offers them as candidates under `scope = NULL`. Everything downstream -- the
+#' score statistic, the design-matrix column -- wants a numeric vector, so the
+#' translation happens once here rather than teaching each site about logicals.
+#'
+#' Returns `NULL` for anything that is not modellable as a single numeric
+#' column, which is the caller's signal to skip or refuse it.
+#'
+#' @keywords internal
+#' @noRd
+.hzr_candidate_numeric <- function(x) {
+  if (is.logical(x)) return(as.numeric(x))
+  if (is.numeric(x)) return(x)
+  NULL
+}

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -483,7 +483,7 @@
     )
     return(invisible(NULL))
   }
-  if (is.numeric(xcand)) {
+  if (!is.null(.hzr_candidate_numeric(xcand))) {
     return(invisible(NULL))
   }
   where <- if (is.null(phase)) "" else paste0(" in phase ", sQuote(phase))
@@ -719,6 +719,13 @@
           "rebuild your candidate as pre-expanded main effects and retry.",
           call. = FALSE
         )
+      }
+      # A single expansion is the term under another name -- a logical becomes
+      # `varTRUE`, a two-level factor `varb`. The name model.matrix() gave it is
+      # the one the coefficient vector carries, so return that rather than the
+      # name we guessed.
+      if (length(expanded) == 1L) {
+        return(expanded)
       }
     }
     return(target)

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -489,10 +489,11 @@
   where <- if (is.null(phase)) "" else paste0(" in phase ", sQuote(phase))
   stop(
     "Stepwise forward: candidate ", sQuote(var), where, " is not numeric (",
-    class(xcand)[1L], "). The score criterion supports single-column ",
-    "main-effect terms only. Expand it into numeric main effects (e.g. a ",
-    "contrast matrix) and retry -- note `criterion = \"wald\"` rejects it ",
-    "too, so switching criterion will not help.",
+    class(xcand)[1L], "). The score criterion tests the column as it stands ",
+    "and cannot expand it. `criterion = \"wald\"` refits once per candidate, ",
+    "so it does handle a term that expands to a single design-matrix column ",
+    "-- a two-level factor or character column. For anything wider, expand it ",
+    "into numeric main effects (e.g. a contrast matrix) and retry.",
     call. = FALSE
   )
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -154,6 +154,7 @@ memoryless
 mis
 misspecified
 mistyped
+modelled
 modelling
 multiphase
 multiplicatively

--- a/tests/testthat/test-stepwise-logical-candidates.R
+++ b/tests/testthat/test-stepwise-logical-candidates.R
@@ -1,0 +1,52 @@
+# A logical column is an ordinary 0/1 predictor -- .hzr_modellable_vars() says
+# so explicitly, and offers logicals as candidates under `scope = NULL`. Both
+# criteria then refused them, so a screen died before step 1 on a column the
+# package had chosen for itself. The assertion that matters is not that the
+# screen runs, but that a logical column and its numeric twin are the same
+# model: same selection, same coefficient, to the optimizer's tolerance.
+
+make_pair <- function() {
+  data(avc, package = "TemporalHazard", envir = environment())
+  d_num <- avc[, c("int_dead", "dead", "age", "mal")]
+  d_lgl <- d_num
+  d_lgl$mal <- as.logical(d_num$mal)
+  list(num = d_num, lgl = d_lgl)
+}
+
+base_fit <- function(d) {
+  hazard(survival::Surv(int_dead, dead) ~ 1, data = d, dist = "multiphase",
+         phases = list(constant = hzr_phase("constant")), fit = TRUE)
+}
+
+for (crit in c("score", "wald")) {
+  test_that(paste0("a logical candidate screens as its numeric twin (", crit, ")"), {
+    skip_on_cran()
+    p <- make_pair()
+
+    # The fixture must actually exercise the logical path, or this proves nothing.
+    expect_type(p$num$mal, "integer")
+    expect_type(p$lgl$mal, "logical")
+    expect_true("mal" %in% TemporalHazard:::.hzr_modellable_vars(p$lgl, "mal"))
+
+    r_num <- hzr_stepwise(base_fit(p$num), scope = NULL, data = p$num,
+                          direction = "forward", criterion = crit)
+    r_lgl <- hzr_stepwise(base_fit(p$lgl), scope = NULL, data = p$lgl,
+                          direction = "forward", criterion = crit)
+
+    # The logical column must actually enter, or comparing the two runs
+    # compares two screens that both ignored it and proves nothing.
+    expect_true("mal" %in% r_num$steps$variable)
+    expect_true("mal" %in% r_lgl$steps$variable)
+
+    # Same variables entered, in the same order, on the same evidence.
+    expect_equal(r_lgl$steps$variable, r_num$steps$variable)
+    expect_equal(r_lgl$steps$action, r_num$steps$action)
+    expect_equal(r_lgl$steps$p_value, r_num$steps$p_value, tolerance = 1e-6)
+
+    # And the same fit underneath, not merely the same bookkeeping. The
+    # coefficient NAMES differ by design (model.matrix() calls the logical's
+    # column malTRUE), so compare the values.
+    expect_equal(unname(stats::coef(r_lgl)), unname(stats::coef(r_num)),
+                 tolerance = 1e-6)
+  })
+}

--- a/tests/testthat/test-stepwise-logical-candidates.R
+++ b/tests/testthat/test-stepwise-logical-candidates.R
@@ -50,3 +50,39 @@ for (crit in c("score", "wald")) {
                  tolerance = 1e-6)
   })
 }
+
+test_that("the score criterion's refusal names an escape hatch that works", {
+  skip_on_cran()
+
+  # A two-level factor expands to one design-matrix column, so the Wald path
+  # refits and tests it. The score path cannot expand it and refuses -- and the
+  # refusal used to tell the caller that `criterion = "wald"` "rejects it too,
+  # so switching criterion will not help". That stopped being true once the
+  # coefficient-name lookup returned the expansion it had found, so the message
+  # was steering people away from the one thing that works.
+
+  data(avc, package = "TemporalHazard", envir = environment())
+  d <- avc[, c("int_dead", "dead", "age", "mal")]
+  d$mal <- factor(ifelse(d$mal > 0, "b", "a"))
+  sc <- stats::setNames(list(~ age + mal), "constant")
+  base <- function() {
+    hazard(survival::Surv(int_dead, dead) ~ 1, data = d, dist = "multiphase",
+           phases = list(constant = hzr_phase("constant")), fit = TRUE)
+  }
+
+  err <- tryCatch(
+    hzr_stepwise(base(), scope = sc, data = d, direction = "forward",
+                 criterion = "score"),
+    error = conditionMessage
+  )
+  expect_match(err, "not numeric", fixed = TRUE)
+  expect_false(grepl("switching criterion will not help", err, fixed = TRUE))
+  expect_match(err, 'criterion = "wald"', fixed = TRUE)
+
+  # Naming an escape hatch that does not work would be worse than naming none.
+  r <- suppressWarnings(
+    hzr_stepwise(base(), scope = sc, data = d, direction = "forward",
+                 criterion = "wald")
+  )
+  expect_true("mal" %in% r$steps$variable)
+})


### PR DESCRIPTION
The one genuine open defect from the `RELEASE.md` step 5 review of the 1.2.2 diff (see #172). Reproduced by execution before and after.

## The contradiction

`.hzr_modellable_vars()` offers logical columns as candidates under `scope = NULL`, and its roxygen says why:

> Logical columns count: they are ordinary 0/1 predictors, and whether a 0/1 field arrives logical or numeric depends on the reader that produced the frame rather than on anything about the variable.

Both criteria then refused what the package had just offered itself:

```
score -> candidate 'mal' in phase 'constant' is not numeric (logical)
wald  -> Unknown coefficient name(s): 'constant.mal'.
         Available: 'constant.log_mu', 'constant.malTRUE'
```

The screen stopped **before step 1**, on a column no caller had named. That also violates the filter's own stated contract, that under `scope = NULL` dropping beats erroring.

## Two independent defects

**1. The score path refused `is.logical` outright**, at three sites (`.hzr_score_check_numeric` plus two guards in `score-test.R`). A new `.hzr_candidate_numeric()` sits beside `.hzr_modellable_vars()` — the function that declares logicals modellable — and coerces once, so the refit sees the same column the screen scored.

**2. `.hzr_candidate_coef_name()` discarded the answer it had found.** When the guessed name is absent from `coef()`, it greps for the expansion and errors if there is more than one — then `return(target)` regardless, throwing away a single match:

```r
      if (length(expanded) > 1L) {
        stop(...)
      }
    }
    return(target)          # <- the one match found above is dropped
```

**This is not logical-specific.** `model.matrix()` renames any single-column expansion — a logical becomes `varTRUE`, a two-level factor `varb` — so a two-level factor was broken the same way and is fixed with it. A candidate expanding to more than one column is still refused, unchanged.

## The test asserts the claim, not the absence of an error

That a screen "runs" is the weak version. What is actually being claimed is that a logical column *is* its numeric twin, so the test compares two runs on identical data differing only in that column's type:

- same variables entered, in the same order (`steps$variable`, `steps$action`)
- on the same evidence (`steps$p_value`, tolerance 1e-6)
- and the same fit underneath (`coef()`, tolerance 1e-6) — names differ by design, so values are compared

It also asserts the logical column **actually enters** (`expect_true("mal" %in% steps$variable)`). Without that, two screens that both ignored it would agree, and the comparison would pass while proving nothing.

**Mutation-tested per half**, since one fix could mask the other:

| Mutant | Result |
|---|---|
| restore the numeric-only score guard | FAIL 1 — the `score` test only |
| discard the single expansion again | FAIL 1 — the `wald` test only |

Each kills its own criterion's test and not the other's.

## Version

Patch bump to **1.2.3**, `v1.2.2` being tagged; `NEWS.md` heading kept in sync by hand, since nothing in this repo greps for it. Minor/major untouched.

## Gate

`document()` clean (no `man/` churn — `@noRd` internals) · `lintr::lint_package()` **0** · `devtools::spell_check()` clean (`modelled` added to `inst/WORDLIST`, matching the existing `behaviour`/`recognise`) · `devtools::test()` **0 FAIL / 6 SKIP / 3214 PASS**

The suite was re-run after `document()` was fixed — an earlier `document()` failure meant the first run executed against a tree whose `man/`/`NAMESPACE` had not been regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)