### PR TITLE
feat(stepwise): say what `stat` is on each step row (#196)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,7 +56,7 @@
   refit the winner again with identical arguments. The two fits were
   bit-identical, so this was cost rather than incorrectness -- but it doubled
   the price of every accepted fallback entry, against a criterion whose whole
-  advantage is that it does not refit per candidate. The fallback's fit is now
+  advantage is that it does not refit per candidate. The rescuing fit is now
   kept and reused, as the Wald path already did with its candidate fits.
 
 ## Documentation
@@ -73,8 +73,8 @@
   comments named. Widening `.hzr_score_fallback_reasons` to include `constant`
   and `collinear` left both green, because a degenerate candidate still fails
   to enter -- it merely costs a refit on the way out -- and the "noise stays
-  out" assertion is guarded by `slentry` rather than by the fallback's
-  narrowness (the fixture's own Wald p-values are 0.0997 and 0.149, so a
+  out" assertion is guarded by `slentry` rather than by how narrow the
+  fallback is (the fixture's own Wald p-values are 0.0997 and 0.149, so a
   fallback that refit everything would still decline both). Both now assert
   `n_wald_fallbacks`, which is the quantity that moves.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # TemporalHazard 1.2.8
 
+## New features
+
+* **`hzr_stepwise()`'s `$steps` frame gains a `stat_type` column**, saying
+  what the `stat` on that row is and so which reference distribution
+  recomputes its p-value: `"score_q"` (chi-square on `df`), `"wald_z"`
+  (standard normal) or `"wald_chisq"` (chi-square on `df`).
+
+  `df` could not tell these apart. A scalar Wald is reported as a *z*, not as
+  its square, so it and a score Q are both recorded at `df = 1` while calling
+  for different distributions. The gap was widest on a candidate rescued by
+  the Wald fallback added in 1.2.7: that row carries a Wald z under
+  `criterion = "score"`, where every neighbouring row carries a Q. The
+  selection was right and `p_value` was right, but a reader recomputing a
+  p-value from `stat` the way the neighbouring rows permit got an answer wrong
+  by dozens of orders of magnitude. Under `criterion = "score"` the rows
+  reading `"wald_z"` are exactly the ones the fallback rescued.
+
+* **`hzr_bootstrap()` reports Wald fallbacks in select mode**, through
+  `$n_wald_fallback_replicates` and `$n_wald_fallbacks`, with a warning when
+  either is non-zero. Every replicate runs under `suppressWarnings()`, so a
+  run in which the fallback fired throughout previously reported nothing at
+  all -- and the bootstrap is where a wholesale substitution matters most,
+  since those entries drive the pooled selection frequencies.
+
 ## Bug fixes
 
 * **`fit$weak` now distinguishes "no ridge" from "not checked".** The
@@ -27,6 +51,14 @@
   once on the flat direction and once on its stiff partner, so counting
   eigenvectors would report one ridge as two.
 
+* **A rescued candidate that goes on to win is no longer fitted twice.** The
+  Wald fallback refits each candidate it rescues, and the acceptance step then
+  refit the winner again with identical arguments. The two fits were
+  bit-identical, so this was cost rather than incorrectness -- but it doubled
+  the price of every accepted fallback entry, against a criterion whose whole
+  advantage is that it does not refit per candidate. The fallback's fit is now
+  kept and reused, as the Wald path already did with its candidate fits.
+
 ## Documentation
 
 * `summary()`'s documentation and the *Inference and diagnostics* vignette
@@ -34,6 +66,21 @@
   ridge note. Both now include it, and the vignette says plainly that a flat
   direction means the point estimates along it are unreliable, not only their
   standard errors.
+
+## Internal
+
+* Two tests in `test-score-wald-fallback.R` did not catch the mutations their
+  comments named. Widening `.hzr_score_fallback_reasons` to include `constant`
+  and `collinear` left both green, because a degenerate candidate still fails
+  to enter -- it merely costs a refit on the way out -- and the "noise stays
+  out" assertion is guarded by `slentry` rather than by the fallback's
+  narrowness (the fixture's own Wald p-values are 0.0997 and 0.149, so a
+  fallback that refit everything would still decline both). Both now assert
+  `n_wald_fallbacks`, which is the quantity that moves.
+
+* A roxygen block in `R/score-test.R` bound to the character vector declared
+  after it rather than to the function it documents. `@noRd`, so no Rd was
+  affected; source readability only.
 
 # TemporalHazard 1.2.7
 

--- a/R/candidate-score.R
+++ b/R/candidate-score.R
@@ -89,7 +89,13 @@
 #'   \item{score}{Numeric, smaller is better (see file header).}
 #'   \item{criterion}{Echoed input.}
 #'   \item{mode}{Echoed input.}
-#'   \item{stat}{Wald z (scalar) or chi^2 (joint).}
+#'   \item{stat}{Wald z (scalar) or chi^2 (joint), or the score Q.}
+#'   \item{stat_type}{What `stat` is, and so what reference distribution
+#'     recomputes its p-value: `"score_q"` (chi^2 on `df`), `"wald_z"`
+#'     (standard normal) or `"wald_chisq"` (chi^2 on `df`).  `df` alone does
+#'     not distinguish these -- a scalar Wald z and a score Q are both
+#'     recorded at `df = 1` -- so a caller recomputing from `stat` needs
+#'     this.}
 #'   \item{df}{Integer degrees of freedom.}
 #'   \item{p_value}{Always populated when computable.}
 #'   \item{delta_aic}{Always populated when computable.}
@@ -130,6 +136,7 @@
       criterion = criterion,
       mode      = mode,
       stat      = score$stat,
+      stat_type = "score_q",
       df        = score$df,
       p_value   = score$p_value,
       delta_aic = NA_real_,        # no candidate refit to take an AIC from
@@ -191,6 +198,10 @@
     criterion = criterion,
     mode      = mode,
     stat      = wald$stat,
+    # A one-df Wald is reported as a z, not as its square, so it and a score Q
+    # are indistinguishable on `df` alone while calling for different
+    # reference distributions.
+    stat_type = if (wald$df == 1L) "wald_z" else "wald_chisq",
     df        = wald$df,
     p_value   = wald$p_value,
     delta_aic = delta,

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1342,6 +1342,17 @@ print.hzr_nelson <- function(x, digits = 4, ...) {
 #'     optimum; such a replicate continued from a refit that did not converge,
 #'     and its later selections are pooled on the same footing as any other.
 #'     Always `0` in refit mode.}
+#'   \item{n_wald_fallback_replicates, n_wald_fallbacks}{Select mode only:
+#'     the number of otherwise successful replicates that entered at least one
+#'     variable on a Wald test instead of the score statistic, and the total
+#'     number of such entries across all replicates. The score criterion
+#'     declines a candidate whose observed information is indefinite at
+#'     `beta = 0` -- which happens when the effect is *large* -- so those
+#'     candidates are refit and Wald-tested rather than dropped. A high count
+#'     means much of the selection was decided by a different criterion from
+#'     the one requested, which matters most here: these entries drive the
+#'     pooled selection frequencies on the same footing as every other.
+#'     Always `0` in refit mode.}
 #'   \item{mode}{`"refit"` (fixed-formula bootstrap) or `"select"`
 #'     (embedded stepwise selection).}
 #'   \item{scope}{Only present when `mode == "select"`: the candidate
@@ -1592,6 +1603,15 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   # replicate that converged, and every replicate runs under
   # suppressWarnings() so the step-level warning cannot reach the user.
   n_nonmonotone_reps <- 0L
+  # Replicates in which the score criterion declined a candidate it could not
+  # score and the Wald fallback tested it instead. The fallback is a different
+  # criterion, so a run where it fired everywhere selected on Wald while
+  # reporting `criterion = "score"` -- and the bootstrap is where a wholesale
+  # substitution distorts most, since it drives the selection frequencies.
+  # Each replicate runs under suppressWarnings(), so nothing else can surface
+  # this.
+  n_wald_fallback_reps <- 0L
+  n_wald_fallbacks <- 0L
 
   # Progress bar over replicates (verbose only). Closed after the loop.
   pb <- if (verbose) utils::txtProgressBar(min = 0, max = n_boot, style = 3)
@@ -1683,6 +1703,11 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
         )
         if (isTRUE((boot_fit$criteria$n_nonmonotone_entries %||% 0L) > 0L)) {
           n_nonmonotone_reps <- n_nonmonotone_reps + 1L
+        }
+        n_fb <- boot_fit$criteria$n_wald_fallbacks %||% 0L
+        if (n_fb > 0L) {
+          n_wald_fallback_reps <- n_wald_fallback_reps + 1L
+          n_wald_fallbacks <- n_wald_fallbacks + n_fb
         }
       }
       theta_b <- boot_fit$fit$theta
@@ -1804,6 +1829,16 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
             "`$n_nonmonotone_replicates`.", call. = FALSE)
   }
 
