### PR TITLE
ci: report the required contexts even when the work is skipped

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,18 +1,12 @@
 name: R-CMD-check
 
 on:
-  # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it is excluded from the built
-  # package, and no step in this workflow reads it from the checkout. Running
-  # this on such a commit burns runner minutes and queues ahead of checks that
-  # can actually fail.
+  # No paths-ignore here: see the `changes` job below. A commit that only
+  # touches the generated house-style artifact still needs every required
+  # context REPORTED, even though it does not need the work done.
   push:
-    paths-ignore:
-      - '.claude/**'
     branches: [main, master]
   pull_request:
-    paths-ignore:
-      - '.claude/**'
     branches: [main, master]
 
 concurrency:
@@ -25,7 +19,49 @@ concurrency:
   cancel-in-progress: ${{ !github.ref_protected }}
 
 jobs:
+  # Whether anything outside .claude/ changed.
+  #
+  # This used to be a `paths-ignore: ['.claude/**']` on the triggers, which
+  # was correct about the work -- a .claude/-only commit cannot change what
+  # this checks -- but made the required status checks unsatisfiable. main's
+  # ruleset requires every context below, and a workflow skipped by a path
+  # filter never reports one. A check that never runs is never passing, so a
+  # recompose-only pull request could not be merged at all (#207).
+  #
+  # The trigger now always fires and the expensive steps are gated instead:
+  # every required context is reported, and on a .claude/-only change the job
+  # reaches the end without doing the work. The cost is a briefly-allocated
+  # runner per matrix entry rather than a full check.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$base" ]; then
+            base="$(git rev-parse HEAD^ 2>/dev/null || echo '')"
+          fi
+          if [ -z "$base" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"   # first commit: do the work
+            exit 0
+          fi
+          changed="$(git diff --name-only "$base" HEAD)"
+          # `grep -qv` is wrong here: it succeeds when ANY line fails to match.
+          # Strip the .claude/ lines and ask whether anything is left.
+          if [ -n "$(printf '%s\n' "$changed" | grep -v '^\.claude/' || true)" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   R-CMD-check:
+    needs: changes
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
@@ -41,22 +77,28 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.run == 'true'
+        uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - if: needs.changes.outputs.run == 'true'
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - if: needs.changes.outputs.run == 'true'
+        uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: quarto-dev/quarto-actions/setup@v2
+      - if: needs.changes.outputs.run == 'true'
+        uses: quarto-dev/quarto-actions/setup@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - if: needs.changes.outputs.run == 'true'
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - uses: r-lib/actions/check-r-package@v2
+      - if: needs.changes.outputs.run == 'true'
+        uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -3,17 +3,12 @@
 # a CRAN-bound package this isn't optional. To add words to the allow-list,
 # add them to inst/WORDLIST (one word per line).
 on:
-  # A commit that only touches the generated house-style artifact cannot change
-  # what this checks: spell_check_package() reads DESCRIPTION, man/, vignettes/
-  # and README, never .claude/. Running it on such a commit burns runner
-  # minutes and queues ahead of checks that can actually fail.
+  # No paths-ignore here: see the `changes` job below. A commit that only
+  # touches the generated house-style artifact still needs this context
+  # REPORTED, even though it does not need the work done.
   push:
-    paths-ignore:
-      - '.claude/**'
     branches: [main]
   pull_request:
-    paths-ignore:
-      - '.claude/**'
 
 name: spelling
 
@@ -30,24 +25,70 @@ permissions:
   contents: read
 
 jobs:
+  # Whether anything outside .claude/ changed.
+  #
+  # This used to be a `paths-ignore: ['.claude/**']` on the triggers, which
+  # was correct about the work -- a .claude/-only commit cannot change what
+  # this checks -- but made the required status checks unsatisfiable. main's
+  # ruleset requires every context below, and a workflow skipped by a path
+  # filter never reports one. A check that never runs is never passing, so a
+  # recompose-only pull request could not be merged at all (#207).
+  #
+  # The trigger now always fires and the expensive steps are gated instead:
+  # every required context is reported, and on a .claude/-only change the job
+  # reaches the end without doing the work. The cost is a briefly-allocated
+  # runner per matrix entry rather than a full check.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$base" ]; then
+            base="$(git rev-parse HEAD^ 2>/dev/null || echo '')"
+          fi
+          if [ -z "$base" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"   # first commit: do the work
+            exit 0
+          fi
+          changed="$(git diff --name-only "$base" HEAD)"
+          # `grep -qv` is wrong here: it succeeds when ANY line fails to match.
+          # Strip the .claude/ lines and ask whether anything is left.
+          if [ -n "$(printf '%s\n' "$changed" | grep -v '^\.claude/' || true)" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   spelling:
+    needs: changes
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - if: needs.changes.outputs.run == 'true'
+        uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2
+      - if: needs.changes.outputs.run == 'true'
+        uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - if: needs.changes.outputs.run == 'true'
+        uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::spelling
           needs: check
 
       - name: Spell check
+        if: needs.changes.outputs.run == 'true'
         run: |
           misspelled <- spelling::spell_check_package(use_wordlist = TRUE)
           print(misspelled)


### PR DESCRIPTION
Fixes the deadlock that left [#207](https://github.com/ehrlinger/TemporalHazard/pull/207) permanently unmergeable.

## The deadlock

`main`'s ruleset requires eight contexts:

```
R-CMD-check (ubuntu-latest, devel / release / oldrel-1)
R-CMD-check (macos-latest, release)
R-CMD-check (windows-latest, release)
lint  ·  spelling  ·  house-style
```

`R-CMD-check.yaml` and `spelling.yaml` both carried
`paths-ignore: ['.claude/**']` — **correct about the work.** A commit touching
only the generated house-style artifact cannot change what they test, and
`.claude` is in `.Rbuildignore` anyway.

But a workflow skipped by a path filter reports **no context at all**, and a
context that never reports is never passing. #207 sat `MERGEABLE` /
`BLOCKED` with three checks green and five that would never run. The
optimisation and the gate are individually sensible and jointly impossible.

## Why not the usual companion-workflow trick

The common fix is a second workflow with matching job names and the inverse
path filter. I did not use it, deliberately.

GitHub has no "only these paths" filter, so `paths: ['.claude/**']` also fires
on a PR touching **both** `.claude/` and `R/` — and then two check runs share
one context name. If a ruleset resolves duplicates by *latest-wins* rather than
*all-must-pass*, a no-op could mask a real `R-CMD-check` failure. Masking a
genuine failure is worse than the problem being fixed, and I could not verify
which way rulesets resolve it without risking exactly that.

## What this does instead

The triggers always fire. The expensive steps are gated on a small `changes`
job that asks whether anything outside `.claude/` moved:

- every required context is reported **exactly once**;
- on a `.claude/`-only change the job reaches the end without doing the work;
- the cost is a briefly-allocated runner per matrix entry instead of a full
  check, keeping nearly all of the saving the path filters were written for.

If `changes` itself fails, the dependent jobs are skipped, the contexts go
unreported, and the merge is **BLOCKED** rather than waved through — the safe
direction.

## Verification

Contexts render identically to the required list (parsed from the YAML, not
eyeballed):

```
R-CMD-check (ubuntu-latest, devel)     R-CMD-check (macos-latest, release)
R-CMD-check (ubuntu-latest, release)   R-CMD-check (windows-latest, release)
R-CMD-check (ubuntu-latest, oldrel-1)
```

Steps gated: **6/6** in `R-CMD-check`, **4/4** in `spelling`.

The shell was checked under `bash -eo pipefail`, which is what GitHub uses —
with `pipefail`, a `grep -v` matching nothing returns 1 and would fail the
step, so the substitution carries `|| true`:

| changed files | `run` |
|---|---|
| `.claude/house-style.md` | `false` |
| `.claude/…` + `R/foo.R` | `true` |
| `R/foo.R` | `true` |
| *(none)* | `false` |
| `.claude/agents/…`, `.claude/house-style.md` | `false` |
| `docs/.claude/x.md` | `true` — the anchor is top-level only |

**This PR proves the `run=true` path only** — it touches `.github/`, so the
full checks run here. The `run=false` path is verified locally but not yet in
CI. Once this merges, #207 is a `.claude/`-only PR and becomes exactly that
live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)