### PR TITLE
fix(sas): PARMS translation fidelity — WEIBULL, orphaned MU, SETG3_ignore_tau

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TemporalHazard
 Title: Temporal Parametric Hazard Modeling
-Version: 1.2.9
+Version: 1.2.10
 Authors@R: person("John", "Ehrlinger", email = "john.ehrlinger@gmail.com", role = c("aut", "cre", "cph"))
 URL: https://ehrlinger.github.io/TemporalHazard/, https://github.com/ehrlinger/TemporalHazard
 BugReports: https://github.com/ehrlinger/TemporalHazard/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# TemporalHazard 1.2.10
+
+## Bug fixes
+
+* **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
+  statement specified alongside `WEIBULL`.** The translator read the bare
+  `WEIBULL` keyword as a request to constrain the late phase to
+  `alpha = eta = 1` and pinned both. `SETG3_weibull()` in the reference C
+  (`src/model/setg3.c`) is the *generalized* Weibull -- it admits all positive
+  parameter values, validates `gamma > 0`, `eta > 0` and `alpha >= 0`, and
+  assigns nothing. A production job carrying
+  `alpha = 2.501719 ... eta = 0.1365255 weibull` therefore translated to a
+  seven-parameter fit where `PROC HAZARD` estimated nine, with both starting
+  values replaced by 1 and no warning. `WEIBULL` now leaves `ALPHA` and `ETA`
+  as `PARMS` gave them, free unless an explicit `FIXALPHA`/`FIXETA` pins them.
+  The `G3`-collapses-to-Weibull identity at `alpha = eta = 1` is real and
+  unchanged; it was simply not what the keyword requests.
+
 # TemporalHazard 1.2.9
 
 ## Bug fixes

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -379,9 +379,16 @@
   # estimates the product as GAMMA alone. That is one fewer estimated parameter
   # than hazard() would use, on a pair that is not separately identifiable --
   # a different model, not a different label for the same one. Recorded.
+  # Both guards are about the late phase, so both require one to exist. The
+  # alpha default of 1 is right for a late phase PARMS never gave an ALPHA and
+  # meaningless for a job that has no late phase at all -- without this, an
+  # early-only job carrying a stray FIXALPHA was flagged about GAMMA and ETA it
+  # has no phase for. A false positive here is not harmless: $untranslated is
+  # how a caller decides whether a translation can be trusted.
+  has_late <- length(late) > 0L
   alpha_val <- if (!is.null(late[["alpha"]])) late[["alpha"]] else
     .hzr_parms_late_default[["alpha"]]
