### PR TITLE
fix(sas-parity): report every nomogram in a listing, not silently the first (#183)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,10 +125,22 @@ the badge.
 **There are no git hooks and no Claude Code hooks in this repo.** Nothing runs locally on
 your behalf. The definition of done above is entirely manual — run it yourself.
 
-CI is not a substitute for the local suite, for the reason in the previous section: CI's
-`R CMD check` skips 152 tests that the local run exercises --- the difference between the two
-skip counts above, and a figure that only stays honest if it is re-derived from them rather
-than carried forward on its own.
+**CI does not skip `skip_on_cran()` tests, whatever a local `--as-cran` run does.**
+`r-lib/actions/check-r-package` sets `NOT_CRAN: true` itself, so every one of them runs on
+all five platforms. This was verified the hard way on 2026-09-01: a `skip_on_cran()` test
+added in PR #200 passed locally and *failed* on Linux and Windows.
+
+That matters mostly for how you read a red CI. The previous text here claimed CI skipped
+those tests, which would lead you to dismiss a CI-only test failure as impossible --- and the
+CI-only failures are the valuable ones, because they are the platform differences a single
+machine cannot show you. CI does skip more than the local run (42 against 6 on that
+commit), but those are the SAS fixture-availability skips: the local machine has the
+checkouts under `~/Documents/GitHub/hazard` and the runners do not.
+
+CI is still not a substitute for the local suite, for the opposite reason to the one
+previously given: it exercises *more* of the suite than a local `--as-cran` check does, and
+runs it on platforms you do not have --- so a green local check and a green CI answer
+different questions, and you want both.
 
 ## Before you touch code
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,13 @@
   all -- and the bootstrap is where a wholesale substitution matters most,
   since those entries drive the pooled selection frequencies.
 
+* **The nomogram parser accepts `lines =` as well as `path =`.** A multi-fit
+  listing needs each nomogram attributed to the fit whose block contains it,
+  not to the file. Previously a caller who had already split the listing by
+  fit had to write each block back out to a temporary file to parse it, which
+  is a workaround rather than an interface. Passing the lines directly now
+  works, and is what makes the multiple-nomogram warning actionable.
+
 ## Bug fixes
 
 * **`fit$weak` now distinguishes "no ridge" from "not checked".** The
@@ -116,6 +123,22 @@
   The reason is recorded rather than a bare logical because the causes want
   different responses -- and a bare `FALSE` reads as "you turned it off" to a
   user who did the opposite.
+
+* **The SAS `.lst` nomogram parser no longer returns the first of several
+  tables silently.** `.hzr_parse_sas_nomogram()` matched every nomogram header
+  in a listing and read only the first, with no warning and nothing in the
+  return value to say a second existed. That is the same shape as the three
+  layout defects fixed in 1.2.1 -- silent, and discoverable only by pointing
+  the parser at a second study.
+
+  It now warns when a listing holds more than one, and attaches `n_found` to
+  the returned frame whatever the count, so a caller can distinguish "one
+  nomogram" from "the first of several" without reading the source. The
+  behaviour is otherwise unchanged: the first table is still what comes back.
+
+  Every file in the corpus this was found against happens to print exactly one
+  nomogram, so the parser got the right answer there -- by luck of the corpus
+  rather than by construction.
 
 ## Documentation
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -13,6 +13,7 @@ CMD
 CoE
 Codecov
 Commissurotomy
+discoverable
 DSL
 Decile
 EL

--- a/inst/sas-parity/helper-sas-parity.R
+++ b/inst/sas-parity/helper-sas-parity.R
@@ -49,6 +49,27 @@
   strsplit(joined, "\n", fixed = TRUE)[[1]]
 }
 
