### PR TITLE
fix(objective): record the objective on the fit so refits keep the estimand

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,8 +40,11 @@
   `criterion = "score"`, where every neighbouring row carries a Q. The
   selection was right and `p_value` was right, but a reader recomputing a
   p-value from `stat` the way the neighbouring rows permit got an answer wrong
-  by dozens of orders of magnitude. Under `criterion = "score"` the rows
-  reading `"wald_z"` are exactly the ones the fallback rescued.
+  by dozens of orders of magnitude. Under `criterion = "score"` the *entry*
+  rows reading `"wald_z"` are the ones the fallback rescued --- filter on
+  `action == "enter" & stat_type == "wald_z"`. Drop rows are always
+  Wald-tested under that criterion, following SAS, so they read `"wald_z"`
+  whether or not the fallback fired.
 
 * **`hzr_bootstrap()` reports Wald fallbacks in select mode**, through
   `$n_wald_fallback_replicates` and `$n_wald_fallbacks`, with a warning when
@@ -58,6 +61,29 @@
   works, and is what makes the multiple-nomogram warning actionable.
 
 ## Bug fixes
+
+* **`objective` is now recorded on the fit, so refits keep the estimand.**
+  `hazard(objective = "sas")` was accepted and acted on by the optimizer, but
+  the choice was never stored on the object. Everything that rebuilds a
+  `hazard()` call from `fit$spec` therefore reverted to
+  `objective = "likelihood"`: every `hzr_stepwise()` candidate refit, the
+  Wald-fallback refit and each accepted move, plus the score test's numeric
+  Hessian and gradient.
+
+  Selecting on a `"sas"` base fit consequently differenced `delta_logLik`,
+  `aic` and `delta_aic` across *two different estimands*, and the score
+  statistic was computed against a likelihood the fit had not been fitted to.
+  On the esophagectomy reference the two objectives differ by about 22
+  log-likelihood units -- larger than most single-variable effects -- and the
+  run produced a full `$steps` table with no error and no warning.
+
+  `fit$spec$objective` now records it, and one accessor feeds every consumer
+  so they cannot drift apart. A fit that carries no `objective` predates the
+  argument and is read as `"likelihood"`, which is what it was.
+
+  Note the asymmetry this had created: `hzr_bootstrap()` *refit* mode
+  re-evaluates the stored call, which did carry `objective = "sas"`, so it was
+  already consistent; *select* mode goes through the scope refit and was not.
 
 * **A candidate that neither criterion could test is now reported as such.**
   `criterion = "score"` declines a candidate whose observed information is
@@ -86,18 +112,18 @@
   No behaviour changed in what gets selected: a candidate that could not be
   tested is still not entered. What changed is that the run says so.
 
-* **`fit$weak` now distinguishes "no ridge" from "not checked".** The
+* **`fit$fit$weak` now distinguishes "no ridge" from "not checked".** The
   weak-identification diagnostic introduced in 1.2.7 returned `NULL` both when
   a fit had been examined and found well identified and when it could not be
   examined at all -- most importantly when no Hessian was available, which
   happens on an install without the suggested numDeriv package and on fits whose
   rows are left- or interval-censored, where the analytic Hessian declines by
-  design. `NEWS` offered `fit$weak` as the programmatic check, so on those
+  design. `NEWS` offered `fit$fit$weak` as the programmatic check, so on those
   installs it certified as well identified a fit nothing had looked at.
 
   The field now takes three values: a list when a ridge was found, `NULL` when
   the fit was examined and is well identified, and `NA` when the check could
-  not run. Test it with `is.list(fit$weak)` rather than `!is.null()`.
+  not run. Test it with `is.list(fit$fit$weak)` rather than `!is.null()`.
   `summary()` prints a note in the `NA` case saying the check did not run, and
   a fit imported with `hzr_read_outhaz()` -- which has no R Hessian to examine
   -- now reports `NA` rather than reading as certified clean.
@@ -195,6 +221,19 @@
 
 ## Documentation
 