-  if (isTRUE(alpha_val == 1) && "alpha" %in% fixed_late &&
+  if (has_late && isTRUE(alpha_val == 1) && "alpha" %in% fixed_late &&
       !("gamma" %in% fixed_late) && !("eta" %in% fixed_late)) {
     flag_bad(
       "ALPHA=1 FIXALPHA with GAMMA and ETA both estimated",
@@ -396,7 +403,8 @@
   # (g3flag == 3 vs 4) and the job does not run. hzr_phase() accepts alpha = 0
   # as the limiting exponential, so without this the translator would emit a
   # runnable fit for a job SAS refuses outright.
-  if (saw_weibull && isTRUE(alpha_val == 0) && !("alpha" %in% fixed_late)) {
+  if (has_late && saw_weibull && isTRUE(alpha_val == 0) &&
+      !("alpha" %in% fixed_late)) {
     flag_bad(
       "ALPHA=0 with WEIBULL and no FIXALPHA",
       paste0("PROC HAZARD rejects this: SETG3_weibull() raises SETG3980 for ",

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -248,9 +248,22 @@
     if (is.na(token)) {
       flag_bad(op, "unresolved PARMS keyword")
     } else if (token == "WEIBULL") {
-      late[["alpha"]] <- 1
-      late[["eta"]] <- 1
-      fixed_late <- union(fixed_late, c("alpha", "eta"))
+      # setopt(6) -> SETG3_weibull() (setg3.c:427) is the GENERALIZED Weibull:
+      # "NOW HANDLE THE SPECIAL SITUATION OF THE GENERALIZED WEIBULL, WHERE WE
+      # ADMIT ALL POSITIVE VALUES OF THE PARAMETERS." It bumps g3flag and
+      # validates gamma > 0, eta > 0, alpha >= 0. It assigns nothing and fixes
+      # nothing, so neither does this branch -- ALPHA and ETA keep whatever
+      # PARMS specified and stay free unless an explicit FIXALPHA/FIXETA pins
+      # them. Overwriting them with 1 discarded the user's starting values and
+      # silently fitted a smaller model; the listing for
+      # hz.ce_cardioversion_repeated.ehb.sas prints both as "Estimated? Yes".
+      #
+      # g3flag itself has no R counterpart: it selects a numerical branch, and
+      # hzr_decompos_g3() handles the general form directly. The GAMMA*ETA = 2
+      # and GAMMA*ETA/ALPHA = 2 constraint flags SETG3_weibull() also honours
+      # are driven by separate PARMS keywords that this parser does not yet
+      # resolve -- they are recorded as untranslated, not assumed absent.
+      NULL
     } else if (token %in% names(.hzr_parms_fix_map)) {
       param <- .hzr_parms_fix_map[[token]]
       if (param %in% .hzr_parms_early_arg) {

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -379,13 +379,28 @@
   # estimates the product as GAMMA alone. That is one fewer estimated parameter
   # than hazard() would use, on a pair that is not separately identifiable --
   # a different model, not a different label for the same one. Recorded.
-  # Both guards are about the late phase, so both require one to exist. The
-  # alpha default of 1 is right for a late phase PARMS never gave an ALPHA and
-  # meaningless for a job that has no late phase at all -- without this, an
-  # early-only job carrying a stray FIXALPHA was flagged about GAMMA and ETA it
-  # has no phase for. A false positive here is not harmless: $untranslated is
-  # how a caller decides whether a translation can be trusted.
-  has_late <- length(late) > 0L
+  # Both guards describe things SETG3() does, so both require a late phase that
+  # is actually active -- and in PROC HAZARD a phase is active iff its MU was
+  # specified and positive. parmprc.c:19 registers MUL through
+  # setparmno(22, 7, 3, ...) and setparmno.c:14 sets C->phase[3] = 1 only when
+  # stmtfld() > 0; the four shape operands go through setprmf
+  # (parmprc.c:20-23), which never touches C->phase[]. With phase 3 off,
+  # stmtprc.c:113-122 zeroes TAU/GAMMA/ALPHA/ETA and shape.c:31 never calls
+  # SETG3() at all.
+  #
+  # So the gate is MUL, not the presence of shape operands: TAU/GAMMA/ETA with
+  # no MUL is not a late phase, and warning about SETG3_ignore_tau() or
+  # SETG3980 there describes code PROC HAZARD never reaches. A false positive
+  # on $untranslated is not harmless -- that frame is how a caller decides
+  # whether a translation can be trusted.
+  #
+  # Note the asymmetry this leaves inside this function, deliberately and
+  # tracked separately: the phase-building block below still keys on shape
+  # operands (`if (length(late))`), so PARMS carrying TAU/GAMMA with no MUL
+  # emits a late phase that PROC HAZARD would not build at all. No corpus job
+  # does that, so it is latent, and changing how phases are built is a wider
+  # change than gating these two warnings.
+  has_late <- !is.null(mu[["MUL"]]) && isTRUE(mu[["MUL"]] > 0)
   alpha_val <- if (!is.null(late[["alpha"]])) late[["alpha"]] else
     .hzr_parms_late_default[["alpha"]]
   if (has_late && isTRUE(alpha_val == 1) && "alpha" %in% fixed_late &&

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -5,9 +5,9 @@
 # scale each phase, THALF/NU/M shape the early (G1/"cdf") phase, TAU/GAMMA/
 # ALPHA/ETA shape the late (G3) phase, bare FIX<param> tokens freeze a
 # parameter at its starting value, and bare WEIBULL is setopt(6) /
-# SETG3_weibull() in the reference C: it does not add a phase, it constrains
-# the existing late phase to alpha = eta = 1, which collapses the general G3
-# form to a Weibull cumulative hazard (spec S7.1).
+# SETG3_weibull() in the reference C: the GENERALIZED Weibull, which admits
+# all positive parameter values. It neither adds a phase nor constrains one --
+# see the WEIBULL branch below.
 #
 # `theta` is the full interleaved starting vector the multiphase engine
 # expects -- one block per phase, in the same early -> constant -> late
@@ -353,6 +353,25 @@
     theta_blocks <- c(theta_blocks,
       .hzr_parms_theta_block("late", mu_val, late, phase_covar_vals$late)
     )
+  }
+
+  # A MU names its phase. Building a phase only when a *shape* operand
+  # appeared let an orphaned MUE/MUL disappear together with the phase it
+  # scaled -- a one-phase R model against SAS's two, and no untranslated row
+  # to say so. PROC HAZARD would supply its own shape defaults here
+  # (stmtprc.c:30-37: thalf 1, nu 2, m 1; tau = 2*Tmax/3, gamma 1, alpha 1,
+  # eta 2), which are not this parser's defaults, so the MU is recorded
+  # rather than guessed at.
+  # sprintf("%g"), not format(): format() honours getOption("OutDec"), so a
+  # session with OutDec = "," would record "MUE=0,2" and break every grep --
+  # the same trap the DELTA reason string above avoids.
+  if (!is.null(mu[["MUE"]]) && !length(early)) {
+    flag_bad(paste0("MUE=", sprintf("%g", mu[["MUE"]])),
+             "MUE with no early phase shape operand (THALF/NU/M)")
+  }
+  if (!is.null(mu[["MUL"]]) && !length(late)) {
+    flag_bad(paste0("MUL=", sprintf("%g", mu[["MUL"]])),
+             "MUL with no late phase shape operand (TAU/GAMMA/ALPHA/ETA)")
   }
 
   list(

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -194,6 +194,7 @@
   late <- list()
   fixed_early <- character(0)
   fixed_late <- character(0)
+  saw_weibull <- FALSE
   bad_construct <- character(0)
   bad_reason <- character(0)
 
@@ -263,7 +264,7 @@
       # and GAMMA*ETA/ALPHA = 2 constraint flags SETG3_weibull() also honours
       # are driven by separate PARMS keywords that this parser does not yet
       # resolve -- they are recorded as untranslated, not assumed absent.
-      NULL
+      saw_weibull <- TRUE
     } else if (token %in% names(.hzr_parms_fix_map)) {
       param <- .hzr_parms_fix_map[[token]]
       if (param %in% .hzr_parms_early_arg) {
@@ -362,6 +363,47 @@
   # (stmtprc.c:30-37: thalf 1, nu 2, m 1; tau = 2*Tmax/3, gamma 1, alpha 1,
   # eta 2), which are not this parser's defaults, so the MU is recorded
   # rather than guessed at.
+  # SETG3_ignore_tau() (setg3.c:377-424) fires when ALPHA is fixed at 1 --
+  # setg3.c:312-314, before the WEIBULL dispatch. It pins TAU at 1 and rewrites
+  # the GAMMA/ETA split, which at alpha = 1, tau = 1 is a reparameterisation of
+  # a single exponent: the G3 form collapses to t^(gamma*eta), so only the
+  # product is identified. Two consequences, and only one of them is a defect.
+  #
+  # The reported values diverge: SAS's listing prints the rewritten split, this
+  # parser emits what PARMS said. The fit is identical, so that is documented
+  # in hzr_translate_sas() rather than mirrored here -- rewriting the emitted
+  # call would make it disagree with the user's own PARMS text, and across the
+  # public corpus it would change 16 blocks to alter 2 (measured 2026-09-08).
+  #
+  # With GAMMA and ETA *both* free, though, setg3.c:405-406 fixes ETA and
+  # estimates the product as GAMMA alone. That is one fewer estimated parameter
+  # than hazard() would use, on a pair that is not separately identifiable --
+  # a different model, not a different label for the same one. Recorded.
+  alpha_val <- if (!is.null(late[["alpha"]])) late[["alpha"]] else
+    .hzr_parms_late_default[["alpha"]]
+  if (isTRUE(alpha_val == 1) && "alpha" %in% fixed_late &&
+      !("gamma" %in% fixed_late) && !("eta" %in% fixed_late)) {
+    flag_bad(
+      "ALPHA=1 FIXALPHA with GAMMA and ETA both estimated",
+      paste0("SETG3_ignore_tau() estimates GAMMA*ETA as a single parameter ",
+             "here (it fixes ETA); hazard() would estimate both, which is one ",
+             "more free parameter than PROC HAZARD on a product that is not ",
+             "separately identifiable at alpha = 1")
+    )
+  }
+
+  # setg3.c:437: SETG3_weibull() rejects alpha == 0 unless ALPHA is fixed
+  # (g3flag == 3 vs 4) and the job does not run. hzr_phase() accepts alpha = 0
+  # as the limiting exponential, so without this the translator would emit a
+  # runnable fit for a job SAS refuses outright.
+  if (saw_weibull && isTRUE(alpha_val == 0) && !("alpha" %in% fixed_late)) {
+    flag_bad(
+      "ALPHA=0 with WEIBULL and no FIXALPHA",
+      paste0("PROC HAZARD rejects this: SETG3_weibull() raises SETG3980 for ",
+             "alpha = 0 unless ALPHA is fixed, so the job does not run")
+    )
+  }
+
   # sprintf("%g"), not format(): format() honours getOption("OutDec"), so a
   # session with OutDec = "," would record "MUE=0,2" and break every grep --
   # the same trap the DELTA reason string above avoids.

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -106,6 +106,29 @@
 #' confidence limits unless the SAS job says `NOCL`, so such a job stops at
 #' its `predict()` chunks.
 #'
+#' @section Comparing a translated fit against a SAS listing:
+#' The emitted `hzr_phase("g3", ...)` call carries the `TAU`, `GAMMA`,
+#' `ALPHA` and `ETA` that `PARMS` specified. `PROC HAZARD` does not always
+#' report the values it was given: when `ALPHA` is fixed at 1 it rewrites the
+#' late phase before fitting, pinning `TAU` at 1 and folding the two shape
+#' parameters into one exponent, because at `alpha = 1, tau = 1` the G3 form
+#' collapses to \eqn{t^{\gamma\eta}} and only that product is identified.
+#' With `ETA` fixed it reports `GAMMA` as \eqn{\gamma\eta} and `ETA` as 1;
+#' otherwise it reports `ETA` as \eqn{\gamma\eta} and `GAMMA` as 1.
+#'
+#' So a listing can print a `GAMMA`/`ETA` pair that differs from the job's own
+#' `PARMS` text, and from the emitted call, while describing the same fitted
+#' model. Compare the **product** \eqn{\gamma\eta}, not the two parameters
+#' separately, and expect `TAU` to read 1 and fixed. The log-likelihood,
+#' `MUL` and every prediction agree regardless. Most jobs are unaffected in
+#' practice: `GAMMA = 1 FIXGAMMA` is the usual companion to `ALPHA = 1
+#' FIXALPHA`, and it makes the rewrite an identity.
+#'
+#' The one case that is a genuine model difference -- `ALPHA` fixed at 1 with
+#' `GAMMA` and `ETA` *both* estimated, where `PROC HAZARD` fixes `ETA` and
+#' fits one parameter fewer than [hazard()] would -- is recorded in
+#' `$untranslated` rather than left to be discovered in the comparison.
+#'
 #' `$coverage` counts tokens the parser recognised; it is not evidence that
 #' the emitted calls execute, and a job can report full coverage with an
 #' empty `$untranslated` while its document still errors on render. See the

--- a/man/hzr_translate_sas.Rd
+++ b/man/hzr_translate_sas.Rd
@@ -77,6 +77,30 @@ parameter on a composite scale -- the generic unconstrained three-phase
 case, not an exotic one. A translated \verb{PROC HAZPRED} block asks for
 confidence limits unless the SAS job says \code{NOCL}, so such a job stops at
 its \code{predict()} chunks.
+}
+
+\section{Comparing a translated fit against a SAS listing}{
+
+The emitted \code{hzr_phase("g3", ...)} call carries the \code{TAU}, \code{GAMMA},
+\code{ALPHA} and \code{ETA} that \code{PARMS} specified. \verb{PROC HAZARD} does not always
+report the values it was given: when \code{ALPHA} is fixed at 1 it rewrites the
+late phase before fitting, pinning \code{TAU} at 1 and folding the two shape
+parameters into one exponent, because at \verb{alpha = 1, tau = 1} the G3 form
+collapses to \eqn{t^{\gamma\eta}} and only that product is identified.
+With \code{ETA} fixed it reports \code{GAMMA} as \eqn{\gamma\eta} and \code{ETA} as 1;
+otherwise it reports \code{ETA} as \eqn{\gamma\eta} and \code{GAMMA} as 1.
+
+So a listing can print a \code{GAMMA}/\code{ETA} pair that differs from the job's own
+\code{PARMS} text, and from the emitted call, while describing the same fitted
+model. Compare the \strong{product} \eqn{\gamma\eta}, not the two parameters
+separately, and expect \code{TAU} to read 1 and fixed. The log-likelihood,
+\code{MUL} and every prediction agree regardless. Most jobs are unaffected in
+practice: \verb{GAMMA = 1 FIXGAMMA} is the usual companion to \verb{ALPHA = 1 FIXALPHA}, and it makes the rewrite an identity.
+
+The one case that is a genuine model difference -- \code{ALPHA} fixed at 1 with
+\code{GAMMA} and \code{ETA} \emph{both} estimated, where \verb{PROC HAZARD} fixes \code{ETA} and
+fits one parameter fewer than \code{\link[=hazard]{hazard()}} would -- is recorded in
+\verb{$untranslated} rather than left to be discovered in the comparison.
 
 \verb{$coverage} counts tokens the parser recognised; it is not evidence that
 the emitted calls execute, and a job can report full coverage with an

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -232,3 +232,48 @@ test_that("a MUE with no early shape operand is recorded, not dropped", {
   expect_equal(got$untranslated$construct, "MUE=0.2")
   expect_match(got$untranslated$reason, "no early phase")
 })
+
+test_that("alpha = 1 fixed with GAMMA and ETA both free is recorded", {
+  # setg3.c:312-314 routes alpha == 1 && FIXALPHA into SETG3_ignore_tau(),
+  # which at setg3.c:405-406 does `if(hzr_parms_ge_estim()) set_fixed(ETA)`:
+  # with both shape parameters free, SAS fixes ETA and estimates the product
+  # gamma*eta as gamma alone. At alpha = 1, tau = 1 the G3 form collapses to
+  # t^(gamma*eta), so gamma and eta are not separately identifiable and SAS is
+  # resolving that. hazard() would leave both free and fit the ridge -- one
+  # more estimated parameter than PROC HAZARD, with different standard errors.
+  # A model difference, not a reporting one, so it is recorded.
+  #
+  # No corpus job reaches this today (0 of 38 live PARMS blocks, measured
+  # 2026-09-08); the 16 that fire SETG3_ignore_tau() all fix GAMMA.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=2",
+                            "ETA=3", "FIXALPHA"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_match(got$untranslated$reason, "estimates GAMMA\\*ETA")
+})
+
+test_that("alpha = 1 fixed with GAMMA fixed is not recorded", {
+  # The dominant corpus shape -- gamma fixed, eta free. SAS reparameterises to
+  # eta <- gamma*eta, gamma <- 1, which with gamma = 1 is an identity. Nothing
+  # to report. Distinguishes the guard above from "any fixed alpha = 1".
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=1",
+                            "ETA=1.32", "FIXALPHA", "FIXGAMMA", "WEIBULL"))
+  expect_equal(nrow(got$untranslated), 0L)
+})
+
+test_that("ALPHA = 0 under WEIBULL without FIXALPHA is recorded", {
+  # setg3.c:437: SETG3_weibull() rejects alpha == 0 when g3flag == 3, i.e.
+  # ALPHA=0 under WEIBULL without FIXALPHA, with error SETG3980. The job does
+  # not run. hzr_phase() accepts alpha = 0 as the limiting exponential, so
+  # without this the translator would emit a fit for a job SAS refuses.
+  # ALPHA=0 FIXALPHA is legal (g3flag == 4) and stays unflagged.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=0",
+                            "ETA=1", "WEIBULL"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_match(got$untranslated$reason, "SETG3980")
+})
+
+test_that("ALPHA = 0 with FIXALPHA under WEIBULL is not recorded", {
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=0",
+                            "ETA=1", "WEIBULL", "FIXALPHA"))
+  expect_equal(nrow(got$untranslated), 0L)
+})

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -16,17 +16,25 @@ test_that("an early-plus-constant PARMS maps to two phases and a theta", {
   )
 })
 
-test_that("WEIBULL becomes a G3 constrained at alpha = 1, eta = 1", {
-  # PARMS ... WEIBULL is setopt(6) -> SETG3_weibull, g3flag += 2. The R general
-  # form (((t/tau)^gamma + 1)^(1/alpha) - 1)^eta collapses at alpha = eta = 1
-  # to (t/tau)^gamma, a Weibull cumulative hazard. See spec 7.1.
+test_that("WEIBULL leaves unspecified ALPHA and ETA at their defaults, free", {
+  # PARMS ... WEIBULL is setopt(6) -> SETG3_weibull (setg3.c:427), the
+  # generalized Weibull, which admits all positive parameter values. With
+  # ALPHA and ETA absent from PARMS they take hzr_phase()'s defaults of 1 --
+  # so they are omitted from the emitted call -- and stay estimated. Only the
+  # explicit FIXTAU/FIXGAMMA pin anything.
+  #
+  # This test previously asserted alpha = eta = 1, fixed. That was the
+  # translator's behaviour, not SAS's: it read WEIBULL as a constraint to the
+  # alpha = eta = 1 special case. The G3-collapses-to-Weibull identity at
+  # alpha = eta = 1 is real and is covered by
+  # test-g3-weibull-correspondence.R, but it is not what the WEIBULL keyword
+  # requests.
   ops <- c("MUL=0.01", "TAU=2", "GAMMA=1.5", "WEIBULL", "FIXTAU", "FIXGAMMA")
   got <- .hzr_parse_parms(ops)
   expect_equal(
     got$phases,
     quote(list(
-      hzr_phase("g3", tau = 2, gamma = 1.5, alpha = 1, eta = 1,
-                fixed = c("tau", "gamma", "alpha", "eta"))
+      hzr_phase("g3", tau = 2, gamma = 1.5, fixed = c("tau", "gamma"))
     ))
   )
 })
@@ -146,4 +154,41 @@ test_that("the DELTA reason string does not move with OutDec", {
   r <- .hzr_parse_parms(c("MUE=0.2", "DELTA=0.5"))
   expect_match(r$untranslated$reason, "DELTA = 0\\.5", fixed = FALSE)
   expect_false(grepl("0,5", r$untranslated$reason, fixed = TRUE))
+})
+
+test_that("WEIBULL keeps the ALPHA and ETA that PARMS specified, both free", {
+  # setg3.c:427 SETG3_weibull() is the GENERALIZED Weibull: "we admit all
+  # positive values of the parameters". It validates gamma > 0, eta > 0 and
+  # alpha >= 0 and bumps g3flag; it never assigns 1 to alpha or eta and never
+  # fixes either. Operands are from the production job
+  # hz.ce_cardioversion_repeated.ehb.sas, whose listing prints ALPHA and ETA
+  # as "Estimated? Yes" with exactly these starting values.
+  ops <- c("MUE=0.3012686", "THALF=0.01038402", "NU=0.1708571", "M=5.818869",
+           "MUL=0.2450542", "TAU=0.5433813", "ALPHA=2.501719",
+           "GAMMA=6.448979", "ETA=0.1365255", "WEIBULL")
+  got <- .hzr_parse_parms(ops)
+  expect_equal(
+    got$phases,
+    quote(list(
+      hzr_phase("cdf", t_half = 0.01038402, nu = 0.1708571, m = 5.818869),
+      hzr_phase("g3", tau = 0.5433813, gamma = 6.448979, alpha = 2.501719,
+                eta = 0.1365255)
+    ))
+  )
+})
+
+test_that("WEIBULL alongside FIXALPHA fixes alpha and only alpha", {
+  # The fix must not overshoot: an explicit FIX<param> still pins that one
+  # parameter. Distinguishes "WEIBULL fixes nothing" from "nothing is ever
+  # fixed on a WEIBULL phase".
+  ops <- c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=3", "ETA=4",
+           "WEIBULL", "FIXALPHA")
+  got <- .hzr_parse_parms(ops)
+  expect_equal(
+    got$phases,
+    quote(list(
+      hzr_phase("g3", tau = 2, gamma = 1.5, alpha = 3, eta = 4,
+                fixed = "alpha")
+    ))
+  )
 })

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -23,6 +23,12 @@ test_that("WEIBULL leaves unspecified ALPHA and ETA at their defaults, free", {
   # so they are omitted from the emitted call -- and stay estimated. Only the
   # explicit FIXTAU/FIXGAMMA pin anything.
   #
+  # Note those are *R's* defaults, not SAS's: stmtprc.c:30-37 starts an
+  # unspecified late phase at gamma = 1, alpha = 1, eta = 2 (and tau at
+  # 2*Tmax/3, data-dependent). This test pins the translator's behaviour, not
+  # start-value parity with PROC HAZARD -- a separate, pre-existing gap that
+  # WEIBULL jobs now share with every other path.
+  #
   # This test previously asserted alpha = eta = 1, fixed. That was the
   # translator's behaviour, not SAS's: it read WEIBULL as a constraint to the
   # alpha = eta = 1 special case. The G3-collapses-to-Weibull identity at
@@ -152,8 +158,14 @@ test_that("the DELTA reason string does not move with OutDec", {
   old <- options(OutDec = ",")
   on.exit(options(old), add = TRUE)
   r <- .hzr_parse_parms(c("MUE=0.2", "DELTA=0.5"))
-  expect_match(r$untranslated$reason, "DELTA = 0\\.5", fixed = FALSE)
-  expect_false(grepl("0,5", r$untranslated$reason, fixed = TRUE))
+  # MUE here has no early shape operand, so it is recorded too; target the
+  # DELTA row rather than asserting over the whole frame.
+  delta_row <- r$untranslated[grepl("DELTA", r$untranslated$reason), ]
+  expect_equal(nrow(delta_row), 1L)
+  expect_match(delta_row$reason, "DELTA = 0\\.5", fixed = FALSE)
+  expect_false(any(grepl(",", r$untranslated$construct, fixed = TRUE)))
+  expect_false(any(grepl("0,5", r$untranslated$reason, fixed = TRUE)))
+  expect_false(any(grepl("0,2", r$untranslated$construct, fixed = TRUE)))
 })
 
 test_that("WEIBULL keeps the ALPHA and ETA that PARMS specified, both free", {
@@ -175,6 +187,14 @@ test_that("WEIBULL keeps the ALPHA and ETA that PARMS specified, both free", {
                 eta = 0.1365255)
     ))
   )
+  # $phases is what a reader sees; $theta is what reaches the optimizer, and
+  # .hzr_parms_theta_block() reads the shape list independently -- so assert
+  # it too. These are the starting values the old WEIBULL branch discarded.
+  expect_equal(
+    got$theta,
+    quote(c(log(0.3012686), log(0.01038402), 0.1708571, 5.818869,
+            log(0.2450542), log(0.5433813), 6.448979, 2.501719, 0.1365255))
+  )
 })
 
 test_that("WEIBULL alongside FIXALPHA fixes alpha and only alpha", {
@@ -191,4 +211,24 @@ test_that("WEIBULL alongside FIXALPHA fixes alpha and only alpha", {
                 fixed = "alpha")
     ))
   )
+})
+
+test_that("a MUL with no late shape operand is recorded, not dropped", {
+  # PARMS names a late phase by giving it a scale. Building the phase only
+  # when a *shape* operand appeared meant MUL could vanish with the phase --
+  # a one-phase R model against SAS's two, reported as fully translated. The
+  # starting values SAS would default to here (stmtprc.c: tau = 2*Tmax/3,
+  # gamma = 1, alpha = 1, eta = 2) are not this parser's defaults, so the MU
+  # is recorded as untranslated rather than guessed at.
+  got <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "MUL=0.05", "WEIBULL"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_equal(got$untranslated$construct, "MUL=0.05")
+  expect_match(got$untranslated$reason, "no late phase")
+})
+
+test_that("a MUE with no early shape operand is recorded, not dropped", {
+  got <- .hzr_parse_parms(c("MUE=0.2", "MUL=0.05", "TAU=2", "GAMMA=1.5"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_equal(got$untranslated$construct, "MUE=0.2")
+  expect_match(got$untranslated$reason, "no early phase")
 })

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -301,3 +301,35 @@ test_that("the alpha = 1 guard still fires when ALPHA was left to default", {
   expect_equal(nrow(got$untranslated), 1L)
   expect_match(got$untranslated$reason, "estimates GAMMA\\*ETA")
 })
+
+test_that("the alpha = 1 guard does not fire without MUL", {
+  # A phase is active in PROC HAZARD iff its MU is specified and positive.
+  # parmprc.c:19 registers MUL through setparmno(22, 7, 3, ...), and
+  # setparmno.c:14 sets C->phase[3] = 1 only when the value is > 0. The four
+  # shape operands go through setprmf (parmprc.c:20-23), which never touches
+  # C->phase[]. With phase 3 off, stmtprc.c:113-122 zeroes TAU/GAMMA/ALPHA/ETA
+  # and shape.c:31 never calls SETG3(), so SETG3_ignore_tau() cannot run and
+  # there is nothing to warn about.
+  #
+  # Gating on shape operands instead of MUL got this wrong: TAU/GAMMA/ETA with
+  # no MUL is not a late phase at all.
+  got <- .hzr_parse_parms(c("TAU=2", "GAMMA=2", "ETA=3", "FIXALPHA"))
+  expect_false(any(grepl("estimates GAMMA", got$untranslated$reason)))
+})
+
+test_that("the ALPHA = 0 WEIBULL guard does not fire without MUL", {
+  # Same gate: with no MUL there is no phase 3, shape.c:31 never reaches
+  # SETG3(), and SETG3_weibull() cannot raise SETG3980. Claiming PROC HAZARD
+  # refuses the job would be wrong.
+  got <- .hzr_parse_parms(c("TAU=2", "GAMMA=1.5", "ALPHA=0", "ETA=1", "WEIBULL"))
+  expect_false(any(grepl("SETG3980", got$untranslated$reason)))
+})
+
+test_that("both late-phase guards still fire when MUL is present", {
+  # The other side of the gate, so it cannot be satisfied by never firing.
+  g1 <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2", "ETA=3", "FIXALPHA"))
+  expect_true(any(grepl("estimates GAMMA", g1$untranslated$reason)))
+  g2 <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=0",
+                           "ETA=1", "WEIBULL"))
+  expect_true(any(grepl("SETG3980", g2$untranslated$reason)))
+})

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -277,3 +277,27 @@ test_that("ALPHA = 0 with FIXALPHA under WEIBULL is not recorded", {
                             "ETA=1", "WEIBULL", "FIXALPHA"))
   expect_equal(nrow(got$untranslated), 0L)
 })
+
+test_that("the alpha = 1 guard does not fire on a job with no late phase", {
+  # alpha_val falls back to hzr_phase()'s default of 1 when PARMS named no
+  # ALPHA, which is right for a late phase that exists and wrong for one that
+  # does not: an early-only or constant-only job carrying a stray FIXALPHA was
+  # flagged about GAMMA and ETA it has no phase for. A false positive on the
+  # untranslated frame is not harmless -- that frame is how a caller decides
+  # whether a translation is trustworthy.
+  expect_equal(nrow(.hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1",
+                                       "FIXALPHA"))$untranslated), 0L)
+  expect_equal(nrow(.hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1",
+                                       "FIXALPHA", "WEIBULL"))$untranslated), 0L)
+  expect_equal(nrow(.hzr_parse_parms(c("MUC=0.01", "FIXALPHA"))$untranslated), 0L)
+})
+
+test_that("the alpha = 1 guard still fires when ALPHA was left to default", {
+  # The other half of the same boundary: a late phase exists, PARMS never named
+  # ALPHA, and FIXALPHA pins it at the default of 1 with GAMMA and ETA free.
+  # SAS fixes ETA here, so this must still be recorded -- the scope fix above
+  # must not buy its way out of the guard by requiring an explicit ALPHA.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2", "ETA=3", "FIXALPHA"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_match(got$untranslated$reason, "estimates GAMMA\\*ETA")
+})


