### PR TITLE
fix(stepwise): report a candidate neither criterion could test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,33 @@
 
 ## Bug fixes
 
+* **A candidate that neither criterion could test is now reported as such.**
+  `criterion = "score"` declines a candidate whose observed information is
+  indefinite at `beta = 0` -- which happens when the effect is *large* -- and
+  then refits it and tests it by Wald instead. That rescue can converge,
+  producing a perfectly good point estimate, while its Hessian is singular:
+  no standard error, so the Wald test cannot be computed either.
+
+  The fallback dropped that case silently. The row kept the *score's* reason,
+  `information_indefinite`, which describes the first of two independent
+  failures and says nothing about the second, and no counter moved. A
+  strongly predictive variable vanished and the screen rendered as an honest
+  "nothing met `slentry`" -- the same failure this package has twice fixed
+  elsewhere, where a clean-looking screen and an honest null result cannot be
+  told apart.
+
+  Such rows now report `fallback_no_variance`, distinct from
+  `information_indefinite` (the rescue errored or did not converge, and is
+  listed in `$criteria$refit_failures`). `hzr_stepwise()` and
+  `hzr_bootstrap()` both warn on either, saying the candidate was tested by
+  **neither** criterion and which mechanism applied. The
+  `information_indefinite` prose claimed "that refit also failed", which was
+  wrong for the new case and sent readers to an empty `refit_failures`; both
+  it and the bootstrap warning now describe the two mechanisms separately.
+
+  No behaviour changed in what gets selected: a candidate that could not be
+  tested is still not entered. What changed is that the run says so.
+
 * **`fit$weak` now distinguishes "no ridge" from "not checked".** The
   weak-identification diagnostic introduced in 1.2.7 returned `NULL` both when
   a fit had been examined and found well identified and when it could not be

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1799,8 +1799,14 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     }
   }
 