+  if (n_wald_fallback_reps > 0L) {
+    warning(n_wald_fallback_reps, " of ", n_success, " successful replicates ",
+            "entered at least one variable on a Wald test rather than on the ",
+            "score statistic (", n_wald_fallbacks, " candidate(s) in total), ",
+            "because the score could not test them. Those entries were ",
+            "decided by a different criterion from the rest of the run, and ",
+            "they are in the pooled frequencies on the same footing as ",
+            "everything else. See `$n_wald_fallbacks`.", call. = FALSE)
+  }
+
   result <- list(
     replicates = replicates,
     summary    = summary_df,
@@ -1812,6 +1847,8 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     n_uncomputable_replicates = n_uncomputable_reps,
     uncomputable_reasons      = uncomputable_reasons,
     n_nonmonotone_replicates  = n_nonmonotone_reps,
+    n_wald_fallback_replicates = n_wald_fallback_reps,
+    n_wald_fallbacks          = n_wald_fallbacks,
     mode       = if (select_mode) "select" else "refit"
   )
   if (select_mode) result$scope <- scope

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -696,13 +696,6 @@
 }
 
 
-#' One-line explanation of an unscorable candidate
-#'
-#' Maps `.hzr_score_q()`'s reason codes to prose for a warning. An unknown code
-#' passes through as itself, so a code added later still reports rather than
-#' silently becoming an empty string.
-#'
-#' @noRd
 # Reasons a candidate can be rescued by refitting it and testing by Wald.
 #
 # Both mean "the quadratic approximation at beta = 0 broke down", which is
