### PR TITLE
docs(release): use a colon in the tag annotation template, not an em-dash

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -192,13 +192,33 @@ keep the two in agreement.
 
 ## On CRAN acceptance
 
-1. Tag the release and push the tag (annotated, mirroring existing tags), on
-   `main` (the released line):
+1. Tag the release and push the tag (annotated), on `main` (the released line):
 
    ```sh
-   git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z — accepted & published on CRAN YYYY-MM-DD" main
+   git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z: accepted & published on CRAN YYYY-MM-DD" main
    git push origin vX.Y.Z
    ```
+
+   **Colon, not an em-dash.** A tag annotation is outbound text, and the
+   house rule is no em-dashes in outbound prose. This template used an
+   em-dash in that position until 2026-09-02, and every tag through `v1.2.8`
+   followed it, so the existing tags are the old form and are left alone;
+   `v1.2.9` onward uses the colon. Do not "mirror existing tags" here, which
+   is what the previous wording asked for and what carried the em-dash
+   forward.
+
+   **Say which kind of release it is.** The wording above is for a CRAN
+   release. A GitHub-only release takes, following `v1.2.2` and `v1.2.8`:
+
+   ```sh
+   git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z: GitHub release YYYY-MM-DD; not submitted to CRAN" main
+   ```
+
+   The annotation is the only durable record of the distinction. The
+   Historical note below exists because nobody could later tell which of
+   1.2.0 to 1.2.2 reached CRAN, and step 5's `git diff <previous tag>...main`
+   anchor needs to know whether its anchor marks a published state or a
+   GitHub snapshot.
 
    `CRAN-SUBMISSION`'s `SHA:` records the tree `submit_cran()` ran from, which
    is `main` HEAD.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -208,7 +208,8 @@ keep the two in agreement.
    forward.
 
    **Say which kind of release it is.** The wording above is for a CRAN
-   release. A GitHub-only release takes, following `v1.2.2` and `v1.2.8`:
+   release. A GitHub-only release uses this form instead, following `v1.2.2`
+   and `v1.2.8`:
 
    ```sh
    git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z: GitHub release YYYY-MM-DD; not submitted to CRAN" main


### PR DESCRIPTION
`RELEASE.md`'s tag-annotation template carried an em-dash, against the house rule that outbound prose does not use them. A tag annotation is outbound text: it ships with the repository and is what `git tag -n` and the releases page display.

Because the template said "mirroring existing tags", every release copied the previous form forward, so all six annotated tags through `v1.2.8` carry it. Fixing the template is what breaks that loop.

## What changed

- The CRAN template now reads `"TemporalHazard vX.Y.Z: accepted & published on CRAN YYYY-MM-DD"`.
- Dropped "mirroring existing tags" from the instruction, with a note saying explicitly not to, since that phrasing is what carried the punctuation forward.
- Added the **GitHub-only** variant next to the CRAN one:

  ```sh
  git tag -a vX.Y.Z -m "TemporalHazard vX.Y.Z: GitHub release YYYY-MM-DD; not submitted to CRAN" main
  ```

  Both `v1.2.2` and `v1.2.8` were GitHub releases without a CRAN submission, and both had to invent that wording at release time.

## What deliberately did not change

- **`v1.2.8` and earlier keep their annotations.** Retagging a published release to change punctuation is not worth deleting and re-pushing a public tag that a GitHub Release points at. The inconsistency is one tag wide and ends here.
- **The 17 other em-dashes in `RELEASE.md` are untouched.** They are pre-existing maintainer prose, not something this change introduced, and rewriting someone else's voice was not the ask.

## Why the GitHub-only variant is worth the lines

The annotation is the only durable record of which kind of release a tag marks. This file's own Historical note exists because nobody could later tell which of 1.2.0 to 1.2.2 reached CRAN. Step 5 anchors on `git diff <previous release tag>...main`, and a reviewer needs to know whether that anchor marks a CRAN-published state or a GitHub snapshot, because the two imply different things about what users actually have.

## Gate

`RELEASE.md` is `.Rbuildignore`d (line 29), so this cannot reach the tarball or affect `R CMD check`. `spelling::spell_check_package()` re-run: clean. No `R/`, `man/`, `NEWS.md` or test changes, so the full suite and check are unchanged from `f790c73`, where they were 0 FAIL / 6 SKIP / 3577 PASS and Status: OK.

Verified zero em-dashes added by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
