### PR TITLE
docs(agents): re-stamp the check-time table and add a noise floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,21 +197,35 @@ Rscript ~/Documents/GitHub/house-style/compose-house-style.R --repo TemporalHaza
 
 ### Where the check's time actually goes
 
-Overall `R CMD check --as-cran` with the manual: **3m 29s**, tarball **2.8 MB** (measured
-2026-08-23 at `c9f6c28`). CRAN's ceiling is about 10 minutes and it
-rejects on that even at 0/0/0 — that is what got ggRandomForests archived in June 2026.
+Overall `R CMD check --as-cran` with the manual: **3m 33s** (213s), tarball **2.9 MB**
+(measured 2026-09-02 at `f790c73`, the `v1.2.8` release artifact). CRAN's ceiling is about 10
+minutes and it rejects on that even at 0/0/0, which is what got ggRandomForests archived in
+June 2026.
 
 | Component | Time |
 |---|---|
-| Tests | 84s / 89s |
-| Vignette rebuild | 42s / 45s |
+| Tests | 91s / 97s |
+| Vignette rebuild | 44s / 46s |
 | Everything else | the remainder |
 
-Re-measure these when you change them, and stamp the commit. The previous entry read
-2m 52s with tests at 53s, measured 2026-08-22; one release cycle later the total is up
-37 seconds and the tests up 31, which nothing flagged, because a figure in a file does not
-go stale loudly. The margin against CRAN is still wide. It is the direction that is worth
-watching, and it only shows against a dated baseline.
+Re-measure these when you change them, and stamp the commit.
+
+⚠️ **One pair of measurements is not a trend.** Four `--as-cran` runs on 2026-09-02, on
+near-identical code and the same machine, gave **199s, 206s, 213s and 245s**. That is roughly
+215s plus or minus 20s of machine noise, so any two runs can differ by more than a release
+cycle's real growth. Read the dated series, not the last delta:
+
+| Measured | Commit | Overall | Tests |
+|---|---|---|---|
+| 2026-08-22 | (not stamped) | 2m 52s | 53s |
+| 2026-08-23 | `c9f6c28` | 3m 29s | 84s |
+| 2026-09-02 | `f790c73` | 3m 33s | 91s |
+
+Across those three the total moved about 41 seconds and the tests about 38, all of it in
+tests, over two release cycles. Real, slow, and still a wide margin against CRAN. The
+2026-08-23 entry read the 2026-08-22 delta as a 37-second jump that "nothing flagged"; against
+the noise floor above, most of one such delta can be the machine. The direction is what is
+worth watching, and it only shows against several dated points.
 
 Both dominant costs are the ones that grow silently. Watch the budget when adding a vignette
 chunk or an unskipped slow test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,10 +210,13 @@ June 2026.
 
 Re-measure these when you change them, and stamp the commit.
 
-⚠️ **One pair of measurements is not a trend.** Four `--as-cran` runs on 2026-09-02, on
-near-identical code and the same machine, gave **199s, 206s, 213s and 245s**. That is roughly
-215s plus or minus 20s of machine noise, so any two runs can differ by more than a release
-cycle's real growth. Read the dated series, not the last delta:
+⚠️ **One pair of measurements is not a trend.** Five `--as-cran` runs on 2026-09-02, on the
+same machine, gave **199s, 206s, 212s, 213s and 245s**: an observed range of 199s to 245s, a
+**46-second spread**, around a median of 212s. Two of those runs, `d5212d9` at 245s and
+`8f68f2a` at 206s, differ by 39s while their test content differs by six assertions, so the
+spread is the machine and not the code. Quote the range rather than a mean and a band; five
+runs do not support a distribution. The practical consequence is that any two runs can differ
+by more than a release cycle's real growth, so read the dated series, not the last delta:
 
 | Measured | Commit | Overall | Tests |
 |---|---|---|---|
@@ -224,7 +227,7 @@ cycle's real growth. Read the dated series, not the last delta:
 Across those three the total moved about 41 seconds and the tests about 38, all of it in
 tests, over two release cycles. Real, slow, and still a wide margin against CRAN. The
 2026-08-23 entry read the 2026-08-22 delta as a 37-second jump that "nothing flagged"; against
-the noise floor above, most of one such delta can be the machine. The direction is what is
+a 46-second spread on unchanged code, a delta that size can be entirely the machine. The direction is what is
 worth watching, and it only shows against several dated points.
 
 Both dominant costs are the ones that grow silently. Watch the budget when adding a vignette


### PR DESCRIPTION
`AGENTS.md` asked for the check-time figures to be re-measured and stamped. They were last stamped at `c9f6c28` on 2026-08-23, two release cycles ago.

## Re-measured

On the `v1.2.8` release artifact, `f790c73`, from a clean `git archive` export with the manual built:

| | Was (`c9f6c28`) | Now (`f790c73`) |
|---|---|---|
| Overall | 3m 29s | **3m 33s** (213s) |
| Tests | 84s / 89s | **91s / 97s** |
| Vignette rebuild | 42s / 45s | **44s / 46s** |
| Tarball | 2.8 MB | **2.9 MB** |

## The part worth more than the numbers

Five `--as-cran` runs on 2026-09-02, on the same machine, gave **199s, 206s, 212s, 213s and 245s**: an observed range of 199s to 245s, a **46-second spread**, median 212s. Two of them, `d5212d9` at 245s and `8f68f2a` at 206s, differ by 39s while their test content differs by six assertions, so the spread is the machine and not the code. Any two runs can therefore differ by more than a release cycle's real growth.

> **Corrected after review.** This PR first said "four runs ... roughly 215s plus or minus 20s". Copilot caught that the band excluded the 245s run it cited (30s above the mean). Checking it surfaced a second error: there were five runs, not four, and the omitted one (212s, `main` at `602e294`) is the nearest to the median, so dropping it made the spread look tidier than it was. Fixed in `65747f5`; the section now quotes the observed range, which is what five runs support.

That matters for how this section gets read. The 2026-08-23 entry described the move from 2026-08-22 as a 37-second jump that "nothing flagged". Against the noise floor above, most of a single delta that size can be the machine. I made the same mistake earlier today: I flagged the budget as "drifting" on `#217` off two measurements, then watched the next two land 39s apart on nearly identical code.

The conclusion survives, the evidence for it did not. Three dated points do show real growth, about **41s overall and 38s in tests over two cycles**, all of it in tests, with a wide margin still against CRAN's ~10-minute ceiling. So the section now carries the series rather than a single stamp:

| Measured | Commit | Overall | Tests |
|---|---|---|---|
| 2026-08-22 | (not stamped) | 2m 52s | 53s |
| 2026-08-23 | `c9f6c28` | 3m 29s | 84s |
| 2026-09-02 | `f790c73` | 3m 33s | 91s |

Keeping the earlier rows means the next re-stamp appends a point instead of overwriting the only one, which is what let a stale figure sit for two cycles.

## Gate

`AGENTS.md` is `.Rbuildignore`d (line 31), so this cannot reach the tarball or affect `R CMD check`, and it is not scanned by `spelling::spell_check_package()`, which was re-run clean anyway. No `R/`, `man/`, `NEWS.md`, `DESCRIPTION` or test changes, so the suite and check are unchanged from `f790c73`: 0 FAIL / 6 SKIP / 3577 PASS, Status: OK.

Every figure quoted traces to a run in this session or to the text being replaced. Zero em-dashes added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
