### PR TITLE
docs: state the SAS 1-SD band convention where predict() is used (#204)

### DIFF
--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -13,7 +13,7 @@
     writing-voice.md               sha256:15e75ca9cb97
     writing-reader-profile.md      sha256:5131ade189c9
     writing-context.md             sha256:51f197dc0c97
-    r-package-structure.md         sha256:c43a528bedf9
+    r-package-structure.md         sha256:cc35f4c2e152
 -->
 
 # House Style — TemporalHazard
@@ -943,8 +943,75 @@ incremental work, and the minor and major digits reserved for the
 maintainer's own consolidation decisions — never rolled by an agent on its
 own judgment.
 
-A documentation-only retrofit against this house style is a patch bump, with
-the matching `NEWS.md` entry so the version-grep test passes.
+### The bump is not part of the pull request
+
+Bumping on every merge turns the version into a count of branches. The number
+then tells you how the work was divided, not what changed in the package.
+hvtiRtables moved through eight versions in the ten days from 0.9.1 to 1.0.0,
+three of them on 2026-08-05 alone, and its `NEWS.md` for that stretch reads as
+a branch log.
+
+So a pull request lands without touching `Version:`. The bump is a separate,
+deliberate act, at most once a day and only on a day the package changed.
+
+`NEWS.md` carries a standing heading at the top for work that has merged and
+not yet been named:
+
+```markdown
+# <package> (unreleased)
+```
+
+Every pull request adds its entry under that heading, a documentation-only
+change included. That case used to carry a bump of its own, which is the rule
+this replaces. When you want a marker, one commit renames the heading to the
+new version and moves `DESCRIPTION` to match.
+
+### Heading level
+
+Version headings are level one, and so is the unreleased heading. That is not
+only tidiness. pkgdown reads the top heading level present in the file as the
+version level, so a `NEWS.md` opening with a bare `# <package>` title pushes
+its versions to level two, and pkgdown then reports no releases at all.
+hvtiRpropensity published an empty changelog page that way. It went unseen
+because `utils::news()` uses a different parser and read the same file
+correctly the whole time, so nothing local ever failed.
+
+Nine packages already used level one. ggRandomForests writes its level-one
+headings in setext form, with a rule of `=` underneath, which is the same
+level spelled differently and needs no change. hvtiR and hvtiRpropensity were
+at level two and moved. Subsections within a release, `## New features` and
+the like, sit below the version heading as usual.
+
+The two records answer different questions. `NEWS.md` answers what changed,
+and it is best written while the change is fresh, in the branch that made it.
+The version answers which set of changes is worth naming, and only the
+maintainer knows when a set has reached that point. Tying them to one commit
+forces the second question to be answered every time the first one is.
+
+### What this asks of the version checks
+
+Three packages check the version against `NEWS.md` today, and they do not all
+need the same change.
+
+`hvtiRbootstrap` takes the first `# hvtiRbootstrap` heading in `NEWS.md` and
+requires it to equal the `DESCRIPTION` version. An unreleased heading now sits
+above that one and breaks it. Skip headings that carry no version, and compare
+against the first heading that does.
+
+`ggRandomForests` asks only that the `DESCRIPTION` version appear somewhere in
+`NEWS.md`. An unreleased heading above it changes nothing, so that test is
+already correct.
+
+`hvtiR` is the one that conflicts outright. `tools/check_version.py` fails a
+pull request whose version has not moved past the base branch, which is what
+most pull requests now look like. The defect it was built for is real, two
+branches claiming one number after a silent merge, so the rule becomes: the
+version must not go backwards, and when it moves it moves by a legal step. Not
+moving is no longer a failure.
+
+The other nine packages have no such check. Adding one is worth doing, and the
+unreleased heading makes it easier to write than it was, since the test finally
+has something unambiguous to key on.
 
 What has to happen before a version actually ships — the CRAN Cookbook audit,
 `R CMD check --as-cran` with the manual built, the check-time budget, the

--- a/NEWS.md
+++ b/NEWS.md
@@ -142,6 +142,25 @@
 
 ## Documentation
 
+* **`predict()` and `hzr_nelson()` now say that SAS draws narrower bands.**
+  SAS `%KAPLAN`, `%NELSONT` and `PROC HAZPRED` all take their band width from
+  `CLEVEL`, whose default is `0.68268948` -- documented in the macro source as
+  "(1 sd)". That makes the multiplier `1`, so the band is one standard error,
+  68.3%, not 95%.
+
+  Nothing here computed the wrong thing: parity is tested and passing, and
+  `hzr_kaplan()` already documented the convention. The gap was that the other
+  three entry points did not, and they are the ones a reader meets when
+  checking an R fit against an existing SAS figure. At the R default of
+  `level = 0.95` the reproduced band is about 1.96 times wider than the one
+  being checked against, with no error on either side -- so the two look like
+  they disagree numerically when they do not.
+
+  The defaults are unchanged. `0.95` is the right R-side default, and adopting
+  SAS's silently would make `predict()` disagree with every other R modelling
+  function. The help pages now carry the level to pass instead:
+  `level = 2 * stats::pnorm(1) - 1`.
+
 * `summary()`'s documentation and the *Inference and diagnostics* vignette
   both listed the notes the method prints and had not been updated for the
   ridge note. Both now include it, and the vignette says plainly that a flat

--- a/NEWS.md
+++ b/NEWS.md
@@ -145,8 +145,8 @@
 * **`predict()` and `hzr_nelson()` now say that SAS draws narrower bands.**
   SAS `%KAPLAN`, `%NELSONT` and `PROC HAZPRED` all take their band width from
   `CLEVEL`, whose default is `0.68268948` -- documented in the macro source as
-  "(1 sd)". That makes the multiplier `1`, so the band is one standard error,
-  68.3%, not 95%.
+  "(1 sd)". That makes the multiplier `1` to seven decimals -- the literal is
+  truncated -- so the band is one standard error, 68.3%, not 95%.
 
   Nothing here computed the wrong thing: parity is tested and passing, and
   `hzr_kaplan()` already documented the convention. The gap was that the other

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1027,6 +1027,10 @@ print.hzr_calibrate <- function(x, digits = 3, ...) {
 #'   Weights are applied only to events (censored observations contribute
 #'   zero weight). Use for severity-weighted repeated events.
 #' @param conf_level Confidence level for the interval (default 0.95).
+#'   SAS `%NELSONT` defaults to `CLEVEL = 0.68268948`, a 1-SD (68.3%)
+#'   interval, so a band reproduced at this function's default is about 1.96
+#'   times wider than the SAS one. Pass `conf_level = 2 * stats::pnorm(1) - 1`
+#'   to match. Same convention as [hzr_kaplan()].
 #'
 #' @return A data frame with one row per unique event time and columns:
 #' \describe{

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -915,6 +915,23 @@ hazard <- function(formula = NULL,
 #'   survival is not additive).
 #' @param level Numeric confidence level in `(0, 1)`; default `0.95`.
 #'   Only used when `se.fit = TRUE`.
+#'
+#'   **SAS draws narrower bands than this by default.** `PROC HAZPRED` takes
+#'   its width from `CLEVEL`, whose default is `0.68268948` --- documented in
+#'   the macro source as "(1 sd)" --- so its `T_ALPHA` multiplier is `1` and
+#'   the band is one standard error, 68.3%, not 95%. Reproducing a SAS figure at this
+#'   function's default therefore yields a band about 1.96 times wider than the
+#'   one being checked against, with no error and no warning on either side.
+#'   Pass the SAS level explicitly to match:
+#'
+#'   ```r
+#'   predict(fit, newdata, type = "survival", se.fit = TRUE,
+#'           level = 2 * stats::pnorm(1) - 1, conf.type = "logit")
+#'   ```
+#'
+#'   The default is left at `0.95` deliberately: it is the right R-side
+#'   default, and silently adopting SAS's would make this method disagree with
+#'   every other R modelling function.
 #' @param conf.type Transform for `type = "survival"` confidence limits when
 #'   `se.fit = TRUE`: `"log-log"` (default) builds them on `log(-log S)` (the
 #'   `survival::survfit` standard); `"logit"` builds them on `logit(1 - S)`,

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -918,8 +918,9 @@ hazard <- function(formula = NULL,
 #'
 #'   **SAS draws narrower bands than this by default.** `PROC HAZPRED` takes
 #'   its width from `CLEVEL`, whose default is `0.68268948` --- documented in
-#'   the macro source as "(1 sd)" --- so its `T_ALPHA` multiplier is `1` and
-#'   the band is one standard error, 68.3%, not 95%. Reproducing a SAS figure at this
+#'   the macro source as "(1 sd)" --- so its `T_ALPHA` multiplier is `1` to
+#'   seven decimals (the literal is truncated) and the band is one standard
+#'   error, 68.3%, not 95%. Reproducing a SAS figure at this
 #'   function's default therefore yields a band about 1.96 times wider than the
 #'   one being checked against, with no error and no warning on either side.
 #'   Pass the SAS level explicitly to match:

--- a/R/read-outhaz.R
+++ b/R/read-outhaz.R
@@ -452,8 +452,25 @@ hzr_read_outhaz <- function(path) {
 #'   the total prediction instead would answer a question that was not asked.
 #' @param se.fit Logical; add delta-method standard errors and confidence
 #'   limits, as [predict.hazard()] does.
-#' @param level Numeric confidence level in `(0, 1)`; default `0.95`. Only
-#'   used when `se.fit = TRUE`.
+#' @param level Numeric confidence level in `(0, 1)`; default `0.95`.
+#'   Only used when `se.fit = TRUE`.
+#'
+#'   **SAS draws narrower bands than this by default.** `PROC HAZPRED` takes
+#'   its width from `CLEVEL`, whose default is `0.68268948` --- documented in
+#'   the macro source as "(1 sd)" --- so its `T_ALPHA` multiplier is `1` and
+#'   the band is one standard error, 68.3%, not 95%. Reproducing a SAS figure at this
+#'   function's default therefore yields a band about 1.96 times wider than the
+#'   one being checked against, with no error and no warning on either side.
+#'   Pass the SAS level explicitly to match:
+#'
+#'   ```r
+#'   predict(fit, newdata, type = "survival", se.fit = TRUE,
+#'           level = 2 * stats::pnorm(1) - 1, conf.type = "logit")
+#'   ```
+#'
+#'   The default is left at `0.95` deliberately: it is the right R-side
+#'   default, and silently adopting SAS's would make this method disagree with
+#'   every other R modelling function.
 #' @param conf.type Transform for `type = "survival"` confidence limits when
 #'   `se.fit = TRUE`: `"log-log"` (default) or `"logit"`, which reproduces
 #'   SAS `PROC HAZPRED`'s survival limits. A real argument rather than part

--- a/R/read-outhaz.R
+++ b/R/read-outhaz.R
@@ -457,8 +457,9 @@ hzr_read_outhaz <- function(path) {
 #'
 #'   **SAS draws narrower bands than this by default.** `PROC HAZPRED` takes
 #'   its width from `CLEVEL`, whose default is `0.68268948` --- documented in
-#'   the macro source as "(1 sd)" --- so its `T_ALPHA` multiplier is `1` and
-#'   the band is one standard error, 68.3%, not 95%. Reproducing a SAS figure at this
+#'   the macro source as "(1 sd)" --- so its `T_ALPHA` multiplier is `1` to
+#'   seven decimals (the literal is truncated) and the band is one standard
+#'   error, 68.3%, not 95%. Reproducing a SAS figure at this
 #'   function's default therefore yields a band about 1.96 times wider than the
 #'   one being checked against, with no error and no warning on either side.
 #'   Pass the SAS level explicitly to match:

--- a/man/hzr_nelson.Rd
+++ b/man/hzr_nelson.Rd
@@ -18,7 +18,11 @@ hzr_nelson(time, event, weight = NULL, conf_level = 0.95)
 Weights are applied only to events (censored observations contribute
 zero weight). Use for severity-weighted repeated events.}
 
-\item{conf_level}{Confidence level for the interval (default 0.95).}
+\item{conf_level}{Confidence level for the interval (default 0.95).
+SAS \verb{\%NELSONT} defaults to \code{CLEVEL = 0.68268948}, a 1-SD (68.3\%)
+interval, so a band reproduced at this function's default is about 1.96
+times wider than the SAS one. Pass \code{conf_level = 2 * stats::pnorm(1) - 1}
+to match. Same convention as \code{\link[=hzr_kaplan]{hzr_kaplan()}}.}
 
 \item{x}{An \code{hzr_nelson} object.}
 

--- a/man/predict.hazard.Rd
+++ b/man/predict.hazard.Rd
@@ -54,7 +54,23 @@ The combination is not available for \code{type = "survival"} (per-phase
 survival is not additive).}
 
 \item{level}{Numeric confidence level in \verb{(0, 1)}; default \code{0.95}.
-Only used when \code{se.fit = TRUE}.}
+Only used when \code{se.fit = TRUE}.
+
+\strong{SAS draws narrower bands than this by default.} \verb{PROC HAZPRED} takes
+its width from \code{CLEVEL}, whose default is \code{0.68268948} --- documented in
+the macro source as "(1 sd)" --- so its \code{T_ALPHA} multiplier is \code{1} and
+the band is one standard error, 68.3\%, not 95\%. Reproducing a SAS figure at this
+function's default therefore yields a band about 1.96 times wider than the
+one being checked against, with no error and no warning on either side.
+Pass the SAS level explicitly to match:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{predict(fit, newdata, type = "survival", se.fit = TRUE,
+        level = 2 * stats::pnorm(1) - 1, conf.type = "logit")
+}\if{html}{\out{</div>}}
+
+The default is left at \code{0.95} deliberately: it is the right R-side
+default, and silently adopting SAS's would make this method disagree with
+every other R modelling function.}
 
 \item{conf.type}{Transform for \code{type = "survival"} confidence limits when
 \code{se.fit = TRUE}: \code{"log-log"} (default) builds them on \verb{log(-log S)} (the

--- a/man/predict.hazard.Rd
+++ b/man/predict.hazard.Rd
@@ -58,8 +58,9 @@ Only used when \code{se.fit = TRUE}.
 
 \strong{SAS draws narrower bands than this by default.} \verb{PROC HAZPRED} takes
 its width from \code{CLEVEL}, whose default is \code{0.68268948} --- documented in
-the macro source as "(1 sd)" --- so its \code{T_ALPHA} multiplier is \code{1} and
-the band is one standard error, 68.3\%, not 95\%. Reproducing a SAS figure at this
+the macro source as "(1 sd)" --- so its \code{T_ALPHA} multiplier is \code{1} to
+seven decimals (the literal is truncated) and the band is one standard
+error, 68.3\%, not 95\%. Reproducing a SAS figure at this
 function's default therefore yields a band about 1.96 times wider than the
 one being checked against, with no error and no warning on either side.
 Pass the SAS level explicitly to match:

--- a/man/predict.hzr_outhaz.Rd
+++ b/man/predict.hzr_outhaz.Rd
@@ -32,8 +32,24 @@ the total prediction instead would answer a question that was not asked.}
 \item{se.fit}{Logical; add delta-method standard errors and confidence
 limits, as \code{\link[=predict.hazard]{predict.hazard()}} does.}
 
-\item{level}{Numeric confidence level in \verb{(0, 1)}; default \code{0.95}. Only
-used when \code{se.fit = TRUE}.}
+\item{level}{Numeric confidence level in \verb{(0, 1)}; default \code{0.95}.
+Only used when \code{se.fit = TRUE}.
+
+\strong{SAS draws narrower bands than this by default.} \verb{PROC HAZPRED} takes
+its width from \code{CLEVEL}, whose default is \code{0.68268948} --- documented in
+the macro source as "(1 sd)" --- so its \code{T_ALPHA} multiplier is \code{1} and
+the band is one standard error, 68.3\%, not 95\%. Reproducing a SAS figure at this
+function's default therefore yields a band about 1.96 times wider than the
+one being checked against, with no error and no warning on either side.
+Pass the SAS level explicitly to match:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{predict(fit, newdata, type = "survival", se.fit = TRUE,
+        level = 2 * stats::pnorm(1) - 1, conf.type = "logit")
+}\if{html}{\out{</div>}}
+
+The default is left at \code{0.95} deliberately: it is the right R-side
+default, and silently adopting SAS's would make this method disagree with
+every other R modelling function.}
 
 \item{conf.type}{Transform for \code{type = "survival"} confidence limits when
 \code{se.fit = TRUE}: \code{"log-log"} (default) or \code{"logit"}, which reproduces

--- a/man/predict.hzr_outhaz.Rd
+++ b/man/predict.hzr_outhaz.Rd
@@ -37,8 +37,9 @@ Only used when \code{se.fit = TRUE}.
 
 \strong{SAS draws narrower bands than this by default.} \verb{PROC HAZPRED} takes
 its width from \code{CLEVEL}, whose default is \code{0.68268948} --- documented in
-the macro source as "(1 sd)" --- so its \code{T_ALPHA} multiplier is \code{1} and
-the band is one standard error, 68.3\%, not 95\%. Reproducing a SAS figure at this
+the macro source as "(1 sd)" --- so its \code{T_ALPHA} multiplier is \code{1} to
+seven decimals (the literal is truncated) and the band is one standard
+error, 68.3\%, not 95\%. Reproducing a SAS figure at this
 function's default therefore yields a band about 1.96 times wider than the
 one being checked against, with no error and no warning on either side.
 Pass the SAS level explicitly to match:

--- a/tests/testthat/test-predict-cl.R
+++ b/tests/testthat/test-predict-cl.R
@@ -450,3 +450,52 @@ test_that("predict(type='survival') conf.type selects the CL transform", {
   expect_error(predict(fit, newdata = grid, type = "survival", se.fit = TRUE,
                        conf.type = "bogus"))
 })
+
+# The SAS band level documented on predict() and hzr_nelson() (#204).
+#
+# SAS %KAPLAN / %NELSONT / HAZPRED default to CLEVEL = 0.68268948, documented
+# in the macro source as "(1 sd)", which makes T_ALPHA 1: a 68.3% band, not
+# 95%. The help pages now tell a caller to pass `level = 2 * pnorm(1) - 1` to
+# reproduce a SAS figure. These pin that recipe, so the documented incantation
+# cannot quietly stop being the right one.
+
+test_that("the documented SAS level is the 1-SD level", {
+  lvl <- 2 * stats::pnorm(1) - 1
+  # This is what SAS computes as T_ALPHA=PROBIT(0.5+(0.5*&CLEVEL)).
+  expect_equal(stats::qnorm(0.5 + 0.5 * lvl), 1, tolerance = 1e-12)
+  # The macro spells CLEVEL as a truncated literal, so its T_ALPHA is 1 only
+  # to about seven decimals -- close enough to reproduce a plot, and worth
+  # recording so "exactly 1" is not carried around as a fact.
+  expect_equal(stats::qnorm(0.5 + 0.5 * 0.68268948), 1, tolerance = 1e-7)
+  expect_lt(abs(lvl - 0.68268948), 1e-7)
+})
+
+test_that("the SAS level narrows a band by the z ratio, on the CL's own scale", {
+  skip_on_cran()
+  # NOT (upper - fit) / se.fit: predict() builds cumulative-hazard limits on
+  # the LOG scale (and survival limits on log-log), so the half-width is not
+  # z * se on the natural scale and asserting that fails against correct code.
+  # The invariant that does hold is that the two levels differ by exactly the
+  # ratio of their z values, measured on the scale the limits are built on.
+  set.seed(4)
+  n <- 200
+  fit <- hazard(time = stats::rweibull(n, 1.3, 2), status = rep(1L, n),
+                theta = c(0.4, 1.0), dist = "weibull", fit = TRUE)
+  nd <- data.frame(time = c(0.5, 1, 2))
+
+  sas <- predict(fit, newdata = nd, type = "cumulative_hazard",
+                 se.fit = TRUE, level = 2 * stats::pnorm(1) - 1)
+  d95 <- predict(fit, newdata = nd, type = "cumulative_hazard", se.fit = TRUE)
+
+  # Guard the guard: a degenerate band makes every ratio below 0/0 or 1.
+  expect_true(all(is.finite(sas$se.fit) & sas$se.fit > 0))
+  expect_true(all(sas$upper > sas$fit))
+
+  ratio <- log(d95$upper / d95$fit) / log(sas$upper / sas$fit)
+  expect_equal(ratio, rep(stats::qnorm(0.975), nrow(nd)), tolerance = 1e-6)
+
+  # And the plain statement the documentation makes: the default band is
+  # materially wider than the SAS one, so reproducing a figure at level = 0.95
+  # does not match it.
+  expect_true(all(d95$upper > sas$upper))
+})

--- a/tests/testthat/test-predict-cl.R
+++ b/tests/testthat/test-predict-cl.R
@@ -454,10 +454,11 @@ test_that("predict(type='survival') conf.type selects the CL transform", {
 # The SAS band level documented on predict() and hzr_nelson() (#204).
 #
 # SAS %KAPLAN / %NELSONT / HAZPRED default to CLEVEL = 0.68268948, documented
-# in the macro source as "(1 sd)", which makes T_ALPHA 1: a 68.3% band, not
-# 95%. The help pages now tell a caller to pass `level = 2 * pnorm(1) - 1` to
-# reproduce a SAS figure. These pin that recipe, so the documented incantation
-# cannot quietly stop being the right one.
+# in the macro source as "(1 sd)", which makes T_ALPHA 1 to seven decimals
+# (the literal is truncated): a 68.3% band, not 95%. The help pages now tell
+# a caller to pass `level = 2 * pnorm(1) - 1` to reproduce a SAS figure.
+# These pin that recipe, so the documented incantation cannot quietly stop
+# being the right one.
 
 test_that("the documented SAS level is the 1-SD level", {
   lvl <- 2 * stats::pnorm(1) - 1


### PR DESCRIPTION
Closes #204.

No version bump — this folds into the existing 1.2.8 `NEWS.md` section.

## The convention

SAS `%KAPLAN`, `%NELSONT` and `PROC HAZPRED` all take their band width from
`CLEVEL`, whose default is `0.68268948`, documented in the macro source as
`(1 sd)`:

```sas
T_ALPHA=PROBIT(0.5+(0.5*&CLEVEL));    /* macros/kaplan.sas:47 */
```

The formula is correct and the SAS side is deliberate. The multiplier is `1`,
so the band is **one standard error — 68.3%, not 95%**.

## Nothing here computed the wrong thing

- `tests/testthat/test-sas-parity.R:640` already derives `2 * pnorm(1) - 1` and
  reproduces HAZPRED's `_CLLSURV` / `_CLUSURV` to 1e-4.
- `hzr_kaplan()` already documented the convention.

The gap was the other three entry points, which said only *"default 0.95"*:

| Entry point | Mirrors | Was documented |
|---|---|---|
| `hzr_nelson(conf_level=)` | `nelsont.sas` | no |
| `predict.hazard(level=)` | **HAZPRED** | no |
| `predict.hzr_outhaz(level=)` | **HAZPRED** | no |

Those are the ones a reader meets when checking an R fit against an existing
SAS figure — and there the reproduced band is about **1.96× wider** than the one
being checked, with no error on either side. The two implementations then look
like they disagree numerically when they agree exactly.

## Defaults are unchanged, deliberately

`0.95` is the right R-side default. Adopting SAS's silently would make
`predict()` disagree with every other R modelling function. The help pages now
carry the level to pass instead:

```r
predict(fit, newdata, type = "survival", se.fit = TRUE,
        level = 2 * stats::pnorm(1) - 1, conf.type = "logit")
```

The `conf.type = "logit"` half was already documented; the `level` half was
not, so the recipe was incomplete.

## Two errors the tests caught in my own first draft

Both recorded in `test-predict-cl.R`, because prose about numbers cannot fail
on its own:

1. I first asserted `(upper - fit) / se.fit == 1` at the SAS level. It failed —
   `predict()` builds cumulative-hazard limits on the **log** scale and survival
   limits on **log-log**, so the half-width is never `z * se` on the natural
   scale. The invariant that does hold is that two levels differ by the ratio
   of their z values *on the scale the limits are built on*, and that is what
   is now asserted.
2. The macro's truncated literal `0.68268948` gives `T_ALPHA = 0.99999997`, not
   exactly `1`. The prose said "exactly"; it no longer does, and a test pins the
   1e-7 agreement.

## Not in scope

The `CLEVEL` default in the SAS macros, and whether the generated outputs label
their bands, belong to the `hazard` repository.

## Gate

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::spell_check()` — clean
- `devtools::test()` — **0 FAIL / 6 SKIP / 3478 PASS**
- `R CMD check --as-cran` from a clean `git archive`, with the manual and
  vignettes — **Status: OK**

🤖 Generated with [Claude Code](https://claude.com/claude-code)