### PR TITLE
fix(stepwise): test strong candidates the score criterion cannot (#130)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.6
+Version: 1.2.7
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/TemporalHazard/, https://github.com/ehrlinger/TemporalHazard
 BugReports: https://github.com/ehrlinger/TemporalHazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,37 @@
+# TemporalHazard 1.2.7
+
+## Bug fixes
+
+* **The score criterion no longer declines a candidate for being too
+  predictive.** `criterion = "score"` computes SAS HAZARD's Q exactly --
+  `Q = grad^2 * I22`, the reciprocal Schur complement of the *observed*
+  information at `beta = 0` (`src/vars/q1.c`). When a candidate's true effect
+  is far from zero the log-likelihood is convex there, the Schur complement
+  turns negative, and Q is undefined. The criterion therefore declined
+  candidates in proportion to how predictive they were: on a fixture with one
+  planted effect (`beta = 0.9`, LR = 178) and two pure-noise columns, the
+  screen entered both noise columns and never tested the real one (#130).
+
+  This is not a deviation from the reference -- it is inherited from it. SAS
+  documents the same failure in `q1.c` ("IT IS POSSIBLE THAT THE PROGRAM WILL
+  RETURN A NEGATIVE Q VALUE ... THE USER SHOULD USE THE MORE EXPENSIVE Q2 AS
+  AN ALTERNATIVE"), and `dqstat.c` declines the candidate with `p = 1`. `Q2`
+  is named once in the C tree and never implemented.
+
+  So Q itself is unchanged and stays bit-faithful; only the *handling*
+  diverges, and only where SAS says its own answer is unusable. A candidate
+  the score cannot test is now refit and tested by Wald -- the substitute the
+  unbuilt `Q2` was for. This is a deliberate, documented divergence from the
+  reference implementation.
+
+  The fallback is deliberately narrow: it applies to `information_indefinite`
+  and `coefficient_diverging`, the two causes that mean "the approximation at
+  zero broke down". Collinear, constant and non-numeric candidates are still
+  declined without a refit, so the screen keeps the speed advantage that the
+  score criterion exists for -- the cost is paid only on the few candidates
+  that trip it. `summary()`'s `$criteria` gains `n_wald_fallbacks`, so the
+  substitution is reported rather than silent.
+
 # TemporalHazard 1.2.6
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,8 +29,10 @@
   zero broke down". Collinear, constant and non-numeric candidates are still
   declined without a refit, so the screen keeps the speed advantage that the
   score criterion exists for -- the cost is paid only on the few candidates
-  that trip it. `summary()`'s `$criteria` gains `n_wald_fallbacks`, so the
-  substitution is reported rather than silent.
+  that trip it. The returned object's `$criteria` gains `n_wald_fallbacks`,
+  so the substitution is reported rather than silent, and a fallback refit
+  that fails is recorded in `$criteria$refit_failures` and warned about
+  rather than leaving a row indistinguishable from one never refit.
 
 # TemporalHazard 1.2.6
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1332,8 +1332,10 @@ print.hzr_nelson <- function(x, digits = 4, ...) {
 #'     counting *why* candidate scores were unavailable, summed over every
 #'     replicate. `information_indefinite` is the one to read first: it marks
 #'     candidates whose effect is too large for the score test's approximation
-#'     at zero -- typically strong variables that were passed over rather than
-#'     tested, understating their selection frequency. Empty in refit mode.}
+#'     at zero -- typically strong variables. Those are refit and Wald-tested
+#'     automatically, so a candidate reaching this count is one whose refit
+#'     also failed and which therefore went untested, understating its
+#'     selection frequency. Empty in refit mode.}
 #'   \item{n_nonmonotone_replicates}{Select mode only: number of otherwise
 #'     successful replicates in which a forward step *lowered* the
 #'     log-likelihood. Entered models are nested, so this cannot occur at the
@@ -1768,15 +1770,16 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
             "reported selection frequency is depressed by them.",
             .hzr_format_reasons(uncomputable_reasons), call. = FALSE)
   } else if (n_indefinite > 0L) {
-    # No replicate stopped, so the branch above stays quiet. Candidates the
-    # score test could not evaluate at beta = 0 were still passed over, and
-    # they are typically the strong ones -- which depresses exactly the
-    # selection frequencies a screen exists to measure.
+    # No replicate stopped, so the branch above stays quiet. Under
+    # `criterion = "score"` such a candidate is refit and Wald-tested, so
+    # reaching this count means the refit failed and it went untested after
+    # all -- and these are typically the strong ones, which depresses exactly
+    # the selection frequencies a screen exists to measure.
     warning(n_indefinite, " candidate score(s) ",
             "across ", n_success, " replicates could not be computed because ",
             .hzr_score_reason_text("information_indefinite"),
-            ". Those candidates were passed over rather than tested, so their ",
-            "selection frequencies are understated. See ",
+            ". The automatic Wald refit failed for these, so they went ",
+            "untested and their selection frequencies are understated. See ",
             "`$uncomputable_reasons`.", call. = FALSE)
   }
 

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -703,6 +703,23 @@
 #' silently becoming an empty string.
 #'
 #' @noRd
+# Reasons a candidate can be rescued by refitting it and testing by Wald.
+#
+# Both mean "the quadratic approximation at beta = 0 broke down", which is
+# what a LARGE true effect looks like -- so declining them is exactly backwards
+# and a refit gives the right answer. SAS's own q1.c says as much ("IT IS
+# POSSIBLE THAT THE PROGRAM WILL RETURN A NEGATIVE Q VALUE ... THE USER SHOULD
+# USE THE MORE EXPENSIVE Q2 AS AN ALTERNATIVE"); Q2 is named once in the C
+# tree and never implemented, and dqstat.c instead declines the candidate with
+# p = 1. This is that unbuilt alternative.
+#
+# Kept deliberately narrow. The degenerate reasons -- collinear, constant,
+# non_numeric, nuisance_singular -- are NOT here: no refit can make those
+# candidates testable, and paying one per degenerate candidate would give back
+# the whole speed advantage the score criterion exists for.
+.hzr_score_fallback_reasons <- c("information_indefinite",
+                                 "coefficient_diverging")
+
 .hzr_score_reason_text <- function(reason) {
   txt <- c(
     information_indefinite = paste(

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -726,8 +726,9 @@
       "the observed information at beta = 0 was indefinite. That usually means",
       "the candidate's effect is too large for the score test's approximation",
       "at zero, so these are typically STRONG candidates rather than",
-      "degenerate ones; `criterion = \"wald\"` tests them. It is also reached",
-      "when the current fit has not truly converged"
+      "degenerate ones. `criterion = \"score\"` refits and Wald-tests them",
+      "itself, so reaching this reason means that refit also failed. It is",
+      "also reached when the current fit has not truly converged"
     ),
     information_nonpositive = paste(
       "the candidate's own observed information was not positive, before any",

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -372,6 +372,7 @@
   # dropping the screen's best variables. Only the reasons a refit can
   # actually rescue qualify -- see .hzr_score_fallback_reasons.
   all_scores$fallback <- FALSE
+  fallback_failures <- character()
   for (i in which(is.na(all_scores$score) &
                     all_scores$reason %in% .hzr_score_fallback_reasons)) {
     cand_phase <- if (is.na(all_scores$phase[i])) NULL else all_scores$phase[i]
@@ -383,8 +384,21 @@
     )
     # A refit that fails or does not converge leaves the row NA with its
     # original reason, so it still counts as uncomputable below rather than
-    # quietly becoming a candidate with no score.
-    if (is.null(refit) || isFALSE(refit$fit$converged)) next
+    # quietly becoming a candidate with no score.  Record and warn as every
+    # other refit failure in the package does: without this the row is
+    # byte-identical to one that was never refit at all, and the only signal
+    # left is an uncomputable_reasons count that now means the opposite.
+    if (is.null(refit) || isFALSE(refit$fit$converged)) {
+      fallback_token <- if (is.null(cand_phase)) {
+        all_scores$variable[i]
+      } else {
+        paste0(all_scores$variable[i], "@", cand_phase)
+      }
+      warning("Stepwise forward: Wald-fallback refit failed for ",
+              fallback_token, ".", call. = FALSE)
+      fallback_failures <- c(fallback_failures, fallback_token)
+      next
+    }
     w <- .hzr_candidate_score(
       criterion = "wald", mode = "entry", current = current, candidate = refit,
       names = .hzr_candidate_coef_name(refit, all_scores$variable[i],
@@ -422,6 +436,7 @@
     out$n_uncomputable <- n_uncomputable
     out$uncomputable_reasons <- uncomputable_reasons
     out$n_wald_fallbacks <- n_wald_fallbacks
+    out$refit_failures <- fallback_failures
     out$stop_reason    <- if (n_uncomputable > 0L) {
       "scores_uncomputable"
     } else {
@@ -439,6 +454,7 @@
     out$n_uncomputable <- n_uncomputable
     out$uncomputable_reasons <- uncomputable_reasons
     out$n_wald_fallbacks <- n_wald_fallbacks
+    out$refit_failures <- fallback_failures
     out$stop_reason    <- "no_candidate_met_slentry"
     return(out)
   }
@@ -465,7 +481,7 @@
             failure_token, ".", call. = FALSE)
     out <- null_result()
     out$all_scores     <- all_scores
-    out$refit_failures <- failure_token
+    out$refit_failures <- c(fallback_failures, failure_token)
     out$n_uncomputable <- n_uncomputable
     out$uncomputable_reasons <- uncomputable_reasons
     out$n_wald_fallbacks <- n_wald_fallbacks
@@ -484,7 +500,7 @@
     stat      = best$stat,
     df        = best$df,
     all_scores = all_scores,
-    refit_failures = character(),
+    refit_failures = fallback_failures,
     n_uncomputable = n_uncomputable,
     uncomputable_reasons = uncomputable_reasons,
     n_wald_fallbacks = n_wald_fallbacks,

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -364,6 +364,42 @@
   }
   all_scores <- do.call(rbind, rows)
 
+  # --- Wald fallback for candidates the score could not test (#130) --------
+  # Q is SAS's exactly (src/vars/q1.c), and so is its blind spot: the observed
+  # information at beta = 0 goes indefinite precisely when the candidate's
+  # effect is LARGE, so the criterion declines candidates in proportion to how
+  # predictive they are. Refit those few and test them by Wald rather than
+  # dropping the screen's best variables. Only the reasons a refit can
+  # actually rescue qualify -- see .hzr_score_fallback_reasons.
+  all_scores$fallback <- FALSE
+  for (i in which(is.na(all_scores$score) &
+                    all_scores$reason %in% .hzr_score_fallback_reasons)) {
+    cand_phase <- if (is.na(all_scores$phase[i])) NULL else all_scores$phase[i]
+    refit <- tryCatch(
+      .hzr_refit_with_scope(current, action = "add",
+                            var = all_scores$variable[i], phase = cand_phase,
+                            data = data, ...),
+      error = function(e) NULL
+    )
+    # A refit that fails or does not converge leaves the row NA with its
+    # original reason, so it still counts as uncomputable below rather than
+    # quietly becoming a candidate with no score.
+    if (is.null(refit) || isFALSE(refit$fit$converged)) next
+    w <- .hzr_candidate_score(
+      criterion = "wald", mode = "entry", current = current, candidate = refit,
+      names = .hzr_candidate_coef_name(refit, all_scores$variable[i],
+                                       cand_phase)
+    )
+    if (is.na(w$score)) next
+    all_scores$score[i]    <- w$score
+    all_scores$p_value[i]  <- w$p_value
+    all_scores$stat[i]     <- w$stat
+    all_scores$df[i]       <- w$df
+    all_scores$fallback[i] <- TRUE
+    all_scores$reason[i]   <- NA_character_
+  }
+  n_wald_fallbacks <- sum(all_scores$fallback)
+
   valid <- which(!is.na(all_scores$score))
 
   # A candidate whose Q could not be computed scores NA and drops out of
@@ -385,6 +421,7 @@
     out$all_scores     <- all_scores
     out$n_uncomputable <- n_uncomputable
     out$uncomputable_reasons <- uncomputable_reasons
+    out$n_wald_fallbacks <- n_wald_fallbacks
     out$stop_reason    <- if (n_uncomputable > 0L) {
       "scores_uncomputable"
     } else {
@@ -401,6 +438,7 @@
     out$all_scores     <- all_scores
     out$n_uncomputable <- n_uncomputable
     out$uncomputable_reasons <- uncomputable_reasons
+    out$n_wald_fallbacks <- n_wald_fallbacks
     out$stop_reason    <- "no_candidate_met_slentry"
     return(out)
   }
@@ -430,6 +468,7 @@
     out$refit_failures <- failure_token
     out$n_uncomputable <- n_uncomputable
     out$uncomputable_reasons <- uncomputable_reasons
+    out$n_wald_fallbacks <- n_wald_fallbacks
     out$stop_reason    <- "refit_failed"
     return(out)
   }
@@ -448,6 +487,7 @@
     refit_failures = character(),
     n_uncomputable = n_uncomputable,
     uncomputable_reasons = uncomputable_reasons,
+    n_wald_fallbacks = n_wald_fallbacks,
     stop_reason    = "accepted"
   )
 }

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -144,8 +144,11 @@
 #'       on offer rather than degenerate ones. Those are now refit and tested
 #'       by Wald automatically, counted in `n_wald_fallbacks`; a candidate
 #'       still reaches `uncomputable_reasons` only when that refit itself
-#'       fails, or when the cause is one no refit can rescue (a collinear or
-#'       constant column).  For every criterion it also carries
+#'       fails, or when the cause is one no refit can rescue --- which is
+#'       every cause except `information_indefinite` and
+#'       `coefficient_diverging`, the two a refit exists to rescue. Read
+#'       `uncomputable_reasons` for which one it was in any given run.  For
+#'       every criterion it also carries
 #'       `refit_failures` (the `"var"` / `"var@phase"` tokens of candidate
 #'       moves whose refit errored or failed to converge), `n_refit_failures`,
 #'       and `stopped_refit_failed` --- `TRUE` when the run ended on an

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -583,10 +583,13 @@ hzr_stepwise <- function(fit,
     warning("Stepwise selection completed, but ", n_indefinite,
             " candidate score(s) could not be computed because ",
             .hzr_score_reason_text("information_indefinite"),
-            ". Those candidates were passed over rather than tested, so the ",
-            "selected set may omit strong variables. Re-run with ",
-            "`criterion = \"wald\"` to test them; see ",
-            "`$criteria$uncomputable_reasons`.", call. = FALSE)
+            ". Under `criterion = \"score\"` such candidates are refit and ",
+            "Wald-tested automatically, so reaching this means the refit ",
+            "itself failed and they were never tested -- the selected set ",
+            "may omit strong variables. Re-running with ",
+            "`criterion = \"wald\"` runs the same refit and will fail the ",
+            "same way; see `$criteria$refit_failures` for which candidates, ",
+            "and `$criteria$uncomputable_reasons`.", call. = FALSE)
   }
   if (stopped_refit_failed) {
     warning("Stepwise selection stopped after ", nrow(steps_df),

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -141,14 +141,17 @@
 #'       an unscored candidate as a bad one: `information_indefinite` marks
 #'       candidates whose effect is too large for the score test's
 #'       approximation at zero, which are typically the strongest variables
-#'       on offer rather than degenerate ones. `criterion = "wald"` tests
-#'       them.  For every criterion it also carries `refit_failures` (the
-#'       `"var"` / `"var@phase"` tokens of candidate moves whose refit
-#'       errored or failed to converge), `n_refit_failures`, and
-#'       `stopped_refit_failed` --- `TRUE` when the run ended on an iteration
-#'       in which refits failed, which is a screen that could not test its
-#'       candidates rather than one that tested them and liked none.  Check
-#'       it before reading a zero-row `steps` as an honest null result.}
+#'       on offer rather than degenerate ones. Those are now refit and tested
+#'       by Wald automatically, counted in `n_wald_fallbacks`; a candidate
+#'       still reaches `uncomputable_reasons` only when that refit itself
+#'       fails, or when the cause is one no refit can rescue (a collinear or
+#'       constant column).  For every criterion it also carries
+#'       `refit_failures` (the `"var"` / `"var@phase"` tokens of candidate
+#'       moves whose refit errored or failed to converge), `n_refit_failures`,
+#'       and `stopped_refit_failed` --- `TRUE` when the run ended on an
+#'       iteration in which refits failed, which is a screen that could not
+#'       test its candidates rather than one that tested them and liked none.
+#'       Check it before reading a zero-row `steps` as an honest null result.}
 #'     \item{\code{trace_msg}}{Character vector of the trace lines,
 #'       captured regardless of the `trace` flag.}
 #'     \item{\code{elapsed}}{`difftime` from start to finish.}
@@ -302,6 +305,7 @@ hzr_stepwise <- function(fit,
   # was good enough -- the two produce identical empty steps otherwise.
   n_uncomputable_scores <- 0L
   uncomputable_reasons  <- stats::setNames(integer(0), character(0))
+  n_wald_fallbacks      <- 0L
   stopped_uncomputable  <- FALSE
   # Candidates whose REFIT failed, summed over steps.  The per-candidate
   # warning already fires inside the step, but nothing recorded it on the
@@ -420,6 +424,7 @@ hzr_stepwise <- function(fit,
 
       n_uncomputable_scores <- n_uncomputable_scores +
         (fwd$n_uncomputable %||% 0L)
+      n_wald_fallbacks <- n_wald_fallbacks + (fwd$n_wald_fallbacks %||% 0L)
       uncomputable_reasons <- .hzr_merge_reasons(
         uncomputable_reasons, fwd$uncomputable_reasons
       )
@@ -551,6 +556,7 @@ hzr_stepwise <- function(fit,
     hit_max_steps = stopped_by_max_steps,
     n_uncomputable_scores = n_uncomputable_scores,
     uncomputable_reasons  = uncomputable_reasons,
+    n_wald_fallbacks      = n_wald_fallbacks,
     stopped_uncomputable  = stopped_uncomputable,
     n_refit_failures      = length(refit_failures),
     refit_failures        = refit_failures,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -60,6 +60,7 @@ Reoperation
 Rmpfr
 Roxygen
 SAS's
+Schur
 SETCOE
 SEs
 SLENTRY
@@ -75,6 +76,7 @@ TGA
 THALF
 Technometrics
 UAB
+unbuilt
 Univariable
 Walkthrough
 additively

--- a/man/hzr_bootstrap.Rd
+++ b/man/hzr_bootstrap.Rd
@@ -103,8 +103,10 @@ depressed. Always \code{0} in refit mode.}
 counting \emph{why} candidate scores were unavailable, summed over every
 replicate. \code{information_indefinite} is the one to read first: it marks
 candidates whose effect is too large for the score test's approximation
-at zero -- typically strong variables that were passed over rather than
-tested, understating their selection frequency. Empty in refit mode.}
+at zero -- typically strong variables. Those are refit and Wald-tested
+automatically, so a candidate reaching this count is one whose refit
+also failed and which therefore went untested, understating its
+selection frequency. Empty in refit mode.}
 \item{n_nonmonotone_replicates}{Select mode only: number of otherwise
 successful replicates in which a forward step \emph{lowered} the
 log-likelihood. Entered models are nested, so this cannot occur at the

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -106,8 +106,11 @@ approximation at zero, which are typically the strongest variables
 on offer rather than degenerate ones. Those are now refit and tested
 by Wald automatically, counted in \code{n_wald_fallbacks}; a candidate
 still reaches \code{uncomputable_reasons} only when that refit itself
-fails, or when the cause is one no refit can rescue (a collinear or
-constant column).  For every criterion it also carries
+fails, or when the cause is one no refit can rescue --- which is
+every cause except \code{information_indefinite} and
+\code{coefficient_diverging}, the two a refit exists to rescue. Read
+\code{uncomputable_reasons} for which one it was in any given run.  For
+every criterion it also carries
 \code{refit_failures} (the \code{"var"} / \code{"var@phase"} tokens of candidate
 moves whose refit errored or failed to converge), \code{n_refit_failures},
 and \code{stopped_refit_failed} --- \code{TRUE} when the run ended on an

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -103,14 +103,17 @@ settings actually applied, plus, under \code{criterion = "score"},
 an unscored candidate as a bad one: \code{information_indefinite} marks
 candidates whose effect is too large for the score test's
 approximation at zero, which are typically the strongest variables
-on offer rather than degenerate ones. \code{criterion = "wald"} tests
-them.  For every criterion it also carries \code{refit_failures} (the
-\code{"var"} / \code{"var@phase"} tokens of candidate moves whose refit
-errored or failed to converge), \code{n_refit_failures}, and
-\code{stopped_refit_failed} --- \code{TRUE} when the run ended on an iteration
-in which refits failed, which is a screen that could not test its
-candidates rather than one that tested them and liked none.  Check
-it before reading a zero-row \code{steps} as an honest null result.}
+on offer rather than degenerate ones. Those are now refit and tested
+by Wald automatically, counted in \code{n_wald_fallbacks}; a candidate
+still reaches \code{uncomputable_reasons} only when that refit itself
+fails, or when the cause is one no refit can rescue (a collinear or
+constant column).  For every criterion it also carries
+\code{refit_failures} (the \code{"var"} / \code{"var@phase"} tokens of candidate
+moves whose refit errored or failed to converge), \code{n_refit_failures},
+and \code{stopped_refit_failed} --- \code{TRUE} when the run ended on an
+iteration in which refits failed, which is a screen that could not
+test its candidates rather than one that tested them and liked none.
+Check it before reading a zero-row \code{steps} as an honest null result.}
 \item{\code{trace_msg}}{Character vector of the trace lines,
 captured regardless of the \code{trace} flag.}
 \item{\code{elapsed}}{\code{difftime} from start to finish.}

--- a/tests/testthat/test-score-uncomputable-reasons.R
+++ b/tests/testthat/test-score-uncomputable-reasons.R
@@ -108,7 +108,12 @@ test_that("hzr_stepwise now tests the strong candidate instead of passing it ove
 test_that("the reason text tells a user to keep the candidate, not drop it", {
   txt <- .hzr_score_reason_text("information_indefinite")
   expect_match(txt, "STRONG")
-  expect_match(txt, "wald")
+  # The remedy changed with the fallback: the score criterion Wald-tests
+  # these itself, so the text must say the refit failed rather than advise a
+  # re-run under `criterion = "wald"` -- which now runs the identical refit
+  # and fails identically.
+  expect_match(txt, "Wald-tests")
+  expect_match(txt, "refit also failed")
   # And it must not be reachable from the collinear code, which is the
   # opposite advice.
   expect_no_match(.hzr_score_reason_text("collinear"), "STRONG")

--- a/tests/testthat/test-score-uncomputable-reasons.R
+++ b/tests/testthat/test-score-uncomputable-reasons.R
@@ -81,23 +81,28 @@ test_that("degenerate and collinear candidates keep their own reasons", {
   }
 })
 
-test_that("hzr_stepwise reports the reasons and names the strong-candidate case", {
+test_that("hzr_stepwise now tests the strong candidate instead of passing it over", {
+  # Was: this run warned "passed over rather than tested", left
+  # n_uncomputable_scores > 0, and selected nothing -- the candidate with the
+  # largest effect on offer was the one the criterion could not test (#130).
+  # The Wald fallback now refits exactly those candidates, so the screen
+  # reaches them.  The reporting path below has not gone away; it is now only
+  # for candidates whose fallback refit itself fails.
   fx <- .reason_fixture(0.8)
-  expect_warning(
-    r <- hzr_stepwise(
-      fx$fit, scope = list(early = ~ z + w, const = ~ z + w), data = fx$data,
-      direction = "forward", criterion = "score", slentry = 0.2,
-      trace = FALSE, control = list(n_starts = 1L)),
-    "passed over rather than tested")
+  r <- suppressWarnings(hzr_stepwise(
+    fx$fit, scope = list(early = ~ z + w, const = ~ z + w), data = fx$data,
+    direction = "forward", criterion = "score", slentry = 0.2,
+    trace = FALSE, control = list(n_starts = 1L)))
 
-  # The run COMPLETED -- it did not stop -- which is precisely the case the
-  # old code left silent: an empty selection and no warning at all.
   expect_false(isTRUE(r$criteria$stopped_uncomputable))
-  expect_gt(r$criteria$n_uncomputable_scores, 0L)
-  expect_identical(
-    names(r$criteria$uncomputable_reasons), "information_indefinite")
-  expect_equal(
-    sum(r$criteria$uncomputable_reasons), r$criteria$n_uncomputable_scores)
+  # Rescued, not merely counted: nothing is left uncomputable, and the
+  # fallback is reported rather than silently switching criterion.
+  expect_identical(r$criteria$n_uncomputable_scores, 0L)
+  expect_gt(r$criteria$n_wald_fallbacks, 0L)
+  # z carries the planted effect; asserting it ENTERED is what distinguishes
+  # "the fallback ran" from "the fallback got the right answer".
+  steps <- as.data.frame(r)
+  expect_true("z" %in% steps$variable[toupper(steps$action) == "ENTER"])
 })
 
 test_that("the reason text tells a user to keep the candidate, not drop it", {

--- a/tests/testthat/test-score-wald-fallback.R
+++ b/tests/testthat/test-score-wald-fallback.R
@@ -111,3 +111,31 @@ test_that("fallback reasons are classified, not lumped together", {
   expect_false("non_numeric" %in% .hzr_score_fallback_reasons)
   expect_true("information_indefinite" %in% .hzr_score_fallback_reasons)
 })
+
+test_that("a fallback refit that fails is recorded and warned, not silent", {
+  skip_on_cran()
+  # Before this, a failed fallback refit hit `next` and recorded nothing: no
+  # warning, no refit_failures token, no stopped_refit_failed. The resulting
+  # row was byte-identical to one from a run where no refit was attempted at
+  # all, so the only signal left -- an information_indefinite count -- meant
+  # the opposite of what a reader would take it to mean.
+  D <- planted()
+  base <- planted_fit(D)
+
+  testthat::local_mocked_bindings(
+    .hzr_refit_with_scope = function(...) stop("forced refit failure")
+  )
+
+  w <- testthat::capture_warnings(
+    sw <- hzr_stepwise(fit = base, scope = list(const = ~ x1 + x2 + x3),
+                       data = D, direction = "both", slentry = 0.05)
+  )
+
+  # The candidate the score could not test is x1; its refit was attempted
+  # and failed, so it must appear by name.
+  expect_true(any(grepl("Wald-fallback refit failed", w)))
+  expect_true(any(grepl("x1", sw$criteria$refit_failures, fixed = TRUE)))
+  expect_gt(sw$criteria$n_refit_failures, 0L)
+  # And nothing may be reported as a successful substitution.
+  expect_identical(sw$criteria$n_wald_fallbacks, 0L)
+})

--- a/tests/testthat/test-score-wald-fallback.R
+++ b/tests/testthat/test-score-wald-fallback.R
@@ -1,0 +1,113 @@
+# Wald fallback for candidates the score statistic cannot test (#130).
+#
+# The score criterion computes SAS HAZARD's Q exactly: Q = grad^2 * I22, the
+# reciprocal Schur complement of the OBSERVED information at beta = 0
+# (src/vars/q1.c).  When a candidate's true effect is far from zero the
+# log-likelihood is convex there, the Schur complement turns negative, and the
+# statistic is undefined -- so the criterion declines candidates in proportion
+# to how predictive they are.
+#
+# SAS has the same defect.  q1.c documents it ("IT IS POSSIBLE THAT THE
+# PROGRAM WILL RETURN A NEGATIVE Q VALUE ... THE USER SHOULD USE THE MORE
+# EXPENSIVE Q2 AS AN ALTERNATIVE") and dqstat.c declines the candidate with
+# p = 1.  Q2 is referenced once in the C tree and never implemented.
+#
+# So the statistic stays bit-faithful and only the *handling* diverges: a
+# candidate the score cannot test is refit and tested by Wald, which is what
+# the unbuilt Q2 was for.  These tests pin down both halves -- that the
+# statistic is unchanged, and that the screen no longer misses strong
+# candidates.
+
+planted <- function(seed = 11, n = 400, beta = 0.9) {
+  set.seed(seed)
+  x1 <- stats::rnorm(n)
+  x2 <- stats::rnorm(n)
+  x3 <- stats::rnorm(n)
+  data.frame(
+    tt = stats::rexp(n, rate = 0.3 * exp(beta * x1)) + 0.01,
+    ev = stats::rbinom(n, 1, 0.85),
+    x1 = x1, x2 = x2, x3 = x3
+  )
+}
+
+# Formula interface deliberately: hzr_stepwise() refuses a vector-interface
+# base fit up front (.hzr_refit_blocker(), #159), because every candidate
+# refit would fail.  Nothing about the Wald fallback depends on the
+# interface -- the score criterion sees the same fitted MLE either way.
+planted_fit <- function(D) {
+  suppressWarnings(hazard(
+    survival::Surv(tt, ev) ~ 1, data = D, dist = "multiphase",
+    phases = list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+                  const = hzr_phase("constant")),
+    fit = TRUE))
+}
+
+test_that("the score statistic itself is unchanged for an untestable candidate", {
+  skip_on_cran()
+  # Parity guard. The divergence from SAS is in the handling, not in Q, so
+  # .hzr_score_q() must still decline x1 with the same reason as before.
+  D <- planted()
+  q <- .hzr_score_q(planted_fit(D), var = "x1", phase = "const", data = D)
+  expect_true(is.na(q$stat))
+  expect_identical(q$reason, "information_indefinite")
+})
+
+test_that("the planted strong effect is selected, not the noise variables", {
+  skip_on_cran()
+  # x1 has beta_true = 0.9 (LR ~ 178, p ~ 0); x2 and x3 are pure noise. Before
+  # the fallback the screen entered x2 and x3 and never tested x1 -- a
+  # confident, plausible, wrong selection.
+  D <- planted()
+  sw <- suppressWarnings(hzr_stepwise(
+    fit = planted_fit(D), scope = list(const = ~ x1 + x2 + x3),
+    data = D, direction = "both", slentry = 0.05))
+
+  steps <- as.data.frame(sw)
+  entered <- steps$variable[toupper(steps$action) == "ENTER"]
+  expect_true("x1" %in% entered)
+  # Asserting the noise stays out is the half that can fail for the right
+  # reason: a fallback that simply refit everything would enter all three.
+  expect_false("x2" %in% entered)
+  expect_false("x3" %in% entered)
+})
+
+test_that("the Wald fallback is reported rather than silent", {
+  skip_on_cran()
+  D <- planted()
+  sw <- suppressWarnings(hzr_stepwise(
+    fit = planted_fit(D), scope = list(const = ~ x1 + x2 + x3),
+    data = D, direction = "both", slentry = 0.05))
+  # A criterion that quietly switched itself for some candidates would be the
+  # same class of defect as the one being fixed.
+  expect_true(sw$criteria$n_wald_fallbacks >= 1L)
+})
+
+test_that("only untestable-because-strong candidates fall back", {
+  skip_on_cran()
+  # A constant column is declined for a reason a refit cannot rescue, so it
+  # must not cost one. Paying a refit per degenerate candidate would give back
+  # the whole point of the score criterion.
+  D <- planted()
+  D$flat <- 1
+  sw <- suppressWarnings(hzr_stepwise(
+    fit = planted_fit(D), scope = list(const = ~ x1 + flat),
+    data = D, direction = "both", slentry = 0.05))
+  entered <- as.data.frame(sw)$variable[toupper(as.data.frame(sw)$action) == "ENTER"]
+  expect_false("flat" %in% entered)
+  expect_true("x1" %in% entered)
+})
+
+test_that("fallback reasons are classified, not lumped together", {
+  # Every reason eligible for a refit must be one .hzr_score_reason_text()
+  # knows, or the warning would print a bare code.
+  expect_false(any(
+    .hzr_score_reason_text(.hzr_score_fallback_reasons) %in%
+      .hzr_score_fallback_reasons
+  ))
+  # Degenerate causes must stay out of the fallback set: a refit cannot make a
+  # constant or collinear column testable.
+  expect_false("collinear" %in% .hzr_score_fallback_reasons)
+  expect_false("constant" %in% .hzr_score_fallback_reasons)
+  expect_false("non_numeric" %in% .hzr_score_fallback_reasons)
+  expect_true("information_indefinite" %in% .hzr_score_fallback_reasons)
+})


### PR DESCRIPTION
Rescues the unique work from `feat/sas-selection-stepwise`, a branch cut against the deleted
`origin/dev` and stranded since. This is the findings half of the 1.2.2 cycle; the release
shipped without it.

## The defect

`criterion = "score"` declined candidates **in proportion to how predictive they were**. Q is
evaluated at `beta = 0` on the observed information, and the observed information there goes
indefinite precisely when the candidate's effect is large. So the screen dropped its best
variables and entered noise instead.

On a planted fixture (`beta = 0.9`, LR ≈ 178) with two pure-noise columns, the screen entered
**both noise columns and never tested the real effect** — a confident, plausible, wrong
selection with no warning. Pre-existing, and it reproduces identically on the formula interface.

## The parity answer inverts the issue's framing

From the C source (`~/Documents/GitHub/hazard/src`), which #130 said to consult first:

- `vars/q1.c` computes `Q = GRAD^2 * I22` with `I22 = 1/(H22 - H1' A^-1 H1)` — algebraically
  **identical** to our `u_beta^2 / v_beta`. Observed information, `beta = 0`. Ours is SAS's, exactly.
- `q1.c` documents this very failure: *"IT IS POSSIBLE THAT THE PROGRAM WILL RETURN A NEGATIVE Q
  VALUE ... THE USER SHOULD USE THE MORE EXPENSIVE Q2"*.
- **Q2 is named once in the whole tree and never implemented.**
- `vars/dqstat.c` initialises `qp = 1.0` and returns early on `qflag > 0`, so SAS **declines** the
  candidate (`p = 1`) and records a flag; it also hard-declines `|qbeta| > 50` (Dec 1986 revision).
  `swvarq.c` stores `pvalue[j] = qp`.

**So R and SAS agree, and the shared behaviour is statistically wrong.** That rules out two of the
three directions in the issue: switching to expected information (direction 1) would be a *parity
break*, and reporting the cause (direction 2) was already done by #117/#129.

## What this ships — direction 3

Q is left **untouched**, and a test asserts `.hzr_score_q()` still declines with reason
`"information_indefinite"` as a standing parity guard. Only the *handling* diverges:

- candidates declined for a reason a refit can rescue — `.hzr_score_fallback_reasons`, i.e.
  `"information_indefinite"` and `"coefficient_diverging"` — are refit and Wald-tested in a
  second pass in `.hzr_stepwise_forward_step_score()`;
- degenerate reasons (collinear, constant, non-numeric) are deliberately **excluded**, or the
  criterion gives back the whole speed advantage it exists for. The cost is paid only on the few
  candidates that trip it;
- `$criteria$n_wald_fallbacks` reports the substitution rather than leaving it silent.

Effectively, this is what the unbuilt Q2 was for.

## One fixture repair, and why

Three tests in the new file failed on first run against `main`. All three built their base fit
through the **vector interface**, which only worked on the original branch because its *other*
commit (`f8e8a56`) had lifted that guard. `main` has since hardened that refusal into
`.hzr_refit_blocker()` (#159), and re-landing `f8e8a56` is a design change tracked separately —
see the write-up on #160.

`planted_fit()` now builds through the formula interface, with a comment saying why. **No
assertion was weakened.** The phenomenon is preserved end to end: the parity test still gets
`information_indefinite` from `.hzr_score_q()` on the new base, `n_wald_fallbacks >= 1` still
holds (so a vacuous pass would fail), `x1` is entered, and `x2`/`x3` are asserted to stay out —
the half that catches a fallback that simply refit everything.

## Conflicts resolved

- `R/stepwise.R` `@return` roxygen: `main` added a `refit_failures` / `n_refit_failures` /
  `stopped_refit_failed` paragraph after this branch was cut. Kept it, and applied this commit's
  correction to the neighbouring sentence — which previously said `criterion = "wald"` tests the
  indefinite candidates, and is no longer true now that `score` tests them itself.
- `man/hzr_stepwise.Rd`: generated, regenerated by `document()`.
- `NEWS.md` merged without a conflict but placed the entry in the **1.2.2** section. Moved to a
  new 1.2.7 section; verified purely additive (zero removed lines against `origin/main`).

The rest of the plumbing (`n_wald_fallbacks` through `stepwise-step.R` → `stepwise.R` →
`$criteria`) merged cleanly.

## Gate

Run in full, in a clean worktree off `origin/main`:

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` with `NOT_CRAN=true` — **FAIL 0 | SKIP 6 | PASS 3327**
- `R CMD check --as-cran` with the manual, from a `git archive` export of the committed tree —
  **Status: OK**, no WARNINGs or NOTEs (tests 85s/91s, vignettes 45s/54s). Confirmed no
  `CLAUDE`/`AGENTS` files in the tarball.

Version bumped 1.2.6 → **1.2.7** (patch; `DESCRIPTION` and the `NEWS.md` heading kept in sync by
hand).

> [!NOTE]
> #194 also opens a 1.2.7 `NEWS.md` section. Whichever merges second takes a trivial `NEWS.md`
> conflict under the shared heading.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)