### PR TITLE
fix(sas-parity): identify the nomogram counter structurally, not by name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.5
+Version: 1.2.6
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
 BugReports: https://github.com/ehrlinger/temporal_hazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# TemporalHazard 1.2.6
+
+## Bug fixes
+
+* `.hzr_parse_sas_nomogram()` no longer discards a nomogram whose PROC PRINT
+  counter column is labelled `OBS` rather than `Obs` (#184). The counter was
+  dropped by exact name, so on the other casing it stayed among the header
+  names, the row-width guard rejected every data row, and the parser returned
+  `NULL` -- indistinguishable from a listing that printed no nomogram at all.
+  A corpus sweep therefore reported its own parse failures as gaps in the SAS
+  output. The counter is now identified structurally, as a leading column
+  running exactly `1..n`, so any label parses.
+
+* `.hzr_parse_sas_nomogram()` now warns rather than returning `NULL` in
+  silence when a nomogram header matched but no data rows could be read.
+  `NULL` again means "no such table", and only that.
+
 # TemporalHazard 1.2.5
 
 ## New features

--- a/inst/sas-parity/helper-sas-parity.R
+++ b/inst/sas-parity/helper-sas-parity.R
@@ -626,7 +626,13 @@
   # below, instead of having to be known here.
   num_rx <- "^[-+]?([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][-+]?[0-9]+)?$"
   raw <- list()
-  for (ln in lines[(h[1] + 1L):length(lines)]) {
+  # Guard the scan range explicitly. A header on the final line makes
+  # (h[1] + 1L):length(lines) a DECREASING sequence, which walks off the end
+  # and then back over the header itself. That happens to reach the warning
+  # below -- nzchar(NA) is TRUE, and the width test short-circuits before the
+  # NA can reach all() -- but only by accident of evaluation order. Say it.
+  scan <- if (h[1] < length(lines)) lines[(h[1] + 1L):length(lines)] else character(0)
+  for (ln in scan) {
     if (!nzchar(trimws(ln))) next
     toks <- strsplit(trimws(ln), "[[:space:]]+")[[1]]
     if (!(length(toks) %in% c(length(cols), length(cols) + 1L)) ||

--- a/inst/sas-parity/helper-sas-parity.R
+++ b/inst/sas-parity/helper-sas-parity.R
@@ -609,36 +609,83 @@
   # header regex, the column names and the toks[2:9] slice made the parser
   # silently return NULL on the second layout.
   #
-  # Read the header instead: drop the leading "Obs" counter, strip the
-  # underscore prefixes SAS puts on computed variables, and take exactly that
-  # many values from each row. Any future column set parses without a change
-  # here -- the same header-driven approach .hzr_parse_sas_lifetable() uses.
+  # Read the header instead: strip the underscore prefixes SAS puts on
+  # computed variables and take exactly that many values from each row. Any
+  # future column set parses without a change here -- the same header-driven
+  # approach .hzr_parse_sas_lifetable() uses.
   h <- grep("\\bYEARS\\b.*_SURVIV", lines)
   if (!length(h)) return(NULL)
 
-  cols <- strsplit(trimws(lines[h[1]]), "[[:space:]]+")[[1]]
-  cols <- cols[cols != "Obs"]
-  cols <- sub("^_", "", cols)
+  cols <- sub("^_", "", strsplit(trimws(lines[h[1]]), "[[:space:]]+")[[1]])
   if (!length(cols)) return(NULL)
 
-  rows <- list()
+  # A data row is numeric all the way across and as wide as the header -- or
+  # one wider, on layouts where PROC PRINT emits the counter without naming it
+  # in the header. Deciding by width and content rather than "the first token
+  # is an integer" is what lets the counter be identified after the fact,
+  # below, instead of having to be known here.
+  num_rx <- "^[-+]?([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][-+]?[0-9]+)?$"
+  raw <- list()
   for (ln in lines[(h[1] + 1L):length(lines)]) {
     if (!nzchar(trimws(ln))) next
     toks <- strsplit(trimws(ln), "[[:space:]]+")[[1]]
-    # Data rows lead with the integer Obs counter.
-    if (!grepl("^[0-9]+$", toks[1])) {
-      if (length(rows)) break else next
+    if (!(length(toks) %in% c(length(cols), length(cols) + 1L)) ||
+        !all(toks == "." | grepl(num_rx, toks))) {
+      if (length(raw)) break else next
     }
-    if (length(toks) < length(cols) + 1L) next
-    # SAS prints a bare "." for a missing value. Normalise it to NA before
-    # coercing, the same way .hzr_parse_sas_lifetable() does -- otherwise
-    # as.numeric() emits a coercion warning per row and the NA arrives anyway.
-    vals <- toks[seq_along(cols) + 1L]
-    vals[vals == "."] <- NA
-    rows[[length(rows) + 1L]] <- as.numeric(vals)
+    raw[[length(raw) + 1L]] <- toks
   }
-  if (!length(rows)) return(NULL)
-  df <- as.data.frame(do.call(rbind, rows))
+
+  # NULL must mean "no such table". Reaching here with a matched header and no
+  # rows means the table IS present and this parser did not understand it --
+  # a defect, and one a caller cannot distinguish from absence unless it says
+  # so. Silence here is what made the OBS-vs-Obs bug (#184) read as "this job
+  # printed no nomogram" across a whole corpus sweep.
+  if (!length(raw)) {
+    warning("nomogram header found at line ", h[1],
+            " but no data rows parsed -- unrecognised layout: ",
+            trimws(lines[h[1]]), call. = FALSE)
+    return(NULL)
+  }
+
+  # Rows are ragged only if something other than the table crept in; take the
+  # first row's width as canonical and keep the rows that agree with it.
+  w <- length(raw[[1]])
+  raw <- raw[vapply(raw, length, integer(1)) == w]
+
+  # SAS prints a bare "." for a missing value. Normalise it to NA before
+  # coercing, the same way .hzr_parse_sas_lifetable() does -- otherwise
+  # as.numeric() emits a coercion warning per row and the NA arrives anyway.
+  m <- do.call(rbind, lapply(raw, function(v) {
+    v[v == "."] <- NA
+    as.numeric(v)
+  }))
+
+  # Drop PROC PRINT's observation counter.
+  #
+  # Its LABEL is not stable across the corpus -- one listing prints "Obs",
+  # another "OBS" -- so dropping it by name left the counter in `cols` on the
+  # second, which made the row-width guard reject every row and the parser
+  # return NULL as though the table were absent (#184). Identify it
+  # structurally instead: the counter is a leading column running exactly
+  # 1..n. No measurement column here is a gapless 1-based integer run --
+  # YEARS goes 0.0821, 0.25, 0.5, 1 and MONTHS goes 0.986, 3, 6 -- and when
+  # the counter is suppressed the leading column is a time in years, so the
+  # test does not fire at all. Whatever SAS calls it next parses unchanged.
+  if (w == length(cols) + 1L) {
+    m <- m[, -1L, drop = FALSE]            # counter emitted but not in header
+  } else if (identical(m[, 1L], as.numeric(seq_len(nrow(m))))) {
+    m <- m[, -1L, drop = FALSE]            # counter named in the header
+    cols <- cols[-1L]
+  }
+
+  if (ncol(m) != length(cols)) {
+    warning("nomogram at line ", h[1], " has ", ncol(m),
+            " data columns against ", length(cols), " header names",
+            call. = FALSE)
+    return(NULL)
+  }
+  df <- as.data.frame(m)
   names(df) <- cols
   df
 }

--- a/tests/testthat/test-lst-parser-layouts.R
+++ b/tests/testthat/test-lst-parser-layouts.R
@@ -175,6 +175,23 @@ test_that("an unparseable table warns instead of returning NULL in silence", {
   expect_null(res)
 })
 
+test_that("a header on the final line warns rather than erroring", {
+  # (h + 1):length(lines) is a DECREASING sequence when the header is last,
+  # which would walk off the end of the file. The scan range is guarded, so
+  # this lands on the same "no data rows parsed" warning as any other
+  # unreadable table -- not an error, and not a silent NULL.
+  for (tail_line in list(character(0), "")) {
+    tmp <- withr::local_tempfile(fileext = ".lst")
+    writeLines(c(
+      "preamble",
+      "     Obs     YEARS     _SURVIV   _CLLSURV   _CLUSURV   _HAZARD   _CLLHAZ   _CLUHAZ",
+      tail_line
+    ), tmp)
+    expect_warning(res <- .hzr_parse_sas_nomogram(tmp), "no data rows parsed")
+    expect_null(res)
+  }
+})
+
 test_that("the nomogram parser still returns NULL when no table is present", {
   tmp <- withr::local_tempfile(fileext = ".lst")
   writeLines(c("nothing here", "no nomogram at all"), tmp)

--- a/tests/testthat/test-lst-parser-layouts.R
+++ b/tests/testthat/test-lst-parser-layouts.R
@@ -91,6 +91,90 @@ test_that("SAS missing markers become NA without a coercion warning", {
   expect_equal(nom$CLUSURV[2], 0.95062, tolerance = 1e-6)
 })
 
+test_that("the nomogram parses when the counter column is labelled OBS", {
+  # #184. SAS's casing for PROC PRINT's counter is not stable across the
+  # corpus. Dropping it with cols[cols != "Obs"] left "OBS" in the header
+  # names, which made the row-width guard reject every data row -- so the
+  # parser returned NULL as though the job had printed no nomogram at all.
+  tmp <- withr::local_tempfile(fileext = ".lst")
+  writeLines(c(
+    "        OBS    MONTHS     YEARS     _SURVIV   _CLLSURV   _CLUSURV   _HAZARD   _CLLHAZ   _CLUHAZ",
+    "",
+    "          1     0.986    0.0821     0.99983    0.99961    0.99993   0.00208   0.00091   0.00477",
+    "",
+    "          2     3.000    0.2500     0.99946    0.99879    0.99976   0.00238   0.00112   0.00504",
+    ""
+  ), tmp)
+  nom <- .hzr_parse_sas_nomogram(tmp)
+  expect_s3_class(nom, "data.frame")
+  expect_equal(nrow(nom), 2L)
+  expect_equal(names(nom),
+               c("MONTHS", "YEARS", "SURVIV", "CLLSURV", "CLUSURV",
+                 "HAZARD", "CLLHAZ", "CLUHAZ"))
+  # The counter must be gone, not shifted into the first data column.
+  expect_false("OBS" %in% names(nom))
+  expect_equal(nom$MONTHS[1], 0.986, tolerance = 1e-6)
+  expect_equal(nom$YEARS[2], 0.2500, tolerance = 1e-6)
+  expect_equal(nom$CLUHAZ[2], 0.00504, tolerance = 1e-6)
+})
+
+test_that("the counter is found structurally, whatever SAS calls it", {
+  # The fix must not trade one hardcoded label for two. Any label works
+  # because the counter is identified as a leading 1..n run, not by name.
+  for (label in c("Obs", "OBS", "Observation", "#")) {
+    tmp <- withr::local_tempfile(fileext = ".lst")
+    writeLines(c(
+      paste0("        ", label,
+             "     YEARS     _SURVIV   _CLLSURV   _CLUSURV   _HAZARD   _CLLHAZ   _CLUHAZ"),
+      "",
+      "          1    0.0821     0.97106    0.96812    0.97373   0.24456   0.22241   0.26891",
+      "          2    0.2500     0.94683    0.94276    0.95062   0.09424   0.08597   0.10332",
+      ""
+    ), tmp)
+    nom <- .hzr_parse_sas_nomogram(tmp)
+    expect_equal(names(nom),
+                 c("YEARS", "SURVIV", "CLLSURV", "CLUSURV",
+                   "HAZARD", "CLLHAZ", "CLUHAZ"),
+                 info = label)
+    expect_equal(nom$YEARS[1], 0.0821, tolerance = 1e-6, info = label)
+  }
+})
+
+test_that("a leading measurement column is not mistaken for the counter", {
+  # The structural test must fire on a 1..n run and nothing else. Here the
+  # counter is suppressed and YEARS leads; dropping it would silently shift
+  # every column left and corrupt the whole table.
+  tmp <- withr::local_tempfile(fileext = ".lst")
+  writeLines(c(
+    "           YEARS     _SURVIV   _CLLSURV   _CLUSURV   _HAZARD   _CLLHAZ   _CLUHAZ",
+    "",
+    "          0.0821     0.97106    0.96812    0.97373   0.24456   0.22241   0.26891",
+    "          0.2500     0.94683    0.94276    0.95062   0.09424   0.08597   0.10332",
+    ""
+  ), tmp)
+  nom <- .hzr_parse_sas_nomogram(tmp)
+  expect_equal(names(nom),
+               c("YEARS", "SURVIV", "CLLSURV", "CLUSURV",
+                 "HAZARD", "CLLHAZ", "CLUHAZ"))
+  expect_equal(nom$YEARS, c(0.0821, 0.2500), tolerance = 1e-6)
+  expect_equal(nom$SURVIV, c(0.97106, 0.94683), tolerance = 1e-6)
+})
+
+test_that("an unparseable table warns instead of returning NULL in silence", {
+  # #184's real damage was the silence: a caller cannot tell "no table" from
+  # "table I failed to read", so a sweep reports its own parse failures as
+  # properties of the SAS corpus. Once a header has matched, NULL must talk.
+  tmp <- withr::local_tempfile(fileext = ".lst")
+  writeLines(c(
+    "        Obs     YEARS     _SURVIV   _CLLSURV   _CLUSURV   _HAZARD   _CLLHAZ   _CLUHAZ",
+    "",
+    "          1     0.0821    not-a-number   0.96812   0.97373   0.24456   0.22241   0.26891",
+    ""
+  ), tmp)
+  expect_warning(res <- .hzr_parse_sas_nomogram(tmp), "no data rows parsed")
+  expect_null(res)
+})
+
 test_that("the nomogram parser still returns NULL when no table is present", {
   tmp <- withr::local_tempfile(fileext = ".lst")
   writeLines(c("nothing here", "no nomogram at all"), tmp)


### PR DESCRIPTION
Closes #184.

## The bug

`.hzr_parse_sas_nomogram()` dropped PROC PRINT's observation counter **by name**:

```r
cols <- cols[cols != "Obs"]
```

SAS's casing for that label is not stable across the corpus. On a listing printing `OBS`, the counter stayed among the header names, `length(cols)` was one too large, and the row-width guard then rejected every data row. The function returned `NULL`.

## Why the silence was the real defect

`NULL` was indistinguishable from a listing that never printed a nomogram. A caller cannot tell "no table here" from "table here, not parsed", so a corpus sweep reports its own parse failures as gaps in the SAS output — attributing a defect in this package to the twenty-year-old SAS corpus it is being validated against.

Same failure *class* as #183, wider blast radius: #183 loses tables 2..n, this loses the table entirely.

## The fix

**1. Structural counter detection.** The counter is a leading column running exactly `1..n`. No measurement column in this table is a gapless 1-based integer run — `YEARS` goes `0.0821, 0.25, 0.5, 1`, `MONTHS` goes `0.986, 3, 6` — and when the counter is suppressed the leading column is a time in years, so the test does not fire at all. Whatever SAS calls it next parses without a change here.

Row detection changed to match: a data row is numeric all the way across and as wide as the header (or one wider, where the counter is emitted but unlabelled). Deciding by width and content rather than "the first token is an integer" is what lets the counter be identified *after* the rows are read instead of having to be known before.

**2. `NULL` now talks.** Once a `YEARS ... _SURVIV` header has matched, failing to read rows warns. `NULL` again means "no such table", and only that.

## Verification

Full suite: **2,473 pass, 0 fail, 0 error**, 134 skipped.

Five new tests in `test-lst-parser-layouts.R`, following that file's synthetic-fixture convention:

- a nomogram whose counter is labelled `OBS` parses, counter dropped rather than shifted into the first data column
- the counter is found whatever it is called (`Obs`, `OBS`, `Observation`, `#`) — so the fix does not trade one hardcoded label for two
- a **leading measurement column is not mistaken for the counter** when the counter is suppressed, which is the failure mode the structural rule could plausibly introduce
- an unparseable table warns instead of returning `NULL` in silence
- existing behaviour preserved: no header still returns `NULL`, quietly

Against two production listings outside this repo (not included — public repo): a 23-row nomogram that returned `NULL` on `main` now parses in full, and both fits reproduce SAS's printed survival and hazard at **23/23 points each**, evaluated at SAS's own converged estimates with cohort gates matching the printed blocks.

One of those two turns out to be a **Late-only** fit — Λ(t) = μL·G3(t), with no Early phase — which makes it a pure `hzr_decompos_g3()` oracle. Together with the other (all four of `TAU`/`GAMMA`/`ALPHA`/`ETA` free), this takes `hzr_decompos_g3` from being pinned at a single point of its parameter space to being pinned across all four dimensions.

Worth noting: fixing the silence immediately surfaced a latent crash in the downstream sweep harness, which had assumed every fit has an Early phase. While the parser returned `NULL` that harness reported a tidy "no nomogram in this fit" and moved on. Silence upstream was manufacturing a false all-clear downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
