### PR TITLE
fix(stepwise): refuse a conflicting objective in a refit rather than dropping it silently

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,15 @@
   re-evaluates the stored call, which did carry `objective = "sas"`, so it was
   already consistent; *select* mode goes through the scope refit and was not.
 
+  Following from this, **`objective` cannot be overridden per refit.** Passing it
+  through `hzr_stepwise()`'s `...` is accepted when it restates the base fit's
+  own objective and refused when it conflicts, with a message saying why:
+  a candidate refit under a different objective would make `delta_logLik`,
+  `aic` and `delta_aic` differences between two estimands rather than between
+  two models. It is refused rather than quietly ignored, because a full
+  `$steps` table that silently disregarded an explicit argument is the failure
+  this entry is about.
+
 * **A candidate that neither criterion could test is now reported as such.**
   `criterion = "score"` declines a candidate whose observed information is
   indefinite at `beta = 0` -- which happens when the effect is *large* -- and

--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -162,8 +162,30 @@
     default_windows
   }
 
+  # `objective` is supplied from the base fit below, so a user-supplied one
+  # would match the same formal twice and error inside do.call() with a message
+  # about argument matching that says nothing about estimands. Unlike `weights`
+  # and `time_windows`, it is NOT user-overridable: the whole point of carrying
+  # it is that a candidate refit must be comparable to the model it is being
+  # compared against. A redundant value is dropped; a conflicting one is
+  # refused, because silently discarding it would return a full result that
+  # ignored an explicit argument.
+  if ("objective" %in% names(user_args)) {
+    fit_objective <- .hzr_fit_objective(current)
+    if (!identical(user_args$objective, fit_objective)) {
+      stop("`objective` cannot be changed in a refit. The base fit was ",
+           "estimated under objective = \"", fit_objective, "\", and refitting ",
+           "candidates under ", deparse1(user_args$objective), " would make ",
+           "`delta_logLik`, `aic` and `delta_aic` differences between two ",
+           "estimands rather than between two models -- a populated `$steps` ",
+           "table whose comparisons do not mean what they appear to. Refit the ",
+           "base model with that objective and run the selection from there.",
+           call. = FALSE)
+    }
+  }
+
   extra_args <- user_args[!names(user_args) %in%
-                            c("weights", "time_windows")]
+                            c("weights", "time_windows", "objective")]
 
   blocker <- .hzr_refit_blocker(current)
   if (!is.null(blocker)) {

--- a/tests/testthat/test-sas-interval-objective.R
+++ b/tests/testthat/test-sas-interval-objective.R
@@ -489,3 +489,41 @@ test_that("a vector-interface sas fit keeps its objective across a scope refit",
   expect_equal(out$data$time_upper, D$up)
   expect_equal(out$data$time_lower, D$lo)
 })
+
+test_that("a refit refuses a conflicting objective and tolerates a redundant one", {
+  skip_on_cran()
+  # `objective` reaches .hzr_refit_with_scope() through `...` -- hzr_stepwise()
+  # documents `...` as "Passed to the underlying hazard() refits" -- while the
+  # refit also supplies it from the base fit. Before the guard this matched the
+  # same formal twice and died inside do.call() with a message about argument
+  # matching that says nothing about estimands.
+  D <- sas_obj_data()
+  f <- suppressWarnings(hazard(Surv(tt, ev) ~ 1, data = D, dist = "multiphase",
+                               phases = sas_obj_phases(), objective = "sas",
+                               fit = TRUE))
+  refit <- function(...) {
+    TemporalHazard:::.hzr_refit_with_scope(f, action = "add", var = "x1",
+                                           data = D, phase = "early", ...)
+  }
+
+  # Conflicting: refused, and the message has to say WHY a refit cannot change
+  # estimand or the next reader deletes the guard as pedantry.
+  expect_error(suppressWarnings(refit(objective = "likelihood")),
+               "cannot be changed in a refit")
+  expect_error(suppressWarnings(refit(objective = "likelihood")),
+               "between two estimands rather than between two models")
+  # Specifically NOT the bare R argument-matching error it used to raise: the
+  # regression would still "error", so asserting only that it errors would pass
+  # against the broken code.
+  msg <- tryCatch(suppressWarnings(refit(objective = "likelihood")),
+                  error = conditionMessage)
+  expect_false(grepl("matched by multiple actual arguments", msg, fixed = TRUE))
+
+  # Redundant: dropped, not refused -- restating the base fit's own objective
+  # asks for nothing the refit was not already going to do.
+  out <- suppressWarnings(refit(objective = "sas"))
+  expect_identical(out$spec$objective, "sas")
+
+  # Absent: unchanged.
+  expect_identical(suppressWarnings(refit())$spec$objective, "sas")
+})


