### PR TITLE
feat(coe): record whether Conservation of Events was actually applied (#146)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,32 @@
   unsafe case produced the identical generic note "PARMS keyword has no phase
   target", which distinguished nothing.
 
+* **A multiphase fit now records whether Conservation of Events was actually
+  applied.** CoE counts exact events, so it is disabled whenever any `status`
+  falls outside \{0, 1\} -- which interval or left censoring guarantees -- and
+  whenever the model has fewer than two phases. That is deliberate and
+  correct. What was missing is that **nothing on the returned object said it
+  had happened**: a caller who passed `control = list(conserve = TRUE)` got a
+  fit carrying `conserve = TRUE` over a computation that did not run.
+
+  It is not an edge case. `ICENSOR` appears on 42 to 74 blocks per production
+  study, and `ICENSOR` guarantees `status` leaves \{0, 1\}, so the auto-disable
+  fires constantly. Production also writes `NOCONSERVE` on 16 to 68 blocks per
+  study, so R and SAS usually agree on the *outcome* -- but for different
+  reasons, and a job carrying both `CONSERVE` and `ICENSOR` is exactly where
+  the two could diverge unobserved.
+
+  A fitted multiphase object now carries `fit$spec$control$conserve_applied`
+  (logical) alongside the requested `conserve`, and
+  `conserve_disabled_reason`, one of `"not_requested"`,
+  `"unsupported_censoring"`, `"single_phase"`, `"no_events"` or
+  `"setup_failed"`, and `NA` when CoE was applied. Read `conserve_applied`:
+  `conserve` says only what you asked for.
+
+  The reason is recorded rather than a bare logical because the causes want
+  different responses -- and a bare `FALSE` reads as "you turned it off" to a
+  user who did the opposite.
+
 ## Documentation
 
 * `summary()`'s documentation and the *Inference and diagnostics* vignette

--- a/NEWS.md
+++ b/NEWS.md
@@ -100,12 +100,18 @@
   reasons, and a job carrying both `CONSERVE` and `ICENSOR` is exactly where
   the two could diverge unobserved.
 
-  A fitted multiphase object now carries `fit$spec$control$conserve_applied`
-  (logical) alongside the requested `conserve`, and
-  `conserve_disabled_reason`, one of `"not_requested"`,
-  `"unsupported_censoring"`, `"single_phase"`, `"no_events"` or
-  `"setup_failed"`, and `NA` when CoE was applied. Read `conserve_applied`:
-  `conserve` says only what you asked for.
+  A fitted multiphase object now carries two new fields, both alongside the
+  requested `conserve` under `fit$spec$control`:
+
+  * `fit$spec$control$conserve_applied` -- logical, whether CoE was actually
+    applied;
+  * `fit$spec$control$conserve_disabled_reason` -- one of `"not_requested"`,
+    `"unsupported_censoring"`, `"single_phase"`, `"no_events"` or
+    `"setup_failed"`, and `NA` when CoE was applied.
+
+  Read `fit$spec$control$conserve_applied`, not `fit$spec$control$conserve`:
+  the latter says only what you asked for. `conserve` is a
+  `dist = "multiphase"` control; the single-distribution fits do not use it.
 
   The reason is recorded rather than a bare logical because the causes want
   different responses -- and a bare `FALSE` reads as "you turned it off" to a

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -221,17 +221,20 @@ NULL
 #'   not reproduce SAS's estimates, and `hzr_translate_sas()` records the
 #'   keyword as untranslated rather than dropping it.
 #' - `condition`: Condition number control (default 14)
-#' - `conserve`: Apply Conservation of Events (default `TRUE`). CoE counts
-#'   exact events, so it is **automatically disabled** whenever any `status`
-#'   falls outside \{0, 1\} -- which interval or left censoring guarantees --
-#'   and whenever the model has fewer than two phases. On a fitted multiphase
-#'   object the outcome is recorded next to the request, as
-#'   `fit$spec$control$conserve_applied` (logical) and
-#'   `conserve_disabled_reason` (one of `"not_requested"`,
-#'   `"unsupported_censoring"`, `"single_phase"`, `"no_events"`,
-#'   `"setup_failed"`, or `NA` when CoE was applied). Read
-#'   `conserve_applied`, not `conserve`: the latter says only what you asked
-#'   for.
+#' - `conserve`: Apply Conservation of Events (**`dist = "multiphase"` only**;
+#'   default `TRUE`). CoE counts exact events, so it is **automatically
+#'   disabled** whenever any `status` falls outside \{0, 1\} -- which interval
+#'   or left censoring guarantees -- and whenever the model has fewer than two
+#'   phases. On a fitted multiphase object the outcome is recorded next to the
+#'   request, both fields living under `fit$spec$control`:
+#'   - `fit$spec$control$conserve_applied` -- logical, whether CoE was actually
+#'     applied;
+#'   - `fit$spec$control$conserve_disabled_reason` -- one of
+#'     `"not_requested"`, `"unsupported_censoring"`, `"single_phase"`,
+#'     `"no_events"`, `"setup_failed"`, or `NA` when CoE was applied.
+#'
+#'   Read `fit$spec$control$conserve_applied`, not
+#'   `fit$spec$control$conserve`: the latter says only what you asked for.
 #' - `nocov`, `nocor`: Suppress covariance/correlation output (legacy; no-op in M2)
 #'
 #' Censoring status coding:

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -221,6 +221,17 @@ NULL
 #'   not reproduce SAS's estimates, and `hzr_translate_sas()` records the
 #'   keyword as untranslated rather than dropping it.
 #' - `condition`: Condition number control (default 14)
+#' - `conserve`: Apply Conservation of Events (default `TRUE`). CoE counts
+#'   exact events, so it is **automatically disabled** whenever any `status`
+#'   falls outside \{0, 1\} -- which interval or left censoring guarantees --
+#'   and whenever the model has fewer than two phases. On a fitted multiphase
+#'   object the outcome is recorded next to the request, as
+#'   `fit$spec$control$conserve_applied` (logical) and
+#'   `conserve_disabled_reason` (one of `"not_requested"`,
+#'   `"unsupported_censoring"`, `"single_phase"`, `"no_events"`,
+#'   `"setup_failed"`, or `NA` when CoE was applied). Read
+#'   `conserve_applied`, not `conserve`: the latter says only what you asked
+#'   for.
 #' - `nocov`, `nocor`: Suppress covariance/correlation output (legacy; no-op in M2)
 #'
 #' Censoring status coding:
@@ -749,6 +760,11 @@ hazard <- function(formula = NULL,
     fit_state$x_list <- optim_result$x_list
     fit_state$fixed_mask <- optim_result$fixed_mask
     fit_state$starts <- optim_result$starts
+    # Applied CoE state, recorded next to the requested one in spec$control
+    # below. Kept here first so the assembly reads the optimizer's answer
+    # rather than re-deriving it from `status`.
+    control$conserve_applied <- optim_result$conserve_applied
+    control$conserve_disabled_reason <- optim_result$conserve_disabled_reason
 
   } else if (fit && !is.null(theta)) {
     optim_fn <- switch(

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1503,6 +1503,24 @@
   # left censoring require a different event-counting formulation.
   coe_supported_data <- all(status %in% c(0, 1))
 
+  # A caller who passed conserve = TRUE and got a fit with CoE silently not
+  # applied had no way to tell: the requested state was on the object and the
+  # applied state was nowhere. That is this package's signature defect shape --
+  # an output that looks like a result over a computation that did not happen --
+  # and it fires constantly, since ICENSOR appears on 42-74 blocks per
+  # production study and guarantees status leaves {0, 1}. Record WHY, not just
+  # that: the causes want different responses, and a bare FALSE reads as
+  # "you turned it off" for a user who did the opposite.
+  coe_reason <- if (!use_conserve) {
+    "not_requested"
+  } else if (!coe_supported_data) {
+    "unsupported_censoring"
+  } else if (length(phases) < 2L) {
+    "single_phase"
+  } else {
+    NA_character_
+  }
+
   if (use_conserve && coe_supported_data && length(phases) >= 2L) {
     total_events <- sum(weights[status == 1])
     if (total_events > 0) {
@@ -1572,6 +1590,7 @@
       }
     } else {
       use_conserve <- FALSE
+      coe_reason <- "no_events"
     }
   } else {
     use_conserve <- FALSE
@@ -1995,6 +2014,20 @@
 
   # Restore parameter names
   names(best_result$par) <- theta_names
+
+  # Whether CoE was actually applied, taken from the same expression the mask
+  # uses (`use_conserve && !is.null(fixmu_pos)`) rather than restated, so the
+  # recorded state cannot drift from the applied one.
+  best_result$conserve_applied <- use_conserve && !is.null(fixmu_pos)
+  best_result$conserve_disabled_reason <- if (best_result$conserve_applied) {
+    NA_character_
+  } else if (is.na(coe_reason)) {
+    # use_conserve survived every gate above but fixmu_pos is absent, so the
+    # setup did not complete. Name it rather than reporting NA next to FALSE.
+    "setup_failed"
+  } else {
+    coe_reason
+  }
 
   # Store phase metadata for downstream use (predict, summary)
   best_result$phases <- phases

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -189,17 +189,22 @@ on a different optimum: a fit translated from a job using \code{STEEPEST} may
 not reproduce SAS's estimates, and \code{hzr_translate_sas()} records the
 keyword as untranslated rather than dropping it.
 \item \code{condition}: Condition number control (default 14)
-\item \code{conserve}: Apply Conservation of Events (default \code{TRUE}). CoE counts
-exact events, so it is \strong{automatically disabled} whenever any \code{status}
-falls outside \{0, 1\} -- which interval or left censoring guarantees --
-and whenever the model has fewer than two phases. On a fitted multiphase
-object the outcome is recorded next to the request, as
-\code{fit$spec$control$conserve_applied} (logical) and
-\code{conserve_disabled_reason} (one of \code{"not_requested"},
-\code{"unsupported_censoring"}, \code{"single_phase"}, \code{"no_events"},
-\code{"setup_failed"}, or \code{NA} when CoE was applied). Read
-\code{conserve_applied}, not \code{conserve}: the latter says only what you asked
-for.
+\item \code{conserve}: Apply Conservation of Events (\strong{\code{dist = "multiphase"} only};
+default \code{TRUE}). CoE counts exact events, so it is \strong{automatically
+disabled} whenever any \code{status} falls outside \{0, 1\} -- which interval
+or left censoring guarantees -- and whenever the model has fewer than two
+phases. On a fitted multiphase object the outcome is recorded next to the
+request, both fields living under \code{fit$spec$control}:
+\itemize{
+\item \code{fit$spec$control$conserve_applied} -- logical, whether CoE was actually
+applied;
+\item \code{fit$spec$control$conserve_disabled_reason} -- one of
+\code{"not_requested"}, \code{"unsupported_censoring"}, \code{"single_phase"},
+\code{"no_events"}, \code{"setup_failed"}, or \code{NA} when CoE was applied.
+}
+
+Read \code{fit$spec$control$conserve_applied}, not
+\code{fit$spec$control$conserve}: the latter says only what you asked for.
 \item \code{nocov}, \code{nocor}: Suppress covariance/correlation output (legacy; no-op in M2)
 }
 

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -189,6 +189,17 @@ on a different optimum: a fit translated from a job using \code{STEEPEST} may
 not reproduce SAS's estimates, and \code{hzr_translate_sas()} records the
 keyword as untranslated rather than dropping it.
 \item \code{condition}: Condition number control (default 14)
+\item \code{conserve}: Apply Conservation of Events (default \code{TRUE}). CoE counts
+exact events, so it is \strong{automatically disabled} whenever any \code{status}
+falls outside \{0, 1\} -- which interval or left censoring guarantees --
+and whenever the model has fewer than two phases. On a fitted multiphase
+object the outcome is recorded next to the request, as
+\code{fit$spec$control$conserve_applied} (logical) and
+\code{conserve_disabled_reason} (one of \code{"not_requested"},
+\code{"unsupported_censoring"}, \code{"single_phase"}, \code{"no_events"},
+\code{"setup_failed"}, or \code{NA} when CoE was applied). Read
+\code{conserve_applied}, not \code{conserve}: the latter says only what you asked
+for.
 \item \code{nocov}, \code{nocor}: Suppress covariance/correlation output (legacy; no-op in M2)
 }
 

--- a/tests/testthat/test-coe-applied.R
+++ b/tests/testthat/test-coe-applied.R
@@ -1,0 +1,100 @@
+# Conservation of Events: recording whether it was actually applied (#146).
+#
+# R/likelihood-multiphase.R disables CoE whenever any status falls outside
+# {0, 1}. That is deliberate and correct -- the CoE identity counts only exact
+# events -- but the fact that it happened was not recorded anywhere. A caller
+# who passed control = list(conserve = TRUE) got a fit carrying conserve = TRUE
+# over a computation that did not run: the package's documented signature
+# defect shape.
+#
+# It is not an edge case. ICENSOR appears on 42-74 blocks per production study,
+# and ICENSOR guarantees status leaves {0, 1}, so this fires constantly.
+
+# Explicit starts rather than hzr_phase("cdf")'s defaults: the default start
+# does not survive left-censored rows on this fixture ("t_half must be a
+# positive scalar" out of the optimizer), which is unrelated to CoE and would
+# make the -1 case below fail for the wrong reason. Explicit starts with
+# n_starts = 1 is also the house preference -- it removes the optimizer path
+# from what the test depends on.
+coe_fit <- function(status_pattern, conserve = TRUE,
+                    phases = list(
+                      early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+                      const = hzr_phase("constant")
+                    )) {
+  set.seed(42)
+  n <- 60
+  time <- stats::rexp(n, 0.2) + 0.05
+  status <- rep(status_pattern, length.out = n)
+
+  # Interval rows (status 2) need bounds; left-censored rows (-1) take their
+  # upper bound from `time` and must NOT be given interval-style bounds, or
+  # the fit walks onto an invalid shape. Supply the bounds only where the
+  # fixture actually has interval rows.
+  args <- list(time = time, status = status)
+  if (any(status == 2)) {
+    args$time_lower <- time
+    args$time_upper <- ifelse(status == 2, time * 1.5, time)
+  }
+
+  # fit = TRUE is required: hazard() defaults to FALSE, and an unfitted object
+  # never reaches the optimizer, so every assertion below would be about a
+  # model that was never run. (The test proposed in #146 omitted it, and would
+  # have passed against a model that never ran.)
+  suppressWarnings(do.call(hazard, c(args, list(
+    phases = phases, dist = "multiphase", fit = TRUE,
+    control = list(conserve = conserve, n_starts = 1)
+  ))))
+}
+
+test_that("CoE is disabled, and says so, when interval rows are present", {
+  skip_on_cran()
+  fit <- coe_fit(c(1, 0, 2))
+  # Guard the guard: assert the fit actually ran, or the assertions below are
+  # about an unfitted object where every field is absent.
+  expect_false(is.null(fit$fit$theta))
+  expect_true(fit$spec$control$conserve)          # what was asked for
+  expect_false(fit$spec$control$conserve_applied) # what happened
+  expect_identical(fit$spec$control$conserve_disabled_reason,
+                   "unsupported_censoring")
+})
+
+test_that("CoE is applied, and says so, on exact + right-censored data", {
+  skip_on_cran()
+  # The column has to vary or it reports nothing. Same fixture, same request,
+  # only the censoring differs.
+  fit <- coe_fit(c(1, 0))
+  expect_false(is.null(fit$fit$theta))
+  expect_true(fit$spec$control$conserve_applied)
+  expect_true(is.na(fit$spec$control$conserve_disabled_reason))
+})
+
+test_that("left-censored rows disable CoE too, not only interval ones", {
+  skip_on_cran()
+  # status -1 is left-censored in this package's coding. The identity counts
+  # exact events, so anything outside {0, 1} disables it.
+  fit <- coe_fit(c(1, 0, -1))
+  expect_false(is.null(fit$fit$theta))
+  expect_false(fit$spec$control$conserve_applied)
+  expect_identical(fit$spec$control$conserve_disabled_reason,
+                   "unsupported_censoring")
+})
+
+test_that("a caller who declined CoE is distinguished from one who was refused", {
+  skip_on_cran()
+  # A bare FALSE reads as "you turned it off" to a user who did the opposite.
+  # The reason is what separates the two.
+  fit <- coe_fit(c(1, 0), conserve = FALSE)
+  expect_false(is.null(fit$fit$theta))
+  expect_false(fit$spec$control$conserve_applied)
+  expect_identical(fit$spec$control$conserve_disabled_reason, "not_requested")
+})
+
+test_that("a single-phase model reports its own reason", {
+  skip_on_cran()
+  # CoE distributes a conserved event total across phases; with one phase there
+  # is nothing to distribute.
+  fit <- coe_fit(c(1, 0), phases = list(const = hzr_phase("constant")))
+  expect_false(is.null(fit$fit$theta))
+  expect_false(fit$spec$control$conserve_applied)
+  expect_identical(fit$spec$control$conserve_disabled_reason, "single_phase")
+})


### PR DESCRIPTION
Closes #146.

> ⚠️ **Merge after [#199](https://github.com/ehrlinger/TemporalHazard/pull/199) (1.2.8), [#200](https://github.com/ehrlinger/TemporalHazard/pull/200) (1.2.9) and [#201](https://github.com/ehrlinger/TemporalHazard/pull/201) (1.2.10).** This takes 1.2.11; `DESCRIPTION` and `NEWS.md` conflict on any out-of-order merge — keep every section and the highest `Version:`.

## What

`R/likelihood-multiphase.R` disables CoE whenever any `status` falls outside
`{0, 1}`, and whenever the model has fewer than two phases. That is deliberate
and correct — the CoE identity counts only exact events. What was missing is
that **nothing on the returned object said it had happened**. A caller who
passed `control = list(conserve = TRUE)` got a fit carrying `conserve = TRUE`
over a computation that did not run.

`ICENSOR` appears on 42/74/42 blocks across three production studies and
guarantees `status` leaves `{0, 1}`, so this fires constantly.

A fitted multiphase object now carries, next to the requested `conserve`:

| Field | Value |
|---|---|
| `spec$control$conserve_applied` | logical |
| `spec$control$conserve_disabled_reason` | `"not_requested"`, `"unsupported_censoring"`, `"single_phase"`, `"no_events"`, `"setup_failed"`, or `NA` when applied |

`conserve_applied` is taken from **the same expression the parameter mask uses**
(`use_conserve && !is.null(fixmu_pos)`) rather than restated, so the recorded
state cannot drift from the applied one.

The reason is recorded rather than a bare logical because the causes want
different responses, and a bare `FALSE` reads as *"you turned it off"* to a user
who did the opposite — the same argument `uncomputable_reasons` was built on.

## The test in the issue could not have caught this

Worth recording, since the issue is *about* silent defects. The proposed test:

```r
expect_false(isTRUE(fit$control$conserve_applied))
```

fails to fail three separate ways:

1. **`fit$control` is `NULL`** — control lives at `fit$spec$control`. So this is
   `isTRUE(NULL)`, which is `FALSE`, and the assertion passes whatever the code
   does.
2. **`time_lower = NA` on non-interval rows is rejected** by `hazard()`'s
   validator, so it errors before reaching the assertion.
3. **`fit` defaults to `FALSE`** — the call omits `fit = TRUE`, so nothing is
   optimised and every field the assertion reads is absent.

Replaced with five tests covering both outcomes: interval rows, left-censored
rows, exact + right-censored (CoE *applied* — the column has to vary or it
reports nothing), an explicit `conserve = FALSE`, and a single-phase model.

Two fixture notes, both recorded in the test file: bounds are supplied only
where the fixture has interval rows, since a left-censored row takes its upper
bound from `time`; and the `cdf` phase uses explicit starts, because
`hzr_phase("cdf")`'s default start does not survive left-censored rows here
(`t_half must be a positive scalar` out of the optimizer). That is unrelated to
CoE and would have made the `-1` case fail for the wrong reason.

## Gate

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` — **0 FAIL / 6 SKIP / 3389 PASS**
- `R CMD check --as-cran` from a clean `git archive`, with the manual and
  vignettes — **Status: OK**, vignettes 45s/50s

Mutation-checked: reporting the requested state instead of the applied one
fails 5 tests; collapsing the reason to a bare `NA` fails 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)