### PR TITLE
feat(stepwise): let a multiphase model refit from a vector-interface base fit

### DIFF
--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -39,6 +39,18 @@
 #' (#159). Both callers read this one function so the two answers cannot
 #' drift apart.
 #'
+#' The answer differs by distribution, and deliberately so. A
+#' single-distribution scope change adds or drops a term in the **global**
+#' formula, so without one there is nothing to mutate. A multiphase scope
+#' change rewrites the **phase** formula instead, and the global formula only
+#' ever carried the response --- so a vector-interface multiphase fit refits
+#' perfectly well from its stored response vectors (#160). Blocking it shut
+#' out every translated SAS `SELECTION` job, since SAS's censoring statements
+#' map onto this package's `-1/0/1/2` coding, which `survival::Surv()` does
+#' not share; 25 of the 26 such jobs also use `ICENSOR`. Requiring a formula
+#' there would have forced exactly the status-code round-trip `AGENTS.md`
+#' records as having shipped a wrong-answer bug.
+#'
 #' @param fit A fitted `hazard` object.
 #' @return `NULL` when the fit can be refit, otherwise a character scalar
 #'   naming the obstruction, phrased to follow "... because".
@@ -46,13 +58,31 @@
 #' @keywords internal
 #' @noRd
 .hzr_refit_blocker <- function(fit) {
-  if (is.null(fit$call$formula)) {
+  if (!is.null(fit$call$formula)) {
+    return(NULL)
+  }
+
+  if (!identical(fit$spec$dist, "multiphase")) {
     return(paste0(
       "it was built via the vector interface (`time =` / `status =`) ",
       "rather than the formula interface, so it stores no model formula ",
-      "to mutate"
+      "to mutate. A multiphase fit does not need one --- its scope lives in ",
+      "the phase formulas --- but a single-distribution fit adds and drops ",
+      "terms in the global formula"
     ))
   }
+
+  # Multiphase and no formula: the refit rebuilds the call from the stored
+  # response vectors, so they have to be there. hazard() always records them,
+  # so this fires only for a hand-assembled object -- but an absent `time`
+  # would otherwise reach hazard() as a missing argument several frames later.
+  if (is.null(fit$data$time) || is.null(fit$data$status)) {
+    return(paste0(
+      "it was built via the vector interface but stores no `time` / ",
+      "`status` vectors to refit from"
+    ))
+  }
+
   NULL
 }
 
@@ -116,8 +146,14 @@
     stop("`current` cannot be refit because ", blocker, ".", call. = FALSE)
   }
   # Recover the original formula; see .hzr_stored_formula() for why this
