### PR TITLE
chore: recompose the house style artifact (wording clarification)

### DIFF
--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -13,7 +13,7 @@
     writing-voice.md               sha256:15e75ca9cb97
     writing-reader-profile.md      sha256:5131ade189c9
     writing-context.md             sha256:51f197dc0c97
-    r-package-structure.md         sha256:81d181998e89
+    r-package-structure.md         sha256:d1dbeb83c1e7
 -->
 
 # House Style — TemporalHazard
@@ -487,11 +487,17 @@ keeps this rule honest rather than aspirational.
 
 ## Development records
 
-Design documents and implementation plans are tracked in `dev/specs/`, one
-directory per repository, with the whole `dev/` tree carried by a single
-`^dev$` line in `.Rbuildignore`. They are tracked rather than ignored because
-the record of why a thing was built the way it was outlives the diff that built
-it, and it is worth more to the next reader.
+Design documents and implementation plans live in `dev/specs/` — one directory,
+where the convention this replaced used a `specs/` and `specs/plans/` pair. That
+is all "one directory" claims: it says nothing about nesting, since
+`dev/specs/artifacts/` sits below it, and there is no per-repository
+subdirectory.
+
+They are committed to git rather than gitignored, because the record of why a
+thing was built the way it was outlives the diff that built it, and is worth
+more to the next reader. A single `^dev$` line in `.Rbuildignore` then keeps the
+whole tree out of the built package — out of the tarball, not out of the
+repository.
 
 A file is named `<YYYY-MM-DD>-<slug>-<kind>.md`. The kind carries the
 design/plan distinction, and the path does not: a design and the plan

--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -13,7 +13,7 @@
     writing-voice.md               sha256:15e75ca9cb97
     writing-reader-profile.md      sha256:5131ade189c9
     writing-context.md             sha256:51f197dc0c97
-    r-package-structure.md         sha256:d1dbeb83c1e7
+    r-package-structure.md         sha256:c43a528bedf9
 -->
 
 # House Style — TemporalHazard
@@ -487,17 +487,17 @@ keeps this rule honest rather than aspirational.
 
 ## Development records
 
-Design documents and implementation plans live in `dev/specs/` — one directory,
-where the convention this replaced used a `specs/` and `specs/plans/` pair. That
-is all "one directory" claims: it says nothing about nesting, since
-`dev/specs/artifacts/` sits below it, and there is no per-repository
-subdirectory.
+Design documents and implementation plans live in `dev/specs/`. That is one
+directory; the convention it replaced used two, a `specs/` directory paired with
+a `specs/plans/` subdirectory beneath it. Only the count is being claimed. There
+is no per-repository subdirectory, and nesting below `dev/specs/` is expected
+rather than forbidden — `dev/specs/artifacts/` is required further down.
 
-They are committed to git rather than gitignored, because the record of why a
-thing was built the way it was outlives the diff that built it, and is worth
-more to the next reader. A single `^dev$` line in `.Rbuildignore` then keeps the
-whole tree out of the built package — out of the tarball, not out of the
-repository.
+These files are committed to the repository, and nothing in `.gitignore` covers
+them: the record of why a thing was built the way it was outlives the diff that
+built it. Separately, a single `^dev$` line in `.Rbuildignore` keeps the tree out
+of the built package. The two mechanisms are unrelated — one decides what the
+repository stores, the other what the tarball ships.
 
 A file is named `<YYYY-MM-DD>-<slug>-<kind>.md`. The kind carries the
 design/plan distinction, and the path does not: a design and the plan


### PR DESCRIPTION
Recomposes `.claude/house-style.md` against `house-style-v1`, now at [`64c9e23`](https://github.com/ehrlinger/house-style/commit/64c9e23) and archived immutably as `standard-2026-08-28-2` (ehrlinger/house-style#28).

**Wording only — the rule is unchanged** from `standard-2026-08-28`.

## What changed

Copilot raised two ambiguities against the *generated* artifact in ehrlinger/hvtiRbootstrap#14 and ehrlinger/hvtiRlifetables#14, and correctly said the fix belonged in the upstream sources rather than in the recomposed copy.

**1. `"tracked rather than ignored"`** sat one sentence after `.Rbuildignore`, using "ignore" in two senses in adjacent sentences — excluded from the built package, then not gitignored. The paragraph now separates them and says which is which, ending *"out of the tarball, not out of the repository."*

**2. `"one directory per repository"`** was read as `dev/specs/<repo>/`, which would put artifacts at `dev/specs/<repo>/artifacts/`. That reading is wrong — there is no per-repository subdirectory — but two reviewers reached it, and the phrase sits four paragraphs above a rule *requiring* a nested `artifacts/`. It now names what it contrasts against (the `specs/` + `specs/plans/` pair it replaced) and says outright that it is not a claim about nesting.

## Verification

`Rscript compose-house-style.R --check --all` reports **13 OK, 0 drift**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)