### PR DESCRIPTION
Fixes a regression introduced by #217 and caught by its Copilot review, which landed after the PR was already merged.

## The regression

`.hzr_refit_with_scope()` now always supplies `objective = .hzr_fit_objective(current)` to `hazard()`, but it still forwarded `...` as `extra_args`, which filtered only `weights` and `time_windows`. `hzr_stepwise()` documents `...` as *"Passed to the underlying `hazard()` refits"*, so `hzr_stepwise(fit, objective = ...)` reached `do.call()` with the argument twice:

```
formal argument "objective" matched by multiple actual arguments
```

Reproduced at `d5212d9` before fixing. It never shipped; `v1.2.8` is untagged.

## Why not the one-line fix

Copilot suggested adding `"objective"` to the filter. That is one line and matches the shape of the neighbouring code, and I did not take it.

It would **silently discard an explicit user argument**: `hzr_stepwise(fit, objective = "likelihood")` on a `"sas"` fit would return a full `$steps` table that ignored what was asked for. That is the failure mode `AGENTS.md` opens with, and it is exactly what #217 existed to stop: the fix would have reinstated the disease in the cure.

## What it does instead

The supplied value is compared against the base fit's:

- **redundant** (restates the fit's own objective) → dropped; it asks for nothing the refit was not already doing;
- **conflicting** → refused, with a message that says *why*:

> `objective` cannot be changed in a refit. The base fit was estimated under objective = "sas", and refitting candidates under "likelihood" would make `delta_logLik`, `aic` and `delta_aic` differences between two estimands rather than between two models -- a populated `$steps` table whose comparisons do not mean what they appear to. Refit the base model with that objective and run the selection from there.

The rationale is in the message on purpose. A guard whose reason is not on the page gets deleted as pedantry by the next reader.

Unlike `weights` and `time_windows`, `objective` is deliberately **not** user-overridable, and the code comment says so: a candidate refit has to be comparable to the model it is being compared against. Local inconsistency with a stated reason beats consistency that reintroduces the bug.

## Tests

Six assertions in `tests/testthat/test-sas-interval-objective.R`, covering conflicting / redundant / absent.

They discriminate between the three candidate *designs*, not merely between working and broken:

| Mutation | Result |
|---|---|
| the silent-drop one-liner (Copilot's suggestion) | **3 fail** |
| guard present but `"objective"` left in `extra_args` | **1 fails**, the original regression |

One assertion exists specifically because **the regression also errored**: `expect_error(refit(...))` passes against the broken code, since both versions throw. So the test pins the message *and* asserts it is not `"matched by multiple actual arguments"`.

## NEWS

Folded into the existing 1.2.8 `objective` entry rather than opening a bug-fix bullet: 1.2.8 is untagged, so the regression never reached a release and there is nothing for a user to have been bitten by.

## Gate: complete before opening

Branched from `641ec87`.

| Step | Result |
|---|---|
| `devtools::document()` | clean, no `man/` / `NAMESPACE` drift |
| `lintr::lint_package()` | **0 lints** |
| `spelling::spell_check_package(use_wordlist = TRUE)` | **clean** |
| `devtools::test()` (`NOT_CRAN=true`) | **0 FAIL / 6 SKIP / 3577 PASS** |
| `R CMD check --as-cran`, manual built, clean `git archive` | **Status: OK**, 0/0/0, 206s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