### PR DESCRIPTION
Three fidelity defects in `.hzr_parse_parms()`, each verified against the reference C and against production listings before being acted on.

## 1. `WEIBULL` is the generalized Weibull (`babddbd`)

The translator read a bare `WEIBULL` operand as a request to constrain the late phase to `alpha = eta = 1`, and pinned both — overwriting whatever `ALPHA` and `ETA` the statement specified.

`SETG3_weibull()` (`hazard/src/model/setg3.c:427`) does no such thing: *"NOW HANDLE THE SPECIAL SITUATION OF THE GENERALIZED WEIBULL, WHERE WE ADMIT ALL POSITIVE VALUES OF THE PARAMETERS."* It bumps `g3flag` and validates `gamma > 0`, `eta > 0`, `alpha >= 0`. It assigns nothing and fixes nothing.

| Job | `PARMS` | Listing says | Translator emitted |
|---|---|---|---|
| `hz.ce_cardioversion_repeated.ehb` | `alpha=2.501719 … eta=0.1365255 weibull` | both `Estimated? Yes` | `alpha=1, eta=1, fixed` |
| `hz.svdcd.cvt` | `eta=3.42 … weibull` | `Estimated? Yes`, final `3.406023` | `eta=1, fixed` |

The cardioversion job therefore translated to a seven-parameter fit where `PROC HAZARD` estimated nine, with no warning and no untranslated row.

