### PR TITLE
chore: repoint temporal_hazard references at TemporalHazard

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -132,8 +132,8 @@ jobs:
           # the runner's checkout. A sed that matches nothing exits 0, and the
           # failure would surface two steps later as "path not found" drift --
           # a true failure with a misleading cause. Check first and say so.
-          if ! grep -qF 'path: ~/Documents/GitHub/temporal_hazard' .house-style-tools/repos.yml; then
-            echo "::error::repos.yml no longer contains 'path: ~/Documents/GitHub/temporal_hazard'. The registry format or this repo's entry changed upstream; update this workflow rather than trusting the check." >&2
+          if ! grep -qF 'path: ~/Documents/GitHub/TemporalHazard' .house-style-tools/repos.yml; then
+            echo "::error::repos.yml no longer contains 'path: ~/Documents/GitHub/TemporalHazard'. The registry format or this repo's entry changed upstream; update this workflow rather than trusting the check." >&2
             exit 1
           fi
           # & means "the whole match" to sed, and \ and the | delimiter are
@@ -144,7 +144,7 @@ jobs:
           # know that -- and keeps this correct on a self-hosted runner whose
           # workspace root is not so constrained.
           workspace=$(printf '%s' "$GITHUB_WORKSPACE" | sed 's/[&|\\]/\\&/g')
-          sed -i "s|path: ~/Documents/GitHub/temporal_hazard|path: $workspace|" \
+          sed -i "s|path: ~/Documents/GitHub/TemporalHazard|path: $workspace|" \
             .house-style-tools/repos.yml
 
       - name: Verify the house style artifact is current

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
 Version: 1.2.6
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
-URL: https://ehrlinger.github.io/temporal_hazard/, https://github.com/ehrlinger/temporal_hazard
-BugReports: https://github.com/ehrlinger/temporal_hazard/issues
+URL: https://ehrlinger.github.io/TemporalHazard/, https://github.com/ehrlinger/TemporalHazard
+BugReports: https://github.com/ehrlinger/TemporalHazard/issues
 Description: Provides native R implementations of the multiphase parametric
     hazard model of Blackstone, Naftel, and Turner (1986)
     <doi:10.1080/01621459.1986.10478314> with a focus on behavioral parity,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://ehrlinger.github.io/temporal_hazard/
+url: https://ehrlinger.github.io/TemporalHazard/
 title: TemporalHazard
 description: Pure-R implementation of the HAZARD model with transparency and parity validation
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -4,7 +4,7 @@ bibentry(
   author   = person("John", "Ehrlinger"),
   year     = "2026",
   note     = paste("R package version", meta$Version),
-  url      = "https://ehrlinger.github.io/temporal_hazard/"
+  url      = "https://ehrlinger.github.io/TemporalHazard/"
 )
 
 bibentry(

--- a/man/TemporalHazard-package.Rd
+++ b/man/TemporalHazard-package.Rd
@@ -121,9 +121,9 @@ nonlinear temporal decomposition mixed effects model. \emph{Stat Methods Med Res
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://ehrlinger.github.io/temporal_hazard/}
-  \item \url{https://github.com/ehrlinger/temporal_hazard}
-  \item Report bugs at \url{https://github.com/ehrlinger/temporal_hazard/issues}
+  \item \url{https://ehrlinger.github.io/TemporalHazard/}
+  \item \url{https://github.com/ehrlinger/TemporalHazard}
+  \item Report bugs at \url{https://github.com/ehrlinger/TemporalHazard/issues}
 }
 
 }


### PR DESCRIPTION
Wave 2 of the HVTI naming convention. Repo renamed `temporal_hazard` → `TemporalHazard`; the package name was already `TemporalHazard`, so **no namespace changes** and no `library()` call moves.

| file | change |
|---|---|
| `DESCRIPTION` | `URL:` and `BugReports:` |
| `_pkgdown.yml` | canonical site `url:` |
| `inst/CITATION` | the cited site URL |
| `.github/workflows/lint.yaml` | the `repos.yml` path guard |

Depends on ehrlinger/house-style#20 (merged), which repointed the registry.

## Deliberately not changed

`R/parity-helpers.R` matches the old string three times, and all three are **left alone**:

- `options(temporal_hazard.binary = ...)`
- `options(temporal_hazard.hazpred_binary = ...)`
- the `TEMPORAL_HAZARD_BIN` environment variable

These are user-facing API, not references to the repository. Renaming them would break any caller setting the option, and that is a breaking change with its own version decision — not something a repo rename should smuggle in.

## Note

GitHub redirects the old repo URL indefinitely, so existing remotes and `pak::pak("ehrlinger/temporal_hazard")` keep resolving. GitHub Pages does **not** redirect, so the old pkgdown URL will 404 once the site rebuilds at the new path — same behaviour observed in Wave 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)