+* **Corrected the documented paths for two fit fields.** The weak-identification
+  result is at `fit$fit$weak` and the phase shares at `fit$fit$phase_share`;
+  `NEWS.md` and, for the shares, `?hazard` had both named them one level too
+  high. Code following the documented recipe got `FALSE` from
+  `is.list(fit$weak)` for every fit, ridge or not -- the same wrong answer the
+  1.2.8 three-value change was made to prevent, reached by a different route.
+
+* **`stat_type` no longer over-claims which rows the Wald fallback rescued.**
+  Under `criterion = "score"` drop rows are always Wald-tested, following SAS,
+  so they read `"wald_z"` whether or not the fallback fired. The rescued rows
+  are the *entry* rows: filter on
+  `action == "enter" & stat_type == "wald_z"`.
+
 * **`predict()` and `hzr_nelson()` now say that SAS draws narrower bands.**
   SAS `%KAPLAN`, `%NELSONT` and `PROC HAZPRED` all take their band width from
   `CLEVEL`, whose default is `0.68268948` -- documented in the macro source as
@@ -262,7 +301,7 @@
   `hazard()` now warns, once per fit, naming the parameters that span the flat
   direction along with their correlation and the Hessian's `rcond`, and
   `summary()` prints the same note. The finding is recorded on the object as
-  `fit$weak`, so it can be checked programmatically rather than scraped from a
+  `fit$fit$weak`, so it can be checked programmatically rather than scraped from a
   warning. See the 1.2.8 notes below for the three values that field takes.
 
   The direction is read off the *correlation* of the estimates rather than
@@ -356,7 +395,7 @@
   phase already contributed. The share is measured against the cumulative
   hazard rather than the instantaneous hazard for the same reason.
 
-  The shares are recorded on the fit as `fit$phase_share`, so the warning can
+  The shares are recorded on the fit as `fit$fit$phase_share`, so the warning can
   be checked rather than taken on trust, and the threshold is
   `control$phase_share_tol` (default 1e-8).
 

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -208,7 +208,7 @@ NULL
 #'   or when its contribution varies by less than this relative amount across
 #'   them (it finished before the first observation and acts as a constant
 #'   offset -- `mu` stays identified, the shape parameters do not). The
-#'   measured shares are kept on the fit as `fit$phase_share`. Raise it to
+#'   measured shares are kept on the fit as `fit$fit$phase_share`. Raise it to
 #'   catch marginal phases, set it to 0 to silence the check.
 #' - `reltol`: Relative parameter change tolerance (default 1e-5)
 #' - `abstol`: Absolute gradient norm tolerance (default 1e-6)
@@ -853,7 +853,7 @@ hazard <- function(formula = NULL,
     call = captured_call,
     call_env = captured_env,
     spec = list(dist = dist, control = control, time_windows = time_windows,
-                phases = phases),
+                phases = phases, objective = objective),
     data = list(
       time = time,
       time_lower = time_lower,

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -253,7 +253,8 @@
       par, time = d$time, status = d$status,
       time_lower = d$time_lower, time_upper = d$time_upper,
       x = d$x, weights = d$weights, phases = phases,
-      covariate_counts = covariate_counts, x_list = x_list
+      covariate_counts = covariate_counts, x_list = x_list,
+      objective = .hzr_fit_objective(current)
     )
   }
   h <- tryCatch(numDeriv::hessian(nll, theta), error = function(e) NULL)
@@ -492,7 +493,8 @@
       x = d$x, weights = d$weights,
       phases = exp_$phases,
       covariate_counts = exp_$covariate_counts,
-      x_list = exp_$x_list
+      x_list = exp_$x_list,
+      objective = .hzr_fit_objective(current)
     ),
     error = function(e) NULL
   )

--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -29,6 +29,30 @@
 # directly should pre-expand factors and splines into explicit main
 # effects.
 
+#' The objective a fit was estimated under
+#'
+#' `objective` changes the estimand, not just the arithmetic: on the
+#' esophagectomy reference the SAS interval density and the likelihood differ
+#' by about 22 log-likelihood units, which is larger than most single-variable
+#' effects. Anything that refits a stored fit, or evaluates its likelihood
+#' again, has to reuse the same one or it silently compares two estimands ---
+#' a populated `delta_logLik` / `aic` computed against a model the base fit
+#' was never fitted to. Every such caller reads this one accessor so they
+#' cannot drift apart.
+#'
+#' A fit with no `objective` recorded predates the argument, so it was
+#' necessarily estimated under the likelihood; the default is a fact about
+#' those objects, not a fallback guess.
+#'
+#' @param fit A fitted `hazard` object.
+#' @return `"likelihood"` or `"sas"`.
+#'
+#' @keywords internal
+#' @noRd
+.hzr_fit_objective <- function(fit) {
+  fit$spec$objective %||% "likelihood"
+}
+
 #' Why a fit cannot be refit with a mutated scope
 #'
 #' Single decision point for "can `.hzr_refit_with_scope()` handle this
