### PR TITLE
docs(release): correct the release-review findings for 1.2.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,7 +48,10 @@
   removes a correct diagnostic (#211).
 
   Known limitation, unchanged by this work and stated rather than implicit: the
-  per-phase measures are taken over the event times alone. That cuts both ways.
+  per-phase measures are taken over the event times alone, and the count of
+  evaluation points is deliberately conservative -- it does not credit the
+  extra functional a zero entry time makes separately observable, so a fit can
+  be warned about while being identified. That cuts both ways.
   A phase can be flat across the event times while its shape is identified
   through the bounds, so the saturated message can overstate what is lost; and
   the counting rule above is a *local* identification argument for tied event
@@ -109,8 +112,12 @@
 
   Note this reaches only the codes `hazard()` is given. On the **vector**
   interface a `survival::Surv()` object is unclassed without translating its
-  codes, so a left-censored row arrives as `1` and is invisible to the check;
-  the formula interface translates and is guarded. That asymmetry is a
+  codes, so they mean something else on arrival, and what goes wrong depends on
+  `type`: under `type = "left"` a left-censored row is coded `0` and is fitted
+  as *right-censored*; under `type = "interval"` it is coded `2` and is read as
+  an *interval* of zero width, which this guard then rejects; and a genuine
+  interval row, coded `3`, matches no branch of the likelihood and contributes
+  nothing. The formula interface translates and is guarded. That asymmetry is a
   pre-existing defect of the vector path, tracked in #226.
 
 # TemporalHazard 1.2.8

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -222,12 +222,15 @@ NULL
 #'   when their own relative range falls below this threshold and no phase's
 #'   contribution varies across them, they separate no phase from any other
 #'   and none of the shapes is identified. That verdict is withheld when the
-#'   fit supplies counting-process entry times or interval bounds that add an
+#'   fit supplies counting-process entry times or interval bounds that add
 #'   enough evaluation points the measure did not see. "Enough" is counted, not
 #'   assumed: with the event times tied, each added point supplies one more
 #'   functional of the parameters, and one more than the number of added points
 #'   must reach the number of free parameters. A zero entry time, or a bound
-#'   equal to an event time, adds nothing and does not count. For the same reason the per-phase measures can
+#'   equal to an event time, adds nothing and does not count. The count is
+#'   deliberately conservative: it does not credit the extra functional that a
+#'   zero entry time makes separately observable, so a fit can be warned about
+#'   while being identified. For the same reason the per-phase measures can
 #'   overstate what an interval-censored or left-truncated fit loses, since a
 #'   phase flat across the event times may still be identified through the
 #'   bounds. The measured shares are

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -497,10 +497,15 @@
 #'
 #' **This guards the codes it is given, not the ones the user meant.**  On the
 #' vector interface a `survival::Surv()` object is unclassed without
-#' translation, so its `0`/`1`/`2`/`3` codes reach here unchanged and a
-#' left-censored row arrives as `1`, invisible to this check.  The formula
-#' path translates in `.hzr_parse_formula()` and is guarded correctly.  That
-#' asymmetry is a pre-existing defect of the vector path, not of this check.
+#' translation, so its codes reach here meaning something else entirely, and
+#' what goes wrong depends on `type`:  under `type = "left"` a left-censored
+#' row is coded `0` and so arrives as this package's *right-censored*, and is
+#' fitted as one;  under `type = "interval"` it is coded `2` and arrives as
+#' *interval*, where this check rejects it for having zero width.  A genuine
+#' interval row is coded `3`, which no branch of `.hzr_logl_multiphase()`
+#' matches, so it contributes nothing at all.  The formula path translates in
+#' `.hzr_parse_formula()` and is guarded correctly.  That asymmetry is a
+#' pre-existing defect of the vector path, not of this check;  see #226.
 #'
 #' @param status Numeric event indicator.
 #' @param time Event/censoring times.
@@ -510,18 +515,20 @@
 #' @keywords internal
 .hzr_check_sas_data <- function(status, time, time_lower, time_upper,
                                 objective) {
-  if (!identical(objective, "sas")) {
-    return(invisible(NULL))
-  }
-
-  # any(status == -1) is NA-poisoned, so the inner guard's `if` would throw a
-  # bare "missing value where TRUE/FALSE needed" naming neither the argument
-  # nor the row. Name both.
+  # Checked BEFORE the objective gate, because an NA status is a data defect
+  # under every objective. Left inside the gate it reached the user through
+  # the optimizer's per-start handler as "ended where the likelihood is not
+  # defined", which is the framing #213 removed -- and which invites raising
+  # `n_starts`, a remedy that cannot work on a pure function of the data.
   if (anyNA(status)) {
-    stop("objective = \"sas\" requires a complete 'status' vector; ",
+    stop("'status' must be complete; ",
          sum(is.na(status)), " row(s) are NA, at index/indices ",
          paste(utils::head(which(is.na(status)), 10L), collapse = ", "),
          if (sum(is.na(status)) > 10L) ", ..." else "", ".", call. = FALSE)
+  }
+
+  if (!identical(objective, "sas")) {
+    return(invisible(NULL))
   }
 
   .hzr_check_sas_status(status, objective)

--- a/man/dot-hzr_check_sas_data.Rd
+++ b/man/dot-hzr_check_sas_data.Rd
@@ -40,9 +40,14 @@ interval subset the inner guard sees.
 
 \strong{This guards the codes it is given, not the ones the user meant.}  On the
 vector interface a \code{survival::Surv()} object is unclassed without
-translation, so its \code{0}/\code{1}/\code{2}/\code{3} codes reach here unchanged and a
-left-censored row arrives as \code{1}, invisible to this check.  The formula
-path translates in \code{.hzr_parse_formula()} and is guarded correctly.  That
-asymmetry is a pre-existing defect of the vector path, not of this check.
+translation, so its codes reach here meaning something else entirely, and
+what goes wrong depends on \code{type}:  under \code{type = "left"} a left-censored
+row is coded \code{0} and so arrives as this package's \emph{right-censored}, and is
+fitted as one;  under \code{type = "interval"} it is coded \code{2} and arrives as
+\emph{interval}, where this check rejects it for having zero width.  A genuine
+interval row is coded \code{3}, which no branch of \code{.hzr_logl_multiphase()}
+matches, so it contributes nothing at all.  The formula path translates in
+\code{.hzr_parse_formula()} and is guarded correctly.  That asymmetry is a
+pre-existing defect of the vector path, not of this check;  see #226.
 }
 \keyword{internal}

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -189,12 +189,15 @@ condition is a property of the observed times rather than of any phase:
 when their own relative range falls below this threshold and no phase's
 contribution varies across them, they separate no phase from any other
 and none of the shapes is identified. That verdict is withheld when the
-fit supplies counting-process entry times or interval bounds that add an
+fit supplies counting-process entry times or interval bounds that add
 enough evaluation points the measure did not see. "Enough" is counted, not
 assumed: with the event times tied, each added point supplies one more
 functional of the parameters, and one more than the number of added points
 must reach the number of free parameters. A zero entry time, or a bound
-equal to an event time, adds nothing and does not count. For the same reason the per-phase measures can
+equal to an event time, adds nothing and does not count. The count is
+deliberately conservative: it does not credit the extra functional that a
+zero entry time makes separately observable, so a fit can be warned about
+while being identified. For the same reason the per-phase measures can
 overstate what an interval-censored or left-truncated fit loses, since a
 phase flat across the event times may still be identified through the
 bounds. The measured shares are

--- a/tests/testthat/test-lst-parser-layouts.R
+++ b/tests/testthat/test-lst-parser-layouts.R
@@ -120,10 +120,12 @@ test_that("the nomogram parses when the counter column is labelled OBS", {
 
 test_that("the counter is dropped under any of its known labels", {
   # The fix for #184 must not trade one hardcoded label for two, so the set is
-  # case-insensitive and holds every spelling the corpus has shown. The 1..n
-  # run is still required -- the label alone does not drop a column -- but it
-  # is no longer sufficient on its own, because a whole-year YEARS grid runs
-  # 1..n too and was being deleted (#212).
+  # case-insensitive and holds every spelling the corpus has shown. The label
+  # is what decides: a column the header names as a counter is dropped whatever
+  # values it carries, which is why a paginated counter starting at 41 is
+  # dropped too. The 1..n run is only the fallback for an unrecognised name,
+  # and it is not sufficient alone -- a whole-year YEARS grid runs 1..n and was
+  # being deleted (#212).
   # Every member of counter_labels, so the set cannot be silently trimmed.
   # "_N_" is written as SAS prints it; the parser strips the leading
   # underscore before matching, which is why the set holds "n_".

--- a/tests/testthat/test-sas-interval-objective.R
+++ b/tests/testthat/test-sas-interval-objective.R
@@ -689,7 +689,7 @@ test_that("the entry check and the objective agree on which rows offend", {
   }
 })
 
-test_that("an NA status under sas names the argument and the row", {
+test_that("an NA status names the argument and the row, under any objective", {
   # any(status == -1) is NA-poisoned, so without this the inner guard's `if`
   # threw a bare "missing value where TRUE/FALSE needed".
   ph <- list(early = hzr_phase("cdf"), late = hzr_phase("constant"))
@@ -698,7 +698,19 @@ test_that("an NA status under sas names the argument and the row", {
       time = c(1, 2, 3, 4, 5, 6), status = c(1, 0, NA, 1, 0, 1),
       dist = "multiphase", phases = ph, fit = FALSE, objective = "sas")),
     error = conditionMessage)
-  expect_match(err, "complete 'status' vector")
+  expect_match(err, "'status' must be complete")
   expect_match(err, "at index/indices 3")
   expect_no_match(err, "missing value where TRUE/FALSE needed")
+
+  # An NA status is a data defect under EVERY objective. Gated on sas, the
+  # default path still reached the user as "ended where the likelihood is not
+  # defined" -- the framing #213 removed.
+  err2 <- tryCatch(
+    suppressWarnings(hazard(
+      time = c(1, 2, 3, 4, 5, 6), status = c(1, 0, NA, 1, 0, 1),
+      dist = "multiphase", phases = ph, fit = TRUE,
+      objective = "likelihood", control = list(n_starts = 1))),
+    error = conditionMessage)
+  expect_match(err2, "'status' must be complete")
+  expect_no_match(err2, "no usable fit")
 })


### PR DESCRIPTION
`RELEASE.md` step 5 for the 1.2.9 release — the adversarial review of `git diff v1.2.8...main`, 37 commits.

**No interaction defect** between #225, #227 and #229, which was the main risk: all three touch `R/likelihood-multiphase.R` and `R/hazard_api.R`, and their guards now run in sequence in `hazard()`. Traced and confirmed independent.

What it did find, all verified by running before acting:

| | Finding | Disposition |
|---|---|---|
| 1 | **The Surv-code description is false** in `NEWS.md` and the `.hzr_check_sas_data()` roxygen | fixed here |
| 2 | `?hazard` reads "add an enough evaluation points" | fixed here |
| 3 | The `NA`-status guard is gated on `objective = "sas"` | fixed here |
| 4 | A test comment contradicts the code it documents | fixed here |
| 5 | The counting rule is off by one when a row has entry `0` | documented here |
| 6 | `hazard()` returns a populated fit for zero-row data | filed as #231 |
| 7 | `NA` bound reported as `at index/indices NA` | filed as #232 |

### The one that matters

The release documents its own known gap **incorrectly**. Both `NEWS.md` and the roxygen said a left-censored row "arrives as `1` and is invisible to the check". Verified against `survival`:

- `type = "left"` codes left-censored as **`0`** → arrives as this package's *right-censored*, and is **fitted as one**
- `type = "interval"` codes left-censored as **`2`** → arrives as *interval*, and the guard rejects it for zero width
- a genuine interval row is coded **`3`** → matches no branch of `.hzr_logl_multiphase()` and contributes nothing

Three different wrong answers depending on `type`, one of which silently drops rows — not one invisible row. Both places are corrected, since they will be read as the authoritative description of #226, which should be re-scoped accordingly.

### The behaviour change

An `NA` in `status` is a data defect under every objective, but the guard only fired for `objective = "sas"`. Under the default it still produced the framing #213 exists to remove:

```
Multiphase optimization produced no usable fit from 1 start: 0 errored,
1 ended where the likelihood is not defined, ...
```

which invites raising `n_starts` — a remedy that cannot work on a pure function of the data. The check now runs before the objective gate. Mutation-tested: moving it back inside fails 5 tests.

### Gates

- `document()` clean, `lintr::lint_package()` **0 lints**, `spelling::spell_check_package()` clean
- `devtools::test()` (`NOT_CRAN=true`): **0 FAIL / 6 SKIP / 3703 PASS**
- The pre-fix tarball already checked **Status: OK** with the manual (2.91 MB, no `CLAUDE`/`AGENTS`/`.claude`); I will re-run `--as-cran` on the merged result before tagging.

**This blocks the v1.2.9 tag.** Findings 1 and 2 are user-facing text that would otherwise ship in the manual and release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)