-  # cannot be a deparse.
-  current_formula <- .hzr_stored_formula(current, "`current`")
+  # cannot be a deparse. A vector-interface fit has none -- which the blocker
+  # above has already established is survivable on the multiphase path only.
+  has_formula <- !is.null(current$call$formula)
+  current_formula <- if (has_formula) {
+    .hzr_stored_formula(current, "`current`")
+  } else {
+    NULL
+  }
 
   if (dist == "multiphase") {
     if (is.null(phase)) {
@@ -135,10 +171,23 @@
       new_phases[[phase]], action = action, var = var
     )
 
+    # The scope change above rewrote the PHASE formula; the global formula
+    # only ever carried the response. So a vector-interface base fit refits
+    # fine, provided its stored response vectors are handed back --
+    # time_lower / time_upper included. The formula path gets those from
+    # Surv(); a vector refit that dropped them would silently refit a
+    # left-truncated cohort as at risk from time 0.
+    response_args <- if (has_formula) {
+      list(formula = current_formula, data = data)
+    } else {
+      c(Filter(Negate(is.null),
+               current$data[c("time", "status", "time_lower", "time_upper")]),
+        list(data = data))
+    }
+
     do.call(hazard, c(
+      response_args,
       list(
-        formula      = current_formula,
-        data         = data,
         dist         = "multiphase",
         phases       = new_phases,
         weights      = weights,
@@ -149,7 +198,15 @@
     ))
   } else {
     # Single-distribution path: mutate the global formula, warm-start
-    # theta by inserting / dropping the relevant beta slot.
+    # theta by inserting / dropping the relevant beta slot. Unlike multiphase
+    # this genuinely cannot proceed without a formula, which is why
+    # .hzr_refit_blocker() still refuses that combination -- assert it rather
+    # than letting a NULL formula travel into .hzr_formula_update().
+    if (!has_formula) {
+      stop("Internal: a single-distribution refit reached the formula ",
+           "mutation with no formula. .hzr_refit_blocker() should have ",
+           "refused this fit.", call. = FALSE)
+    }
     new_formula <- .hzr_formula_update(current_formula, action, var)
 
     n_shape <- .hzr_shape_parameter_count(dist, control = current$spec$control)

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -239,12 +239,22 @@ hzr_stepwise <- function(fit,
   # is what stops the two answers drifting apart.
   refit_blocker <- .hzr_refit_blocker(fit)
   if (!is.null(refit_blocker)) {
+    # The remedy is distribution-specific. Telling a multiphase caller to
+    # "rebuild with the formula interface" would be wrong twice over: it is
+    # not what blocked them, and for a translated SAS job it would force the
+    # -1/0/1/2 -> Surv() 0/1/2/3 status round-trip this package has already
+    # shipped a wrong answer through.
+    remedy <- if (identical(fit$spec$dist, "multiphase")) {
+      paste0("Refit the base model with hazard(), supplying `time` and ",
+             "`status` (or a formula), and retry.")
+    } else {
+      paste0("Rebuild the base fit with the formula interface -- for a ",
+             "forward screen that usually means an intercept-only base, ",
+             "hazard(Surv(time, status) ~ 1, data = df, ...) -- and retry.")
+    }
     stop("`fit` cannot be used as a stepwise base model because ",
          refit_blocker, ". Every candidate would fail to refit, so the ",
-         "screen could never enter or drop anything. Rebuild the base fit ",
-         "with the formula interface -- for a forward screen that usually ",
-         "means an intercept-only base, hazard(Surv(time, status) ~ 1, ",
-         "data = df, ...) -- and retry.",
+         "screen could never enter or drop anything. ", remedy,
          call. = FALSE)
   }
 

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -402,6 +402,18 @@ test_that(".hzr_refit_blocker is the single answer both callers read", {
 
   expect_null(.hzr_refit_blocker(frmfit))
   expect_match(.hzr_refit_blocker(vecfit), "vector interface")
+
+  # The predicate is distribution-aware (#160): a multiphase fit's scope lives
+  # in the phase formulas, so it needs no global one and is NOT blocked. Both
+  # vector fits above and below are the same interface; only `dist` differs,
+  # which is what makes this a contrast rather than two spellings of one case.
+  vecmp <- suppressWarnings(hazard(
+    time = avc$int_dead, status = avc$dead, dist = "multiphase",
+    phases = list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+                  const = hzr_phase("constant")),
+    fit = TRUE, control = list(n_starts = 1)))
+  expect_null(vecmp$call$formula)
+  expect_null(.hzr_refit_blocker(vecmp))
 })
 
 # Fixture: an intercept-only formula fit whose only candidate names a column

--- a/tests/testthat/test-stepwise-vector-interface.R
+++ b/tests/testthat/test-stepwise-vector-interface.R
@@ -106,6 +106,42 @@ test_that("a vector-interface refit carries weights and time_lower through", {
   expect_equal(out$data$time_lower, D$entry)
 })
 
+test_that("a vector-interface refit carries BOTH censoring bounds through", {
+  skip_on_cran()
+  # The test above uses status 0/1 and entry 0, so `time_upper` is NULL there
+  # and asserting on it would compare NULL with NULL -- an assertion that
+  # cannot fail. This fixture makes both bounds load bearing: interval rows
+  # with genuinely wide intervals, and a non-zero entry time on the rest.
+  D <- vec_data()
+  n <- nrow(D)
+  D$st <- rep(c(1, 0, 2), length.out = n)
+  D$lo <- ifelse(D$st == 2, D$tt, 0.05 + seq_len(n) / (20 * n))
+  D$up <- ifelse(D$st == 2, D$tt + 0.75, D$tt)
+
+  # Guard the guard: if the fixture degenerated to zero entry times or
+  # zero-width intervals, dropping either bound would not change the
+  # likelihood and the assertions below would prove nothing.
+  expect_true(all(D$lo[D$st != 2] > 0))
+  expect_true(all(D$up[D$st == 2] > D$lo[D$st == 2]))
+  expect_gt(sum(D$st == 2), 0L)
+
+  fv <- suppressWarnings(hazard(time = D$tt, status = D$st,
+                                time_lower = D$lo, time_upper = D$up,
+                                dist = "multiphase", phases = vec_phases(),
+                                fit = TRUE))
+  out <- suppressWarnings(
+    .hzr_refit_with_scope(fv, action = "add", var = "x1",
+                          data = D, phase = "early"))
+
+  expect_s3_class(out, "hazard")
+  # Dropping `time_lower` refits a left-truncated cohort as at risk from 0;
+  # dropping `time_upper` turns every interval row into something else. Both
+  # are silent -- the refit still returns a populated fit.
+  expect_equal(out$data$time_lower, D$lo)
+  expect_equal(out$data$time_upper, D$up)
+  expect_equal(out$data$status, D$st)
+})
+
 test_that("a single-distribution vector fit still cannot be refit", {
   skip_on_cran()
   D <- vec_data()

--- a/tests/testthat/test-stepwise-vector-interface.R
+++ b/tests/testthat/test-stepwise-vector-interface.R
@@ -1,0 +1,169 @@
+# Stepwise over a vector-interface base fit (#160).
+#
+# hzr_stepwise()'s refit path required a formula-interface base fit for every
+# distribution. For multiphase models that restriction was incidental: a scope
+# change rewrites the *phase* formula, and the global formula only ever
+# carried the response. Refusing the vector interface shut out every
+# translated SAS SELECTION job, because SAS's censoring statements map onto
+# this package's -1/0/1/2 status coding, which survival::Surv() does not
+# share -- and 25 of the 26 such jobs also use ICENSOR, so requiring a formula
+# would have forced exactly the status round-trip AGENTS.md records as having
+# shipped a wrong answer.
+#
+# The single-distribution path genuinely does mutate the global formula, so it
+# still requires one. That difference is asserted here so it stays deliberate.
+
+vec_phases <- function() {
+  list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+       const = hzr_phase("constant"))
+}
+
+vec_data <- function(n = 300, seed = 3, beta = 0) {
+  set.seed(seed)
+  x1 <- stats::rnorm(n)
+  data.frame(tt = stats::rexp(n, 0.3 * exp(beta * x1)) + 0.01,
+             ev = stats::rbinom(n, 1, 0.75),
+             x1 = x1, x2 = stats::rnorm(n))
+}
+
+vec_fit <- function(D, ...) {
+  suppressWarnings(hazard(time = D$tt, status = D$ev, dist = "multiphase",
+                          phases = vec_phases(), fit = TRUE, ...))
+}
+
+test_that("the blocker refuses by distribution, not by interface alone", {
+  skip_on_cran()
+  D <- vec_data()
+  fv <- vec_fit(D)
+  fw <- suppressWarnings(hazard(time = D$tt, status = D$ev, dist = "weibull",
+                                theta = c(0.3, 1), fit = TRUE))
+  # Guard the guard: both really are vector-interface fits, or the contrast
+  # below is between two formula fits and says nothing.
+  expect_null(fv$call$formula)
+  expect_null(fw$call$formula)
+
+  # Multiphase: scope lives in the phase formulas, so no global one is needed.
+  expect_null(.hzr_refit_blocker(fv))
+  # Single-distribution: scope lives in the global formula, so one is.
+  expect_match(.hzr_refit_blocker(fw), "vector interface")
+})
+
+test_that("a multiphase vector fit with no stored response is still refused", {
+  # hazard() always records time/status, so this is a hand-assembled object --
+  # but without the check an absent `time` reaches hazard() as a missing
+  # argument several frames down, where the message names nothing useful.
+  hollow <- structure(
+    list(call = list(), spec = list(dist = "multiphase"), data = list()),
+    class = "hazard")
+  expect_match(.hzr_refit_blocker(hollow), "no `time` / `status` vectors")
+})
+
+test_that("a vector-interface multiphase fit refits with an added covariate", {
+  skip_on_cran()
+  D <- vec_data()
+  fv <- vec_fit(D)
+  out <- suppressWarnings(
+    .hzr_refit_with_scope(fv, action = "add", var = "x1",
+                          data = D, phase = "early"))
+  expect_s3_class(out, "hazard")
+  expect_true("early.x1" %in% names(out$fit$par))
+  # It must stay on the vector interface rather than acquiring a formula it
+  # was never given.
+  expect_null(out$call$formula)
+})
+
+test_that("a vector-interface refit can drop a covariate again", {
+  skip_on_cran()
+  D <- vec_data()
+  ph <- vec_phases()
+  ph$early <- hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0, formula = ~x1)
+  fv <- suppressWarnings(hazard(time = D$tt, status = D$ev, data = D,
+                                dist = "multiphase", phases = ph, fit = TRUE))
+  expect_true("early.x1" %in% names(fv$fit$par))
+  out <- suppressWarnings(
+    .hzr_refit_with_scope(fv, action = "drop", var = "x1",
+                          data = D, phase = "early"))
+  expect_false("early.x1" %in% names(out$fit$par))
+})
+
+test_that("a vector-interface refit carries weights and time_lower through", {
+  skip_on_cran()
+  D <- vec_data()
+  D$w <- rep(c(1, 2), length.out = nrow(D))
+  D$entry <- 0
+  fv <- suppressWarnings(hazard(time = D$tt, status = D$ev,
+                                time_lower = D$entry, weights = D$w,
+                                dist = "multiphase", phases = vec_phases(),
+                                fit = TRUE))
+  out <- suppressWarnings(
+    .hzr_refit_with_scope(fv, action = "add", var = "x1",
+                          data = D, phase = "early"))
+  expect_s3_class(out, "hazard")
+  # Dropping either silently changes the likelihood -- a left-truncated cohort
+  # refit without time_lower is at risk from 0. Assert they survived rather
+  # than that the refit merely returned.
+  expect_equal(out$data$weights, D$w)
+  expect_equal(out$data$time_lower, D$entry)
+})
+
+test_that("a single-distribution vector fit still cannot be refit", {
+  skip_on_cran()
+  D <- vec_data()
+  fw <- suppressWarnings(hazard(time = D$tt, status = D$ev, dist = "weibull",
+                                theta = c(0.3, 1), fit = TRUE))
+  # Deliberate, not incidental: the single-distribution path rewrites the
+  # global formula, so there is nothing to mutate.
+  expect_error(
+    .hzr_refit_with_scope(fw, action = "add", var = "x1", data = D),
+    "vector interface")
+})
+
+test_that("a stepwise screen over a vector base fit TAKES a step", {
+  skip_on_cran()
+  # THE ACCEPTANCE CRITERION from #160. A call that merely executes is the
+  # defect the issue exists to avoid: before this, every candidate refit
+  # failed, the forward step downgraded those failures to warnings, and the
+  # screen returned zero steps -- rendering clean and selecting nothing,
+  # indistinguishable from an honest "nothing met slentry".
+  # beta = 0.4, not larger: at 0.5+ the score statistic goes indefinite on x1
+  # (the #130 case -- the criterion declines candidates in proportion to how
+  # predictive they are) and the run depends on the Wald fallback instead.
+  # That machinery is tested in test-score-wald-fallback.R; this test is about
+  # the refit INTERFACE, so it uses an effect the score can test directly.
+  # Measured here: p = 1.8e-08 against slentry = 0.05.
+  D <- vec_data(n = 400, seed = 7, beta = 0.4)   # x1 planted, x2 noise
+  sw <- suppressWarnings(hzr_stepwise(
+    fit = vec_fit(D), scope = list(const = ~ x1 + x2), data = D,
+    direction = "both", criterion = "score", slentry = 0.05, trace = FALSE))
+
+  steps <- as.data.frame(sw)
+  entered <- steps$variable[toupper(steps$action) == "ENTER"]
+  expect_gte(nrow(steps), 1L)
+  expect_true("x1" %in% entered)
+  # And it entered the phase the scope named, not somewhere else.
+  expect_identical(steps$phase[steps$variable == "x1"][1], "const")
+  # The noise stays out, so this is selection rather than "refit everything".
+  expect_false("x2" %in% entered)
+  # No candidate was silently skipped: a refit failure here would look like a
+  # clean screen, which is the failure mode being fixed.
+  expect_length(sw$criteria$refit_failures %||% character(0), 0L)
+  # And the score criterion actually scored it, so this exercises the ordinary
+  # path rather than leaning on the fallback.
+  expect_identical(sw$criteria$n_wald_fallbacks, 0L)
+  expect_identical(steps$stat_type[1], "score_q")
+})
+
+test_that("hzr_stepwise()'s pre-flight names a remedy that fits the model", {
+  skip_on_cran()
+  D <- vec_data()
+  fw <- suppressWarnings(hazard(time = D$tt, status = D$ev, dist = "weibull",
+                                theta = c(0.3, 1), fit = TRUE))
+  # A single-distribution fit is told to rebuild with a formula...
+  expect_error(
+    suppressWarnings(hzr_stepwise(fit = fw, scope = ~ x1, data = D,
+                                  direction = "forward")),
+    "Surv\\(time, status\\)")
+  # ...and a multiphase one is never told that, because for a translated SAS
+  # job it would force the -1/0/1/2 -> Surv() status round-trip.
+  expect_null(.hzr_refit_blocker(vec_fit(D)))
+})


### PR DESCRIPTION
Requirement 1 of #160: `hzr_stepwise()` can now take a **multiphase** base fit
built through the vector interface (`time =` / `status =`), not only through
the formula interface.

## Why the restriction was incidental

`.hzr_refit_blocker()` (#159) refused every fit with no stored formula, for
every distribution. That is right for a single distribution: a scope change
there adds or drops a term in the **global** formula, so without one there is
nothing to mutate. It is wrong for multiphase: a multiphase scope change
rewrites the **phase** formula, and the global formula only ever carried the
response. Such a fit refits perfectly well from its stored response vectors.

The cost of the blanket refusal was every translated SAS `SELECTION` job. SAS's
censoring statements map onto this package's `-1/0/1/2` coding, which
`survival::Surv()` does not share, and 25 of the 26 such jobs also use
`ICENSOR`. Requiring a formula there would have forced exactly the status-code
round-trip `AGENTS.md` records as having shipped a wrong answer.

## What changed

- `.hzr_refit_blocker()` is distribution-aware **without a signature change**:
  it reads `fit$spec$dist` itself, so both callers still share one predicate
  and cannot drift, which was the stated reason for sharing it in #159.
- It also refuses a multiphase vector fit with no stored `time`/`status`,
  which would otherwise reach `hazard()` as a missing argument several frames
  down.
- The refit hands back `time_lower` / `time_upper` explicitly. The formula path
  gets those from `Surv()`; a vector refit that dropped them would silently
  refit a left-truncated cohort as at risk from time 0: a full result, no
  error, wrong answer. `expect_equal(out$data$time_lower, D$entry)` is the test
  that stands between the code and that failure mode.
- The single-distribution path keeps erroring, deliberately, and now asserts
  rather than letting a `NULL` formula travel into `.hzr_formula_update()`.
- `hzr_stepwise()`'s pre-flight remedy is distribution-specific: telling a
  multiphase caller to "rebuild with the formula interface" would be wrong
  twice over.

## Note on the re-land

This is **not** a cherry-pick of the earlier `f8e8a56`. `main` added
`.hzr_refit_blocker()` upstream of the lines that commit changed, so a
mechanical re-land would have merged cleanly and been **inert**. It is
rewritten against main's guard, and rebased onto `602e294`.

## Gate

Run at `015f6d3`, rebased onto `main` @ `602e294`:

- `devtools::document()`: clean, no `man/` / `NAMESPACE` drift
- `lintr::lint_package()`: **0 lints**
- `devtools::test()` with `NOT_CRAN=true`: **0 FAIL / 6 SKIP / 3551 PASS**
  (the 6 skips are the SAS fixture-availability baseline)
- `test-stepwise-vector-interface.R` alone: **0 FAIL / 0 SKIP / 23 PASS**,
  run separately to confirm its 8 `skip_on_cran()` tests genuinely execute
- `R CMD check --as-cran` with the manual, built from a clean `git archive`
  export of the committed tree, **Status: OK** (0 errors, 0 warnings,
  0 notes). Tarball 2.9 MB; tests 107s, vignette rebuild 52s.

## Not in this PR

No `NEWS.md` entry: #160 gets **one** bullet when requirements 2–5 land.
Requirements 2-5, namely phase-keyed scope, withholding the candidate pool from the
phase formulas, `hzr_stepwise()` in its own chunk via `.hzr_retarget_fit()`,
and dropping the translator refusal in `R/sas-parse-job.R`, are not started.

Part of #160.