@@ -185,6 +209,10 @@
         list(data = data))
     }
 
+    # Reuse the base fit's objective. Dropping it refits every candidate
+    # under the likelihood while the base fit's `objective` is the SAS
+    # density, so `delta_logLik` and `aic` would be differenced across two
+    # estimands -- a full `$steps` table, no warning, wrong numbers.
     do.call(hazard, c(
       response_args,
       list(
@@ -192,6 +220,7 @@
         phases       = new_phases,
         weights      = weights,
         time_windows = time_windows,
+        objective    = .hzr_fit_objective(current),
         fit          = TRUE
       ),
       extra_args

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -180,10 +180,14 @@
 #'     \code{"wald_chisq"} (chi-square on \code{df}).  \code{df} alone does
 #'     not distinguish them --- a scalar Wald is reported as a \emph{z}, not
 #'     as its square, so it and a score Q are both recorded at \code{df = 1}
-#'     while calling for different distributions.  This also identifies the
-#'     rows the Wald fallback rescued: under \code{criterion = "score"} they
-#'     are the ones reading \code{"wald_z"} (see \code{$criteria$n_wald_fallbacks}
-#'     for the count).}
+#'     while calling for different distributions.  It also identifies the
+#'     rows the Wald fallback rescued, but only among \emph{entry} rows:
+#'     under \code{criterion = "score"} those are the rows with
+#'     \code{action == "enter" & stat_type == "wald_z"}.  Drop rows are
+#'     always Wald-tested under that criterion --- removal follows SAS and
+#'     is tested on the current model's Wald p-value --- so they read
+#'     \code{"wald_z"} whether or not the fallback ever fired.  See
+#'     \code{$criteria$n_wald_fallbacks} for the count.}
 #'   \item{\code{p_value}, \code{delta_aic}}{Always populated when
 #'     computable, regardless of the active criterion.}
 #'   \item{\code{logLik}, \code{aic}, \code{n_coef}}{Goodness-of-fit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -134,6 +134,22 @@ main (X.Y.Z) accumulates, patch-bumping as fixes land
    two catch different things: the check finds what static analysis sees in a
    built tarball, the review finds what is wrong but passing, including prose
    that contradicts the code. Run it *before* the check so fixes land first.
+
+   **File every finding you do not fix, before you submit.** The review's only
+   output is a session transcript, so a finding that is neither fixed nor filed
+   is gone -- and the next release review pays the full verification cost to
+   rediscover it. Verify the finding first, then either fix it or open an issue
+   carrying the reproduction; "noted and moved on" is the one disposition that
+   loses the work. On 2026-09-02 the review of `v1.2.2...main` returned ten
+   findings: four were fixed in the release branch and six filed as #211-#216,
+   which is what this line exists to make routine.
+
+   Re-verify before you write the issue, not just before you fix. #215 is the
+   worked example: the review reported `$steps` with zero rows and reason
+   `information_indefinite`, and reproducing it gave **one** row and
+   `nuisance_singular`. The conclusion held, the mechanism did not, and the
+   suggested fix keyed on the wrong code. An issue filed verbatim would have
+   sent the next reader after a reproduction that does not reproduce.
 6. `R CMD check --as-cran` **with the manual built** → 0 errors, 0 warnings,
    0 notes. Build the real tarball and check it, *not* `--no-manual`:
 

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -176,7 +176,7 @@ time (it never started -- neither its \code{mu} nor its shape is identified),
 or when its contribution varies by less than this relative amount across
 them (it finished before the first observation and acts as a constant
 offset -- \code{mu} stays identified, the shape parameters do not). The
-measured shares are kept on the fit as \code{fit$phase_share}. Raise it to
+measured shares are kept on the fit as \code{fit$fit$phase_share}. Raise it to
 catch marginal phases, set it to 0 to silence the check.
 \item \code{reltol}: Relative parameter change tolerance (default 1e-5)
 \item \code{abstol}: Absolute gradient norm tolerance (default 1e-6)

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -158,10 +158,14 @@ reference distribution recomputes its p-value: \code{"score_q"}
 \code{"wald_chisq"} (chi-square on \code{df}).  \code{df} alone does
 not distinguish them --- a scalar Wald is reported as a \emph{z}, not
 as its square, so it and a score Q are both recorded at \code{df = 1}
-while calling for different distributions.  This also identifies the
-rows the Wald fallback rescued: under \code{criterion = "score"} they
-are the ones reading \code{"wald_z"} (see \code{$criteria$n_wald_fallbacks}
-for the count).}
+while calling for different distributions.  It also identifies the
+rows the Wald fallback rescued, but only among \emph{entry} rows:
+under \code{criterion = "score"} those are the rows with
+\code{action == "enter" & stat_type == "wald_z"}.  Drop rows are
+always Wald-tested under that criterion --- removal follows SAS and
+is tested on the current model's Wald p-value --- so they read
+\code{"wald_z"} whether or not the fallback ever fired.  See
+\code{$criteria$n_wald_fallbacks} for the count.}
 \item{\code{p_value}, \code{delta_aic}}{Always populated when
 computable, regardless of the active criterion.}
 \item{\code{logLik}, \code{aic}, \code{n_coef}}{Goodness-of-fit

--- a/tests/testthat/test-sas-interval-objective.R
+++ b/tests/testthat/test-sas-interval-objective.R
@@ -453,3 +453,39 @@ test_that("the two objectives are far enough apart for the mix-up to matter", {
   expect_gt(abs(sas_mp_ll(objective = "sas") -
                   sas_mp_ll(objective = "likelihood")), 1)
 })
+
+test_that("a vector-interface sas fit keeps its objective across a scope refit", {
+  skip_on_cran()
+  # The intersection of #160 (multiphase models refit from a vector-interface
+  # base fit) and the objective fix. Neither change tested it on its own, and
+  # it is the combination SAS SELECTION jobs actually land on: 25 of 26 use
+  # ICENSOR, so they arrive interval-censored, through the vector interface,
+  # and are the reason objective = "sas" exists.
+  set.seed(7)
+  n <- 60L
+  D <- data.frame(tt = stats::rexp(n, 0.4) + 0.05,
+                  x1 = stats::rnorm(n), x2 = stats::rnorm(n))
+  D$st <- rep(c(1, 0, 2), length.out = n)
+  D$lo <- ifelse(D$st == 2, D$tt, 0.02)
+  D$up <- ifelse(D$st == 2, D$tt + 0.6, D$tt)
+
+  # Guard the guard: interval rows must be present or objective = "sas" is
+  # indistinguishable from the likelihood and this test proves nothing.
+  expect_gt(sum(D$st == 2), 0L)
+
+  f <- suppressWarnings(hazard(time = D$tt, status = D$st, time_lower = D$lo,
+                               time_upper = D$up, dist = "multiphase",
+                               phases = sas_obj_phases(), objective = "sas",
+                               fit = TRUE))
+  expect_null(f$call$formula)
+  expect_identical(f$spec$objective, "sas")
+
+  out <- suppressWarnings(
+    TemporalHazard:::.hzr_refit_with_scope(f, action = "add", var = "x1",
+                                           data = D, phase = "early"))
+  # Both halves have to survive together: the response vectors rebuilt from
+  # `$data` (#160) and the estimand read from `$spec` (this fix).
+  expect_identical(out$spec$objective, "sas")
+  expect_equal(out$data$time_upper, D$up)
+  expect_equal(out$data$time_lower, D$lo)
+})

--- a/tests/testthat/test-sas-interval-objective.R
+++ b/tests/testthat/test-sas-interval-objective.R
@@ -361,3 +361,95 @@ test_that('objective = "sas" tracks SAS along its own iteration trace', {
   # an artefact of every iterate sitting near the same value.
   expect_gt(abs(trace[[1]]$sas - trace[[4]]$sas), 190)
 })
+
+
+# ---------------------------------------------------------------------------
+# Objective is recorded on the fit and survives every refit path.
+#
+# `objective` was accepted, match.arg'd and threaded to the optimizer, but
+# never stored -- so `.hzr_refit_with_scope()`, which rebuilds the hazard()
+# call from `$spec`, refit every stepwise candidate under the likelihood while
+# the base fit's own objective was the SAS density. That differences
+# `delta_logLik` and `aic` across two estimands and reports a full `$steps`
+# table with no warning. The tests below assert the recording, the default for
+# objects that predate the argument, and the forwarding.
+# ---------------------------------------------------------------------------
+
+sas_obj_data <- function(n = 60, seed = 11) {
+  set.seed(seed)
+  x1 <- stats::rnorm(n)
+  data.frame(
+    tt = stats::rexp(n, 0.4) + 0.05,
+    ev = rep(c(1, 0), length.out = n),
+    x1 = x1,
+    x2 = stats::rnorm(n)
+  )
+}
+
+sas_obj_phases <- function() {
+  list(early = hzr_phase("cdf", t_half = 1, nu = 1.5, m = 0),
+       const = hzr_phase("constant"))
+}
+
+test_that("hazard() records the objective it was fitted under", {
+  skip_on_cran()
+  D <- sas_obj_data()
+  f_lik <- suppressWarnings(hazard(time = D$tt, status = D$ev,
+                                   dist = "multiphase",
+                                   phases = sas_obj_phases(), fit = TRUE))
+  f_sas <- suppressWarnings(hazard(time = D$tt, status = D$ev,
+                                   dist = "multiphase",
+                                   phases = sas_obj_phases(),
+                                   objective = "sas", fit = TRUE))
+  # Distinct values, not merely non-NULL: a spec that hardcoded either one
+  # would pass a `!is.null()` check.
+  expect_identical(f_lik$spec$objective, "likelihood")
+  expect_identical(f_sas$spec$objective, "sas")
+})
+
+test_that(".hzr_fit_objective() defaults only when nothing was recorded", {
+  skip_on_cran()
+  D <- sas_obj_data()
+  f <- suppressWarnings(hazard(time = D$tt, status = D$ev, dist = "multiphase",
+                               phases = sas_obj_phases(), objective = "sas",
+                               fit = TRUE))
+  expect_identical(TemporalHazard:::.hzr_fit_objective(f), "sas")
+
+  # A fit from before the argument existed carries no `objective`; it was
+  # necessarily estimated under the likelihood.
+  legacy <- f
+  legacy$spec$objective <- NULL
+  expect_identical(TemporalHazard:::.hzr_fit_objective(legacy), "likelihood")
+})
+
+test_that("a scope refit keeps the base fit's objective", {
+  skip_on_cran()
+  D <- sas_obj_data()
+  f_sas <- suppressWarnings(hazard(Surv(tt, ev) ~ 1, data = D,
+                                   dist = "multiphase",
+                                   phases = sas_obj_phases(),
+                                   objective = "sas", fit = TRUE))
+  expect_identical(f_sas$spec$objective, "sas")
+
+  out <- suppressWarnings(
+    TemporalHazard:::.hzr_refit_with_scope(f_sas, action = "add", var = "x1",
+                                           data = D, phase = "early"))
+  # The refit is where the estimand used to change silently.
+  expect_identical(out$spec$objective, "sas")
+
+  f_lik <- suppressWarnings(hazard(Surv(tt, ev) ~ 1, data = D,
+                                   dist = "multiphase",
+                                   phases = sas_obj_phases(), fit = TRUE))
+  out_lik <- suppressWarnings(
+    TemporalHazard:::.hzr_refit_with_scope(f_lik, action = "add", var = "x1",
+                                           data = D, phase = "early"))
+  expect_identical(out_lik$spec$objective, "likelihood")
+})
+
+test_that("the two objectives are far enough apart for the mix-up to matter", {
+  # Guards the tests above against becoming cosmetic: if the two objectives
+  # ever agreed numerically, forwarding the label would protect nothing and a
+  # test asserting only the label would still pass.
+  expect_gt(abs(sas_mp_ll(objective = "sas") -
+                  sas_mp_ll(objective = "likelihood")), 1)
+})


### PR DESCRIPTION
Fixes the most severe finding from the `RELEASE.md` step-5 review of `v1.2.2...main`, plus three documentation defects from the same review, plus the process gap that let them sit in a session transcript.

## 1. `objective` was never recorded on the fit

`hazard(objective = "sas")` was accepted, `match.arg`'d and acted on by the optimizer, and then dropped. `spec` was `list(dist, control, time_windows, phases)`, with no `objective`.

Everything that rebuilds a `hazard()` call from `fit$spec` therefore reverted to `"likelihood"`:

- every `hzr_stepwise()` candidate refit, the Wald-fallback refit, and each accepted move (`R/stepwise-refit.R`);
- the score test's numeric Hessian and gradient (`R/score-test.R:252`, `:489`).

So selecting on a `"sas"` base fit differenced `delta_logLik`, `aic` and `delta_aic` across **two different estimands**, and the score statistic was computed against a likelihood the fit was never fitted to. The two objectives differ by about 22 log-likelihood units on the esophagectomy reference, larger than most single-variable effects. The run produced a full `$steps` table with no error and no warning: the signature defect `AGENTS.md` names.

Worth recording the asymmetry it created: `hzr_bootstrap()` **refit** mode re-evaluates the stored call, which *did* carry `objective = "sas"`, so it was already consistent; **select** mode goes through the scope refit and was not. Nothing marked the difference.

**Fix.** `fit$spec$objective` records it, and `.hzr_fit_objective()` is the single accessor every consumer reads, mirroring the `.hzr_refit_blocker()` idiom so the answers cannot drift. A fit carrying no `objective` predates the argument and is read as `"likelihood"`, which is a fact about those objects rather than a fallback guess.

The single-distribution refit path is deliberately untouched: `hazard()` rejects `objective = "sas"` for anything but multiphase at `R/hazard_api.R:443`, so there is nothing there to preserve.

## 2. Three documentation defects

| Was | Is | Where |
|---|---|---|
| `fit$weak` | `fit$fit$weak` | `NEWS.md` ×4 |
| `fit$phase_share` | `fit$fit$phase_share` | `NEWS.md`, roxygen → `man/hazard.Rd` |
| "rows reading `wald_z` are exactly the ones the fallback rescued" | qualified to `action == "enter"` | `NEWS.md`, roxygen → `man/hzr_stepwise.Rd` |

The first is the sharp one. `is.list(fit$weak)` returns `FALSE` for **every** fit, ridge or not: verbatim the failure the 1.2.8 three-value change was made to prevent, reached by a different route. `man/hazard.Rd` already had it right; `NEWS.md` did not, and `NEWS.md` is what the bullet offered as the programmatic check.

The third was simply false: `R/stepwise.R:291` sets `drop_criterion <- "wald"` under `criterion = "score"`, and `R/candidate-score.R:201` stamps `"wald_z"` at `df == 1` regardless of mode, so with `direction = "both"`, **every drop row** reads `"wald_z"` while `n_wald_fallbacks` may be `0`.

## 3. `RELEASE.md`: file what you do not fix

Step 5's only output is a session transcript, so a finding that is neither fixed nor filed is gone, and the next review pays the full verification cost again. That is not hypothetical: this review returned ten findings and the six not fixed here had no home until they were filed as #211–#216.

The same section now records that re-verification applies to *filing*, not only to fixing, with #215 as the worked example: the review reported `$steps` with zero rows and reason `information_indefinite`; reproducing it gave **one** row and `nuisance_singular`. Conclusion held, mechanism did not, suggested fix keyed on the wrong code.

`RELEASE.md` is `.Rbuildignore`d, so this is documentation-only with no package impact.

## Tests

Five new tests in `tests/testthat/test-sas-interval-objective.R`:

- `objective` is recorded, with **distinct** expected values for both settings, since asserting only the `"sas"` case would pass against an implementation that hardcoded it;
- `.hzr_fit_objective()` returns `"sas"` when present and `"likelihood"` when absent;
- a scope refit keeps the base fit's objective, checked for both settings;
- the two objectives differ numerically by more than 1 log-likelihood unit; this one guards the others from going cosmetic, since if the objectives ever agreed, forwarding the label would protect nothing while the label tests stayed green;
- **the vector-interface × `"sas"` intersection**, added at rebase time (see below).

Mutation-tested throughout. Removing the `$spec` recording fails 6 assertions; removing the refit forwarding fails 1; against the post-rebase code, dropping the objective argument fails 2 and dropping `"time_upper"` fails 1.

## Note on the rebase over #210

#210 and this branch both edit the same `do.call(hazard, ...)` in `R/stepwise-refit.R`. Git conflicted on the **comments** and auto-merged the **argument list**, the half where a dropped argument silently reinstates the bug this branch fixes.

Both halves are present and verified live by the mutation tests above. The rebase also manufactured a combination neither branch owned: a vector-interface multiphase fit under `objective = "sas"`. That is exactly what SAS `SELECTION` jobs land on: 25 of 26 use `ICENSOR`, so they arrive interval-censored through the vector interface, which is why `objective = "sas"` exists, so it now has a regression test.

## Gate

Rebased onto `6a73c1a`.

- `devtools::document()`: clean, no `man/` / `NAMESPACE` drift
- `lintr::lint_package()`: **0 lints**
- `spelling::spell_check_package()`: **clean**
- `test-sas-interval-objective.R`: **0 FAIL / 0 SKIP / 56 PASS**
- Full `devtools::test()` and `R CMD check --as-cran` from a clean `git archive`: **running at the time of opening**; results posted below when they land. Pre-rebase, the same commit was 0 FAIL / 6 SKIP / 3534 PASS with `R CMD check` Status: OK at 199s.

Closes #197 is **not** claimed: that was already closed and verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

