### PR TITLE
fix(weak): distinguish "not checked" from "checked, clean" (#197)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.7
+Version: 1.2.8
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/TemporalHazard/, https://github.com/ehrlinger/TemporalHazard
 BugReports: https://github.com/ehrlinger/TemporalHazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,40 @@
+# TemporalHazard 1.2.8
+
+## Bug fixes
+
+* **`fit$weak` now distinguishes "no ridge" from "not checked".** The
+  weak-identification diagnostic introduced in 1.2.7 returned `NULL` both when
+  a fit had been examined and found well identified and when it could not be
+  examined at all -- most importantly when no Hessian was available, which
+  happens on an install without the suggested numDeriv package and on fits whose
+  rows are left- or interval-censored, where the analytic Hessian declines by
+  design. `NEWS` offered `fit$weak` as the programmatic check, so on those
+  installs it certified as well identified a fit nothing had looked at.
+
+  The field now takes three values: a list when a ridge was found, `NULL` when
+  the fit was examined and is well identified, and `NA` when the check could
+  not run. Test it with `is.list(fit$weak)` rather than `!is.null()`.
+  `summary()` prints a note in the `NA` case saying the check did not run, and
+  a fit imported with `hzr_read_outhaz()` -- which has no R Hessian to examine
+  -- now reports `NA` rather than reading as certified clean.
+
+* **A fit with more than one flat direction says so.** The detector reported a
+  single direction, which invited reading every parameter it did not name as
+  identified. It now reports `n_directions`, the number of distinct
+  near-flat directions found, and the warning says when there is more than
+  one. Distinctness is counted over the parameters spanning each direction,
+  not over eigenvectors: a ridge between two parameters clears the gate twice,
+  once on the flat direction and once on its stiff partner, so counting
+  eigenvectors would report one ridge as two.
+
+## Documentation
+
+* `summary()`'s documentation and the *Inference and diagnostics* vignette
+  both listed the notes the method prints and had not been updated for the
+  ridge note. Both now include it, and the vignette says plainly that a flat
+  direction means the point estimates along it are unreliable, not only their
+  standard errors.
+
 # TemporalHazard 1.2.7
 
 ## New features
@@ -14,8 +51,8 @@
   `hazard()` now warns, once per fit, naming the parameters that span the flat
   direction along with their correlation and the Hessian's `rcond`, and
   `summary()` prints the same note. The finding is recorded on the object as
-  `fit$weak` (`NULL` when the fit is well identified), so it can be checked
-  programmatically rather than scraped from a warning.
+  `fit$weak`, so it can be checked programmatically rather than scraped from a
+  warning. See the 1.2.8 notes below for the three values that field takes.
 
   The direction is read off the *correlation* of the estimates rather than
   their raw covariance. Parameters here sit on very different scales -- an `m`

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1483,6 +1483,17 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     # ("candidate refit failed for ..."), the optimizer's
     # non-conformant-Hessian note, and all errors -- so a bad scope is caught
     # once, up front.
+    #
+    # The weak-identification (ridge) warning deliberately passes through.
+    # It is raised with call. = FALSE, so conditionCall(w) is NULL and the
+    # grepl() below cannot match it -- but the pass-through is intended, not
+    # merely a side effect of that: a ridge in the real-data selected model
+    # says the selection itself rests on parameters the data do not pin down,
+    # which is exactly what this up-front screen exists to surface. It fires
+    # once here; the replicates are suppressWarnings()-wrapped, so there is no
+    # flood. Raising it with call. = TRUE would start muffling it silently,
+    # so if that call. ever changes, add the ridge warning to the list this
+    # handler lets through by name.
     withCallingHandlers(
       do.call(hzr_stepwise, c(
         list(

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -383,11 +383,18 @@ NULL
 #'   the \code{best} and so the reported fit, and the \code{message} of any
 #'   error. A start that stops at \code{maxit} has a finite \code{objective}
 #'   and can win the selection, so \code{status} distinguishes it from one
-#'   that converged. Any fit whose likelihood is near-flat along a parameter
-#'   combination also carries \code{weak}, listing the \code{params}
-#'   spanning that direction, their squared loadings (\code{weights}), the
-#'   strongest pairwise \code{correlation} among them, and the Hessian
-#'   \code{rcond} -- \code{NULL} when the fit is well identified),
+#'   that converged. Every fit carries \code{weak}, which takes one of three
+#'   values: a list, when the likelihood is near-flat along a parameter
+#'   combination, giving the \code{params} spanning that direction, their
+#'   squared loadings (\code{weights}), the strongest pairwise
+#'   \code{correlation} among them, the Hessian \code{rcond} and
+#'   \code{n_directions}, the number of near-flat directions found;
+#'   \code{NULL} when the fit was examined and is well identified; and
+#'   \code{NA} when the check could not run because no usable Hessian was
+#'   available -- which includes an unfitted object and an install without
+#'   the suggested \pkg{numDeriv}. Test with \code{is.list(fit$fit$weak)},
+#'   not \code{!is.null()}: the \code{NA} case has not been examined and
+#'   must not be read as a clean result),
 #'   and \code{engine} (implementation tag, \code{"native-r-m2"}).
 #' @export
 hazard <- function(formula = NULL,
@@ -784,9 +791,13 @@ hazard <- function(formula = NULL,
       p = if (is.null(x_fit)) 0L else ncol(x_fit)
     )
   }
+  # is.list(), not !is.null(): the detector now returns NA when it could not
+  # look at all (no Hessian, or a non-finite covariance among the estimated
+  # parameters), and NULL only when it looked and found nothing. Testing for
+  # non-NULL would warn on the NA and print a message built from empty fields.
   fit_state$weak <- .hzr_weak_direction(fit_state$vcov, fit_state$rcond,
                                         weak_names)
-  if (!is.null(fit_state$weak)) {
+  if (is.list(fit_state$weak)) {
     warning(.hzr_weak_direction_message(fit_state$weak), call. = FALSE)
   }
 
@@ -1523,8 +1534,10 @@ summary.hazard <- function(object, ...) {
 #' and log-likelihood.  When the post-fit Hessian is ill-conditioned or not
 #' positive-definite, a note warns that the standard errors may be unreliable;
 #' when the Hessian could not be inverted at all, a note reports that standard
-#' errors are unavailable.  S3 dispatch only -- users call `print(summary(fit))`
-#' rather than invoking this directly.
+#' errors are unavailable.  A further note names the parameters spanning a
+#' weakly identified direction when one was found, or records that the check
+#' could not run when no Hessian was available.  S3 dispatch only -- users
+#' call `print(summary(fit))` rather than invoking this directly.
 #'
 #' @param x A `summary.hazard` object returned by [summary.hazard()].
 #' @param ... Additional arguments (ignored).
@@ -1567,10 +1580,19 @@ print.summary.hazard <- function(x, ...) {
         format(x$rcond, digits = 3),
         "); standard errors may be unreliable.\n", sep = "")
   }
-  if (!is.null(x$weak)) {
+  if (is.list(x$weak)) {
     # Wrapped rather than cat()'d flat: the message names parameters and two
     # diagnostics, and an unwrapped line buries them off the right edge.
     cat(strwrap(paste0("Note: ", .hzr_weak_direction_message(x$weak)),
+                width = 76, indent = 2, exdent = 8),
+        sep = "\n")
+    cat("\n")
+  } else if (length(x$weak) == 1L && is.na(x$weak)) {
+    # Say that the ridge check did not run, rather than leaving its silence to
+    # be read as a clean bill of health.
+    cat(strwrap(paste0(
+          "Note: the fit was not examined for a weakly identified ",
+          "direction; no usable Hessian was available."),
                 width = 76, indent = 2, exdent = 8),
         sep = "\n")
     cat("\n")

--- a/R/hessian-invert.R
+++ b/R/hessian-invert.R
@@ -100,6 +100,12 @@ NULL
 #' reported: that is ordinary low precision, already covered by the
 #' ill-conditioning warning and by the parameter's own standard error.
 #'
+#' Where two eigenvalues are exactly tied, LAPACK may return any basis of the
+#' degenerate eigenspace, so the loadings can spread across both ridges and
+#' the reported parameter set be their union.  \code{n_directions} is the
+#' honest signal in that case: treat a count above one as "look at the whole
+#' coefficient table", not as a precise inventory of two separate ridges.
+#'
 #' @param vcov Variance-covariance matrix of the estimates.  Rows/columns for
 #'   parameters that were not estimated (\code{NA} diagonals) are dropped.
 #' @param rcond Reciprocal condition number of the Hessian, as returned by
@@ -112,28 +118,53 @@ NULL
 #' @param cor_tol Minimum absolute correlation for a trade-off to count.
 #' @param share Cumulative squared-loading share used to decide how many
 #'   parameters span the flat direction.
-#' @return \code{NULL} when there is no ridge, otherwise a list with
-#'   \code{params} (names spanning the flat direction), \code{weights} (their
-#'   squared loadings), \code{correlation} (the strongest pairwise
-#'   correlation among them) and \code{rcond}.  Directions are examined from
-#'   flattest to stiffest and the first one that is a genuine trade-off is
-#'   reported, so a ridge is still found when some larger block of
-#'   moderately correlated parameters carries more variance than it does.
+#' @return One of three values, which callers must keep distinct:
+#'   \code{NULL} when the check ran and found no ridge; \code{NA} when the
+#'   check \emph{could not} run, because no usable Hessian was available; and
+#'   otherwise a list with \code{params} (names spanning the flat direction),
+#'   \code{weights} (their squared loadings), \code{correlation} (the
+#'   strongest pairwise correlation among them), \code{rcond}, and
+#'   \code{n_directions} (how many independent near-flat directions cleared
+#'   the gate, of which this is the flattest).
+#'
+#'   Collapsing \code{NA} into \code{NULL} is the defect this separation
+#'   exists to prevent: \code{numDeriv} is a \code{Suggests} and the
+#'   analytic Hessian declines for left- and interval-censored rows by
+#'   design, so "no Hessian" is reachable on a real install, and reporting
+#'   it as "well identified" is a result-shaped answer over a computation
+#'   that never happened.
+#'
+#'   Directions are examined from flattest to stiffest and the flattest
+#'   genuine trade-off is reported, so a ridge is still found when some larger
+#'   block of moderately correlated parameters carries more variance than it
+#'   does.
 #' @noRd
 .hzr_weak_direction <- function(vcov, rcond, param_names = NULL,
                                 tol = .hzr_rcond_tol,
                                 cor_tol = .hzr_ridge_cor_tol,
                                 share = 0.9) {
-  # (1) Gate on the existing ill-conditioning threshold.
-  if (length(rcond) != 1L || is.na(rcond) || rcond >= tol) return(NULL)
-  if (is.null(vcov) || !is.matrix(vcov) || nrow(vcov) < 2L) return(NULL)
+  # (1) Gate on the existing ill-conditioning threshold. Each exit below is
+  #     either NA ("could not look") or NULL ("looked, nothing there"); see
+  #     the @return note on why the two must not be merged.
+  #
+  #     An absent or unassessable rcond means no Hessian was obtained, so
+  #     nothing was examined. A well-conditioned one is a real answer: the
+  #     likelihood cannot be near-flat in any direction when it is.
+  if (length(rcond) != 1L || is.na(rcond)) return(NA)
+  if (rcond >= tol) return(NULL)
+  if (is.null(vcov) || !is.matrix(vcov)) return(NA)
+  # One parameter cannot trade off against another, so there is no ridge to
+  # find. That is a conclusion, not a gap.
+  if (nrow(vcov) < 2L) return(NULL)
 
   # (2) Drop parameters that were not estimated (fixed params carry NA rows).
   d <- diag(vcov)
   keep <- which(is.finite(d) & d > 0)
   if (length(keep) < 2L) return(NULL)
   V <- vcov[keep, keep, drop = FALSE]
-  if (anyNA(V) || any(!is.finite(V))) return(NULL)
+  # A non-finite entry among parameters that *were* estimated is a gap: the
+  # covariance exists but cannot be decomposed.
+  if (anyNA(V) || any(!is.finite(V))) return(NA)
 
   nms <- if (length(param_names) == nrow(vcov)) {
     as.character(param_names)[keep]
@@ -144,7 +175,7 @@ NULL
   # (3) Standardise to a correlation matrix (see note above on scaling).
   s <- sqrt(diag(V))
   R <- V / outer(s, s)
-  if (anyNA(R) || any(!is.finite(R))) return(NULL)
+  if (anyNA(R) || any(!is.finite(R))) return(NA)
 
   # (4) Scan the standardised directions from flattest to stiffest, rather
   #     than gating only the leading one. Taking just the top eigenvector
@@ -158,7 +189,7 @@ NULL
   #     reports "well identified" for a fit that is not, which is the exact
   #     failure this function exists to prevent.
   e <- tryCatch(eigen(R, symmetric = TRUE), error = function(e) NULL)
-  if (is.null(e)) return(NULL)
+  if (is.null(e)) return(NA)
 
   # eigen() returns values in decreasing order, so this walks flattest first
   # and the first direction that is a genuine trade-off wins. No separate
@@ -166,6 +197,23 @@ NULL
   # reported: clearing cor_tol requires a strongly correlated pair among the
   # selected parameters, and such a pair always puts a high-variance
   # direction earlier in this same scan, so the flat one is returned first.
+  #     The scan runs to the end rather than returning on the first hit. A
+  #     second flat direction means a second set of parameters is unidentified
+  #     too, and reporting only the first invites reading every parameter it
+  #     does not name as identified. Counting them costs one pass over an
+  #     already-computed eigendecomposition; the flattest is still what gets
+  #     named, since it is the one the data constrain least.
+  #
+  #     Distinctness is measured on the parameter SET, not on the eigenvector.
+  #     A ridge between a and b clears the gate twice -- once on the flat
+  #     direction (a - b) and again on its stiff partner (a + b), since the
+  #     gate tests the correlation among the selected parameters and both
+  #     directions select the same pair. Counting eigenvectors would report a
+  #     single ridge as two. Only the first direction over each set of
+  #     parameters is counted.
+  found <- NULL
+  seen <- character(0)
+
   for (j in seq_along(e$values)) {
     w <- e$vectors[, j]^2
 
@@ -184,11 +232,19 @@ NULL
     r_max <- off[which.max(abs(off))]
     if (abs(r_max) < cor_tol) next
 
-    return(list(params = nms[idx], weights = w[idx],
-                correlation = r_max, rcond = rcond))
+    key <- paste(sort(idx), collapse = ",")
+    if (key %in% seen) next
+    seen <- c(seen, key)
+
+    if (is.null(found)) {
+      found <- list(params = nms[idx], weights = w[idx],
+                    correlation = r_max, rcond = rcond)
+    }
   }
 
-  NULL
+  if (is.null(found)) return(NULL)
+  found$n_directions <- length(seen)
+  found
 }
 
 
@@ -197,10 +253,22 @@ NULL
 #' Shared by the fit-time warning and the \code{summary()} note so the two
 #' never drift apart.
 #'
-#' @param weak A non-\code{NULL} result from \code{.hzr_weak_direction()}.
+#' @param weak A list result from \code{.hzr_weak_direction()}.
 #' @return A single string.
 #' @noRd
 .hzr_weak_direction_message <- function(weak) {
+  # Naming one direction and stopping invites the reader to treat every
+  # parameter it does not mention as identified. When the scan cleared the
+  # gate more than once, say so rather than letting the omission speak.
+  more <- if (isTRUE(weak$n_directions > 1L)) {
+    paste0(
+      " ", weak$n_directions, " near-flat directions were found; this is ",
+      "the flattest, and parameters it does not name may be unidentified ",
+      "too."
+    )
+  } else {
+    ""
+  }
   paste0(
     "weakly identified fit: ",
     paste0("'", weak$params, "'", collapse = " and "),
@@ -209,6 +277,7 @@ NULL
     ", Hessian rcond = ", format(weak$rcond, digits = 3),
     "). The likelihood is near-flat along that direction, so their ",
     "individual point estimates -- not just their standard errors -- are ",
-    "not pinned down by the data."
+    "not pinned down by the data.",
+    more
   )
 }

--- a/R/read-outhaz.R
+++ b/R/read-outhaz.R
@@ -238,10 +238,14 @@ hzr_read_outhaz <- function(path) {
   x_list <- stats::setNames(vector("list", length(phases)), names(phases))
   free_slot <- status[theta_sas] == 1L
 
+  # weak = NA, not absent. An imported SAS fit is never run through
+  # .hzr_weak_direction() -- there is no R Hessian to examine -- and leaving
+  # the element off makes fit$weak NULL, which is the signal for "examined and
+  # well identified". Say "not checked" explicitly.
   fit <- list(
     theta = theta, par = theta,
     converged = TRUE, objective = NA_real_,
-    se = NULL, vcov = NULL,
+    se = NULL, vcov = NULL, weak = NA,
     phases = phases, covariate_counts = cov_counts, x_list = x_list,
     fixed_mask = !free_slot
   )

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -133,11 +133,18 @@ unless the start reached a point where the likelihood is defined),
 the \code{best} and so the reported fit, and the \code{message} of any
 error. A start that stops at \code{maxit} has a finite \code{objective}
 and can win the selection, so \code{status} distinguishes it from one
-that converged. Any fit whose likelihood is near-flat along a parameter
-combination also carries \code{weak}, listing the \code{params}
-spanning that direction, their squared loadings (\code{weights}), the
-strongest pairwise \code{correlation} among them, and the Hessian
-\code{rcond} -- \code{NULL} when the fit is well identified),
+that converged. Every fit carries \code{weak}, which takes one of three
+values: a list, when the likelihood is near-flat along a parameter
+combination, giving the \code{params} spanning that direction, their
+squared loadings (\code{weights}), the strongest pairwise
+\code{correlation} among them, the Hessian \code{rcond} and
+\code{n_directions}, the number of near-flat directions found;
+\code{NULL} when the fit was examined and is well identified; and
+\code{NA} when the check could not run because no usable Hessian was
+available -- which includes an unfitted object and an install without
+the suggested \pkg{numDeriv}. Test with \code{is.list(fit$fit$weak)},
+not \code{!is.null()}: the \code{NA} case has not been examined and
+must not be read as a clean result),
 and \code{engine} (implementation tag, \code{"native-r-m2"}).
 }
 \description{

--- a/man/print.summary.hazard.Rd
+++ b/man/print.summary.hazard.Rd
@@ -20,7 +20,9 @@ phase list (for multiphase), coefficient table with standard errors,
 and log-likelihood.  When the post-fit Hessian is ill-conditioned or not
 positive-definite, a note warns that the standard errors may be unreliable;
 when the Hessian could not be inverted at all, a note reports that standard
-errors are unavailable.  S3 dispatch only -- users call \code{print(summary(fit))}
-rather than invoking this directly.
+errors are unavailable.  A further note names the parameters spanning a
+weakly identified direction when one was found, or records that the check
+could not run when no Hessian was available.  S3 dispatch only -- users
+call \code{print(summary(fit))} rather than invoking this directly.
 }
 \keyword{internal}

--- a/tests/testthat/test-predict-outhaz.R
+++ b/tests/testthat/test-predict-outhaz.R
@@ -627,3 +627,14 @@ test_that("conf.type is validated where it is used, not before", {
   )
   expect_match(conditionMessage(err), "conf_type", fixed = TRUE)
 })
+
+test_that("an imported SAS fit records 'not checked' for the ridge diagnostic", {
+  # An OUTHAZ fit assembles its $fit list outside hazard(), so the ridge
+  # detector never runs on it -- there is no R Hessian to examine. Leaving the
+  # element off would make fit$weak NULL, which is the documented signal for
+  # "examined and well identified", and an imported fit would read as
+  # certified clean by a check that never happened.
+  spec <- .hzr_outhaz_to_spec(hzr_read_outhaz(fixture_path()))
+  expect_false(is.list(spec$fit$weak))
+  expect_true(length(spec$fit$weak) == 1L && is.na(spec$fit$weak))
+})

--- a/tests/testthat/test-weak-direction.R
+++ b/tests/testthat/test-weak-direction.R
@@ -33,9 +33,20 @@ test_that("rcond above tolerance suppresses detection even on a ridge", {
 test_that("a two-parameter ridge names both parameters", {
   w <- .hzr_weak_direction(ridge_vcov(), rcond = 1e-10,
                            param_names = c("a", "b"))
-  expect_false(is.null(w))
+  expect_true(is.list(w))
   expect_setequal(w$params, c("a", "b"))
-  expect_gt(abs(w$correlation), 0.99)
+  # The fixture's own correlation, not the gate. `abs(w$correlation) > 0.99`
+  # cannot fail: the function returns NULL unless it clears cor_tol (0.99),
+  # and the assertion above already establishes it did not.
+  expect_equal(abs(w$correlation), 0.99999, tolerance = 1e-9)
+  # `weights` is a documented field and was asserted nowhere. On a perfect
+  # two-parameter ridge the flat direction is (1, -1)/sqrt(2), so the SQUARED
+  # loadings are (0.5, 0.5). Loadings left un-squared would be +/-0.7071 and
+  # fail both of these -- which is the mutation this pins.
+  expect_equal(unname(w$weights), c(0.5, 0.5), tolerance = 1e-4)
+  expect_true(all(w$weights >= 0))
+  expect_equal(sum(w$weights), 1, tolerance = 1e-8)
+  expect_identical(w$n_directions, 1L)
 })
 
 test_that("the flat direction is scale-invariant", {
@@ -80,36 +91,131 @@ test_that("a moderate correlation is not a ridge", {
   )
 })
 
-test_that("degenerate covariances yield no weak direction rather than an error", {
+test_that("a check that could not run returns NA, not NULL", {
+  # THE SENTINEL. NULL is the documented signal for "examined, well
+  # identified", so every path that never examined anything must be
+  # distinguishable from it. numDeriv is a Suggests and the analytic Hessian
+  # declines for left- and interval-censored rows by design, so an install
+  # with no Hessian at all is reachable -- and there NULL would report a
+  # clean bill of health for a fit nothing looked at.
   nms <- c("a", "b")
-  expect_null(.hzr_weak_direction(NULL, rcond = 1e-10, param_names = nms))
-  expect_null(.hzr_weak_direction(NA, rcond = 1e-10, param_names = nms))
-  expect_null(.hzr_weak_direction(ridge_vcov(), rcond = NA_real_,
+  expect_identical(.hzr_weak_direction(NULL, rcond = 1e-10,
+                                       param_names = nms), NA)
+  expect_identical(.hzr_weak_direction(NA, rcond = 1e-10,
+                                       param_names = nms), NA)
+  # rcond = NA is the numDeriv-absent path: .hzr_safe_solve() returns
+  # list(vcov = NA, rcond = NA_real_, pd = NA).
+  expect_identical(.hzr_weak_direction(ridge_vcov(), rcond = NA_real_,
+                                       param_names = nms), NA)
+  expect_identical(.hzr_weak_direction(ridge_vcov(), rcond = numeric(0),
+                                       param_names = nms), NA)
+  # A non-finite entry among parameters that *were* estimated: the covariance
+  # exists but cannot be decomposed.
+  expect_identical(.hzr_weak_direction(matrix(c(1, NA, NA, 1), 2, 2),
+                                       rcond = 1e-10, param_names = nms), NA)
+  expect_identical(.hzr_weak_direction(matrix(c(1, Inf, Inf, 1), 2, 2),
+                                       rcond = 1e-10, param_names = nms), NA)
+})
+
+test_that("a check that ran and found nothing returns NULL", {
+  nms <- c("a", "b")
+  # Well conditioned: the likelihood cannot be near-flat in any direction,
+  # so this is a conclusion rather than a gap.
+  expect_null(.hzr_weak_direction(ridge_vcov(), rcond = 1e-3,
                                   param_names = nms))
-  expect_null(.hzr_weak_direction(matrix(c(1, NA, NA, 1), 2, 2),
-                                  rcond = 1e-10, param_names = nms))
-  # A non-estimated (fixed) parameter carries an NA row/column.
-  V <- ridge_vcov()
-  V3 <- matrix(NA_real_, 3, 3)
-  V3[1:2, 1:2] <- V
-  expect_setequal(
-    .hzr_weak_direction(V3, rcond = 1e-10,
-                        param_names = c("a", "b", "fixed"))$params,
-    c("a", "b")
-  )
-  # Zero variance makes the correlation undefined.
+  # A zero-variance parameter is dropped by the `keep` filter, leaving one
+  # estimated parameter and so no pair to trade off. (It never reaches the
+  # correlation step, which an earlier comment here claimed it tested.)
   expect_null(.hzr_weak_direction(diag(c(0, 1)), rcond = 1e-10,
                                   param_names = nms))
+  # A single-parameter fit, likewise.
+  expect_null(.hzr_weak_direction(matrix(1e12, 1, 1), rcond = 1e-10,
+                                  param_names = "a"))
+})
+
+test_that("a fixed parameter's NA row is dropped rather than blocking the check", {
+  # A non-estimated (fixed) parameter carries an NA row/column. That is not a
+  # gap -- the remaining block is intact and is examined.
+  V3 <- matrix(NA_real_, 3, 3)
+  V3[1:2, 1:2] <- ridge_vcov()
+  w <- .hzr_weak_direction(V3, rcond = 1e-10,
+                           param_names = c("a", "b", "fixed"))
+  expect_true(is.list(w))
+  expect_setequal(w$params, c("a", "b"))
+})
+
+test_that("two independent ridges are counted, not silently reduced to one", {
+  # Reporting one direction and stopping invites reading every parameter it
+  # does not name as identified. Two disjoint near-perfect pairs among four
+  # parameters: whichever is reported, n_directions must say there is more.
+  R <- diag(4)
+  R[1, 2] <- R[2, 1] <- 0.99999
+  R[3, 4] <- R[4, 3] <- 0.9999
+  w <- .hzr_weak_direction(R, rcond = 1e-10,
+                           param_names = paste0("p", 1:4))
+  expect_true(is.list(w))
+  expect_identical(w$n_directions, 2L)
+  # The flattest is reported: p1/p2 is the more strongly correlated pair.
+  expect_setequal(w$params, c("p1", "p2"))
+  # And the message says the other one exists.
+  expect_match(.hzr_weak_direction_message(w), "2 near-flat directions")
+  expect_match(.hzr_weak_direction_message(w), "may be unidentified too")
 })
 
 test_that("unnamed parameters fall back to positional labels", {
   w <- .hzr_weak_direction(ridge_vcov(), rcond = 1e-10, param_names = NULL)
-  expect_false(is.null(w))
-  expect_length(w$params, 2)
+  expect_true(is.list(w))
+  # expect_length(w$params, 2) was the whole test, and it passes for
+  # c("", ""), c(NA, NA) and c("par1", "par2") alike -- so it asserted
+  # nothing about the labels the fallback exists to produce. The positions
+  # are indices into the kept parameters, so both rows survive as par1/par2.
+  expect_setequal(w$params, c("par1", "par2"))
+  # A fixed (dropped) parameter shifts the labels, since they are indices
+  # into the original vcov rather than into the kept block.
+  V3 <- matrix(NA_real_, 3, 3)
+  V3[2:3, 2:3] <- ridge_vcov()
+  w3 <- .hzr_weak_direction(V3, rcond = 1e-10, param_names = NULL)
+  expect_setequal(w3$params, c("par2", "par3"))
 })
 
-test_that("the multiphase ridge fixture warns and records nu and m", {
+test_that("a multiphase ridge is reported under phase-qualified names", {
+  # The naming half of the multiphase case, without the optimizer. Building
+  # the covariance directly makes this deterministic: the end-to-end test
+  # below depends on which optimum the perturbed start finds, and cannot pin
+  # the labels without inheriting that dependence.
+  phases <- list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+                 const = hzr_phase("constant"))
+  nms <- unlist(lapply(names(phases), function(nm) {
+    .hzr_phase_theta_names(phases[[nm]], nm)
+  }), use.names = FALSE)
+  expect_true(all(c("early.nu", "early.m") %in% nms))
+
+  # A near-perfect trade-off between nu and m, on the wildly different scales
+  # they actually occupy (m ~ 27 against nu ~ 0.027), with every other
+  # parameter well determined.
+  R <- diag(length(nms))
+  i <- match(c("early.nu", "early.m"), nms)
+  R[i[1], i[2]] <- R[i[2], i[1]] <- -0.99999
+  sdv <- rep(1, length(nms))
+  sdv[i] <- c(0.03, 30)
+  V <- outer(sdv, sdv) * R
+  dimnames(V) <- list(nms, nms)
+
+  w <- .hzr_weak_direction(V, rcond = 1e-10, param_names = nms)
+  expect_true(is.list(w))
+  expect_setequal(w$params, c("early.nu", "early.m"))
+  expect_identical(w$n_directions, 1L)
+})
+
+test_that("the multiphase fit path wires a ridge through to the object", {
   skip_on_cran()
+  # The WIRING half: that hazard()'s multiphase branch runs the detector and
+  # stores the result under phase-qualified names. Which pair it finds is
+  # deliberately not asserted -- see the naming test above, which pins that
+  # deterministically. This fixture reaches its ridge only via the n_starts=5
+  # perturbed start (n_starts=1 lands on a different, degenerate optimum) at a
+  # correlation of -0.995 against a 0.99 gate, so tying the assertion to the
+  # exact pair would make an optimizer-path change look like a detector bug.
   set.seed(42)
   n <- 100
   time   <- rexp(n, rate = 0.5) + 0.01
@@ -122,11 +228,17 @@ test_that("the multiphase ridge fixture warns and records nu and m", {
                   phases = phases, fit = TRUE,
                   control = list(n_starts = 5, maxit = 500))
   )
-  # The perturbed start wins and lands on the m*nu ridge, where m (~27) and nu
-  # (~0.027) are identified only through their product.
+  # Named separately so a fixture that stops landing on the ridge reads as a
+  # fixture problem rather than as the detector failing.
+  expect_true(
+    is.list(fit$fit$weak),
+    info = paste("the multiphase ridge fixture no longer lands on a ridge;",
+                 "re-tune the fixture rather than the detector")
+  )
   expect_true(any(grepl("only in combination", w)))
-  expect_false(is.null(fit$fit$weak))
-  expect_setequal(fit$fit$weak$params, c("early.nu", "early.m"))
+  expect_gte(length(fit$fit$weak$params), 2L)
+  expect_true(all(grepl("^(early|const)\\.", fit$fit$weak$params)))
+  expect_gte(abs(fit$fit$weak$correlation), .hzr_ridge_cor_tol)
 })
 
 test_that("a well-identified fit stays silent and records no weak direction", {
@@ -199,7 +311,10 @@ test_that("summary() prints the ridge note when one is recorded", {
   out <- paste(capture.output(print(summary(fit))), collapse = " ")
   out <- gsub("\\s+", " ", out)
   expect_match(out, "only in combination")
-  expect_match(out, "early\\.nu")
+  # A phase-qualified name, not a specific one: this test is about the note
+  # reaching the console, and the fixture's pair is pinned deterministically
+  # by "a multiphase ridge is reported under phase-qualified names" above.
+  expect_match(out, "'(early|const)\\.[a-z_]+'")
 })
 
 test_that("a single-distribution ridge is reported under the real parameter names", {
@@ -227,4 +342,26 @@ test_that("a single-distribution ridge is reported under the real parameter name
   expect_false(is.null(fit$fit$weak))
   expect_null(names(fit$fit$par))          # the condition the fallback exists for
   expect_setequal(fit$fit$weak$params, c("beta1", "beta2"))
+})
+
+test_that("an unfitted object records 'not checked', not 'well identified'", {
+  # hazard(fit = FALSE) never reaches an optimizer, so there is no Hessian and
+  # nothing was examined. NULL here would be the documented signal for "well
+  # identified" over a fit that does not exist.
+  set.seed(11)
+  n <- 50
+  fit0 <- hazard(time = stats::rweibull(n, 1.4, 2),
+                 status = rep(1L, n), dist = "weibull", fit = FALSE)
+  expect_false(is.list(fit0$fit$weak))
+  expect_true(length(fit0$fit$weak) == 1L && is.na(fit0$fit$weak))
+})
+
+test_that("summary() says so when the ridge check could not run", {
+  set.seed(11)
+  n <- 50
+  fit0 <- hazard(time = stats::rweibull(n, 1.4, 2),
+                 status = rep(1L, n), dist = "weibull", fit = FALSE)
+  out <- paste(capture.output(print(summary(fit0))), collapse = " ")
+  out <- gsub("\\s+", " ", out)
+  expect_match(out, "not examined for a weakly identified direction")
 })

--- a/vignettes/inference-diagnostics.qmd
+++ b/vignettes/inference-diagnostics.qmd
@@ -177,10 +177,15 @@ asymptotically correct, but they lean on the Hessian-derived
 parameter vcov — which can mislead when the likelihood surface is
 poorly behaved near the MLE (boundary fits, near-degenerate
 parameter combinations, small samples). The package flags these
-cases for you: each fit carries `rcond` and `pd` diagnostics, and
-`summary()` prints a note (with a matching warning at fit time) when
-the Hessian is ill-conditioned or not positive-definite — a strong
-signal to prefer the bootstrap. Bootstrap resampling is the
+cases for you: each fit carries `rcond`, `pd` and `weak` diagnostics,
+and `summary()` prints a note (with a matching warning at fit time)
+when the Hessian is ill-conditioned, is not positive-definite, could
+not be inverted at all, or is flat along some combination of
+parameters — any of which is a strong signal to prefer the bootstrap.
+That last one is worth reading closely: it means the individual
+estimates along that direction are not pinned down by the data, so it
+is not only the standard errors that are unreliable. Bootstrap
+resampling is the
 robust alternative: refit the model on each resampled dataset,
 collect the resulting parameter and prediction values, and read the
 empirical 2.5th / 97.5th percentiles as the 95% CI. It's


### PR DESCRIPTION
Closes #197 — the six medium/low findings deferred from the review of #194.

## The one that matters

`fit$weak` returned `NULL` both when a fit had been examined and found well
identified and when it **could not be examined at all**. The second case is
reachable on a real install: `numDeriv` is a `Suggests`, and the analytic
Hessian declines for left- and interval-censored rows by design, so
`.hzr_safe_solve()` returns `rcond = NA` and nothing was ever looked at.
`NEWS.md` offered `is.null(fit$weak)` as the *programmatic* check, so on those
installs it certified as well identified a fit nothing had inspected. That is
the shape `AGENTS.md` opens with — a result-shaped answer over a computation
that did not happen.

`fit$weak` now takes three values:

| Value | Meaning |
|---|---|
| list | a ridge was found |
| `NULL` | the check ran and found nothing |
| `NA` | the check could not run — no usable Hessian |

Callers test with `is.list()`. `hzr_read_outhaz()` sets `NA` explicitly: an
imported SAS fit has no R Hessian to examine and previously read as certified
clean. `summary()` prints a note in the `NA` case.

The split is not mechanical. `rcond >= tol` is a genuine **clean** — a
well-conditioned Hessian cannot be near-flat in any direction — while
`rcond` being `NA` means nothing was examined. Same for `nrow(vcov) < 2`
(one parameter cannot trade off against another: a conclusion) versus a
non-finite entry among parameters that *were* estimated (a gap).

## `n_directions`

Reporting one direction invited reading every parameter it did not name as
identified. The scan now runs to the end and reports how many directions
cleared the gate.

Counting them is subtler than it looks. The original loop was correct because
`eigen()` orders decreasing and the flat direction of a correlated pair always
precedes its stiff partner — but that invariant only supports *first match
wins*. Both directions span the same parameters and clear the same gate, so
counting eigenvectors reports one ridge as two. This is not hypothetical: it
was the first implementation, and the tests caught it. Distinctness is counted
over the parameter **set**.

## Test repairs

Four assertions that could not fail:

- `expect_gt(abs(w$correlation), 0.99)` restated the gate the function already
  passed. Now asserts the fixture's own 0.99999.
- `expect_length(w$params, 2)` was the only test of the unnamed-parameter
  fallback and passed for `c("", "")` and `c(NA, NA)` alike. Now asserts
  `par1`/`par2`, plus the fixed-parameter case where the indices shift.
- `weights` was a documented field asserted nowhere. Now pinned at
  `c(0.5, 0.5)` — loadings left un-squared would be ±0.7071 and fail.
- One comment claimed `diag(c(0, 1))` tested the correlation step; it exits at
  the zero-variance filter.

## The fixture

The multiphase ridge test reached its ridge only via the `n_starts = 5`
perturbed start, at correlation **−0.99533** against a **0.99** gate — and
`n_starts = 1` lands on a different, degenerate optimum (one eigenvalue of the
correlation matrix is −24.6) with no ridge at all. Across BLAS that is a
plausible flake, and it would fail as a *false alarm*: the detector looking
broken when it is not.

Split in two. Naming is pinned deterministically on a constructed covariance
carrying real phase-qualified `dimnames`; the end-to-end test asserts the
wiring without the exact pair, and says explicitly in its failure message that
a fixture that stops landing on a ridge is a fixture problem.

## Also

- The bootstrap select-mode pre-flight's ridge pass-through is now recorded as
  deliberate, with what to change if that `call. = FALSE` ever flips.
- `print.summary.hazard`'s roxygen and `vignettes/inference-diagnostics.qmd`
  both enumerated the notes `summary()` prints and had not been updated.

## Gate

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` — **0 FAIL / 6 SKIP / 3399 PASS** (skips are fixture
  availability only)
- `R CMD check --as-cran` from a clean `git archive`, with the manual and
  vignettes — **Status: OK**, 3m25s (tests 83s/88s, vignettes 42s/45s), in
  line with the 3m29s baseline in `AGENTS.md`

Mutation-checked: collapsing `NA` back into `NULL` fails 4 tests; removing the
parameter-set dedup fails 4.

Version 1.2.7 → 1.2.8 (patch). Because 1.2.7 is unreleased, its `NEWS.md`
entry — which stated the `NULL`-only contract — was corrected in place rather
than left standing wrong next to 1.2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)