The existing test asserted the old behaviour by name, so it is rewritten rather than kept — it now covers the case the fix does not change (`ALPHA`/`ETA` absent). Two new tests cover the specified-value case and the `FIXALPHA` interaction. The `G3`→Weibull identity at `alpha = eta = 1` is real and untouched.

## 2. An orphaned `MUE`/`MUL` no longer drops its phase (`82210d4`)

A regression `babddbd` introduced, found by `r-reviewer` and reproduced before acting on it. Phases are built only when a *shape* operand appeared, and the old `WEIBULL` branch seeded `late$alpha`/`late$eta` as a side effect:

```
.hzr_parse_parms(c("MUE=0.2","THALF=1","NU=1","MUL=0.05","WEIBULL"))
# phases: list(hzr_phase("cdf", t_half = 1, nu = 1))
# untranslated: 0 rows
```

A one-phase R model against SAS's two, reported as fully translated. The same hole was already present on the early side, pre-existing, and is closed by the same rule: a MU names its phase. The orphaned MU is recorded rather than guessed at, since `PROC HAZARD`'s shape defaults (`stmtprc.c:30-37`) are not this parser's.

Also from that review: the module header still documented the removed reading; the cardioversion test now asserts `$theta` as well as `$phases`; and the repo's `OutDec` test caught a real bug in the first draft of this patch, which used `format()` where it needed `sprintf("%g")`.

