### PR TITLE
test: two tests that passed over computations that never ran (#215, #216)

### DIFF
--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -316,6 +316,16 @@ test_that("hzr_stepwise warns when a screen stops on uncomputable scores", {
 test_that("scope = NULL works when the base formula was passed by variable", {
   data(avc)
   avc <- na.omit(avc)
+  # Standardize the continuous columns. Raw, they span five orders of
+  # magnitude -- `op_age` reaches 1.3e05 and `age` 791 -- and every refit in
+  # the screen below then came back with an ill-conditioned Hessian (rcond
+  # 2.5e-09 down to 1.5e-10) and no standard errors. The screen ran, but over
+  # models the package itself flags, which is a thin thing to assert against.
+  # Scaling leaves the column *names* alone, so the candidate pool and the
+  # by-symbol path under test are unchanged: base rcond 4.2e-05 -> 0.060,
+  # final 2.4e-06 -> 0.0023, five warnings -> none, SEs present throughout.
+  num_cols <- c("age", "opmos", "op_age")
+  avc[num_cols] <- lapply(avc[num_cols], function(z) as.numeric(scale(z)))
 
   f    <- Surv(int_dead, dead) ~ age
   base <- hazard(f, data = avc, dist = "weibull", fit = TRUE,
@@ -350,7 +360,16 @@ test_that("scope = NULL works when the base formula was passed by variable", {
   # aic it is refit failure that silently empties a screen, and this field
   # counts it (0 healthy, 7 when every candidate refit is made to fail).
   expect_identical(sw$criteria$n_refit_failures, 0L)
-  expect_gt(nrow(sw$steps), 0L)
+  # Name the entries rather than counting them. `nrow(sw$steps) > 0` conflates
+  # two things -- that the screen ran, and that it liked something -- and a
+  # healthy screen is allowed to accept nothing. The screen still has to enter
+  # something here, or the response-column assertion below is vacuous, which
+  # is #215 itself. So pin the three entries whose AIC margins are comfortable
+  # (dAIC -29.5, -8.9, -3.4) and leave `mal` out of the assertion: it enters
+  # last on -0.99, thin enough for a BLAS difference to flip it on one of the
+  # five CI platforms. Membership, not order -- the per-step ranking among
+  # candidates is not what this test is about.
+  expect_true(all(c("status", "com_iv", "orifice") %in% sw$steps$variable))
   expect_false(any(c("int_dead", "dead") %in% sw$steps$variable))
 })
 

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -322,10 +322,26 @@ test_that("scope = NULL works when the base formula was passed by variable", {
                  theta = c(mu = 0.01, nu = 0.5, 0))
   expect_true(is.symbol(base$call$formula))
 
+  # The claim is about what the screen is OFFERED, so assert it on the pool
+  # itself, as the multiphase sibling below does. Reading it off `$steps`
+  # instead only ever inspects what entered, and a name cannot appear in a
+  # screen that stopped early -- so a broken candidate builder and a screen
+  # that scored nothing are indistinguishable there.
+  cands <- .hzr_stepwise_candidates(base, scope = NULL, data = avc)
+  expect_setequal(vapply(cands, function(c) c$var, character(1L)),
+                  c("status", "inc_surg", "opmos", "mal", "com_iv",
+                    "orifice", "op_age"))
+
+  # `criterion = "score"` is deliberately not used here. On this fixture the
+  # current model's nuisance block goes singular the moment `status` enters,
+  # so the run stops after one step having scored none of the six survivors
+  # (#215); the screen below has to actually work for its result to mean
+  # anything. The uncomputable-score path has its own test above.
   sw <- hzr_stepwise(base, scope = NULL, data = avc, direction = "forward",
-                     slentry = 0.05, trace = FALSE)
+                     criterion = "aic", trace = FALSE)
   expect_s3_class(sw, "hazard")
-  # The Surv() response columns must not be offered as candidates.
+  expect_identical(sum(sw$criteria$uncomputable_reasons), 0L)
+  expect_gt(nrow(sw$steps), 0L)
   expect_false(any(c("int_dead", "dead") %in% sw$steps$variable))
 })
 

--- a/tests/testthat/test-stepwise-integration.R
+++ b/tests/testthat/test-stepwise-integration.R
@@ -328,6 +328,9 @@ test_that("scope = NULL works when the base formula was passed by variable", {
   # screen that stopped early -- so a broken candidate builder and a screen
   # that scored nothing are indistinguishable there.
   cands <- .hzr_stepwise_candidates(base, scope = NULL, data = avc)
+  # expect_setequal() alone would accept a pool that emitted a variable twice,
+  # so pin the length too.
+  expect_length(cands, 7L)
   expect_setequal(vapply(cands, function(c) c$var, character(1L)),
                   c("status", "inc_surg", "opmos", "mal", "com_iv",
                     "orifice", "op_age"))
@@ -335,12 +338,18 @@ test_that("scope = NULL works when the base formula was passed by variable", {
   # `criterion = "score"` is deliberately not used here. On this fixture the
   # current model's nuisance block goes singular the moment `status` enters,
   # so the run stops after one step having scored none of the six survivors
-  # (#215); the screen below has to actually work for its result to mean
-  # anything. The uncomputable-score path has its own test above.
+  # (#215); the screen below has to get through its candidates for the result
+  # to mean anything. The uncomputable-score path has its own test above.
   sw <- hzr_stepwise(base, scope = NULL, data = avc, direction = "forward",
                      criterion = "aic", trace = FALSE)
   expect_s3_class(sw, "hazard")
-  expect_identical(sum(sw$criteria$uncomputable_reasons), 0L)
+  # `n_refit_failures`, NOT `uncomputable_reasons`: the latter is written only
+  # by .hzr_stepwise_forward_step_score(), so under any other criterion it is
+  # `integer(0)` and `sum()` of it is 0L no matter what happened -- an
+  # assertion that cannot fail, which is the very defect #215 is about. Under
+  # aic it is refit failure that silently empties a screen, and this field
+  # counts it (0 healthy, 7 when every candidate refit is made to fail).
+  expect_identical(sw$criteria$n_refit_failures, 0L)
   expect_gt(nrow(sw$steps), 0L)
   expect_false(any(c("int_dead", "dead") %in% sw$steps$variable))
 })

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -698,8 +698,8 @@ test_that("weighted multiphase fit matches duplicated-row fit, covariates, CoE o
       survival::Surv(time, status) ~ 1,
       data = data, dist = "multiphase",
       phases = list(
-        early    = hzr_phase("cdf", t_half = 0.3, nu = 1, m = 1,
-                             fixed = "shapes", formula = ~ x),
+        early    = hzr_phase("cdf", t_half = 0.5, nu = 0, m = -0.4,
+                             fixed = c("nu", "m"), formula = ~ x),
         constant = hzr_phase("constant", formula = ~ x)
       ),
       weights = weights, fit = TRUE,
@@ -710,6 +710,23 @@ test_that("weighted multiphase fit matches duplicated-row fit, covariates, CoE o
   fit_w   <- mk_fit(df,     d$w)
   fit_dup <- mk_fit(df_exp, NULL)
 
+  # Parity only means something over parameters the data determines. The
+  # former spec pinned all three shapes (`fixed = "shapes"` is t_half, nu and
+  # m), which left `early` contributing 2.7e-09 of the cumulative hazard: its
+  # mu and beta drifted freely, and the two fits agreed on them only because
+  # both took the identical deterministic path from the identical start
+  # (#216). Freeing t_half revives the phase -- rcond 5.3e-12 -> 2.4e-04 --
+  # so assert it is alive before trusting the comparison below.
+  early_share <- function(f) {
+    f$fit$phase_share$share[f$fit$phase_share$phase == "early"]
+  }
+  expect_gt(early_share(fit_w),   1e-3)
+  expect_gt(early_share(fit_dup), 1e-3)
+
+  # These agree to machine precision, not merely to `tolerance`: the weighted
+  # and duplicated objectives are algebraically the same function, so the
+  # optimizer walks one path. That is the expected result here, not a sign
+  # that nothing was compared -- the guard against that is `early_share`.
   expect_equal(coef(fit_w), coef(fit_dup), tolerance = 1e-3)
   expect_equal(fit_w$fit$objective, fit_dup$fit$objective, tolerance = 1e-4)
 })

--- a/tests/testthat/test-weights.R
+++ b/tests/testthat/test-weights.R
@@ -723,10 +723,12 @@ test_that("weighted multiphase fit matches duplicated-row fit, covariates, CoE o
   expect_gt(early_share(fit_w),   1e-3)
   expect_gt(early_share(fit_dup), 1e-3)
 
-  # These agree to machine precision, not merely to `tolerance`: the weighted
-  # and duplicated objectives are algebraically the same function, so the
-  # optimizer walks one path. That is the expected result here, not a sign
-  # that nothing was compared -- the guard against that is `early_share`.
+  # Observed agreement here is ~5e-17, far inside `tolerance`: the weighted and
+  # duplicated objectives are algebraically the same function, so the optimizer
+  # walks one path. That near-exactness is the expected result, not a sign that
+  # nothing was compared -- the guard against that is `early_share` above. The
+  # tolerance stays loose deliberately, because the one path is not guaranteed
+  # to be bit-identical across the five CI platforms' BLAS implementations.
   expect_equal(coef(fit_w), coef(fit_dup), tolerance = 1e-3)
   expect_equal(fit_w$fit$objective, fit_dup$fit$objective, tolerance = 1e-4)
 })


### PR DESCRIPTION
Fixes the two test-quality defects found by the `RELEASE.md` step-5 review. Both are the
signature failure of this package: an assertion evaluated over a computation that did not
happen, reported as a pass.

## #215 — the `scope = NULL` screen scored nothing

`test-stepwise-integration.R`'s *"scope = NULL works when the base formula was passed by
variable"* asserted only `expect_false(any(c("int_dead","dead") %in% sw$steps$variable))`.

Reproduced, with two corrections to the issue's own account:

- `$steps` has **1** row, not zero — `status` (a genuine `avc` column) does enter at step 1.
- The screen scores the full 7-candidate pool at step 1; it is **step 2** that fails, on all
  six survivors, with `nuisance_singular` — the model's information matrix goes singular once
  `status` is in. The conclusion stands: six candidates were never scored, and a name cannot
  appear in a screen that stopped, so the assertion could not discriminate anything.

Two changes:

- The claim is about what the screen is **offered**, so it is now asserted on the candidate
  pool via `.hzr_stepwise_candidates()` — exactly as the multiphase sibling test three lines
  below already does. Asserting it on `$steps` tests the wrong object.
- The end-to-end run uses `criterion = "aic"`, which completes with every candidate refit, so
  its result means something. The uncomputable-score path keeps its own dedicated test above.

## #216 — parity asserted over unidentified coefficients

`test-weights.R`'s weighted-vs-duplicated comparison covered the whole coefficient vector.
`fixed = "shapes"` expands to `c("t_half", "nu", "m")` — all three — so the early phase had no
free shape at all and its `mu` collapsed to `e^-24`, contributing 2.7e-09 of the cumulative
hazard. `early.log_mu` and `early.x` were drifting freely; the two fits agreed on them only
because both took the identical deterministic path from the identical start.

Freeing `t_half` (`nu = 0`, `m = -0.4`, start `t_half = 0.5`) revives the phase:

| | before | after |
|---|---|---|
| early share | 2.7e-09 | 0.0399 |
| `rcond` | 5.3e-12 | 2.4e-04 |
| standard errors | absent | present |
| free parameters estimated | 4 | 5 |

The identifiability warning this fixture emitted on all five CI platforms is gone. An explicit
`phase_share` assertion now guards the fixture, so a future change that kills the phase fails
the test rather than quietly hollowing it out.

## The third commit: the fix had reproduced the defect

Worth reading on its own. The `r-reviewer` pass over the diff caught that commit 1's headline
assertion was itself vacuous:

```r
expect_identical(sum(sw$criteria$uncomputable_reasons), 0L)   # cannot fail under aic
```

`uncomputable_reasons` is written only inside `.hzr_stepwise_forward_step_score()`, reached
only from the `criterion == "score"` dispatch at `R/stepwise-step.R:203`. On an `aic` run it is
permanently `integer(0)`, and `sum(integer(0))` is `0L`. Confirmed empirically by injecting a
failure into `.hzr_refit_with_scope()`: with **all seven** candidate refits failing and **zero**
steps entering, the assertion still passed.

Under `aic` it is refit failure, not an uncomputable score, that silently empties a screen.
`n_refit_failures` counts it (0 healthy, 7 under injection), so the test asserts that instead.

## Mutation testing

Every guard was shown to fail when the defect is reinstated:

| Mutant | Result |
|---|---|
| #215 back to `criterion = "score"` | 1 failure |
| `.hzr_stepwise_candidates()` stops excluding `Surv()` response columns | 2 failures |
| all candidate refits fail under `aic` | target test fails |
| candidate pool emits a duplicate | 5 failures |
| #216 back to `t_half = 0.3, fixed = "shapes"` | 2 failures |

## Gate

- `devtools::document()` — no drift in `man/`/`NAMESPACE`
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` (`NOT_CRAN=true`) — **0 failures, 0 errors, 6 skips, 3583 passes**
- `R CMD check --as-cran` with the manual, from a clean `git archive` export of the committed
  tree — **Status: OK** (0/0/0), 3m59s, tests 92s, vignettes 45s

No product, `NAMESPACE`, `man/`, vignette or `NEWS.md` change; no API surface touched. Per this
repo's convention, per-PR commits do not bump `DESCRIPTION` — that happens at release.

### A retracted finding

An earlier revision of this description reported the check at 261s with tests at 107s, and
flagged growth on `main` since the `f790c73` stamp. The re-run on the final tree came in at
239s with tests at **92s**, against 91s stamped. That was machine noise, not growth — precisely
the trap `AGENTS.md` documents ("any two runs can differ by more than a release cycle's real
growth"). No timing finding stands, and the table needs no re-stamp from this PR.

Closes #215
Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: fixture hardening and Copilot triage

### The screen now fits a well-conditioned chain

Raw, `avc`'s covariates span five orders of magnitude — `op_age` reaches 1.3e05, `age` 791 — and
every refit in the screen came back ill-conditioned with no standard errors. The screen ran, but
over models the package itself flags. Standardizing the three continuous columns leaves the
column *names* alone, so the candidate pool and the by-symbol path under test are unchanged:

| | before | after |
|---|---|---|
| base `rcond` | 4.2e-05 | 0.060 |
| final `rcond` | 2.4e-06 | 0.0023 |
| `ill-conditioned` warnings in the file | 5 | **0** |
| standard errors | absent | present |

### Copilot review — partially accepted

> `expect_gt(nrow(sw$steps), 0L)` is not a reliable guard that the screen actually ran: a valid
> stepwise run can score candidates and still accept none.

**The observation is right; the suggested remedy is not, and would reintroduce #215.** Copilot
proposes replacing the step-count guard with the recorded `criteria` fields. Those are already
asserted one line above (`n_refit_failures`), and they are not what this assertion is for: the
step count is what keeps `expect_false(any(c("int_dead","dead") %in% sw$steps$variable))`
non-vacuous. Delete it and that assertion can no longer fail over an empty `steps` — which is
precisely the defect this PR exists to fix.

The real weakness is that `nrow > 0` conflates *ran* with *liked something*. Fixed by naming the
entries instead of counting them:

```r
expect_true(all(c("status", "com_iv", "orifice") %in% sw$steps$variable))
```

`mal` is deliberately excluded: it enters last on dAIC −0.99, against −29.5, −8.9 and −3.4 for
the three asserted, and a margin that thin could flip on one of the five CI platforms' BLAS.
Membership rather than order, since the per-step ranking among candidates is not what this test
is about.

### Re-gate

- `lintr::lint_package()` — **0 lints**
- `devtools::test()` (`NOT_CRAN=true`) — **0 failures, 0 errors, 6 skips, 3583 passes**
- `R CMD check --as-cran` with the manual, clean `git archive` export — **Status: OK**, 0/0/0,
  3m24s, tests 80s
- Mutation battery re-run against the hardened fixture: dropping the response-column exclusion,
  emitting a duplicate candidate, and failing every refit under `aic` all still fail this test