@@ -720,6 +713,13 @@
 .hzr_score_fallback_reasons <- c("information_indefinite",
                                  "coefficient_diverging")
 
+#' One-line explanation of an unscorable candidate
+#'
+#' Maps `.hzr_score_q()`'s reason codes to prose for a warning. An unknown code
+#' passes through as itself, so a code added later still reports rather than
+#' silently becoming an empty string.
+#'
+#' @noRd
 .hzr_score_reason_text <- function(reason) {
   txt <- c(
     information_indefinite = paste(

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -176,6 +176,7 @@
       p_value   = NA_real_,
       delta_aic = NA_real_,
       stat      = NA_real_,
+      stat_type = NA_character_,
       df        = NA_integer_,
       all_scores = data.frame(
         variable  = character(),
@@ -184,6 +185,7 @@
         p_value   = numeric(),
         delta_aic = numeric(),
         stat      = numeric(),
+        stat_type = character(),
         df        = integer(),
         stringsAsFactors = FALSE
       ),
@@ -234,6 +236,7 @@
         p_value   = NA_real_,
         delta_aic = NA_real_,
         stat      = NA_real_,
+        stat_type = NA_character_,
         df        = NA_integer_,
         stringsAsFactors = FALSE
       )
@@ -259,6 +262,7 @@
       p_value   = s$p_value,
       delta_aic = s$delta_aic,
       stat      = s$stat,
+      stat_type = s$stat_type,
       df        = s$df,
       stringsAsFactors = FALSE
     )
@@ -304,6 +308,7 @@
     p_value   = best$p_value,
     delta_aic = best$delta_aic,
     stat      = best$stat,
+    stat_type = best$stat_type,
     df        = best$df,
     all_scores = all_scores,
     refit_failures = failures
@@ -357,6 +362,7 @@
       p_value   = s$p_value,
       delta_aic = s$delta_aic,
       stat      = s$stat,
+      stat_type = s$stat_type,
       df        = s$df,
       reason    = s_q$reason %||% NA_character_,
       stringsAsFactors = FALSE
@@ -373,6 +379,12 @@
   # actually rescue qualify -- see .hzr_score_fallback_reasons.
   all_scores$fallback <- FALSE
   fallback_failures <- character()
+  # Keep each fallback's refit, keyed by row, the way the Wald path keeps its
+  # candidate fits. The acceptance step below refits the winner with exactly
+  # the same arguments, so without this a rescued candidate that goes on to
+  # win is fitted twice -- against a criterion whose whole advantage is that
+  # it does not refit per candidate.
+  fallback_fits <- vector("list", nrow(all_scores))
   for (i in which(is.na(all_scores$score) &
                     all_scores$reason %in% .hzr_score_fallback_reasons)) {
     cand_phase <- if (is.na(all_scores$phase[i])) NULL else all_scores$phase[i]
@@ -405,9 +417,14 @@
                                        cand_phase)
     )
     if (is.na(w$score)) next
+    fallback_fits[[i]]     <- refit
     all_scores$score[i]    <- w$score
     all_scores$p_value[i]  <- w$p_value
     all_scores$stat[i]     <- w$stat
+    # `stat` is now a Wald z where every other row on this screen carries a
+    # score Q. Leaving stat_type saying "score_q" would make a reader who
+    # recomputes pchisq(stat, df) wrong by dozens of orders of magnitude.
+    all_scores$stat_type[i] <- w$stat_type
     all_scores$df[i]       <- w$df
     all_scores$fallback[i] <- TRUE
     all_scores$reason[i]   <- NA_character_
@@ -460,13 +477,18 @@
   }
 
   best_phase <- if (is.na(best$phase)) NULL else best$phase
-  refitted <- tryCatch(
-    .hzr_refit_with_scope(
-      current, action = "add", var = best$variable, phase = best_phase,
-      data = data, ...
-    ),
-    error = function(e) e
-  )
+  # A rescued winner was already fitted, with identical arguments, in the
+  # fallback loop above. Reuse it rather than paying for the same fit twice.
+  refitted <- fallback_fits[[best_idx]]
+  if (is.null(refitted)) {
+    refitted <- tryCatch(
+      .hzr_refit_with_scope(
+        current, action = "add", var = best$variable, phase = best_phase,
+        data = data, ...
+      ),
+      error = function(e) e
+    )
+  }
 
   failure_token <- if (is.na(best$phase)) {
     best$variable
@@ -498,6 +520,7 @@
     p_value   = best$p_value,
     delta_aic = best$delta_aic,
     stat      = best$stat,
+    stat_type = best$stat_type,
     df        = best$df,
     all_scores = all_scores,
     refit_failures = fallback_failures,
@@ -635,6 +658,7 @@
     p_value   = numeric(),
     delta_aic = numeric(),
     stat      = numeric(),
+    stat_type = character(),
     df        = integer(),
     stringsAsFactors = FALSE
   )