+# Accept either a file path or already-split lines.
+#
+# A multi-fit listing has to be parsed one fit at a time -- the nomogram
+# belongs to the fit whose block contains it, not to the file -- and every
+# parser here took a `path`, so a caller who had already split the lines by
+# fit had to write each block back out to a tempfile to use them. That is a
+# workaround, not an interface.
+.hzr_lst_lines <- function(path = NULL, lines = NULL) {
+  if (!is.null(lines)) {
+    if (!is.character(lines)) {
+      stop("`lines` must be a character vector of listing lines.",
+           call. = FALSE)
+    }
+    return(lines)
+  }
+  if (is.null(path)) {
+    stop("Supply either `path` or `lines`.", call. = FALSE)
+  }
+  .hzr_read_lst(path)
+}
+
 .hzr_extract_loglik <- function(lines) {
   m <- regmatches(
     lines,
@@ -623,8 +644,8 @@
 # Returns a data frame (Obs dropped) with the leading underscores stripped from
 # the column names: YEARS, MONTHS, SURVIV, CLLSURV, CLUSURV, HAZARD, CLLHAZ,
 # CLUHAZ. NULL if the table is absent.
-.hzr_parse_sas_nomogram <- function(path) {
-  lines <- .hzr_read_lst(path)
+.hzr_parse_sas_nomogram <- function(path = NULL, lines = NULL) {
+  lines <- .hzr_lst_lines(path, lines)
 
   # The column set is NOT fixed. hp.death.AVC prints
   #   Obs YEARS MONTHS _SURVIV _CLLSURV _CLUSURV _HAZARD _CLLHAZ _CLUHAZ
@@ -638,6 +659,24 @@
   # approach .hzr_parse_sas_lifetable() uses.
   h <- grep("\\bYEARS\\b.*_SURVIV", lines)
   if (!length(h)) return(NULL)
+
+  # `h` may hold several headers, and only h[1] is read. Returning the first of
+  # N with nothing in the value to say a second existed is the same shape as
+  # the three layout defects fixed in #110 -- silent, and found only by
+  # pointing the parser at a second study. Every file in the resilia corpus
+  # happens to print exactly one, so the current code gets the right answer
+  # here by luck of the corpus rather than by construction.
+  #
+  # Say how many were seen, and say it two ways: a warning for the caller who
+  # is not looking, and `n_found` on the result for the one who is. A
+  # multi-fit listing wants splitting by fit and re-parsing per block, which
+  # the `lines` argument now makes possible without a tempfile.
+  if (length(h) > 1L) {
+    warning("nomogram: ", length(h), " tables found in this listing; only ",
+            "the first (line ", h[1], ") is returned. Split the listing by ",
+            "fit and parse each block via `lines =` to attribute a nomogram ",
+            "to the fit that printed it.", call. = FALSE)
+  }
 
   cols <- sub("^_", "", strsplit(trimws(lines[h[1]]), "[[:space:]]+")[[1]])
   if (!length(cols)) return(NULL)
@@ -716,6 +755,10 @@
   }
   df <- as.data.frame(m)
   names(df) <- cols
+  # How many nomograms the listing held, of which this is the first. Present
+  # whatever the count, so a caller can test it without having to know whether
+  # the attribute is set only in the plural case.
+  attr(df, "n_found") <- length(h)
   df
 }
 

--- a/tests/testthat/test-lst-parser-layouts.R
+++ b/tests/testthat/test-lst-parser-layouts.R
@@ -374,3 +374,65 @@ test_that("a .lst with DELTA != 0 warns that R fits a different function", {
   expect_warning(.hzr_extract_natural(.hzr_delta_lst(-0.2)),
                  "different function")
 })
+
+# A listing holding more than one nomogram (#183).
+#
+# `h <- grep(...)` may match several headers; the parser reads h[1] and never
+# looks at the rest, with no warning and nothing in the return value to say a
+# second existed. Same shape as the three layout defects fixed in #110 --
+# silent, and found only by pointing the parser at a second study. Every file
+# in the resilia corpus prints exactly one, so the code gets the right answer
+# there by luck of the corpus, not by construction.
+
+.hzr_nomo_block <- function(surv) {
+  c(
+    "         Obs     YEARS    _SURVIV   _CLLSURV   _CLUSURV",
+    "",
+    paste0("           1    0.0821    ", format(surv, nsmall = 5),
+           "    0.96812    0.97373"),
+    ""
+  )
+}
+
+test_that("a single nomogram parses silently and reports n_found = 1", {
+  tmp <- withr::local_tempfile(fileext = ".lst")
+  writeLines(.hzr_nomo_block(0.97106), tmp)
+  expect_no_warning(nom <- .hzr_parse_sas_nomogram(tmp))
+  # n_found is present whatever the count, so a caller can test it without
+  # knowing whether it is set only in the plural case.
+  expect_identical(attr(nom, "n_found"), 1L)
+  expect_equal(nom$SURVIV[1], 0.97106, tolerance = 1e-6)
+})
+
+test_that("a listing with two nomograms warns and says how many", {
+  tmp <- withr::local_tempfile(fileext = ".lst")
+  writeLines(c(.hzr_nomo_block(0.97106), "Initial Summary:",
+               .hzr_nomo_block(0.88231)), tmp)
+  expect_warning(nom <- .hzr_parse_sas_nomogram(tmp), "2 tables found")
+  expect_identical(attr(nom, "n_found"), 2L)
+  # Still the FIRST one -- the behaviour is unchanged, only no longer silent.
+  # Asserting the value pins which table was returned; asserting only n_found
+  # would pass if the parser had started returning the second.
+  expect_equal(suppressWarnings(
+    .hzr_parse_sas_nomogram(tmp))$SURVIV[1], 0.97106, tolerance = 1e-6)
+})
+
+test_that("a caller can parse one fit's block without a tempfile round-trip", {
+  # The workaround this replaces: split the listing by fit, write each block
+  # back out to a tempfile, and re-read it. A multi-fit listing needs the
+  # nomogram attributed to the fit whose block contains it, not to the file.
+  all_lines <- c(.hzr_nomo_block(0.97106), "Initial Summary:",
+                 .hzr_nomo_block(0.88231))
+  split_at <- grep("Initial Summary:", all_lines)
+  second <- all_lines[split_at:length(all_lines)]
+
+  expect_no_warning(nom2 <- .hzr_parse_sas_nomogram(lines = second))
+  expect_identical(attr(nom2, "n_found"), 1L)
+  # The SECOND fit's value, which the file-level call cannot reach at all.
+  expect_equal(nom2$SURVIV[1], 0.88231, tolerance = 1e-6)
+})
+
+test_that("the lines argument is validated rather than silently misread", {
+  expect_error(.hzr_parse_sas_nomogram(), "Supply either")
+  expect_error(.hzr_parse_sas_nomogram(lines = 42), "character vector")
+})


### PR DESCRIPTION
Closes #183.

> ⚠️ **Merge after [#199](https://github.com/ehrlinger/TemporalHazard/pull/199)–[#202](https://github.com/ehrlinger/TemporalHazard/pull/202)** (1.2.8–1.2.11). This takes 1.2.12; `DESCRIPTION` and `NEWS.md` conflict on any out-of-order merge — keep every section and the highest `Version:`.

## What

`.hzr_parse_sas_nomogram()` matched **every** nomogram header in a listing and
read only `h[1]`, with no warning and nothing in the return value to say a
second existed. That is the same shape as the three layout defects fixed in
#110: silent, and discoverable only by pointing the parser at a second study.

Every file in the corpus this was found against prints exactly one nomogram, so
the parser gets the right answer there — **by luck of the corpus rather than by
construction**.

Implemented as the issue's option 2, which the issue preferred: still return the
first table, but say so.

- Warns when `length(h) > 1`, naming the count and the line.
- Attaches `n_found` to the returned frame **whatever the count**, so a caller
  can test it without having to know whether the attribute is set only in the
  plural case.
- Behaviour is otherwise unchanged.

## Plus `lines =`, from the same issue

This is the *"related sharp edge, same function"* the issue raises, and it is
here because it is what makes the warning **actionable**. A caller told there
were two nomograms needs a way to reach the second, and previously that meant
splitting the listing by fit and writing each block back out to a temporary
file:

```r
tmp <- tempfile(fileext = ".lst"); writeLines(b, tmp)
nomo <- .hzr_parse_sas_nomogram(tmp)      # one fit's lines at a time
```

A shared `.hzr_lst_lines()` resolver now accepts either. Only the nomogram
parser is changed; the other parsers still take a `path`.

## Noticed while reading

`.hzr_parse_sas_nomogram_mv()` **already** loops `for (hi in h)` over every
header. The two parsers disagreed about the same listing shape, which is
probably why this went unnoticed — one of them handled it.

## Gate

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` — **0 FAIL / 6 SKIP / 3384 PASS**
- `R CMD check --as-cran` from a clean `git archive`, with the manual and
  vignettes — **Status: OK**

Mutant killed: reverting to the silent first-of-N fails 4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)