## 3. `SETG3_ignore_tau()` — documented, and its dangerous case guarded (`ed2adf2`)

`SETG3_ignore_tau()` (`setg3.c:377-424`) fires whenever `ALPHA` is fixed at 1 (`setg3.c:312-314`, before the `WEIBULL` dispatch). It pins `TAU` at 1 and rewrites the `GAMMA`/`ETA` split. At `alpha = 1, tau = 1` the G3 form collapses to `t^(gamma*eta)`, so only the product is identified.

Measured across all 38 live `PARMS` blocks in the public corpus:

| | count |
|---|---|
| never fires | 22 |
| fires, reparameterisation is an **identity** | 14 |
| fires, **reported values** diverge | **2** |
| fires, **degrees of freedom** diverge | **0** |

The identities dominate because `GAMMA=1 FIXGAMMA` is the usual companion to `ALPHA=1 FIXALPHA`. In the two divergent blocks (both `hm.dead.n1surg.sas`) `GAMMA` and `ETA` are both *fixed*, so nothing is estimated, the product is unchanged, and **the fit is identical** — only the reported values differ.

So the emitted call is left alone: mirroring the rewrite would change 16 blocks to alter 2, and would make `hzr_phase()` disagree with the user's own `PARMS` text. It is documented instead, in a new `hzr_translate_sas()` section for whoever compares a fit against a listing — compare the product, expect `TAU` to read 1 and fixed.