-  n_indefinite <- unname(uncomputable_reasons["information_indefinite"])
-  if (is.na(n_indefinite)) n_indefinite <- 0L
+  # Both codes mean "no criterion tested this candidate", and both are
+  # typically STRONG variables, so both belong in the warning below. They
+  # differ in mechanism: information_indefinite means the rescuing refit
+  # errored or did not converge, fallback_no_variance means it converged but
+  # yielded no standard error to test with. The previous text described every
+  # such row as a failed refit, which is wrong for the second.
+  n_indefinite <- sum(unname(uncomputable_reasons[
+    c("information_indefinite", "fallback_no_variance")]), na.rm = TRUE)
 
   if (n_uncomputable_reps > 0L) {
     warning(n_uncomputable_reps, " of ", n_success, " successful replicates ",
@@ -1815,12 +1821,16 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     # reaching this count means the refit failed and it went untested after
     # all -- and these are typically the strong ones, which depresses exactly
     # the selection frequencies a screen exists to measure.
-    warning(n_indefinite, " candidate score(s) ",
-            "across ", n_success, " replicates could not be computed because ",
-            .hzr_score_reason_text("information_indefinite"),
-            ". The automatic Wald refit failed for these, so they went ",
-            "untested and their selection frequencies are understated. See ",
-            "`$uncomputable_reasons`.", call. = FALSE)
+    warning(n_indefinite, " candidate score(s) across ", n_success,
+            " replicates were tested by NEITHER criterion: the score ",
+            "statistic could not be computed, and the Wald refit that would ",
+            "have rescued them either failed to converge ",
+            "(`information_indefinite`) or converged without a usable ",
+            "variance to test with (`fallback_no_variance`). These are ",
+            "typically STRONG candidates -- that is what drives the score's ",
+            "information indefinite -- so their selection frequencies are ",
+            "understated rather than merely noisy. See ",
+            "`$uncomputable_reasons` for which mechanism.", call. = FALSE)
   }
 
   if (n_nonmonotone_reps > 0L) {

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -725,8 +725,19 @@
       "the candidate's effect is too large for the score test's approximation",
       "at zero, so these are typically STRONG candidates rather than",
       "degenerate ones. `criterion = \"score\"` refits and Wald-tests them",
-      "itself, so reaching this reason means that refit also failed. It is",
-      "also reached when the current fit has not truly converged"
+      "itself, so reaching this reason means that refit ERRORED or did not",
+      "converge -- see `refit_failures`. A refit that converged but could not",
+      "be Wald-tested reports `fallback_no_variance` instead. It is also",
+      "reached when the current fit has not truly converged"
+    ),
+    fallback_no_variance = paste(
+      "the score could not test the candidate, and the Wald refit that would",
+      "have rescued it converged but produced no usable variance -- its",
+      "Hessian was not invertible, so the coefficient has an estimate but no",
+      "standard error. The candidate was therefore tested by NEITHER",
+      "criterion. It is typically a STRONG one, since that is what drives the",
+      "score's information indefinite in the first place, so a screen",
+      "reporting this has understated that variable rather than declined it"
     ),
     information_nonpositive = paste(
       "the candidate's own observed information was not positive, before any",

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -416,7 +416,20 @@
       names = .hzr_candidate_coef_name(refit, all_scores$variable[i],
                                        cand_phase)
     )
-    if (is.na(w$score)) next
+    if (is.na(w$score)) {
+      # The refit CONVERGED -- it returned a point estimate -- but its Hessian
+      # was not invertible, so there is no standard error and .hzr_wald_p()
+      # cannot compute a test (it returns NA for "no vcov or non-finite SE").
+      #
+      # A bare `next` here recorded nothing at all. The row kept the SCORE's
+      # reason, which describes the first of two independent failures and says
+      # nothing about the second, and no counter moved -- so a strong
+      # candidate that neither criterion could test vanished, and the screen
+      # rendered as an honest "nothing met slentry". That indistinguishability
+      # is the defect #159 and #130 were both about.
+      all_scores$reason[i] <- "fallback_no_variance"
+      next
+    }
     fallback_fits[[i]]     <- refit
     all_scores$score[i]    <- w$score
     all_scores$p_value[i]  <- w$p_value

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -578,8 +578,13 @@ hzr_stepwise <- function(fit,
     n_nonmonotone_entries = n_nonmonotone_entries
   )
 
-  n_indefinite <- unname(uncomputable_reasons["information_indefinite"])
-  if (is.na(n_indefinite)) n_indefinite <- 0L
+  # Both codes mean "no criterion tested this candidate". Keying the warning
+  # below on information_indefinite alone would go silent the moment the
+  # rescue's own failure was labelled separately -- quieter, for a case that
+  # needs to be louder.
+  untested_codes <- c("information_indefinite", "fallback_no_variance")
+  n_indefinite <- sum(unname(uncomputable_reasons[untested_codes]),
+                      na.rm = TRUE)
 
   if (stopped_uncomputable) {
     warning("Stepwise selection stopped because the score statistic ",
@@ -595,15 +600,20 @@ hzr_stepwise <- function(fit,
     # could be scored.  A completed run is where that is least visible and
     # most misleading, so it warns on its own.
     warning("Stepwise selection completed, but ", n_indefinite,
-            " candidate score(s) could not be computed because ",
-            .hzr_score_reason_text("information_indefinite"),
-            ". Under `criterion = \"score\"` such candidates are refit and ",
-            "Wald-tested automatically, so reaching this means the refit ",
-            "itself failed and they were never tested -- the selected set ",
-            "may omit strong variables. Re-running with ",
-            "`criterion = \"wald\"` runs the same refit and will fail the ",
-            "same way; see `$criteria$refit_failures` for which candidates, ",
-            "and `$criteria$uncomputable_reasons`.", call. = FALSE)
+            " candidate(s) were tested by NEITHER criterion. The score ",
+            "statistic could not be computed for them, and under ",
+            "`criterion = \"score\"` they are then refit and Wald-tested ",
+            "automatically -- so reaching this means that rescue did not ",
+            "produce a test either: it errored or did not converge ",
+            "(`information_indefinite`, listed in ",
+            "`$criteria$refit_failures`), or it converged but yielded no ",
+            "usable variance to test with (`fallback_no_variance`, which ",
+            "leaves `refit_failures` empty). Such candidates are typically ",
+            "STRONG -- that is what drives the score's information ",
+            "indefinite -- so the selected set may omit them. Re-running ",
+            "with `criterion = \"wald\"` runs the same refit and fails the ",
+            "same way. See `$criteria$uncomputable_reasons` for which ",
+            "mechanism applied.", call. = FALSE)
   }
   if (stopped_refit_failed) {
     warning("Stepwise selection stopped after ", nrow(steps_df),

--- a/tests/testthat/test-score-fallback-no-variance.R
+++ b/tests/testthat/test-score-fallback-no-variance.R
@@ -1,0 +1,133 @@
+# A candidate tested by NEITHER criterion is reported as such.
+#
+# criterion = "score" declines a candidate whose observed information is
+# indefinite at beta = 0 -- which happens when the effect is LARGE (#130). The
+# Wald fallback then refits it. But that refit can converge, producing a
+# perfectly good point estimate, while its Hessian is singular: no standard
+# error, so .hzr_wald_p() returns NA and the Wald test cannot run either.
+#
+# The fallback loop used to `next` there silently. The row kept the SCORE's
+# reason, describing the first of two independent failures and saying nothing
+# about the second, and no counter moved. A strongly predictive variable
+# vanished and the screen rendered as an honest "nothing met slentry" -- the
+# indistinguishability #159 and #130 were both about.
+
+fnv_fixture <- function(beta = 0.5, n = 400, seed = 7) {
+  set.seed(seed)
+  x1 <- stats::rnorm(n)
+  data.frame(tt = stats::rexp(n, 0.3 * exp(beta * x1)) + 0.01,
+             ev = stats::rbinom(n, 1, 0.75),
+             x1 = x1, x2 = stats::rnorm(n))
+}
+
+fnv_phases <- function() {
+  list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+       const = hzr_phase("constant"))
+}
+
+fnv_fit <- function(D) {
+  suppressWarnings(hazard(survival::Surv(tt, ev) ~ 1, data = D,
+                          dist = "multiphase", phases = fnv_phases(),
+                          fit = TRUE))
+}
+
+test_that("the rescuing refit converges but has no variance to test with", {
+  skip_on_cran()
+  # Pin the mechanism, not just the label. If the refit ever starts failing
+  # outright, or starts producing an SE, this fixture stops exercising the
+  # path the tests below describe and they would pass for a different reason.
+  D <- fnv_fixture()
+  refit <- .hzr_refit_with_scope(fnv_fit(D), action = "add", var = "x1",
+                                 phase = "const", data = D)
+  expect_true(isTRUE(refit$fit$converged))
+  cname <- .hzr_candidate_coef_name(refit, "x1", "const")
+  # A real estimate: the candidate is not degenerate, it is strong.
+  expect_true(is.finite(refit$fit$par[[cname]]))
+  # But no usable variance, so the Wald test cannot be computed.
+  w <- .hzr_candidate_score(criterion = "wald", mode = "entry",
+                            current = fnv_fit(D), candidate = refit,
+                            names = cname)
+  expect_true(is.na(w$score))
+})
+
+test_that("the row says the rescue failed, not just that the score did", {
+  skip_on_cran()
+  D <- fnv_fixture()
+  out <- suppressWarnings(.hzr_stepwise_forward_step(
+    current = fnv_fit(D), scope = list(const = ~ x1 + x2), data = D,
+    criterion = "score", slentry = 0.05))
+
+  x1_row <- out$all_scores[out$all_scores$variable == "x1", ]
+  expect_equal(nrow(x1_row), 1L)
+  expect_true(is.na(x1_row$score))
+  # THE FIX. Previously "information_indefinite", which is the score's reason
+  # and describes only the first failure.
+  expect_identical(x1_row$reason, "fallback_no_variance")
+
+  # And the noise variable IS rescued, scored and declined on its merits --
+  # so the fallback still works and this is not "the rescue stopped running".
+  x2_row <- out$all_scores[out$all_scores$variable == "x2", ]
+  expect_true(x2_row$fallback)
+  expect_false(is.na(x2_row$score))
+  expect_gt(x2_row$p_value, 0.05)
+})
+
+test_that("n_wald_fallbacks counts rescues, not attempts", {
+  skip_on_cran()
+  # x1 is attempted and yields no test; x2 is attempted and does. Only x2 is a
+  # fallback. Miscounting here would overstate how much of the selection was
+  # decided by the substituted criterion.
+  D <- fnv_fixture()
+  out <- suppressWarnings(.hzr_stepwise_forward_step(
+    current = fnv_fit(D), scope = list(const = ~ x1 + x2), data = D,
+    criterion = "score", slentry = 0.05))
+  expect_identical(out$n_wald_fallbacks, 1L)
+  expect_identical(out$n_uncomputable, 1L)
+  expect_false(out$all_scores$fallback[out$all_scores$variable == "x1"])
+})
+
+test_that("a screen that tested nothing says so rather than looking clean", {
+  skip_on_cran()
+  D <- fnv_fixture()
+  w <- testthat::capture_warnings(
+    sw <- hzr_stepwise(fit = fnv_fit(D), scope = list(const = ~ x1 + x2),
+                       data = D, direction = "both", criterion = "score",
+                       slentry = 0.05, trace = FALSE))
+  # Zero steps is the honest outcome here -- neither criterion could test x1.
+  expect_equal(nrow(as.data.frame(sw)), 0L)
+  # But it must not be SILENT about it, or it is indistinguishable from
+  # "nothing met slentry".
+  expect_true(any(grepl("NEITHER criterion", w)))
+  expect_identical(
+    unname(sw$criteria$uncomputable_reasons["fallback_no_variance"]), 1L)
+  # refit_failures stays empty -- the refit did not fail -- so a reader sent
+  # there by the old wording would have found nothing.
+  expect_length(sw$criteria$refit_failures %||% character(0), 0L)
+})
+
+test_that("the new reason has prose, and it names the right mechanism", {
+  txt <- .hzr_score_reason_text("fallback_no_variance")
+  # An unmapped code passes through as itself; that would be a bare token in a
+  # user-facing warning.
+  expect_false(identical(txt, "fallback_no_variance"))
+  expect_match(txt, "no usable variance")
+  expect_match(txt, "NEITHER")
+  # And information_indefinite no longer claims the refit failed, which is
+  # what it said before this case was distinguished.
+  expect_false(grepl("that refit also failed",
+                     .hzr_score_reason_text("information_indefinite")))
+})
+
+test_that("a weaker effect is still tested normally", {
+  skip_on_cran()
+  # The contrast that makes the above meaningful: same fixture, smaller beta,
+  # and the score tests x1 directly. Without this, every assertion here could
+  # pass for a screen that had simply stopped working.
+  D <- fnv_fixture(beta = 0.4)
+  sw <- suppressWarnings(hzr_stepwise(
+    fit = fnv_fit(D), scope = list(const = ~ x1 + x2), data = D,
+    direction = "both", criterion = "score", slentry = 0.05, trace = FALSE))
+  st <- as.data.frame(sw)
+  expect_true("x1" %in% st$variable[toupper(st$action) == "ENTER"])
+  expect_identical(st$stat_type[1], "score_q")
+})

--- a/tests/testthat/test-score-uncomputable-reasons.R
+++ b/tests/testthat/test-score-uncomputable-reasons.R
@@ -109,11 +109,18 @@ test_that("the reason text tells a user to keep the candidate, not drop it", {
   txt <- .hzr_score_reason_text("information_indefinite")
   expect_match(txt, "STRONG")
   # The remedy changed with the fallback: the score criterion Wald-tests
-  # these itself, so the text must say the refit failed rather than advise a
-  # re-run under `criterion = "wald"` -- which now runs the identical refit
-  # and fails identically.
+  # these itself, so the text must say why that rescue did not help, rather
+  # than advise a re-run under `criterion = "wald"` -- which now runs the
+  # identical refit and fails identically.
   expect_match(txt, "Wald-tests")
-  expect_match(txt, "refit also failed")
+  # It must name the mechanism precisely. "that refit also failed" was too
+  # broad: the refit can CONVERGE and still yield no test, when its Hessian is
+  # singular so the coefficient has an estimate but no standard error. That
+  # case reports `fallback_no_variance` and leaves `refit_failures` empty, so
+  # a reader sent there by the old wording found nothing.
+  expect_match(txt, "ERRORED or did not converge")
+  expect_match(txt, "fallback_no_variance")
+  expect_false(grepl("refit also failed", txt))
   # And it must not be reachable from the collinear code, which is the
   # opposite advice.
   expect_no_match(.hzr_score_reason_text("collinear"), "STRONG")


### PR DESCRIPTION
Investigation of the zero-step screen with a strongly predictive candidate.
All three questions answered against the code; the third is a real defect.

> Merge after [#207](https://github.com/ehrlinger/TemporalHazard/pull/207), which unblocks the `house-style` CI job for every open PR.

## 1. Which candidate is which — as predicted

`$criteria` exposes only aggregates, so I dumped `all_scores` from
`.hzr_stepwise_forward_step()`:

| candidate | score | reason | fallback |
|---|---|---|---|
| **x1** (planted, β=0.5) | `NA` | `information_indefinite` | **FALSE** |
| **x2** (noise) | 0.579 | — | **TRUE** |

x1 is the row that stayed indefinite. The row counted in `n_wald_fallbacks` is
**x2**, the noise variable — rescued, scored, and correctly declined by
`slentry`.

## 2. `n_wald_fallbacks` does not overcount

The reading in the report is right: `if (is.na(w$score)) next` does precede
`all_scores$fallback[i] <- TRUE`. The count of 1 was x2's genuine rescue. "1
fallback alongside 1 uncomputable" was **two different rows**, not one row
counted twice. No defect there — that counter (added in #200) is sound.

## 3. The real fault

x1's rescuing refit **converged** — estimate `const.x1 = 0.427` against a true
0.5 — but its Hessian was singular:

```
refit converged: TRUE
coef estimate  : 0.4272635
se for that par: NA
rcond          : 2.51689e-23   pd: NA
```

`.hzr_wald_p()` returns `NA` for "no vcov or non-finite SE", so the Wald test
could not run either. The fallback then took the bare `next`: the row kept the
**score's** reason, which describes the first of two independent failures and
says nothing about the second, and no counter moved. A strongly predictive
variable vanished and the screen rendered as an honest "nothing met `slentry`".

Such rows now report **`fallback_no_variance`**, distinct from
`information_indefinite`, which keeps its meaning of *the rescue errored or did
not converge* and is the case that populates `refit_failures`.

## A regression this nearly shipped

`hzr_stepwise()`'s completed-run warning keyed on `information_indefinite`
**alone**, so relabelling would have **silenced it** — quieter, for a case that
needs to be louder. Both that warning and `hzr_bootstrap()`'s aggregate now key
on either code and say the candidate was tested by *neither* criterion, naming
which mechanism applied.

## Two wrong prose claims, corrected

- `information_indefinite`'s text: *"reaching this reason means that refit also
  failed"*
- the bootstrap warning: *"The automatic Wald refit failed for these"*

Both describe a failed refit, which is not what happens when the refit succeeds
and only the scoring fails — and both sent the reader to a `refit_failures`
that is **empty** in that case. `test-score-uncomputable-reasons.R:116` pinned
the old sentence; it now pins the sharper one.

## Scope

Nothing changes about what gets **selected** — an untestable candidate is still
not entered. What changes is that the run says so. Per the report's framing, the
fix makes the two outcomes distinguishable rather than widening the fallback.

`beta = 0.2/0.3/0.4` still enter x1 normally with no fallback; a test asserts
that contrast, so these assertions cannot pass for a screen that merely stopped
working.

## Gate

- `devtools::document()` — clean
- `lintr::lint_package()` — **0 lints**
- `devtools::spell_check()` — clean
- `devtools::test()` — **0 FAIL / 6 SKIP / 3495 PASS**
- `R CMD check --as-cran` from a clean `git archive` with the manual — **Status: OK**

No version bump, per the house-style section added today.

Mutation-checked: restoring the silent `next` fails 2 tests; keying the warning
on `information_indefinite` alone fails 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)