### PR TITLE
feat(diagnostics): name the parameters when a fit sits on a likelihood ridge

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.6
+Version: 1.2.7
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/TemporalHazard/, https://github.com/ehrlinger/TemporalHazard
 BugReports: https://github.com/ehrlinger/TemporalHazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,37 @@
+# TemporalHazard 1.2.7
+
+## New features
+
+* **A fit sitting on a likelihood ridge now says so, and names the
+  parameters.** An ill-conditioned Hessian already warned that standard
+  errors were unreliable. That understates the problem when the
+  ill-conditioning is a ridge: the likelihood is near-flat along some
+  combination of parameters, and there the individual *point estimates* are
+  not determined by the data either -- only the combination is. The fit still
+  reports `converged`, and the coefficient table still prints a number for
+  every parameter, so nothing on the object signalled it.
+
+  `hazard()` now warns, once per fit, naming the parameters that span the flat
+  direction along with their correlation and the Hessian's `rcond`, and
+  `summary()` prints the same note. The finding is recorded on the object as
+  `fit$weak` (`NULL` when the fit is well identified), so it can be checked
+  programmatically rather than scraped from a warning.
+
+  The direction is read off the *correlation* of the estimates rather than
+  their raw covariance. Parameters here sit on very different scales -- an `m`
+  of 27 against a `nu` of 0.027 -- and in raw units a direction that moves
+  both equally in statistical terms loads almost entirely on the larger one,
+  which would report a two-parameter ridge as a single unidentified parameter.
+  A parameter that is merely imprecise, without trading off against another,
+  is deliberately not reported: that is ordinary low precision, and the
+  existing `rcond` warning and the parameter's own standard error already
+  cover it.
+
+  The check is generic -- it runs for every distribution and knows nothing
+  about phase shapes -- and is gated on the `rcond` threshold the package
+  already uses, so it never fires where the ill-conditioning warning stays
+  silent.
+
 # TemporalHazard 1.2.6
 
 ## Bug fixes

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -772,8 +772,20 @@ hazard <- function(formula = NULL,
   # looking coefficient table gives no sign of it. Name the parameters
   # involved instead of leaving them to be read as estimated quantities.
   # Runs for every distribution -- nothing here knows about phase shapes.
+  # optim() hands back an unnamed `par` for the single-distribution fits, so
+  # taking names() alone would label the warning "par1"/"par2" while
+  # summary() prints the real parameter names against the same numbers, and
+  # the reader cannot map one onto the other. Fall back to the same source
+  # summary() uses, so the two cannot disagree.
+  weak_names <- names(fit_state$par)
+  if (is.null(weak_names) && !is.null(fit_state$par)) {
+    weak_names <- .hzr_parameter_names(
+      theta = fit_state$par, dist = dist,
+      p = if (is.null(x_fit)) 0L else ncol(x_fit)
+    )
+  }
   fit_state$weak <- .hzr_weak_direction(fit_state$vcov, fit_state$rcond,
-                                        names(fit_state$par))
+                                        weak_names)
   if (!is.null(fit_state$weak)) {
     warning(.hzr_weak_direction_message(fit_state$weak), call. = FALSE)
   }

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -383,7 +383,11 @@ NULL
 #'   the \code{best} and so the reported fit, and the \code{message} of any
 #'   error. A start that stops at \code{maxit} has a finite \code{objective}
 #'   and can win the selection, so \code{status} distinguishes it from one