Two cases *are* guarded, because they are not cosmetic:

- **`ALPHA` fixed at 1 with `GAMMA` and `ETA` both free.** `setg3.c:405-406` fixes `ETA` and estimates the product as `GAMMA` alone. `hazard()` would estimate both — one more free parameter than `PROC HAZARD`, on a pair not separately identifiable, i.e. a ridge. This branch was missed by the original review and is the one that would produce a wrong answer. No corpus job reaches it today.
- **`ALPHA=0` under `WEIBULL` without `FIXALPHA`.** `setg3.c:437` raises `SETG3980` and the job does not run; the translator would otherwise emit a runnable fit for a job SAS refuses.

Both have a negative-control test so they cannot widen into "any fixed `alpha = 1`" or "any `alpha = 0`".

## 4. Those guards gated on an active `MUL` (`deb4e7d`, `42fd607`)

Self-audit caught the guards firing on jobs with no late phase; a Codex review then showed the fix I reached for used the wrong predicate, and the C settles it.

A phase is active in `PROC HAZARD` **iff its MU was specified and positive**:

| | |
|---|---|
| `parmprc.c:16-23` | three MUs go through `setparmno`, seven shapes through `setprmf` |
| `setparmno.c:14` | sets `C->phase[phaseno] = 1` only when `stmtfld() > ZERO` |
| `setprmf.c` | never touches `C->phase[]` |
| `stmtprc.c:113-122` | zeroes `TAU`/`GAMMA`/`ALPHA`/`ETA` when phase 3 is off |
| `shape.c:31` | calls `SETG3()` only under `Common.phase[3]==1` |

