### PR TITLE
chore: anchor the registry path guard to end-of-line

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -132,7 +132,7 @@ jobs:
           # the runner's checkout. A sed that matches nothing exits 0, and the
           # failure would surface two steps later as "path not found" drift --
           # a true failure with a misleading cause. Check first and say so.
-          if ! grep -qF 'path: ~/Documents/GitHub/TemporalHazard' .house-style-tools/repos.yml; then
+          if ! grep -qE 'path: ~/Documents/GitHub/TemporalHazard$' .house-style-tools/repos.yml; then
             echo "::error::repos.yml no longer contains 'path: ~/Documents/GitHub/TemporalHazard'. The registry format or this repo's entry changed upstream; update this workflow rather than trusting the check." >&2
             exit 1
           fi
@@ -144,7 +144,7 @@ jobs:
           # know that -- and keeps this correct on a self-hosted runner whose
           # workspace root is not so constrained.
           workspace=$(printf '%s' "$GITHUB_WORKSPACE" | sed 's/[&|\\]/\\&/g')
-          sed -i "s|path: ~/Documents/GitHub/TemporalHazard|path: $workspace|" \
+          sed -i "s|path: ~/Documents/GitHub/TemporalHazard$|path: $workspace|" \
             .house-style-tools/repos.yml
 
       - name: Verify the house style artifact is current


### PR DESCRIPTION
Anchors this repo's `repos.yml` path guard to end-of-line.

## Why

The guard matched an **unanchored fixed string**:

```
grep -qF 'path: ~/Documents/GitHub/<name>'
sed -i "s|path: ~/Documents/GitHub/<name>|path: \$workspace|"
```

That is correct for any repo whose name is not a prefix of another — which was every repo until `hvtiR` joined governance. `hvtiR` **is** a prefix of `hvtiRtables`, `hvtiRutilities`, `hvtiRdatabuild` and `hvtiRtemplates`, so unanchored its `sed` rewrites all four of their registry paths (`…/hvtiRutilities` → `<workspace>utilities`) and the check then verifies the wrong tree.

The naming convention makes such collisions **more** likely, not less: `hvtiR<domain>` guarantees every package name shares a prefix with the umbrella.

## Verified, not assumed

Every repo's anchored guard was simulated against the real `repos.yml`: exactly **one** path rewritten, **zero** siblings mangled, for all 13 governed repos.

No behaviour change for this repo today — this closes a latent hazard before another `hvtiR*` repo appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)