-#'   that converged),
+#'   that converged. Any fit whose likelihood is near-flat along a parameter
+#'   combination also carries \code{weak}, listing the \code{params}
+#'   spanning that direction, their squared loadings (\code{weights}), the
+#'   strongest pairwise \code{correlation} among them, and the Hessian
+#'   \code{rcond} -- \code{NULL} when the fit is well identified),
 #'   and \code{engine} (implementation tag, \code{"native-r-m2"}).
 #' @export
 hazard <- function(formula = NULL,
@@ -759,6 +763,19 @@ hazard <- function(formula = NULL,
     fit_state$pd <- optim_result$pd
     fit_state$counts <- optim_result$counts
     fit_state$message <- optim_result$message
+  }
+
+  # An ill-conditioned Hessian already warns that standard errors are
+  # unreliable. That understates a ridge: where the likelihood is near-flat
+  # along a parameter combination, the point estimates along it are not
+  # determined either, and a fit that reports converged with an ordinary-
+  # looking coefficient table gives no sign of it. Name the parameters
+  # involved instead of leaving them to be read as estimated quantities.
+  # Runs for every distribution -- nothing here knows about phase shapes.
+  fit_state$weak <- .hzr_weak_direction(fit_state$vcov, fit_state$rcond,
+                                        names(fit_state$par))
+  if (!is.null(fit_state$weak)) {
+    warning(.hzr_weak_direction_message(fit_state$weak), call. = FALSE)
   }
 
   # Refit-based tooling (hzr_bootstrap()) re-evaluates $call, so it needs the
@@ -1479,6 +1496,7 @@ summary.hazard <- function(object, ...) {
     has_vcov = !is.null(vcov_mat) && is.matrix(vcov_mat),
     rcond = object$fit$rcond,
     pd = object$fit$pd,
+    weak = object$fit$weak,
     phases = object$spec$phases
   )
 
@@ -1536,6 +1554,14 @@ print.summary.hazard <- function(x, ...) {
     cat("  Note: Hessian ill-conditioned (rcond = ",
         format(x$rcond, digits = 3),
         "); standard errors may be unreliable.\n", sep = "")
+  }
+  if (!is.null(x$weak)) {
+    # Wrapped rather than cat()'d flat: the message names parameters and two
+    # diagnostics, and an unwrapped line buries them off the right edge.
+    cat(strwrap(paste0("Note: ", .hzr_weak_direction_message(x$weak)),
+                width = 76, indent = 2, exdent = 8),
+        sep = "\n")
+    cat("\n")
   }
   if (!is.null(x$pd) && !is.na(x$pd) && !isTRUE(x$pd)) {
     cat("  Note: Hessian not positive-definite at the optimum; ",

--- a/R/hessian-invert.R
+++ b/R/hessian-invert.R
@@ -74,3 +74,118 @@ NULL
 
   list(vcov = vcov, rcond = rc, pd = pd)
 }
+
+
+# Minimum |correlation| between two estimates before their trade-off counts as
+# a ridge rather than ordinary imprecision. Kept next to .hzr_rcond_tol so the
+# two thresholds that gate the weak-identification note stay together.
+.hzr_ridge_cor_tol <- 0.99
+
+#' Identify a ridge (weak-identification) direction in a fitted model
+#'
+#' An ill-conditioned Hessian makes standard errors unreliable.  When the
+#' ill-conditioning is a \emph{ridge} the point estimates are unreliable too:
+#' the likelihood is near-flat along some combination of parameters, so the
+#' data pin down only that combination and not the individual values.  This
+#' locates the flat direction and names the parameters spanning it.
+#'
+#' The direction is taken from the \emph{correlation} of the estimates, not
+#' from the raw covariance.  Parameters in this package sit on very different
+#' scales (an \code{m} of 27 against a \code{nu} of 0.027), and in raw units a
+#' direction that moves both equally in statistical terms loads almost
+#' entirely on the larger one -- reporting a two-parameter ridge as a single
+#' unidentified parameter.  Standardising first makes the loadings comparable.
+#'
+#' A single imprecise but uncorrelated parameter is deliberately \emph{not}
+#' reported: that is ordinary low precision, already covered by the
+#' ill-conditioning warning and by the parameter's own standard error.
+#'
+#' @param vcov Variance-covariance matrix of the estimates.  Rows/columns for
+#'   parameters that were not estimated (\code{NA} diagonals) are dropped.
+#' @param rcond Reciprocal condition number of the Hessian, as returned by
+#'   \code{.hzr_safe_solve()}.
+#' @param param_names Optional character vector of parameter names, the same
+#'   length as \code{nrow(vcov)}.  Positional labels are used when absent.
+#' @param tol Gate on \code{rcond}.  Defaults to the package-wide
+#'   ill-conditioning threshold so this never fires where the rcond warning
+#'   stays silent.
+#' @param cor_tol Minimum absolute correlation for a trade-off to count.
+#' @param share Cumulative squared-loading share used to decide how many
+#'   parameters span the flat direction.
+#' @return \code{NULL} when there is no ridge, otherwise a list with
+#'   \code{params} (names spanning the flat direction), \code{weights} (their
+#'   squared loadings), \code{correlation} (the strongest pairwise
+#'   correlation among them) and \code{rcond}.
+#' @noRd
+.hzr_weak_direction <- function(vcov, rcond, param_names = NULL,
+                                tol = .hzr_rcond_tol,
+                                cor_tol = .hzr_ridge_cor_tol,
+                                share = 0.9) {
+  # (1) Gate on the existing ill-conditioning threshold.
+  if (length(rcond) != 1L || is.na(rcond) || rcond >= tol) return(NULL)
+  if (is.null(vcov) || !is.matrix(vcov) || nrow(vcov) < 2L) return(NULL)
+
+  # (2) Drop parameters that were not estimated (fixed params carry NA rows).
+  d <- diag(vcov)
+  keep <- which(is.finite(d) & d > 0)
+  if (length(keep) < 2L) return(NULL)
+  V <- vcov[keep, keep, drop = FALSE]
+  if (anyNA(V) || any(!is.finite(V))) return(NULL)
+
+  nms <- if (length(param_names) == nrow(vcov)) {
+    as.character(param_names)[keep]
+  } else {
+    paste0("par", keep)
+  }
+
+  # (3) Standardise to a correlation matrix (see note above on scaling).
+  s <- sqrt(diag(V))
+  R <- V / outer(s, s)
+  if (anyNA(R) || any(!is.finite(R))) return(NULL)
+
+  # (4) The ridge is the high-variance direction of the standardised
+  #     estimates: the leading eigenvector of their correlation matrix.
+  e <- tryCatch(eigen(R, symmetric = TRUE), error = function(e) NULL)
+  if (is.null(e)) return(NULL)
+  w <- e$vectors[, which.max(e$values)]^2
+
+  ord <- order(w, decreasing = TRUE)
+  k <- which(cumsum(w[ord]) >= share)[1]
+  if (is.na(k)) k <- length(ord)
+  idx <- ord[seq_len(k)]
+  if (length(idx) < 2L) return(NULL)
+
+  # (5) Require a genuine trade-off. Without this an uncorrelated but
+  #     imprecise parameter set (correlation matrix near identity, where the
+  #     eigenvectors are arbitrary) would be reported as a ridge.
+  sub <- R[idx, idx, drop = FALSE]
+  off <- sub[upper.tri(sub)]
+  if (!length(off)) return(NULL)
+  r_max <- off[which.max(abs(off))]
+  if (abs(r_max) < cor_tol) return(NULL)
+
+  list(params = nms[idx], weights = w[idx],
+       correlation = r_max, rcond = rcond)
+}
+
+
+#' Warning text for a detected ridge direction
+#'
+#' Shared by the fit-time warning and the \code{summary()} note so the two
+#' never drift apart.
+#'
+#' @param weak A non-\code{NULL} result from \code{.hzr_weak_direction()}.
+#' @return A single string.
+#' @noRd
+.hzr_weak_direction_message <- function(weak) {
+  paste0(
+    "weakly identified fit: ",
+    paste0("'", weak$params, "'", collapse = " and "),
+    " are determined only in combination (correlation ",
+    format(weak$correlation, digits = 3),
+    ", Hessian rcond = ", format(weak$rcond, digits = 3),
+    "). The likelihood is near-flat along that direction, so their ",
+    "individual point estimates -- not just their standard errors -- are ",
+    "not pinned down by the data."
+  )
+}

--- a/R/hessian-invert.R
+++ b/R/hessian-invert.R
@@ -115,7 +115,10 @@ NULL
 #' @return \code{NULL} when there is no ridge, otherwise a list with
 #'   \code{params} (names spanning the flat direction), \code{weights} (their
 #'   squared loadings), \code{correlation} (the strongest pairwise
-#'   correlation among them) and \code{rcond}.
+#'   correlation among them) and \code{rcond}.  Directions are examined from
+#'   flattest to stiffest and the first one that is a genuine trade-off is
+#'   reported, so a ridge is still found when some larger block of
+#'   moderately correlated parameters carries more variance than it does.
 #' @noRd
 .hzr_weak_direction <- function(vcov, rcond, param_names = NULL,
                                 tol = .hzr_rcond_tol,
@@ -143,29 +146,49 @@ NULL
   R <- V / outer(s, s)
   if (anyNA(R) || any(!is.finite(R))) return(NULL)
 
-  # (4) The ridge is the high-variance direction of the standardised
-  #     estimates: the leading eigenvector of their correlation matrix.
+  # (4) Scan the standardised directions from flattest to stiffest, rather
+  #     than gating only the leading one. Taking just the top eigenvector
+  #     misses a real ridge whenever a larger *block* of moderately
+  #     correlated parameters outranks it: an equicorrelated block of k
+  #     parameters has eigenvalue 1 + (k - 1) * r, which passes a perfect
+  #     two-parameter ridge's ceiling of 2 as soon as r > 1 / (k - 1) --
+  #     0.50 at k = 3, 0.33 at k = 4. The block is the higher-variance
+  #     direction and is not a trade-off, so the gate below rejects it, and
+  #     the ridge underneath it was never looked at. Returning NULL there
+  #     reports "well identified" for a fit that is not, which is the exact
+  #     failure this function exists to prevent.
   e <- tryCatch(eigen(R, symmetric = TRUE), error = function(e) NULL)
   if (is.null(e)) return(NULL)
-  w <- e$vectors[, which.max(e$values)]^2
 
-  ord <- order(w, decreasing = TRUE)
-  k <- which(cumsum(w[ord]) >= share)[1]
-  if (is.na(k)) k <- length(ord)
-  idx <- ord[seq_len(k)]
-  if (length(idx) < 2L) return(NULL)
+  # eigen() returns values in decreasing order, so this walks flattest first
+  # and the first direction that is a genuine trade-off wins. No separate
+  # floor on the eigenvalue is needed to keep a stiff direction from being
+  # reported: clearing cor_tol requires a strongly correlated pair among the
+  # selected parameters, and such a pair always puts a high-variance
+  # direction earlier in this same scan, so the flat one is returned first.
+  for (j in seq_along(e$values)) {
+    w <- e$vectors[, j]^2
 
-  # (5) Require a genuine trade-off. Without this an uncorrelated but
-  #     imprecise parameter set (correlation matrix near identity, where the
-  #     eigenvectors are arbitrary) would be reported as a ridge.
-  sub <- R[idx, idx, drop = FALSE]
-  off <- sub[upper.tri(sub)]
-  if (!length(off)) return(NULL)
-  r_max <- off[which.max(abs(off))]
-  if (abs(r_max) < cor_tol) return(NULL)
+    ord <- order(w, decreasing = TRUE)
+    k <- which(cumsum(w[ord]) >= share)[1]
+    if (is.na(k)) k <- length(ord)
+    idx <- ord[seq_len(k)]
+    if (length(idx) < 2L) next
 
-  list(params = nms[idx], weights = w[idx],
-       correlation = r_max, rcond = rcond)
+    # (5) Require a genuine trade-off. Without this an uncorrelated but
+    #     imprecise parameter set (correlation matrix near identity, where
+    #     the eigenvectors are arbitrary) would be reported as a ridge.
+    sub <- R[idx, idx, drop = FALSE]
+    off <- sub[upper.tri(sub)]
+    if (!length(off)) next
+    r_max <- off[which.max(abs(off))]
+    if (abs(r_max) < cor_tol) next
+
+    return(list(params = nms[idx], weights = w[idx],
+                correlation = r_max, rcond = rcond))
+  }
+
+  NULL
 }
 
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -62,6 +62,7 @@ Roxygen
 SAS's
 SETCOE
 SEs
+signalled
 SLENTRY
 SLSTAY
 STARTTME

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -133,7 +133,11 @@ unless the start reached a point where the likelihood is defined),
 the \code{best} and so the reported fit, and the \code{message} of any
 error. A start that stops at \code{maxit} has a finite \code{objective}
 and can win the selection, so \code{status} distinguishes it from one
-that converged),
+that converged. Any fit whose likelihood is near-flat along a parameter
+combination also carries \code{weak}, listing the \code{params}
+spanning that direction, their squared loadings (\code{weights}), the
+strongest pairwise \code{correlation} among them, and the Hessian
+\code{rcond} -- \code{NULL} when the fit is well identified),
 and \code{engine} (implementation tag, \code{"native-r-m2"}).
 }
 \description{

--- a/tests/testthat/test-weak-direction.R
+++ b/tests/testthat/test-weak-direction.R
@@ -1,0 +1,162 @@
+# Ridge (weak-identification) detection.
+#
+# An ill-conditioned Hessian already warns that *standard errors* are
+# unreliable. That understates the problem when the ill-conditioning is a
+# ridge: there the individual point estimates along the flat direction are not
+# determined by the data either, only their combination is. These tests pin
+# down the detector that names which parameters are jointly identified.
+#
+# The detector works on the correlation of the estimates rather than on raw
+# variances, so it reports trade-offs between parameters. A single imprecise
+# parameter is not a ridge and is left to the existing rcond warning.
+
+ridge_vcov <- function(r = 0.99999, scale = c(1, 1)) {
+  V <- matrix(c(1, r, r, 1), 2, 2)
+  D <- diag(scale)
+  V <- D %*% V %*% D
+  dimnames(V) <- list(c("a", "b"), c("a", "b"))
+  V
+}
+
+test_that("a well-conditioned fit has no weak direction", {
+  V <- solve(matrix(c(4, 1, 1, 3), 2, 2))
+  expect_null(.hzr_weak_direction(V, rcond = 0.3, param_names = c("a", "b")))
+})
+
+test_that("rcond above tolerance suppresses detection even on a ridge", {
+  # The gate is the package's existing ill-conditioning threshold, so the
+  # ridge note never fires where the rcond warning stays silent.
+  expect_null(.hzr_weak_direction(ridge_vcov(), rcond = 1e-3,
+                                  param_names = c("a", "b")))
+})
+
+test_that("a two-parameter ridge names both parameters", {
+  w <- .hzr_weak_direction(ridge_vcov(), rcond = 1e-10,
+                           param_names = c("a", "b"))
+  expect_false(is.null(w))
+  expect_setequal(w$params, c("a", "b"))
+  expect_gt(abs(w$correlation), 0.99)
+})
+
+test_that("the flat direction is scale-invariant", {
+  # THE REGRESSION THIS FILE EXISTS FOR. The same ridge, but with the second
+  # parameter measured on a 1000x larger scale -- as m (~27) is against nu
+  # (~0.027) on the multiphase fixture. A direction taken from the raw
+  # covariance loads almost entirely on the larger-scale parameter and reports
+  # the ridge as a single unidentified parameter; only the correlation-scaled
+  # form recovers the true two-parameter combination.
+  V <- ridge_vcov(scale = c(1, 1000))
+
+  raw <- eigen(V, symmetric = TRUE)
+  raw_w <- raw$vectors[, which.max(raw$values)]^2
+  expect_gt(max(raw_w), 0.99)          # raw units: one parameter dominates
+
+  w <- .hzr_weak_direction(V, rcond = 1e-10, param_names = c("a", "b"))
+  expect_false(is.null(w))
+  expect_setequal(w$params, c("a", "b"))
+})
+
+test_that("an imprecise but uncorrelated parameter is not a ridge", {
+  # Large variance on its own is not a trade-off. The existing rcond warning
+  # and the parameter's own standard error already cover this case.
+  V <- diag(c(1, 1, 1e6))
+  expect_null(.hzr_weak_direction(V, rcond = 1e-10,
+                                  param_names = c("a", "b", "c")))
+})
+
+test_that("a moderate correlation is not a ridge", {
+  # Two parameters that do span the flat direction but trade off only weakly.
+  # This is the case that exercises the correlation threshold itself: the
+  # uncorrelated test above exits earlier, at the "direction spans a single
+  # parameter" guard, and so never reaches it.
+  V <- matrix(c(1, 0.5, 0.5, 1), 2, 2)
+  expect_null(.hzr_weak_direction(V, rcond = 1e-10,
+                                  param_names = c("a", "b")))
+  # Just over the threshold, the same shape is reported.
+  V2 <- matrix(c(1, 0.995, 0.995, 1), 2, 2)
+  expect_setequal(
+    .hzr_weak_direction(V2, rcond = 1e-10, param_names = c("a", "b"))$params,
+    c("a", "b")
+  )
+})
+
+test_that("degenerate covariances yield no weak direction rather than an error", {
+  nms <- c("a", "b")
+  expect_null(.hzr_weak_direction(NULL, rcond = 1e-10, param_names = nms))
+  expect_null(.hzr_weak_direction(NA, rcond = 1e-10, param_names = nms))
+  expect_null(.hzr_weak_direction(ridge_vcov(), rcond = NA_real_,
+                                  param_names = nms))
+  expect_null(.hzr_weak_direction(matrix(c(1, NA, NA, 1), 2, 2),
+                                  rcond = 1e-10, param_names = nms))
+  # A non-estimated (fixed) parameter carries an NA row/column.
+  V <- ridge_vcov()
+  V3 <- matrix(NA_real_, 3, 3)
+  V3[1:2, 1:2] <- V
+  expect_setequal(
+    .hzr_weak_direction(V3, rcond = 1e-10,
+                        param_names = c("a", "b", "fixed"))$params,
+    c("a", "b")
+  )
+  # Zero variance makes the correlation undefined.
+  expect_null(.hzr_weak_direction(diag(c(0, 1)), rcond = 1e-10,
+                                  param_names = nms))
+})
+
+test_that("unnamed parameters fall back to positional labels", {
+  w <- .hzr_weak_direction(ridge_vcov(), rcond = 1e-10, param_names = NULL)
+  expect_false(is.null(w))
+  expect_length(w$params, 2)
+})
+
+test_that("the multiphase ridge fixture warns and records nu and m", {
+  skip_on_cran()
+  set.seed(42)
+  n <- 100
+  time   <- rexp(n, rate = 0.5) + 0.01
+  status <- sample(0:1, n, replace = TRUE, prob = c(0.2, 0.8))
+  phases <- list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+                 const = hzr_phase("constant"))
+
+  w <- testthat::capture_warnings(
+    fit <- hazard(time = time, status = status, dist = "multiphase",
+                  phases = phases, fit = TRUE,
+                  control = list(n_starts = 5, maxit = 500))
+  )
+  # The perturbed start wins and lands on the m*nu ridge, where m (~27) and nu
+  # (~0.027) are identified only through their product.
+  expect_true(any(grepl("only in combination", w)))
+  expect_false(is.null(fit$fit$weak))
+  expect_setequal(fit$fit$weak$params, c("early.nu", "early.m"))
+})
+
+test_that("a well-identified fit stays silent and records no weak direction", {
+  skip_on_cran()
+  set.seed(7)
+  n <- 300
+  time   <- rweibull(n, shape = 1.5, scale = 2)
+  status <- rep(1L, n)
+  w <- testthat::capture_warnings(
+    fit <- hazard(time = time, status = status, dist = "weibull", fit = TRUE)
+  )
+  expect_false(any(grepl("only in combination", w)))
+  expect_null(fit$fit$weak)
+})
+
+test_that("summary() prints the ridge note when one is recorded", {
+  skip_on_cran()
+  set.seed(42)
+  n <- 100
+  time   <- rexp(n, rate = 0.5) + 0.01
+  status <- sample(0:1, n, replace = TRUE, prob = c(0.2, 0.8))
+  phases <- list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+                 const = hzr_phase("constant"))
+  fit <- suppressWarnings(
+    hazard(time = time, status = status, dist = "multiphase", phases = phases,
+           fit = TRUE, control = list(n_starts = 5, maxit = 500)))
+  # The note is strwrap()'d for the console, so collapse whitespace before
+  # matching rather than assuming where the line breaks land.
+  out <- paste(capture.output(print(summary(fit))), collapse = " ")
+  out <- gsub("\\s+", " ", out)
+  expect_match(out, "only in combination")
+  expect_match(out, "early\\.nu")
+})