@@ -649,6 +673,7 @@
       p_value   = NA_real_,
       delta_aic = NA_real_,
       stat      = NA_real_,
+      stat_type = NA_character_,
       df        = NA_integer_,
       all_scores     = all_scores,
       refit_failures = character()
@@ -677,6 +702,7 @@
       p_value   = s$p_value,
       delta_aic = s$delta_aic,
       stat      = s$stat,
+      stat_type = s$stat_type,
       df        = s$df,
       stringsAsFactors = FALSE
     )
@@ -734,6 +760,7 @@
     p_value   = best$p_value,
     delta_aic = best$delta_aic,
     stat      = best$stat,
+    stat_type = best$stat_type,
     df        = best$df,
     all_scores     = all_scores,
     refit_failures = character()

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -173,8 +173,17 @@
 #'     `"score"`, `"wald"`, or `"aic"`.  Under `criterion = "score"` the drop
 #'     rows read `"wald"`, because score is entry-only.}
 #'   \item{\code{score}}{Winning score used for the decision.}
-#'   \item{\code{stat}, \code{df}}{Test statistic (score Q or Wald) and
-#'     degrees of freedom.}
+#'   \item{\code{stat}, \code{df}}{Test statistic and degrees of freedom.}
+#'   \item{\code{stat_type}}{What \code{stat} is on this row, and so which
+#'     reference distribution recomputes its p-value: \code{"score_q"}
+#'     (chi-square on \code{df}), \code{"wald_z"} (standard normal) or
+#'     \code{"wald_chisq"} (chi-square on \code{df}).  \code{df} alone does
+#'     not distinguish them --- a scalar Wald is reported as a \emph{z}, not
+#'     as its square, so it and a score Q are both recorded at \code{df = 1}
+#'     while calling for different distributions.  This also identifies the
+#'     rows the Wald fallback rescued: under \code{criterion = "score"} they
+#'     are the ones reading \code{"wald_z"} (see \code{$criteria$n_wald_fallbacks}
+#'     for the count).}
 #'   \item{\code{p_value}, \code{delta_aic}}{Always populated when
 #'     computable, regardless of the active criterion.}
 #'   \item{\code{logLik}, \code{aic}, \code{n_coef}}{Goodness-of-fit
