### PR TITLE
Add issue templates as YAML forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: TemporalHazard returned a wrong answer, errored, or behaved unexpectedly
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **If the problem is installing or updating**, report it at
+        [ehrlinger/hvtiR](https://github.com/ehrlinger/hvtiR/issues/new/choose)
+        instead. `hvtiR` is the installer for this family, and that is where an
+        install failure can actually be diagnosed.
+
+        This form is for `TemporalHazard` doing the wrong thing once it is installed.
+
+  - type: input
+    id: fn
+    attributes:
+      label: Which function?
+      placeholder: TemporalHazard::some_function()
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What you ran, and what you got
+      description: >-
+        The smallest example that shows the problem, as pasted text rather than
+        a screenshot. Include the error or the wrong output in full.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: dropdown
+    id: origin
+    attributes:
+      label: How was TemporalHazard installed?
+      description: >-
+        This matters more than it looks. Family versions land on GitHub first,
+        so a package installed from CRAN can be behind the one the bug was
+        fixed in — and a plain `update.packages()` can silently move a package
+        back to its CRAN version.
+      options:
+        - hvtiR::install() or hvtiR::update()
+        - pak or remotes, directly from GitHub
+        - CRAN
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: sessioninfo
+    attributes:
+      label: Output of sessionInfo()
+      description: >-
+        Or `hvtiR::status()` if you have it, which also shows how each family
+        package compares with its source.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -8,7 +8,7 @@ body:
       value: |
         If you are not sure this belongs in `TemporalHazard` rather than another
         package in the family, file it anyway and say so — moving an issue is
-        easy, and guessing wrong should not stop you asking.
+        easy, and guessing wrong should not stop you from asking.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest a change or addition to TemporalHazard
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If you are not sure this belongs in `TemporalHazard` rather than another
+        package in the family, file it anyway and say so — moving an issue is
+        easy, and guessing wrong should not stop you asking.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: >-
+        What you were trying to do, and where the current package made it hard.
+        Describing the problem rather than the solution usually leads to a
+        better answer than the one either of us had in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What do you have in mind?
+      description: Optional. A sketch of the interface, or example code that does not exist yet.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What did you do instead?
+      description: >-
+        Optional, and genuinely useful — a workaround shows what the shape of
+        the real solution needs to be.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,5 +13,5 @@ contact_links:
   - name: Not sure which package this belongs to?
     url: https://github.com/ehrlinger/hvtiR
     about: >-
-      hvtiR lists the family and what each package is for. File where it looks
-      closest -- an issue in the wrong place is easy to move.
+      hvtiR lists the family and what each package is for. File it where it
+      looks closest — an issue in the wrong place is easy to move.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+# TemporalHazard is installed through hvtiR, so installation problems are diagnosed
+# there rather than here. These links move that traffic before it is typed.
+
+blank_issues_enabled: true
+
+contact_links:
+  - name: Installation or update problems
+    url: https://github.com/ehrlinger/hvtiR/issues/new/choose
+    about: >-
+      TemporalHazard failed to install or update, or you are not sure it installed at
+      all. hvtiR is the installer for the family, and its form asks for the
+      diagnostics that case needs.
+  - name: Not sure which package this belongs to?
+    url: https://github.com/ehrlinger/hvtiR
+    about: >-
+      hvtiR lists the family and what each package is for. File where it looks
+      closest -- an issue in the wrong place is easy to move.


### PR DESCRIPTION
Brings `TemporalHazard` in line with the templates added to `hvtiR`, so the family presents one intake.

## What's here

| file | intake |
|---|---|
| `01-bug.yml` | `TemporalHazard` returning a wrong answer or erroring. Requires the function, a reproducible example, what was expected, and `sessionInfo()`. |
| `02-feature.yml` | Enhancement requests, asking for the *problem* before the proposed solution. |
| `config.yml` | Blank issues enabled, plus links routing installation problems to `hvtiR`. |

## Two choices worth a look

**Installation problems route to [hvtiR](https://github.com/ehrlinger/hvtiR), not here.** `hvtiR` is the installer, and its form requires `doctor()` and `sessionInfo()` output — the diagnostics an install failure actually needs. A report that lands here instead is one round-trip from being answerable.

**The bug form asks how the package was installed.** Not boilerplate: family versions land on GitHub first, so a CRAN install can be behind the version a bug was fixed in, and a plain `update.packages()` can silently move a package back to its CRAN version. Knowing which of those happened often *is* the answer.

## Verification

- All three files parse and conform to GitHub's issue-form schema — element types, required `id`s, non-empty dropdown options, and `name`/`url`/`about` on every contact link.
- Labels `bug` and `enhancement` already exist here, so nothing is silently dropped.
- `.github` is in this repo's `.Rbuildignore`, so none of it reaches `R CMD check`.
- No version bump or `NEWS.md` entry: this repo has no version-check workflow, and the change is contributor infrastructure rather than package behaviour. Say the word if you'd rather each carried a NEWS line.

⚠️ The chooser renders only from the default branch, so this cannot be confirmed until after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)