--- a/tests/testthat/test-weak-direction.R
+++ b/tests/testthat/test-weak-direction.R
@@ -135,11 +135,52 @@ test_that("a well-identified fit stays silent and records no weak direction", {
   n <- 300
   time   <- rweibull(n, shape = 1.5, scale = 2)
   status <- rep(1L, n)
+  # `theta` is required: hazard()'s single-distribution fit branch is
+  # `else if (fit && !is.null(theta))`, so without it nothing is optimised,
+  # $vcov and $rcond come back NULL, and .hzr_weak_direction() returns at its
+  # first guard.  Both assertions below then pass with the whole detector
+  # deleted -- which is what this test used to do.
   w <- testthat::capture_warnings(
-    fit <- hazard(time = time, status = status, dist = "weibull", fit = TRUE)
+    fit <- hazard(time = time, status = status, dist = "weibull",
+                  theta = c(0.5, 1.0), fit = TRUE)
   )
+  # Guard the guard: assert the fit actually reached the detector, or the
+  # two assertions below are vacuous again.
+  expect_false(is.null(fit$fit$rcond))
+  expect_false(is.null(fit$fit$vcov))
   expect_false(any(grepl("only in combination", w)))
   expect_null(fit$fit$weak)
+})
+
+test_that("a ridge is found even when a larger correlated block outranks it", {
+  # Regression for the leading-eigenvector bug: gating only the top
+  # eigenvector on cor_tol missed a near-perfect two-parameter ridge whenever
+  # some block of k >= 3 moderately correlated parameters carried more
+  # variance.  An equicorrelated k-block has eigenvalue 1 + (k - 1) * r, so it
+  # passes the ridge's ceiling of 2 as soon as r > 1 / (k - 1) -- 0.5 at
+  # k = 3.  The detector then returned NULL, which is the documented signal
+  # for "well identified".
+  ridge_with_block <- function(rho) {
+    R <- diag(5)
+    R[1, 2] <- R[2, 1] <- 0.99999
+    for (i in 3:5) {
+      for (j in 3:5) if (i != j) R[i, j] <- rho
+    }
+    .hzr_weak_direction(R, rcond = 1e-10,
+                        param_names = paste0("p", seq_len(5)))
+  }
+
+  # Below the crossover the block loses on variance and the old code worked.
+  expect_setequal(ridge_with_block(0.45)$params, c("p1", "p2"))
+
+  # Above it the block wins on variance but is not a trade-off. These are the
+  # values that returned NULL before the scan was introduced.
+  for (rho in c(0.51, 0.60, 0.75)) {
+    w <- ridge_with_block(rho)
+    expect_false(is.null(w))
+    expect_setequal(w$params, c("p1", "p2"))
+    expect_gt(abs(w$correlation), 0.999)
+  }
 })
 
 test_that("summary() prints the ridge note when one is recorded", {
@@ -159,4 +200,31 @@ test_that("summary() prints the ridge note when one is recorded", {
   out <- gsub("\\s+", " ", out)
   expect_match(out, "only in combination")
   expect_match(out, "early\\.nu")
+})
+
+test_that("a single-distribution ridge is reported under the real parameter names", {
+  skip_on_cran()
+  # optim() returns an unnamed `par` for the single-distribution fits, so
+  # reading names(fit$par) alone labelled the warning "par3"/"par4" while
+  # summary() printed "beta1"/"beta2" against the same numbers.  The names
+  # must come from the same source summary() uses.
+  set.seed(3)
+  n <- 250
+  x1 <- stats::rnorm(n)
+  x2 <- x1 + stats::rnorm(n, sd = 1e-4)   # near-collinear: a genuine ridge
+  df <- data.frame(
+    tt = stats::rweibull(n, 1.4, 2),
+    st = stats::rbinom(n, 1, 0.9),
+    x1 = x1, x2 = x2
+  )
+  fit <- suppressWarnings(hazard(
+    survival::Surv(tt, st) ~ x1 + x2, data = df, dist = "weibull",
+    theta = c(0.5, 1, 0, 0), fit = TRUE
+  ))
+
+  # Assert the fixture is still a ridge, or the naming assertion below is
+  # vacuous.
+  expect_false(is.null(fit$fit$weak))
+  expect_null(names(fit$fit$par))          # the condition the fallback exists for
+  expect_setequal(fit$fit$weak$params, c("beta1", "beta2"))
 })


### PR DESCRIPTION
Rescues the one unique commit from `claude/competent-pare-7518ac`, a branch cut against the
deleted `origin/dev` and stranded since. This is the findings half of the 1.2.2 cycle; the
release shipped without it.

## Why only one commit

That branch carried two. The first, `31f2821` ("stop losing an optimization start to an
infeasible shape"), is **already on `main`** as `10822c9`, rebased in via #166. Rebasing the
branch would have replayed it against itself. Only `1863a43` is unique, so only `1863a43` is
cherry-picked here.

The branch's *finding* — that the multiphase gradient fixture has no interior optimum in `m`
— also already landed, as prose, in `7a1a904`. What was missing is the detector.

## What this adds

An ill-conditioned Hessian already warned that standard errors were unreliable. That
understates a ridge: where the likelihood is near-flat along a parameter combination, the
individual point estimates along it are not determined by the data either — only the
combination is. The fit still reported `converged` with an ordinary-looking coefficient
table, so nothing on the object signalled it.

`.hzr_weak_direction()` (new, in `R/hessian-invert.R`) reads the flat direction and:

- `hazard()` warns once per fit, naming the spanning parameters with their correlation and `rcond`;
- `summary()` prints the same note;
- the finding is recorded as `fit$weak` (`NULL` when well identified) so it can be checked
  rather than scraped from a warning text.

Two design points worth review:

**The direction comes from the correlation of the estimates, not the raw covariance.**
Parameters sit on very different scales — `m ~ 27` against `nu ~ 0.027` — and a raw-covariance
eigenvector loads 1.000 on `m` alone, which would report this two-parameter ridge as one
unidentified parameter. The correlation form splits it 0.487/0.481.

**A merely imprecise parameter is deliberately not reported.** It must clear
`.hzr_ridge_cor_tol` (0.99), and the whole check is gated on the *existing* `.hzr_rcond_tol`,
so it never fires where the `rcond` warning is already silent.

Generic across distributions — nothing in it knows about phase shapes.

## Conflicts resolved

- `R/hazard_api.R` `@return`: `main` grew a richer multi-start `status` vocabulary
  (`"nonconverged"`, `"infeasible"`, the `maxit` note) after this branch was cut. Kept `main`'s
  text verbatim and appended the `weak` component. The incoming version had also placed `weak`
  inside the *multiphase-`starts`* parenthetical, which is wrong — `weak` is a component of
  `fit` and applies to every distribution — so it is described there instead.
- `man/hazard.Rd`: generated, regenerated by `document()`.
- `NEWS.md` merged without a conflict but placed the entry in the **1.2.2** section. Moved to
  a new 1.2.7 section; verified the move is purely additive (zero removed lines against
  `origin/main`).

## Gate

Run in full, in a clean worktree off `origin/main`:

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` with `NOT_CRAN=true` — **FAIL 0 | SKIP 6 | PASS 3341**
- `R CMD check --as-cran` with the manual, from a `git archive` export of the committed tree —
  **Status: OK**, 3m30s overall (tests 86s/91s, vignettes 47s/50s), tarball 2.9 MB. Confirmed
  no `CLAUDE`/`AGENTS` files in the tarball.

Version bumped 1.2.6 → **1.2.7** (patch; `DESCRIPTION` and the `NEWS.md` heading kept in sync
by hand, since nothing here greps for it).

> [!NOTE]
> The companion PR re-landing #130 also opens a 1.2.7 `NEWS.md` section. Whichever merges
> second will take a trivial `NEWS.md` conflict under the shared heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)