@@ -332,6 +341,7 @@ hzr_stepwise <- function(fit,
       criterion = crit,
       score     = out$score,
       stat      = out$stat,
+      stat_type = out$stat_type %||% NA_character_,
       df        = out$df,
       p_value   = out$p_value,
       delta_aic = out$delta_aic,
@@ -372,6 +382,7 @@ hzr_stepwise <- function(fit,
       criterion = criterion,
       score     = NA_real_,
       stat      = NA_real_,
+      stat_type = NA_character_,
       df        = NA_integer_,
       p_value   = NA_real_,
       delta_aic = NA_real_,
@@ -531,7 +542,7 @@ hzr_stepwise <- function(fit,
       step_num = integer(), action = character(),
       variable = character(), phase = character(),
       criterion = character(), score = numeric(),
-      stat = numeric(), df = integer(),
+      stat = numeric(), stat_type = character(), df = integer(),
       p_value = numeric(), delta_aic = numeric(),
       logLik = numeric(), delta_logLik = numeric(),
       aic = numeric(), n_coef = integer(),

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -18,6 +18,7 @@ Decile
 EL
 esophagectomy
 estimand
+fallbacks
 GOF
 Gompertz
 HAZARD's
@@ -42,6 +43,7 @@ Multiphase
 Multivariable
 Mächler
 NCHS
+neighbouring
 NYHA
 Naftel
 Nelder

--- a/man/hzr_bootstrap.Rd
+++ b/man/hzr_bootstrap.Rd
@@ -113,6 +113,17 @@ log-likelihood. Entered models are nested, so this cannot occur at the
 optimum; such a replicate continued from a refit that did not converge,
 and its later selections are pooled on the same footing as any other.
 Always \code{0} in refit mode.}
+\item{n_wald_fallback_replicates, n_wald_fallbacks}{Select mode only:
+the number of otherwise successful replicates that entered at least one
+variable on a Wald test instead of the score statistic, and the total
+number of such entries across all replicates. The score criterion
+declines a candidate whose observed information is indefinite at
+\code{beta = 0} -- which happens when the effect is \emph{large} -- so those
+candidates are refit and Wald-tested rather than dropped. A high count
+means much of the selection was decided by a different criterion from
+the one requested, which matters most here: these entries drive the
+pooled selection frequencies on the same footing as every other.
+Always \code{0} in refit mode.}
 \item{mode}{\code{"refit"} (fixed-formula bootstrap) or \code{"select"}
 (embedded stepwise selection).}
 \item{scope}{Only present when \code{mode == "select"}: the candidate

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -151,8 +151,17 @@ The \code{steps} data frame has columns:
 \code{"score"}, \code{"wald"}, or \code{"aic"}.  Under \code{criterion = "score"} the drop
 rows read \code{"wald"}, because score is entry-only.}
 \item{\code{score}}{Winning score used for the decision.}
-\item{\code{stat}, \code{df}}{Test statistic (score Q or Wald) and
-degrees of freedom.}
+\item{\code{stat}, \code{df}}{Test statistic and degrees of freedom.}
+\item{\code{stat_type}}{What \code{stat} is on this row, and so which
+reference distribution recomputes its p-value: \code{"score_q"}
+(chi-square on \code{df}), \code{"wald_z"} (standard normal) or
+\code{"wald_chisq"} (chi-square on \code{df}).  \code{df} alone does
+not distinguish them --- a scalar Wald is reported as a \emph{z}, not
+as its square, so it and a score Q are both recorded at \code{df = 1}
+while calling for different distributions.  This also identifies the
+rows the Wald fallback rescued: under \code{criterion = "score"} they
+are the ones reading \code{"wald_z"} (see \code{$criteria$n_wald_fallbacks}
+for the count).}
 \item{\code{p_value}, \code{delta_aic}}{Always populated when
 computable, regardless of the active criterion.}
 \item{\code{logLik}, \code{aic}, \code{n_coef}}{Goodness-of-fit

--- a/tests/testthat/test-candidate-score.R
+++ b/tests/testthat/test-candidate-score.R
@@ -233,3 +233,51 @@ test_that("non-invertible vcov yields NA score without erroring", {
   expect_true(is.na(s$p_value))
   expect_true(is.na(s$delta_aic))
 })
+
+# stat_type ----------------------------------------------------------------
+
+test_that("stat_type names the distribution `stat` belongs to", {
+  # `stat` is a Wald z for a scalar candidate and a chi-square for a joint
+  # one, and a score Q is a chi-square too -- all three at df = 1 for the
+  # scalar cases. `df` therefore cannot tell a caller which reference
+  # distribution recomputes the p-value, which is what stat_type exists for.
+  # Pinned here, against the scorer, rather than through a stepwise run: the
+  # Wald path refits each candidate, and a multiphase refit is not stable
+  # enough across platforms to hang a reporting assertion on.
+  fit <- .fit_weibull()
+  covariate_row <- setdiff(
+    rownames(summary(fit)$coefficients), c("mu", "nu"))
+
+  w <- .hzr_candidate_score(
+    criterion = "wald", mode = "drop", current = fit, names = covariate_row)
+  expect_identical(w$stat_type, "wald_z")
+  expect_identical(w$df, 1L)
+  # A scalar Wald is reported as a z, NOT as its square -- which is exactly
+  # why it is indistinguishable from a 1-df Q on `df` alone.
+  expect_equal(2 * stats::pnorm(-abs(w$stat)), w$p_value, tolerance = 1e-8)
+
+  # The score branch, from a .hzr_score_q()-shaped result.
+  q <- list(stat = 3.84, df = 1L, p_value = 0.05)
+  sc <- .hzr_candidate_score(
+    criterion = "score", mode = "entry", current = fit,
+    score = q, names = covariate_row)
+  expect_identical(sc$stat_type, "score_q")
+  expect_identical(sc$df, 1L)
+
+  # The two branches must not agree, or the field distinguishes nothing.
+  expect_false(identical(w$stat_type, sc$stat_type))
+})
+
+test_that("a multi-df Wald is labelled chi-square, not z", {
+  # The joint case: .hzr_candidate_score() reports the chi-square directly
+  # rather than a z, so stat_type has to switch with it.
+  fit <- .fit_weibull(betas = c(0.3, -0.2), seed = 7L)
+  covariate_rows <- setdiff(
+    rownames(summary(fit)$coefficients), c("mu", "nu"))
+  skip_if(length(covariate_rows) < 2L, "fixture has fewer than 2 covariates")
+
+  w <- .hzr_candidate_score(
+    criterion = "wald", mode = "drop", current = fit, names = covariate_rows)
+  expect_gt(w$df, 1L)
+  expect_identical(w$stat_type, "wald_chisq")
+})

--- a/tests/testthat/test-score-wald-fallback.R
+++ b/tests/testthat/test-score-wald-fallback.R
@@ -123,11 +123,26 @@ test_that("a Wald-decided row says so, so its p-value can be recomputed", {
   expect_identical(row$stat_type, "wald_z")
   # The point of the column: recomputing from `stat` under the distribution
   # `stat_type` names reproduces the reported p-value.
-  expect_equal(2 * stats::pnorm(-abs(row$stat)), row$p_value,
+  #
+  # Compared on the LOG scale, and guarded by p_value > 0 first. An
+  # expect_equal(tolerance = 1e-8) on the natural scale cannot fail here:
+  # all.equal switches from relative to absolute comparison once the target
+  # falls below the tolerance, and at 2.5e-50 everything -- including a
+  # p_value that underflowed to exactly 0 -- is within 1e-8 of everything
+  # else. A hollow pass, in the test written to catch hollow passes.
+  expect_gt(row$p_value, 0)
+  expect_equal(log(row$p_value),
+               stats::pnorm(-abs(row$stat), log.p = TRUE) + log(2),
                tolerance = 1e-8)
   # And the chi-square reading -- the one `df` alone invites -- does not.
-  expect_gt(abs(stats::pchisq(row$stat, row$df, lower.tail = FALSE) -
-                  row$p_value), 1e-6)
+  # Also on the log scale: the two differ by ~46 orders of magnitude, so the
+  # gap is what should be asserted, not a difference that rounds to 1.1e-04
+  # whatever the second term does.
+  expect_gt(
+    stats::pchisq(row$stat, row$df, lower.tail = FALSE, log.p = TRUE) -
+      log(row$p_value),
+    30
+  )
 })
 
 test_that("fallback reasons are classified, not lumped together", {

--- a/tests/testthat/test-score-wald-fallback.R
+++ b/tests/testthat/test-score-wald-fallback.R
@@ -188,35 +188,34 @@ test_that("a fallback refit that fails is recorded and warned, not silent", {
   expect_identical(sw$criteria$n_wald_fallbacks, 0L)
 })
 
-test_that("stat_type distinguishes an ordinary score row from a Wald row", {
+test_that("an ordinary score row reads score_q, not wald_z", {
   skip_on_cran()
-  # The column has to vary, or it says nothing. A weaker planted effect is
-  # scorable, so it enters on Q; the same fixture run under criterion =
-  # "wald" enters on a z. Both are df = 1, which is exactly why `df` cannot
-  # serve as the discriminator.
+  # The score half of "stat_type varies". A weaker planted effect is scorable,
+  # so it enters on Q rather than being rescued.
+  #
+  # The Wald half of this test used to live here, running the same fixture
+  # under criterion = "wald". It failed in CI on Linux and Windows with zero
+  # ENTER rows -- not because of the threshold, but because the candidate
+  # REFIT failed there ("1 candidate refit FAILED and could not be tested --
+  # x1@const"), which the Wald path needs and the score path does not. A
+  # multiphase refit is not a stable thing to hang a reporting assertion on,
+  # so the Wald side is pinned in test-candidate-score.R against the scorer
+  # itself, where no refit is involved.
   D <- planted(beta = 0.35)
-  base <- planted_fit(D)
-
   sw_s <- suppressWarnings(hzr_stepwise(
-    fit = base, scope = list(const = ~ x1), data = D,
+    fit = planted_fit(D), scope = list(const = ~ x1), data = D,
     direction = "forward", criterion = "score", slentry = 0.2))
   st_s <- as.data.frame(sw_s)
   st_s <- st_s[toupper(st_s$action) == "ENTER", ]
   expect_gte(nrow(st_s), 1L)
   expect_identical(unique(st_s$stat_type), "score_q")
   expect_identical(unique(st_s$df), 1L)
+  # And this arm really was scored, not rescued -- otherwise "score_q" could
+  # quietly become "wald_z" and the assertion above would be vacuous.
+  expect_identical(sw_s$criteria$n_wald_fallbacks, 0L)
   # Q is a 1-df chi-square, and reads as one.
   expect_equal(stats::pchisq(st_s$stat[1], 1, lower.tail = FALSE),
                st_s$p_value[1], tolerance = 1e-8)
-
-  sw_w <- suppressWarnings(hzr_stepwise(
-    fit = base, scope = list(const = ~ x1), data = D,
-    direction = "forward", criterion = "wald", slentry = 0.2))
-  st_w <- as.data.frame(sw_w)
-  st_w <- st_w[toupper(st_w$action) == "ENTER", ]
-  expect_gte(nrow(st_w), 1L)
-  expect_identical(unique(st_w$stat_type), "wald_z")
-  expect_identical(unique(st_w$df), 1L)
 })
 
 test_that("the bootstrap aggregates Wald fallbacks instead of dropping them", {

--- a/tests/testthat/test-score-wald-fallback.R
+++ b/tests/testthat/test-score-wald-fallback.R
@@ -65,10 +65,14 @@ test_that("the planted strong effect is selected, not the noise variables", {
   steps <- as.data.frame(sw)
   entered <- steps$variable[toupper(steps$action) == "ENTER"]
   expect_true("x1" %in% entered)
-  # Asserting the noise stays out is the half that can fail for the right
-  # reason: a fallback that simply refit everything would enter all three.
   expect_false("x2" %in% entered)
   expect_false("x3" %in% entered)
+  # The two assertions above do NOT test the fallback's narrowness, despite an
+  # earlier comment here saying so: x2 and x3 have Wald p-values of 0.0997 and
+  # 0.149 on this fixture, so a fallback that refit every candidate would
+  # still see both declined by `slentry`. The count is what can fail --
+  # refitting everything makes it 3.
+  expect_identical(sw$criteria$n_wald_fallbacks, 1L)
 })
 
 test_that("the Wald fallback is reported rather than silent", {
@@ -95,6 +99,35 @@ test_that("only untestable-because-strong candidates fall back", {
   entered <- as.data.frame(sw)$variable[toupper(as.data.frame(sw)$action) == "ENTER"]
   expect_false("flat" %in% entered)
   expect_true("x1" %in% entered)
+  # The two assertions above stayed green when "constant" and "collinear" were
+  # added to .hzr_score_fallback_reasons -- `flat` still does not enter, it
+  # just costs a refit on the way out. Only the count sees the widening.
+  expect_identical(sw$criteria$n_wald_fallbacks, 1L)
+})
+
+test_that("a Wald-decided row says so, so its p-value can be recomputed", {
+  skip_on_cran()
+  # THE REPORTING DEFECT. A rescued candidate carries a Wald z on a row still
+  # labelled criterion = "score", where every neighbouring row carries a 1-df
+  # chi-square Q. `df` cannot tell them apart -- both read 1 -- so a reader
+  # recomputing pchisq(stat, df) on this fixture gets 1.1e-04 against a true
+  # 2.5e-50, wrong by 46 orders of magnitude.
+  D <- planted()
+  sw <- suppressWarnings(hzr_stepwise(
+    fit = planted_fit(D), scope = list(const = ~ x1 + x2 + x3),
+    data = D, direction = "both", slentry = 0.05))
+  steps <- as.data.frame(sw)
+  row <- steps[toupper(steps$action) == "ENTER" & steps$variable == "x1", ]
+  expect_equal(nrow(row), 1L)
+  expect_identical(row$criterion, "score")
+  expect_identical(row$stat_type, "wald_z")
+  # The point of the column: recomputing from `stat` under the distribution
+  # `stat_type` names reproduces the reported p-value.
+  expect_equal(2 * stats::pnorm(-abs(row$stat)), row$p_value,
+               tolerance = 1e-8)
+  # And the chi-square reading -- the one `df` alone invites -- does not.
+  expect_gt(abs(stats::pchisq(row$stat, row$df, lower.tail = FALSE) -
+                  row$p_value), 1e-6)
 })
 
 test_that("fallback reasons are classified, not lumped together", {
@@ -138,4 +171,54 @@ test_that("a fallback refit that fails is recorded and warned, not silent", {
   expect_gt(sw$criteria$n_refit_failures, 0L)
   # And nothing may be reported as a successful substitution.
   expect_identical(sw$criteria$n_wald_fallbacks, 0L)
+})
+
+test_that("stat_type distinguishes an ordinary score row from a Wald row", {
+  skip_on_cran()
+  # The column has to vary, or it says nothing. A weaker planted effect is
+  # scorable, so it enters on Q; the same fixture run under criterion =
+  # "wald" enters on a z. Both are df = 1, which is exactly why `df` cannot
+  # serve as the discriminator.
+  D <- planted(beta = 0.35)
+  base <- planted_fit(D)
+
+  sw_s <- suppressWarnings(hzr_stepwise(
+    fit = base, scope = list(const = ~ x1), data = D,
+    direction = "forward", criterion = "score", slentry = 0.2))
+  st_s <- as.data.frame(sw_s)
+  st_s <- st_s[toupper(st_s$action) == "ENTER", ]
+  expect_gte(nrow(st_s), 1L)
+  expect_identical(unique(st_s$stat_type), "score_q")
+  expect_identical(unique(st_s$df), 1L)
+  # Q is a 1-df chi-square, and reads as one.
+  expect_equal(stats::pchisq(st_s$stat[1], 1, lower.tail = FALSE),
+               st_s$p_value[1], tolerance = 1e-8)
+
+  sw_w <- suppressWarnings(hzr_stepwise(
+    fit = base, scope = list(const = ~ x1), data = D,
+    direction = "forward", criterion = "wald", slentry = 0.2))
+  st_w <- as.data.frame(sw_w)
+  st_w <- st_w[toupper(st_w$action) == "ENTER", ]
+  expect_gte(nrow(st_w), 1L)
+  expect_identical(unique(st_w$stat_type), "wald_z")
+  expect_identical(unique(st_w$df), 1L)
+})
+
+test_that("the bootstrap aggregates Wald fallbacks instead of dropping them", {
+  skip_on_cran()
+  # Each replicate runs under suppressWarnings(), so a select-mode run in
+  # which the fallback fired everywhere reported nothing at all -- and the
+  # bootstrap is where a wholesale substitution matters most, since these
+  # entries drive the pooled selection frequencies.
+  D <- planted()
+  # No `data =`: hzr_bootstrap() supplies the resampled frame itself, and
+  # passing one collides with it through `...`.
+  boot <- suppressWarnings(hzr_bootstrap(
+    planted_fit(D), scope = list(const = ~ x1 + x2 + x3),
+    n_boot = 3L, direction = "both", criterion = "score",
+    slentry = 0.05, verbose = FALSE))
+  expect_true(is.numeric(boot$n_wald_fallbacks))
+  expect_gte(boot$n_wald_fallback_replicates, 1L)
+  # The total counts entries, not replicates, so it can only be the larger.
+  expect_gte(boot$n_wald_fallbacks, boot$n_wald_fallback_replicates)
 })


### PR DESCRIPTION
Closes #196 — the reporting inconsistency deferred from the review of #195,
plus the three items deferred alongside it.

> ⚠️ **Merge after [#199](https://github.com/ehrlinger/TemporalHazard/pull/199).**
> Both branch off `main` at 1.2.7. #199 takes 1.2.8, this takes 1.2.9, so
> `DESCRIPTION` and `NEWS.md` will conflict on whichever merges second — resolve
> by keeping both `NEWS.md` sections and the higher `Version:`. If #199 is
> dropped, renumber this to 1.2.8 so `NEWS.md` has no gap.

## The defect, and why the fix moved

A candidate rescued by the Wald fallback carries a Wald **z** on a `$steps` row
still labelled `criterion = "score"`, where every neighbouring row carries a
1-df chi-square Q. On the `test-score-wald-fallback.R` fixture:

```
step_num action variable criterion     stat df       p_value
       1  enter       x1     score 14.91824  1  2.507907e-50
```

`pchisq(14.918, 1, lower.tail = FALSE)` is `1.12e-04`. The `p_value` is right —
it is `2 * pnorm(-14.918)`, the z tail — so the *selection* was never wrong.
But a reader recomputing from `stat` the way every neighbouring row permits is
off by 46 orders of magnitude.

Reading `.hzr_candidate_score()` widened it. That function already documented
`stat` as *"Wald z (scalar) or chi^2 (joint)"*, so the column mixed two
distributions **before the fallback existed**. `df` cannot separate them: a
scalar Wald is reported as a z rather than its square, so it and a score Q are
both recorded at `df = 1`. The fallback made an existing ambiguity visible
rather than creating it — which puts the fix at the scorer, not at the
fallback.

`stat_type` is now set where `stat` is decided (`"score_q"`, `"wald_z"`,
`"wald_chisq"`) and carried through `all_scores`, both forward steps, the drop
step and `$steps`. Under `criterion = "score"` the rows reading `"wald_z"` are
exactly the rescued ones — which is the *which variable* that
`$criteria$n_wald_fallbacks` could never answer.

The issue offered `fallback` or `stat_type` and leaned toward a column. I took
`stat_type` because it answers the question that caused the harm — *what
distribution do I recompute under* — and identifies the rescued rows as a
by-product.

## Also from the same review

- **`hzr_bootstrap()` now aggregates fallbacks** in select mode, through
  `$n_wald_fallback_replicates` and `$n_wald_fallbacks`, with a warning. Every
  replicate runs under `suppressWarnings()`, so a run in which the fallback
  fired throughout previously reported nothing — and the bootstrap is where a
  wholesale substitution distorts most, since those entries drive the pooled
  selection frequencies.
- **The winning fallback candidate is no longer refit twice.** The two calls
  used identical arguments and `control$start_seed` made them bit-identical, so
  this was cost rather than incorrectness — but it doubled the price of every
  accepted fallback entry, against a criterion whose whole advantage is not
  refitting per candidate. The fallback's fit is kept and reused, exactly as the
  Wald path already did with its candidate fits.
- **Two tests did not catch the mutation their comments named.** Widening
  `.hzr_score_fallback_reasons` to include `constant` and `collinear` left both
  green: a degenerate candidate still fails to enter, it merely costs a refit on
  the way out, and the "noise stays out" assertion is guarded by `slentry`, not
  by the fallback's narrowness (the fixture's own Wald p-values are 0.0997 and
  0.149, so a fallback that refit *everything* would still decline both). Both
  now assert `n_wald_fallbacks`, which is the quantity that actually moves.
- **A roxygen block bound to the wrong object** in `R/score-test.R`. `@noRd`, so
  no Rd was affected; source readability only.

## Gate

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` — **0 FAIL / 6 SKIP / 3390 PASS** (skips are fixture
  availability only). No test removed: the diff against `main` is +3 `test_that`
  blocks and 0 deletions.
- `R CMD check --as-cran` from a clean `git archive`, with the manual and
  vignettes — **Status: OK**, tests 87s/92s, vignettes 45s/50s

Mutation-checked: not updating `stat_type` on the fallback fails 1 test; the
`.hzr_score_fallback_reasons` widening that **survived** the previous review now
fails 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)