So `TAU`/`GAMMA`/`ETA` with no `MUL` is not a late phase, and both guards were describing code that is never reached — `SETG3_ignore_tau()` cannot run and `SETG3_weibull()` cannot raise `SETG3980` when `SETG3()` is not called. Gating on shape operands (`deb4e7d`) fixed the symptom; gating on an active `MUL` (`42fd607`) fixes the rule. Three regression tests, including a positive control so the gate cannot be satisfied by never firing.

A false positive on `$untranslated` is the same class of defect as a silent drop — that frame is how a caller decides whether a translation can be trusted.

## Verification

Two independent parity runs against real listings, row coverage asserted before any value compared.

**`hz.svdcd.cvt`**, through the translator, 13850 rows / 813 events / 13037 right-censored:

| | SAS | R | rel. diff |
|---|---|---|---|
| log likelihood | −3987.13 | −3987.1301 | 2.2e-08 |
| `ln(MUL)` | −11.0294 | −11.029337 | 5.7e-06 |
| `ETA` | 3.406023 | 3.406011 | 3.5e-06 |
| `var(L0)` | 0.0489445 | 0.04889484 | 1.0e-03 |

**`hz.te123.OMC`** (`ALPHA=1 FIXALPHA GAMMA=1 FIXGAMMA ETA=1.32` — an identity by §3, and its listing does report `GAMMA 1`, `TAU 1`), 382 obs / 44 events:

