### PR TITLE
fix(phases): reject 'total' as a phase name (#214)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.8
+Version: 1.2.9
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/TemporalHazard/, https://github.com/ehrlinger/TemporalHazard
 BugReports: https://github.com/ehrlinger/TemporalHazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# TemporalHazard 1.2.9
+
+## Bug fixes
+
+* **A phase named `total` is now rejected rather than silently losing its
+  contribution.** `total` is the key the multiphase cumulative-hazard
+  accumulator is stored under, so `phases = list(total = hzr_phase("cdf"), ...)`
+  overwrote that phase's own contribution vector with the summed hazard. The fit
+  returned normally; the phase then reported a contribution share of exactly 1
+  and the identifiability diagnostic read it as dominating the model. The name is
+  reserved across the decomposition and prediction output as well, where it
+  labels the total column. `hazard()` and `hzr_theta_names()` -- which applies
+  the same validation -- now stop with an explanatory message, and the
+  reservation is documented on the `phases` argument (#214).
+
 # TemporalHazard 1.2.8
 
 ## New features

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -161,7 +161,10 @@ NULL
 #'   and requires `phases`.  See the **Baseline distributions** section for what
 #'   each means and when to use it.
 #' @param phases Optional named list of [hzr_phase()] objects specifying the
-#'   phases for a multiphase model (`dist = "multiphase"`).  See Examples.
+#'   phases for a multiphase model (`dist = "multiphase"`).  Names must be
+#'   unique, and `"total"` is reserved: it labels the summed column in the
+#'   decomposed output of [predict.hazard()], so a phase of that name is
+#'   rejected.  See Examples.
 #' @param fit Logical; if TRUE, fit the model via maximum likelihood (default FALSE).
 #' @param weights Optional numeric vector of observation weights (non-negative).
 #'   Each observation's log-likelihood contribution is multiplied by its weight.

--- a/R/phase-spec.R
+++ b/R/phase-spec.R
@@ -469,6 +469,8 @@ is_hzr_phase <- function(x) {
 #' @seealso [hzr_phase()] for building a specification, [hazard()] for the fit
 #'   whose `theta` this names.
 #' @export
+#' @details Phase names must be unique, and `"total"` is reserved; this applies
+#'   the same validation [hazard()] does, so both reject it identically.
 hzr_theta_names <- function(phases, covariates = NULL) {
   # The same validation hazard() applies, so auto-named phases get the same
   # phase_1/phase_2 labels here as they will in the fit. Re-deriving them
@@ -676,6 +678,13 @@ hzr_theta_names <- function(phases, covariates = NULL) {
   empty <- nms == "" | is.na(nms)
   if (any(empty)) {
     nms[empty] <- paste0("phase_", which(empty))
+  }
+
+  # 'total' is the key .hzr_multiphase_cumhaz() stores the accumulator under, so
+  # a phase of that name would lose its own contribution vector to it.
+  if (any(nms == "total")) {
+    stop("'total' is a reserved phase name. Rename the phase: it collides with ",
+         "the accumulator holding the summed cumulative hazard.", call. = FALSE)
   }
 
   # Check for duplicate names

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -92,7 +92,10 @@ and requires \code{phases}.  See the \strong{Baseline distributions} section for
 each means and when to use it.}
 
 \item{phases}{Optional named list of \code{\link[=hzr_phase]{hzr_phase()}} objects specifying the
-phases for a multiphase model (\code{dist = "multiphase"}).  See Examples.}
+phases for a multiphase model (\code{dist = "multiphase"}).  Names must be
+unique, and \code{"total"} is reserved: it labels the summed column in the
+decomposed output of \code{\link[=predict.hazard]{predict.hazard()}}, so a phase of that name is
+rejected.  See Examples.}
 
 \item{fit}{Logical; if TRUE, fit the model via maximum likelihood (default FALSE).}
 

--- a/man/hzr_theta_names.Rd
+++ b/man/hzr_theta_names.Rd
@@ -44,6 +44,9 @@ retyped.
 Phase names come from \code{names(phases)}; unnamed phases are labelled
 \code{phase_1}, \code{phase_2}, ... by the same validation \code{\link[=hazard]{hazard()}} applies, so the
 labels here are the labels a fit will use.
+
+Phase names must be unique, and \code{"total"} is reserved; this applies
+the same validation \code{\link[=hazard]{hazard()}} does, so both reject it identically.
 }
 \examples{
 phases <- list(early = hzr_phase("cdf"), late = hzr_phase("g3"))

--- a/tests/testthat/test-phase-spec.R
+++ b/tests/testthat/test-phase-spec.R
@@ -292,6 +292,47 @@ test_that("validate_phases rejects duplicate names", {
                "unique")
 })
 
+test_that("validate_phases rejects a phase named 'total'", {
+  # 'total' is the key .hzr_multiphase_cumhaz() writes the accumulator under,
+  # so a phase of that name loses its own contribution vector entirely.
+  phases <- list(total = hzr_phase("cdf"), late = hzr_phase("constant"))
+  expect_error(.hzr_validate_phases(phases), "reserved")
+})
+
+test_that("hazard() rejects a phase named 'total' before it can collide", {
+  # The guard runs during validation, so the call fails before the optimizer is
+  # reached even with fit = TRUE. Without it this returned a populated fit whose
+  # 'total' phase had lost its contribution vector to the accumulator.
+  dat <- data.frame(time = c(1, 2, 3, 4, 5), status = c(1, 1, 0, 1, 0))
+  expect_error(
+    hazard(survival::Surv(time, status) ~ 1, data = dat, dist = "multiphase",
+           fit = TRUE,
+           phases = list(total = hzr_phase("cdf"), late = hzr_phase("constant"))),
+    "reserved")
+})
+
+test_that("hzr_theta_names() rejects a phase named 'total'", {
+  # Exported, and validates through the same path, so the reservation reaches it.
+  expect_error(hzr_theta_names(list(total = hzr_phase("cdf"))), "reserved")
+})
+
+test_that("'total' is still the name the cumhaz accumulator is stored under", {
+  # Cross-check for the guard above. Asserting only that "reserved" is thrown
+  # restates the guard's own string: rename the accumulator and that test stays
+  # green while the guard protects a name that no longer collides. This reads
+  # the key off the returned object instead, so it fails when the two drift.
+  phases <- .hzr_validate_phases(
+    list(early = hzr_phase("cdf"), late = hzr_phase("constant")))
+  tt <- c(0.5, 1, 2, 3, 5)
+  theta <- unlist(lapply(phases, .hzr_phase_start))
+  cc <- stats::setNames(as.list(rep(0L, length(phases))), names(phases))
+  xl <- stats::setNames(vector("list", length(phases)), names(phases))
+  contrib <- .hzr_multiphase_cumhaz(tt, theta, phases, cc, xl, per_phase = TRUE)
+
+  expect_equal(setdiff(names(contrib), names(phases)), "total")
+  expect_length(contrib, length(phases) + 1L)
+})
+
 
 # ============================================================================
 # Round-trip: start values match theta names in length


### PR DESCRIPTION
Closes #214.

## The defect

`total` is the key `.hzr_multiphase_cumhaz()` stores its accumulator under, so a phase of that name lost its own contribution vector to it. Reproduced on `main` before the fix:

```
names(contrib): total, late
length: 2  -- 2 phases + accumulator should be 3
  phase     share variation
1 total 1.0000000 0.8722437
```

`.hzr_phase_shares()` then read the accumulator as that phase's contribution and reported `share == 1`, which the identifiability diagnostic at `R/likelihood-multiphase.R:1234` takes as a phase dominating the fit. `hazard()` returned a normal, populated fit throughout — no error, no warning.

## The fix

One guard in `.hzr_validate_phases()` (`R/phase-spec.R:681`), placed after auto-naming so `phase_N` names cannot trip it. All three `R/` callers reach it, and the only other phase-construction site (`R/read-outhaz.R:207`) hardcodes `early`/`constant`/`late`.

Reserving the name rather than renaming the accumulator is the right way round: `total` is *documented public output* — the decompose column at `R/hazard_api.R:959` and the ordered factor level at `R/predict-cl.R:500` — so renaming it would be the breaking change. Any script that used a `total` phase was already getting a wrong answer, so erroring is strictly better than what it had.

The guard also closes two collisions on the same name the issue did not mention: `predict(decompose = TRUE)` labels its summed column `total`, and `predict_cl()` builds its component levels as `c("total", names(phases))`, where the phase name would have produced a duplicated factor level.

## Tests

Four, all verified failing without the guard (run against the parent commit in a throwaway worktree, not assumed):

- the validator directly;
- `hazard()` with `fit = TRUE`, the shape a user actually writes;
- `hzr_theta_names()`, which is exported and validates through the same path — so its behaviour changed too, and NEWS says so;
- a cross-check that reads the accumulator key **off the returned object** rather than restating the guard's error string. Asserting only that `"reserved"` is thrown would stay green if the accumulator were renamed, leaving the guard protecting a name that no longer collides. Mutation-tested: renaming `phase_contributions$total` to `$sum` leaves the three `"reserved"` tests green and fails this one alone.

## Scope

A phase named `time` collides with the prediction-time column of `predict(decompose = TRUE)` in the same shape and with the same silence. That is a different key in a different container, and is filed as #224 rather than widened into this fix.

Pre-existing fits saved by 1.2.8 or earlier still contain the bad phase list and still return the overwritten decomposition; `predict.hazard()` reads `object$fit$phases` without re-validating. This fix is fit-time only.

## Gates

- `devtools::document()` clean, `lintr::lint_package()` **0 lints**, `spelling::spell_check_package()` clean
- `devtools::test()` (`NOT_CRAN=true`): **0 FAIL / 6 SKIP / 3588 PASS** — skips are SAS fixture availability only
- `R CMD check --as-cran` from a clean `git archive` export, with the manual and vignettes: **Status: OK** (tests 80s/87s, vignettes 42s/46s, tarball 2.89 MB, no `CLAUDE`/`AGENTS` files)

Version bumped 1.2.8 → **1.2.9**, patch digit only; `NEWS.md` heading updated by hand to match, since nothing in this repo greps for the mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)