### PR TITLE
docs: remove the obsolete directory note, fix the codemap command

### DIFF
--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -13,7 +13,7 @@
     writing-voice.md               sha256:15e75ca9cb97
     writing-reader-profile.md      sha256:5131ade189c9
     writing-context.md             sha256:51f197dc0c97
-    r-package-structure.md         sha256:5729e9210a1f
+    r-package-structure.md         sha256:c1758211012e
 -->
 
 # House Style — TemporalHazard
@@ -350,8 +350,8 @@ Where the thing behind a badge exists, the badge is required: what is missing
 is more often the badge than the machinery. A check running green that the
 README never mentions is signal nobody can see, which is its own small version
 of the staleness problem — the check works, and the reader has no way to know.
-Two of the six need no machinery at all: repostatus is a static shield, and the
-version badge just reads `DESCRIPTION`, so neither has an excuse.
+Some need no machinery at all: repostatus is a static shield, and the version
+badge just reads `DESCRIPTION`, so neither has an excuse.
 
 Where a badge is genuinely missing because the underlying thing is missing,
 the fix is to add the workflow, not to drop the badge.
@@ -372,9 +372,9 @@ between the released version and the development one is worth seeing.
 DOI appears only where a Zenodo deposit exists; lifecycle only where the
 package makes a stability claim it means.
 
-Because five of the six required badges report on a workflow, this rule and
-the CI standard have to move together. Requiring the codecov, pkgdown, and
-lint badges is the same as requiring those three workflows.
+Because most of the required badges report on a workflow, this rule and the CI
+standard have to move together. Requiring the codecov, pkgdown, and lint
+badges is the same as requiring those three workflows.
 
 The hand-rolled dynamic-regex version badge currently living in
 hvtiRutilities is replaced by the standard GitHub r-package badge — it's

--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -13,7 +13,7 @@
     writing-voice.md               sha256:15e75ca9cb97
     writing-reader-profile.md      sha256:5131ade189c9
     writing-context.md             sha256:51f197dc0c97
-    r-package-structure.md         sha256:532534260e0f
+    r-package-structure.md         sha256:5729e9210a1f
 -->
 
 # House Style — TemporalHazard
@@ -346,17 +346,15 @@ Six are required of every package, in this order:
 5. **GitHub r-package version**
 6. **lint**
 
-These are required because they're already true. Every governed package runs
-the lint, pkgdown, and test-coverage workflows today; what's missing is
-sometimes the badge, not the machinery. A workflow running green that the README
-never mentions is coverage nobody can see, which is its own small version of
-the staleness problem — the check works, and the reader has no way to know.
-repostatus is a static shield with no infrastructure behind it at all, and the
+Where the thing behind a badge exists, the badge is required: what is missing
+is more often the badge than the machinery. A check running green that the
+README never mentions is signal nobody can see, which is its own small version
+of the staleness problem — the check works, and the reader has no way to know.
+Two of the six need no machinery at all: repostatus is a static shield, and the
 version badge just reads `DESCRIPTION`, so neither has an excuse.
 
 Where a badge is genuinely missing because the underlying thing is missing,
-the fix is to add the workflow, not to drop the badge. No governed repo is in
-that position today; every one carries lint, pkgdown and test-coverage.
+the fix is to add the workflow, not to drop the badge.
 
 **Required for the `package-cran` profile**, after the six:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,6 @@ recompose reverts you. Edit the sources under `~/Documents/ObsidianVault/memory/
 Rscript ~/Documents/GitHub/house-style/compose-house-style.R --repo TemporalHazard
 ```
 
-Note the registry name is `TemporalHazard` while the directory is `temporal_hazard`.
-
 ## Rules for this repo
 
 - **Censoring status is coded `-1` left, `0` right, `1` event, `2` interval.** `survival::Surv()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ affordances live here.
 
 `AGENTS.md` says to orient on the public API surface before editing. In Claude Code the way to
 do that is the codemap: it lives in the Obsidian vault under `Claude/repomaps/` and is read via
-the `read-codemap` skill (`/codemap temporal_hazard`). If the codemap looks stale, say so and
+the `read-codemap` skill (`/codemap TemporalHazard`). If the codemap looks stale, say so and
 offer to refresh it (`/regenerate-codemap`) rather than working from a guess.
 
 ## Prose


### PR DESCRIPTION
Wave 4 documentation pass.

## The directory note is obsolete

`AGENTS.md` said:

> Note the registry name is `TemporalHazard` while the directory is `temporal_hazard`.

Wave 2 renamed both the repository and the local clone directory to `TemporalHazard`. They agree now, so this is a deletion rather than a rename.

## The codemap command

`CLAUDE.md` documented `/codemap temporal_hazard`. The vault's repomaps are keyed by repository name, so the map was renamed there first (`temporal_hazard.md` → `TemporalHazard.md`) and the command updated to match — otherwise the new command would have missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)