| | SAS | R | rel. diff |
|---|---|---|---|
| log likelihood | −322.226 | −322.22613 | 4.0e-07 |
| `THALF` | 0.05727665 | 0.057274883 | 3.1e-05 |
| `NU` | −1.73544 | −1.7355441 | 6.0e-05 |
| `ETA` | 1.319369 | 1.3193771 | 6.1e-06 |
| `MUE` | 0.01739989 | 0.017399697 | 1.1e-05 |
| `MUL` | 0.000210256 | 0.00021024824 | 3.7e-05 |

Point estimates agree to the limit of the listings' printed precision. The `hz.svdcd.cvt` variance gap is the analytic-vs-numeric Hessian difference — that listing says *"Quasi-Newton method using numeric derivatives"*.

## Gate

```
devtools::document()                clean, no man/ or NAMESPACE drift
lintr::lint_package()               0 lints
devtools::test()                    0 FAIL | 6 SKIP | 3730 PASS
R CMD check --as-cran (with manual) Status: OK
```

Check run from a clean `git archive` export of the committed tree. Version 1.2.9 → 1.2.10 (patch), `DESCRIPTION` and `NEWS.md` together.

## Filed separately

- Stale tolerances on the OMC parity tests: they allow a 0.2 log-likelihood gap and skip `MUE` entirely, citing a CoE discrepancy that the run above does not reproduce (measured offset 1.3e-04; `MUE` matches to 1.1e-05).
- Reimplementing the SAS `%repeat` macro in R, which is what still blocks the cardioversion job — a data problem now, not a translation one.
- Phase **building** still keys on shape operands rather than the MU, so `PARMS` carrying `TAU`/`GAMMA` with no `MUL` emits a late phase `PROC HAZARD` would not build (mu defaulted to 0.1, zero untranslated rows). Same root confusion as §4, wider blast radius, and **0 of 38** live corpus `PARMS` blocks reach it. A comment marks the asymmetry where the two rules sit side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
