### PR TITLE
docs(agents): correct the ruleset bypass claim, and document the approval requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,14 @@ gh api repos/ehrlinger/TemporalHazard/rulesets/15010037 \
 #  "current_user_can_bypass":"always"}
 ```
 
+Read `current_user_can_bypass`, not `actor_id`. GitHub does not publish what its `RepositoryRole`
+ids mean, and no endpoint resolves them on a personal repo — `repos/:o/:r/roles` and
+`orgs/:o/custom-repository-roles` both 404 here. The documentation says only that a
+`RepositoryRole` bypass actor is an admin, a maintain or write role, or a custom role built on
+write, so `5` is one of those four and which one is not checkable from here. Naming it would be a
+guess wearing the costume of a fact, which is the house failure mode. `current_user_can_bypass`
+answers the question that actually matters and is evaluated for whoever holds the token.
+
 It is not theoretical: PR #222 merged with **zero** approving reviews. So the rule is a matter of
 practice, not of enforcement — which is the stronger reason to follow it, not a licence to skip
 it. **An agent still never merges and never bypasses**; the maintainer decides when to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,9 +117,9 @@ force-push, requires a pull request, auto-requests Copilot review, and requires 
 review**.
 
 That last one is what actually blocks a merge, and it is easy to miss: a PR with all eight
-required checks green still sits at `mergeStateStatus: BLOCKED` and `reviewDecision:
-REVIEW_REQUIRED` until someone approves it. Copilot does not satisfy it — its reviews come back
-`COMMENTED`, never `APPROVED`.
+required checks green still sits at `mergeStateStatus: BLOCKED` and
+`reviewDecision: REVIEW_REQUIRED` until someone approves it. Copilot does not satisfy it — its
+reviews come back `COMMENTED`, never `APPROVED`.
 
 ⚠️ **The maintainer can bypass all of it.** An earlier version of this paragraph said there were
 no bypass actors and the rules therefore applied to the maintainer too. That was wrong on both

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,8 +113,29 @@ on `main`, not before it lands.
 The rules live in the repository **ruleset** `protect main`, not in the legacy branch-protection
 settings — the two are separate systems, and the `branches/main/protection` API returns 404 here
 even though `main` is protected. Alongside the required checks the ruleset blocks deletion and
-force-push, requires a pull request, and auto-requests Copilot review. There are **no bypass
-actors**, so it applies to the maintainer too.
+force-push, requires a pull request, auto-requests Copilot review, and requires **one approving
+review**.
+
+That last one is what actually blocks a merge, and it is easy to miss: a PR with all eight
+required checks green still sits at `mergeStateStatus: BLOCKED` and `reviewDecision:
+REVIEW_REQUIRED` until someone approves it. Copilot does not satisfy it — its reviews come back
+`COMMENTED`, never `APPROVED`.
+
+⚠️ **The maintainer can bypass all of it.** An earlier version of this paragraph said there were
+no bypass actors and the rules therefore applied to the maintainer too. That was wrong on both
+halves, and it mattered, because "nobody can bypass this" is the sentence that makes *branch,
+PR, stop* feel non-negotiable. Verified 2026-09-03:
+
+```bash
+gh api repos/ehrlinger/TemporalHazard/rulesets/15010037 \
+  --jq '{bypass_actors, current_user_can_bypass}'
+# {"bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}],
+#  "current_user_can_bypass":"always"}
+```
+
+It is not theoretical: PR #222 merged with **zero** approving reviews. So the rule is a matter of
+practice, not of enforcement — which is the stronger reason to follow it, not a licence to skip
+it. **An agent still never merges and never bypasses**; the maintainer decides when to.
 
 Required checks are *not* strict: a PR is not forced to re-run the matrix every time `main`
 moves. That is a deliberate trade against a roughly 45-minute Windows job, and it means a branch


### PR DESCRIPTION
`AGENTS.md`'s automated-gates section made a claim about the `protect main` ruleset that is
wrong in both halves:

> There are **no bypass actors**, so it applies to the maintainer too.

That sentence is load-bearing. "Nobody can bypass this" is what makes *branch, PR, stop* read as
non-negotiable rather than as a convention an agent might reasonably weigh against expediency —
so it is worth getting right.

## What the ruleset actually says

```bash
gh api repos/ehrlinger/TemporalHazard/rulesets/15010037 \
  --jq '{bypass_actors, current_user_can_bypass}'
```

```json
{"bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}],
 "current_user_can_bypass":"always"}
```

There is one bypass actor, and the maintainer can bypass **always**. Not theoretical either:
**PR #222 merged with zero approving reviews** (its only two reviews were `COMMENTED`).

I deliberately did **not** write down which role `actor_id: 5` is. GitHub's `RepositoryRole` ids
are not self-documenting and there is no endpoint on a personal repo that resolves them, so
naming it would be a guess dressed as a fact — exactly the failure mode this repo cares about.
`current_user_can_bypass` answers the question that actually matters without the guess.

## The correction

The rule is a matter of **practice, not enforcement** — which is a stronger reason to follow it
than a false claim that it cannot be broken. The agent-facing instruction is unchanged and now
stated outright: an agent never merges and never bypasses; the maintainer decides when to.

## Also: the approval requirement was undocumented

The paragraph never mentioned `required_approving_review_count: 1`, which is the thing that
actually blocks a merge. A PR with all eight required checks green still sits at
`mergeStateStatus: BLOCKED` / `reviewDecision: REVIEW_REQUIRED`. Copilot never satisfies it —
its reviews come back `COMMENTED`, never `APPROVED` — so this is worth knowing now that review
is going through Codex.

## Gate

Docs-only, and `AGENTS.md` is excluded from the tarball (`.Rbuildignore:31`), so no product
change. Ran the contract anyway:

- `devtools::document()` — no drift in `man/`/`NAMESPACE`/`DESCRIPTION`
- `lintr::lint_package()` — **0 lints**
- `spelling::spell_check_package(use_wordlist = TRUE)` — clean
- `devtools::test()` (`NOT_CRAN=true`) — **0 failures, 0 errors, 6 skips, 3583 passes**

No `R CMD check` run: this file is not in the built package, and nothing it could affect changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: the role id, verified as far as it goes

The review asked to *confirm* which role `actor_id: 5` is rather than assert it. The answer is
that it is **not confirmable**, and the second commit records that rather than leaving a silent
gap:

- GitHub does not publish the `RepositoryRole` id mapping.
- No endpoint resolves it on a personal repo — `repos/:o/:r/roles` and
  `orgs/:o/custom-repository-roles` both **404** here.
- [The docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
  narrow it to four possibilities and no further: a repository admin, the maintain or write role,
  or a custom role based on write.

So `5` is one of those four. "Very likely admin" is a good hunch, and a hunch written into the
operational contract reads exactly like a verified fact to the next agent — which is the failure
mode this repo exists to guard against.

What *is* verifiable is the thing the paragraph actually needs, and it is now the thing the file
points at:

```
authenticated as:         ehrlinger
repo owner:               ehrlinger
permissions:              admin, maintain, pull, push, triage
current_user_can_bypass:  always
```

Plus the empirical confirmation: PR #222 merged with zero approving reviews.

Re-gated after the second commit: `lintr::lint_package()` 0 lints, `spell_check_package()` clean.
