### PR TITLE
test(sas-parity): tighten CoE tolerances that could not fail

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,6 +120,26 @@
   nothing. The formula interface translates and is guarded. That asymmetry is a
   pre-existing defect of the vector path, tracked in #226.
 
+## Testing
+
+* **The SAS parity tests for `hz.te123.OMC` fit 1 and `hz.tm123.OMC` still
+  described the P1 #6 Conservation-of-Events gap that PR #65 closed, and their
+  tolerances were set from that gap rather than from the code's behaviour.**
+  Fit 1 asserted the log-likelihood within `0.2` where R and SAS now agree to
+  1.3e-04, `hz.tm123.OMC` within `0.5` against 4.6e-04, and neither asserted `MUE`
+  at all, each carrying a comment quoting a value the fix had already moved. Restoring
+  the pre-PR-#65 defect -- dropping the entry-time term from
+  `.hzr_conserve_events()` -- left every one of those assertions passing, so
+  they could not have caught the regression they were nominally about. The
+  log-likelihood tolerances are now `1e-5` (relative), both
+  Conservation-of-Events intercepts `MUE` and `MUL` are asserted, and each fit
+  first checks `conserve_applied`, since CoE disables itself silently on
+  unsupported data and the shape assertions pass either way. The same mutation
+  now fails four assertions. `hz.te123.OMC` fit 2's log-likelihood tolerance
+  goes from `1e-2` to `1e-5` for the same reason; it carried no stale claim, but
+  `1e-2` admitted a drift of 3.1 in log-likelihood on a quantity matching to
+  1.5e-04. No package code changed.
+
 # TemporalHazard 1.2.8
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -134,8 +134,18 @@
   log-likelihood tolerances are now `1e-5` (relative), both
   Conservation-of-Events intercepts `MUE` and `MUL` are asserted, and each fit
   first checks `conserve_applied`, since CoE disables itself silently on
-  unsupported data and the shape assertions pass either way. The same mutation
-  now fails four assertions. `hz.te123.OMC` fit 2's log-likelihood tolerance
+  unsupported data. The same mutation now fails six assertions.
+
+  `MUL` is compared as a ratio to the SAS value rather than directly, and that
+  distinction is the point rather than a detail. `expect_equal()` divides by
+  `mean(abs(expected))` only when that exceeds `tolerance`; `MUL` is 2.1e-04,
+  below any tolerance worth setting for it, so a direct comparison silently
+  becomes an *absolute* one -- `MUL = 0` passes at `5e-04`, and so does the
+  regression above. A first version of this change asserted `MUL` directly and
+  reproduced, in the fix, the defect it was removing. Against an expected value
+  of `1` the comparison is relative, as the tolerance implies. `hz.te123.OMC`
+  fit 2's pre-existing `MUL` assertion sat 7% above that branch point and moves
+  to the same form. `hz.te123.OMC` fit 2's log-likelihood tolerance
   goes from `1e-2` to `1e-5` for the same reason; it carried no stale claim, but
   `1e-2` admitted a drift of 3.1 in log-likelihood on a quantity matching to
   1.5e-04. No package code changed.

--- a/inst/dev/FIXTURE-GAP-LIST.md
+++ b/inst/dev/FIXTURE-GAP-LIST.md
@@ -118,7 +118,7 @@ fixture to drive the fix:
 |---|---|
 | 2-phase E+C (standard): CoE via closed-form μ_C | Covered — `hz.death.AVC` |
 | 3-phase E+C+L (standard): CoE distributes across 3 phases | Covered — `hz.deadp.KUL` |
-| 2-phase E+L (no constant): CoE under left-truncation — ~~**P1 #6 gap**~~ **FIXED (PR #65)** | `hz.te123.OMC` fit 1 / `hz.tm123.OMC` documented the discrepancy; root cause was the omitted `CF(ST)` term, fixed in R. SAS parity assertion still gated on `HAZARD_OMC_RAW`. |
+| 2-phase E+L (no constant): CoE under left-truncation — ~~**P1 #6 gap**~~ **FIXED (PR #65)** | `hz.te123.OMC` fit 1 / `hz.tm123.OMC` documented the discrepancy; root cause was the omitted `CF(ST)` term, fixed in R. Both tests now assert the fix (LL 1e-5, MUE, MUL, plus a `conserve_applied` guard), still gated on `HAZARD_OMC_RAW`. |
 | NOCONSERVE explicit: no CoE applied | Covered — `hz.deadp.KUL` (NOCONSERVE) |
 | CONSERVE with all phases free-shape | Need a job where CoE interacts with free-shape estimation | No fixture |
 
@@ -222,7 +222,7 @@ feature value and estimated complexity, not release blocking.
 | P1 — high value, low effort | Materialize stepwise parity fixture (`cabgkul-forward-wald.rds`) and confirm `test-stepwise-parity.R` passes | 1 day |
 | P1 — high value, low effort | Kaplan + Nelson parity tests (`ac.death.AVC`) | 0.5 days |
 | P1 — high value, low effort | Predict parity tests (`hp.*` fixtures) | 1 day |
-| ~~P2~~ DONE | ~~Fix P1 #6 CoE Lagrange~~ — fixed in PR #65 (left-truncation `CF(ST)` term, not Lagrange). Remaining: tighten `hz.te123.OMC` fit-1 tolerances once `HAZARD_OMC_RAW` is available | ~0.5 day (tolerances) |
+| ~~P2~~ DONE | ~~Fix P1 #6 CoE Lagrange~~ — fixed in PR #65 (left-truncation `CF(ST)` term, not Lagrange). Tolerances tightened 2026-09-08 on the `HAZARD_OMC_RAW` checkout: LL 0.2/0.5 → 1e-5, MUE and MUL now asserted. | done |
 | P2 — high value, more work | Interval censoring SAS sample job (confirm SAS HAZARD syntax first) | 1–2 days |
 | P2 — high value, more work | TGA dataset sample jobs (null model + multivariable) | 1 day |
 | P2 — high value, more work | 3-phase free-shape SAS job + R parity | 1 day |

--- a/inst/dev/PRE-CRAN-PARITY-INVENTORY.md
+++ b/inst/dev/PRE-CRAN-PARITY-INVENTORY.md
@@ -97,13 +97,15 @@ verified against SAS.
 - `hz.death.AVC` (2-phase free-shape Early): LL=−210.501,
   THALF/NU/MUE/MUC natural-scale, SE(E2) [SE(E0) skipped per P2 #11]
   (9 expectations).
-- `hz.te123.OMC` fit 1 (left-truncated 2-phase): LL within 0.2 (P1 #6 gap),
-  THALF/NU/ETA natural-scale (5e-3) — MUE skipped per P1 #6 (5 expectations).
-- `hz.te123.OMC` fit 2 (modulated renewal + late covariates): LL within 1e-2,
+- `hz.te123.OMC` fit 1 (left-truncated 2-phase): CoE-applied guard, LL within
+  1e-5, THALF/NU/ETA natural-scale (5e-3), MUE (1e-4) and MUL (5e-4)
+  (8 expectations).  P1 #6 closed; tolerances re-measured 2026-09-08.
+- `hz.te123.OMC` fit 2 (modulated renewal + late covariates): LL within 1e-5,
   THALF/NU/MUE/MUL natural-scale (1e-3), NOPREVTE/NOTEE coefficients,
   SE(E2/NOPREVTE/NOTEE) (14 expectations).
-- `hz.tm123.OMC` fit 1 (morbidity-weighted 2-phase): LL within 0.5 (P1 #6),
-  THALF/ETA natural-scale (5e-3) — MUE skipped per P1 #6 (4 expectations).
+- `hz.tm123.OMC` fit 1 (morbidity-weighted 2-phase): CoE-applied guard, LL
+  within 1e-5, THALF/ETA natural-scale (5e-3), MUE and MUL (1e-3)
+  (7 expectations).  P1 #6 closed; tolerances re-measured 2026-09-08.
 - `hm.deadp.VALVES` null model (Case 2L: m<0, nu=0): LL=−1864.76 exact,
   finite MUE/MUC (3 expectations).  Confirms P1 #5 closed (misdiagnosis).
 
@@ -182,17 +184,18 @@ via ordered RP3→RP2→RP1 overwrites; multi-row expansion per patient
 (died same day as TE) dropped to match SAS LCENSOR auto-exclusion.
 Final n_obs=382, n_events=44 verified.
 
-**P1 #6 — CoE for 2-phase early+late models (no constant phase).** When
-`conserve = TRUE` with phases = {early, late} (no constant phase), R
-fixes `late.log_mu` via a closed-form constraint, leaving 4 free params.
-SAS CONSERVE keeps all 5 mus free under a Lagrange constraint, reporting
-both MUE and MUL as free in the natural-scale table.  Consequence: R
-finds a slightly worse LL (−322.37 vs SAS −322.23 for hz.te123.OMC fit 1;
-−581.96 vs SAS −581.53 for hz.tm123.OMC) and the late-constrained MUE
-shifts ~10%.  Shape params (THALF, NU, ETA) still match within 5e-3.
-Tests assert shape params within tolerance and note MUE as skipped.
-Affects: `hz.te123.OMC` fit 1, `hz.tm123.OMC`.  Fix: implement Lagrange-
-style CoE for any 2-phase model in `R/likelihood-multiphase.R`.
+**P1 #6 — CLOSED 2026-06-05 (PR #65); diagnosis above was wrong.** The
+gap was never Lagrange-vs-closed-form: the C binary's `consrv` also
+fixes one mu, so R already matched it.  The cause was left truncation.
+Under `LCENSOR STARTTME` the CoE constraint summed `CF(T)` from zero and
+omitted the entry-time term, so the conserved phase absorbed a spurious
+`Sum CF(ST)` — biasing its intercept (MUE 0.01601 vs SAS 0.01740) and
+offsetting the LL by ~0.14 while leaving the shapes correct.  Fixed by
+threading `time_lower` into `.hzr_conserve_events()` and
+`.hzr_select_fixmu_phase()`.  Since then `hz.te123.OMC` fit 1 agrees with
+SAS to 1.3e-04 in LL and 1.1e-05 relative in MUE, and `hz.tm123.OMC` to
+4.6e-04 and 9.5e-05.  Tolerances tightened accordingly 2026-09-08; the
+old ones (LL within 0.2 / 0.5, MUE not asserted) could not fail.
 
 **P1 #5 — CLOSED 2026-05-12 (misdiagnosis).** The alleged ~17-unit LL
 gap at `nu = 0`, `m < 0` was a spurious comparison: the "SAS LL" used

--- a/inst/dev/PRE-CRAN-PARITY-INVENTORY.md
+++ b/inst/dev/PRE-CRAN-PARITY-INVENTORY.md
@@ -98,14 +98,17 @@ verified against SAS.
   THALF/NU/MUE/MUC natural-scale, SE(E2) [SE(E0) skipped per P2 #11]
   (9 expectations).
 - `hz.te123.OMC` fit 1 (left-truncated 2-phase): CoE-applied guard, LL within
-  1e-5, THALF/NU/ETA natural-scale (5e-3), MUE (1e-4) and MUL (5e-4)
-  (8 expectations).  P1 #6 closed; tolerances re-measured 2026-09-08.
+  1e-5, THALF/NU/ETA natural-scale (5e-3), MUE (1e-4) and MUL as a ratio to
+  SAS (5e-4) (8 expectations).  P1 #6 closed; tolerances re-measured
+  2026-09-08.  MUL is asserted as a ratio because at 2.1e-04 a direct
+  `expect_equal()` falls into waldo's absolute branch and cannot fail.
 - `hz.te123.OMC` fit 2 (modulated renewal + late covariates): LL within 1e-5,
   THALF/NU/MUE/MUL natural-scale (1e-3), NOPREVTE/NOTEE coefficients,
   SE(E2/NOPREVTE/NOTEE) (14 expectations).
 - `hz.tm123.OMC` fit 1 (morbidity-weighted 2-phase): CoE-applied guard, LL
-  within 1e-5, THALF/ETA natural-scale (5e-3), MUE and MUL (1e-3)
-  (7 expectations).  P1 #6 closed; tolerances re-measured 2026-09-08.
+  within 1e-5, THALF/ETA natural-scale (5e-3), MUE (1e-3) and MUL as a ratio
+  to SAS (1e-3) (7 expectations).  P1 #6 closed; tolerances re-measured
+  2026-09-08.
 - `hm.deadp.VALVES` null model (Case 2L: m<0, nu=0): LL=−1864.76 exact,
   finite MUE/MUC (3 expectations).  Confirms P1 #5 closed (misdiagnosis).
 

--- a/inst/dev/PRE-CRAN-PARITY-INVENTORY.md
+++ b/inst/dev/PRE-CRAN-PARITY-INVENTORY.md
@@ -2,7 +2,7 @@
 
 **Source:** `~/Documents/GitHub/hazard/examples/` (18 paired `.sas`/`.lst` fixtures)
 **Capture vintage:** v4.4.6 macOS (refreshed 2026-05-12)
-**Status:** Complete. Captures finalized 2026-05-12; all 54 parity expectations passing.
+**Status:** Complete. Captures finalized 2026-05-12; all 63 parity expectations passing.
 
 ## Scope summary
 
@@ -91,15 +91,20 @@ step reproduced in `.hzr_derive_primisol()`; raw file discovered at
 `~/Documents/GitHub/hazard/examples/data/omc`; n_obs=382 / n_events=44
 verified against SAS.
 
-**Parity tests** at `tests/testthat/test-sas-parity.R` — **54/54 PASS**:
+**Parity tests** at `tests/testthat/test-sas-parity.R` — **63/63 PASS**.
+Counts below are `testthat`'s own per-test expectation counts, so they can be
+re-derived rather than tallied by eye:
+`as.data.frame(testthat::test_local(filter = "sas-parity"))[, c("test", "passed")]`
+(measured 2026-09-08).  The previous total of 54 had drifted by 2 before this
+PR, and two of the per-test counts with it.
 - `hz.deadp.KUL` (3-phase all-fixed, 3 free): LL=−3740.52, MUE/MUC/MUL
   natural-scale, SE(E0/C0/L0), 3 off-diagonal vcov entries (14 expectations).
 - `hz.death.AVC` (2-phase free-shape Early): LL=−210.501,
   THALF/NU/MUE/MUC natural-scale, SE(E2) [SE(E0) skipped per P2 #11]
-  (9 expectations).
+  (11 expectations).
 - `hz.te123.OMC` fit 1 (left-truncated 2-phase): CoE-applied guard, LL within
   1e-5, THALF/NU/ETA natural-scale (5e-3), MUE (1e-4) and MUL as a ratio to
-  SAS (5e-4) (8 expectations).  P1 #6 closed; tolerances re-measured
+  SAS (5e-4) (12 expectations).  P1 #6 closed; tolerances re-measured
   2026-09-08.  MUL is asserted as a ratio because at 2.1e-04 a direct
   `expect_equal()` falls into waldo's absolute branch and cannot fail.
 - `hz.te123.OMC` fit 2 (modulated renewal + late covariates): LL within 1e-5,
@@ -107,7 +112,7 @@ verified against SAS.
   SE(E2/NOPREVTE/NOTEE) (14 expectations).
 - `hz.tm123.OMC` fit 1 (morbidity-weighted 2-phase): CoE-applied guard, LL
   within 1e-5, THALF/ETA natural-scale (5e-3), MUE (1e-3) and MUL as a ratio
-  to SAS (1e-3) (7 expectations).  P1 #6 closed; tolerances re-measured
+  to SAS (1e-3) (9 expectations).  P1 #6 closed; tolerances re-measured
   2026-09-08.
 - `hm.deadp.VALVES` null model (Case 2L: m<0, nu=0): LL=−1864.76 exact,
   finite MUE/MUC (3 expectations).  Confirms P1 #5 closed (misdiagnosis).

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -958,12 +958,16 @@ test_that("hs.death.AVC.hm1: per-stratum mean survival curve matches SAS", {
 # Data derivation: PRIMISOL DATA step reproduced in .hzr_derive_primisol();
 # raw fixed-width file from ~/Documents/GitHub/hazard/examples/data/omc.
 #
-# Known gaps:
-#   P1 #6 (fit 1): CoE for early+late 2-phase differs from SAS CONSERVE.
-#   SAS keeps all 5 mus free under Lagrange constraint; R fixes late.log_mu
-#   via closed-form CoE, yielding LL offset ~0.14 and MUE shifted.
-#   Shape params (THALF, NU, ETA) still match well; asserted below.
-#   MUE NOT asserted (affected by P1 #6 gap).
+# The "P1 #6" CoE gap that these fits once documented is CLOSED (PR #65).
+# Conservation of Events summed each phase's cumulative hazard from zero and
+# ignored the counting-process entry time, so under LCENSOR STARTTME the
+# conserved phase absorbed a spurious sum CF(ST): the LL sat ~0.14 low and MUE
+# was biased (0.01601 against SAS 0.01740) while the shapes stayed correct.
+# Both fits now agree with SAS to within the .lst's own printed precision, and
+# the tolerances below are set from measured agreement rather than from a
+# documented offset.  Measured 2026-09-08 at 8133b2a; the numbers were stable
+# across seeds 1/2/3/7/42/104/999/2026 and n_starts 1/3/5, so they are the
+# single dominant optimum and not a multi-start artifact.
 test_that("hz.te123.OMC fit 1: left-truncated 2-phase shape params match SAS", {
   testthat::skip_on_cran()
   dir  <- skip_if_no_sas_fixtures()
@@ -995,9 +999,17 @@ test_that("hz.te123.OMC fit 1: left-truncated 2-phase shape params match SAS", {
     control = list(n_starts = 3, maxit = 500, conserve = TRUE)
   )
 
-  # LL: P1 #6 gap produces ~0.14 offset; assert within 0.2.
-  expect_equal(fit$fit$objective, ref$loglik, tolerance = 0.2,
-               label = "R LL vs SAS (P1 #6 gap: CoE implementation differs)")
+  # CoE auto-disables silently on unsupported data.  Without this guard every
+  # assertion below still passes with conservation switched off, and the test
+  # stops exercising the conserved parameterisation it exists to check.
+  expect_true(fit$spec$control$conserve_applied,
+              label = "Conservation of Events actually applied")
+
+  # LL agrees to 1.3e-04 absolute (4.0e-07 relative), inside the three-decimal
+  # printed precision of the .lst.  1e-05 relative leaves ~25x margin for
+  # optimizer noise and still fails on any regression above 3e-03 in LL.
+  expect_equal(fit$fit$objective, ref$loglik, tolerance = 1e-5,
+               label = "R LL vs SAS")
 
   # Shape params from "Estimates for Model Parameters" natural-scale table.
   nat       <- ref$natural
@@ -1013,8 +1025,16 @@ test_that("hz.te123.OMC fit 1: left-truncated 2-phase shape params match SAS", {
   expect_equal(unname(th["late.eta"]),              eta_ref,   tolerance = 5e-3,
                label = "ETA (Late) natural-scale")
 
-  # NOTE: MUE NOT asserted — affected by P1 #6 CoE gap.
-  # R: MUE ~ 0.01601; SAS: MUE = 0.01740.
+  # MUE and MUL are the Conservation-of-Events intercepts — the parameters the
+  # PR #65 entry-time fix moved, so they are the direct regression guard for it.
+  # Measured relative differences: MUE 1.1e-05, MUL 3.7e-05 (worst across
+  # n_starts 1/3/5: 1.7e-05 and 6.9e-05).
+  mue_ref <- nat$estimate[nat$name == "MUE"]
+  mul_ref <- nat$estimate[nat$name == "MUL"]
+  expect_equal(unname(exp(th["early.log_mu"])), mue_ref, tolerance = 1e-4,
+               label = "MUE (Early) natural-scale")
+  expect_equal(unname(exp(th["late.log_mu"])),  mul_ref, tolerance = 5e-4,
+               label = "MUL (Late) natural-scale")
 })
 
 test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS LL/MLEs", {
@@ -1047,7 +1067,12 @@ test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS L
     control = list(n_starts = 3, maxit = 500, conserve = TRUE)
   )
 
-  expect_equal(fit$fit$objective, ref$loglik, tolerance = 1e-2,
+  expect_true(fit$spec$control$conserve_applied,
+              label = "Conservation of Events actually applied")
+
+  # LL agrees to 1.5e-04 absolute (4.9e-07 relative); 1e-05 relative leaves
+  # ~20x margin.  The former 1e-02 admitted a 3.1 drift in log-likelihood.
+  expect_equal(fit$fit$objective, ref$loglik, tolerance = 1e-5,
                label = "R LL vs SAS (fit 2)")
 
   nat       <- ref$natural
@@ -1097,9 +1122,11 @@ test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS L
 # censored intervals contribute to the survival function with weight = 1.
 # R: pass weights = ifelse(te==1, morbid, 1) to reproduce this semantics.
 #
-# Known gaps:
-#   Same P1 #6 gap as fit 1 above (CoE for early+late, MUE shifted ~10%).
-#   LL offset ~0.43.  THALF and ETA assert within 5e-3.
+# The P1 #6 CoE gap described above for hz.te123.OMC fit 1 applied here too and
+# is likewise closed (PR #65); LL and both CoE intercepts assert against SAS.
+# Measured 2026-09-08 at 8133b2a, stable across seeds 1/2/42/106/999 and
+# n_starts 1/3/5.  Tolerances are looser than fit 1's because the WEIGHT MORBID
+# fit reproduces SAS about an order of magnitude less closely.
 test_that("hz.tm123.OMC: morbidity-weighted 2-phase shape params match SAS", {
   testthat::skip_on_cran()
   dir  <- skip_if_no_sas_fixtures()
@@ -1133,9 +1160,13 @@ test_that("hz.tm123.OMC: morbidity-weighted 2-phase shape params match SAS", {
     control = list(n_starts = 3, maxit = 500, conserve = TRUE)
   )
 
-  # LL: P1 #6 gap produces ~0.43 offset; assert within 0.5.
-  expect_equal(fit$fit$objective, ref$loglik, tolerance = 0.5,
-               label = "R LL vs SAS (P1 #6 gap: CoE implementation differs)")
+  expect_true(fit$spec$control$conserve_applied,
+              label = "Conservation of Events actually applied")
+
+  # LL agrees to 4.6e-04 absolute (7.8e-07 relative), inside the .lst's
+  # three-decimal printed precision; 1e-05 relative leaves ~13x margin.
+  expect_equal(fit$fit$objective, ref$loglik, tolerance = 1e-5,
+               label = "R LL vs SAS")
 
   nat       <- ref$natural
   thalf_ref <- nat$estimate[nat$name == "THALF" & nat$phase == "Early"]
@@ -1147,6 +1178,14 @@ test_that("hz.tm123.OMC: morbidity-weighted 2-phase shape params match SAS", {
   expect_equal(unname(th["late.eta"]),              eta_ref,   tolerance = 5e-3,
                label = "ETA (Late) natural-scale")
 
-  # NOTE: MUE NOT asserted — P1 #6 CoE gap shifts MUE ~10% (R 0.01643 vs SAS 0.01828).
+  # CoE intercepts: measured relative differences MUE 9.5e-05, MUL 6.8e-05
+  # (worst across n_starts 1/3/5: 1.3e-04 and 1.5e-04); 1e-03 leaves ~7x.
+  mue_ref <- nat$estimate[nat$name == "MUE"]
+  mul_ref <- nat$estimate[nat$name == "MUL"]
+  expect_equal(unname(exp(th["early.log_mu"])), mue_ref, tolerance = 1e-3,
+               label = "MUE (Early) natural-scale")
+  expect_equal(unname(exp(th["late.log_mu"])),  mul_ref, tolerance = 1e-3,
+               label = "MUL (Late) natural-scale")
+
   # NOTE: NU=1 FIXNU (fixed); M=1e-6 FIXM (fixed) — not compared.
 })

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -965,9 +965,10 @@ test_that("hs.death.AVC.hm1: per-stratum mean survival curve matches SAS", {
 # was biased (0.01601 against SAS 0.01740) while the shapes stayed correct.
 # Both fits now agree with SAS to within the .lst's own printed precision, and
 # the tolerances below are set from measured agreement rather than from a
-# documented offset.  Measured 2026-09-08 at 8133b2a; the numbers were stable
-# across seeds 1/2/3/7/42/104/999/2026 and n_starts 1/3/5, so they are the
-# single dominant optimum and not a multi-start artifact.
+# documented offset.  Measured 2026-09-08 at 8133b2a: fit 1 was stable across
+# seeds 1/2/3/7/42/104/999/2026 and fit 2 across 1/42/105, both over n_starts
+# 1/3/5, so these are the single dominant optimum and not a multi-start
+# artifact.
 test_that("hz.te123.OMC fit 1: left-truncated 2-phase shape params match SAS", {
   testthat::skip_on_cran()
   dir  <- skip_if_no_sas_fixtures()

--- a/tests/testthat/test-sas-parity.R
+++ b/tests/testthat/test-sas-parity.R
@@ -1000,9 +1000,11 @@ test_that("hz.te123.OMC fit 1: left-truncated 2-phase shape params match SAS", {
     control = list(n_starts = 3, maxit = 500, conserve = TRUE)
   )
 
-  # CoE auto-disables silently on unsupported data.  Without this guard every
-  # assertion below still passes with conservation switched off, and the test
-  # stops exercising the conserved parameterisation it exists to check.
+  # CoE auto-disables silently on unsupported data.  With the tolerances below
+  # that shows up as four numeric mismatches (refitting `conserve = FALSE`
+  # moves THALF 18%, NU 12%, MUE 12%), which says nothing about the cause; this
+  # guard fails first and names it.  It is also the only assertion here that
+  # still catches a silent disable if the tolerances are ever loosened again.
   expect_true(fit$spec$control$conserve_applied,
               label = "Conservation of Events actually applied")
 
@@ -1030,12 +1032,19 @@ test_that("hz.te123.OMC fit 1: left-truncated 2-phase shape params match SAS", {
   # PR #65 entry-time fix moved, so they are the direct regression guard for it.
   # Measured relative differences: MUE 1.1e-05, MUL 3.7e-05 (worst across
   # n_starts 1/3/5: 1.7e-05 and 6.9e-05).
+  #
+  # MUL is compared as a ratio deliberately.  `expect_equal()` scales by
+  # `mean(abs(expected))` only when that exceeds `tolerance`, and MUL is
+  # 2.1e-04 — below any tolerance worth setting here — so comparing it
+  # directly silently becomes an ABSOLUTE check: `MUL = 0` passes at 5e-04,
+  # and so does the PR #65 regression this is meant to catch.  Against an
+  # expected value of 1 the comparison is relative, as the tolerance implies.
   mue_ref <- nat$estimate[nat$name == "MUE"]
   mul_ref <- nat$estimate[nat$name == "MUL"]
   expect_equal(unname(exp(th["early.log_mu"])), mue_ref, tolerance = 1e-4,
                label = "MUE (Early) natural-scale")
-  expect_equal(unname(exp(th["late.log_mu"])),  mul_ref, tolerance = 5e-4,
-               label = "MUL (Late) natural-scale")
+  expect_equal(unname(exp(th["late.log_mu"])) / mul_ref, 1, tolerance = 5e-4,
+               label = "MUL (Late) natural-scale, as a ratio to SAS")
 })
 
 test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS LL/MLEs", {
@@ -1068,6 +1077,7 @@ test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS L
     control = list(n_starts = 3, maxit = 500, conserve = TRUE)
   )
 
+  # See fit 1 for why this guard is here.
   expect_true(fit$spec$control$conserve_applied,
               label = "Conservation of Events actually applied")
 
@@ -1089,8 +1099,10 @@ test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS L
                label = "NU (Early) natural-scale")
   expect_equal(unname(exp(th["early.log_mu"])),     mue_ref,   tolerance = 1e-3,
                label = "MUE (Early) natural-scale")
-  expect_equal(unname(exp(th["late.log_mu"])),      mul_ref,   tolerance = 1e-3,
-               label = "MUL (Late) natural-scale")
+  # Ratio for the same reason as fit 1: MUL is 1.07e-03 against a 1e-03
+  # tolerance, only 7% above the point where this check would turn absolute.
+  expect_equal(unname(exp(th["late.log_mu"])) / mul_ref, 1, tolerance = 1e-3,
+               label = "MUL (Late) natural-scale, as a ratio to SAS")
 
   # Late-phase covariate coefficients — compare to SAS Parameter Estimate Summary.
   params_ref <- ref$params
@@ -1126,8 +1138,9 @@ test_that("hz.te123.OMC fit 2: modulated renewal + late covariates matches SAS L
 # The P1 #6 CoE gap described above for hz.te123.OMC fit 1 applied here too and
 # is likewise closed (PR #65); LL and both CoE intercepts assert against SAS.
 # Measured 2026-09-08 at 8133b2a, stable across seeds 1/2/42/106/999 and
-# n_starts 1/3/5.  Tolerances are looser than fit 1's because the WEIGHT MORBID
-# fit reproduces SAS about an order of magnitude less closely.
+# n_starts 1/3/5.  The LL tolerance matches fit 1's; the MUE one is looser
+# because the WEIGHT MORBID fit reproduces that intercept about an order of
+# magnitude less closely (9.5e-05 against 1.1e-05).
 test_that("hz.tm123.OMC: morbidity-weighted 2-phase shape params match SAS", {
   testthat::skip_on_cran()
   dir  <- skip_if_no_sas_fixtures()
@@ -1161,6 +1174,7 @@ test_that("hz.tm123.OMC: morbidity-weighted 2-phase shape params match SAS", {
     control = list(n_starts = 3, maxit = 500, conserve = TRUE)
   )
 
+  # See hz.te123.OMC fit 1 for why this guard is here.
   expect_true(fit$spec$control$conserve_applied,
               label = "Conservation of Events actually applied")
 
@@ -1181,12 +1195,13 @@ test_that("hz.tm123.OMC: morbidity-weighted 2-phase shape params match SAS", {
 
   # CoE intercepts: measured relative differences MUE 9.5e-05, MUL 6.8e-05
   # (worst across n_starts 1/3/5: 1.3e-04 and 1.5e-04); 1e-03 leaves ~7x.
+  # MUL as a ratio — see hz.te123.OMC fit 1; here MUL is 2.1e-04.
   mue_ref <- nat$estimate[nat$name == "MUE"]
   mul_ref <- nat$estimate[nat$name == "MUL"]
   expect_equal(unname(exp(th["early.log_mu"])), mue_ref, tolerance = 1e-3,
                label = "MUE (Early) natural-scale")
-  expect_equal(unname(exp(th["late.log_mu"])),  mul_ref, tolerance = 1e-3,
-               label = "MUL (Late) natural-scale")
+  expect_equal(unname(exp(th["late.log_mu"])) / mul_ref, 1, tolerance = 1e-3,
+               label = "MUL (Late) natural-scale, as a ratio to SAS")
 
   # NOTE: NU=1 FIXNU (fixed); M=1e-6 FIXM (fixed) — not compared.
 })


### PR DESCRIPTION
`tests/testthat/test-sas-parity.R` still described the P1 #6 Conservation-of-Events gap in three tests, and set their tolerances from it. PR #65 closed that gap on 2026-06-05, and `inst/dev/FIXTURE-GAP-LIST.md` had already recorded the follow-up: *"Remaining: tighten `hz.te123.OMC` fit-1 tolerances once `HAZARD_OMC_RAW` is available."*

The original diagnosis in those comments is wrong twice over. It was never "SAS keeps all 5 mus free under a Lagrange constraint" — C's `consrv` also fixes one `mu`, so R already matched it. The cause was left truncation: CoE summed each phase's cumulative hazard from zero and dropped the counting-process entry time, so under `LCENSOR STARTTME` the conserved phase absorbed a spurious `Σ CF(ST)`.

## Measured

At `8133b2a` on the `HAZARD_OMC_RAW` checkout. Stable to 10 significant figures across seeds 1/2/3/7/42/104/106/999/2026 and `n_starts` ∈ {1,3,5} — a single dominant optimum, not a multi-start artifact.

| Assertion | Comment claimed | Measured | Old tolerance |
|---|---|---|---|
| `te123` fit 1 LL | offset ~0.14 | **1.3e-04** | `0.2` (relative → ±64) |
| `te123` fit 1 MUE | R 0.01601 vs SAS 0.01740 | rel **1.1e-05** | *not asserted* |
| `tm123` LL | offset ~0.43 | **4.6e-04** | `0.5` |
| `tm123` MUE | "shifted ~10%", R 0.01643 | rel **9.5e-05** | *not asserted* |
| `te123` fit 2 LL | (no claim) | **1.5e-04** | `1e-2` (→ ±3.1) |

## The evidence, not the argument

Reinstating the pre-PR-#65 defect — disabling the entry-time subtraction in `.hzr_conserve_events()` — leaves the **old** assertions entirely green (0 failures). Under the new ones it fails **6**. That is what makes "these tolerances could not fail" a measurement rather than a judgement.

## Changes

- LL tolerances → `1e-5` relative (13–25× margin, and inside the `.lst`'s own three-decimal printed precision).
- `MUE` and `MUL` asserted, where both were previously skipped with a stale comment.
- A `conserve_applied` guard on each fit. CoE disables itself silently on unsupported data; the guard fails first and names the cause, and it is the only assertion that still catches a silent disable if these tolerances are ever loosened again.
- Stale P1 #6 prose removed from the two dev inventories, which recorded the fix but kept the superseded diagnosis alongside it.

**No package code changed.** `hz.te123.OMC` fit 2's LL tolerance also moves (`1e-2` → `1e-5`); it carried no stale claim, but `1e-2` admitted a 3.1 drift in log-likelihood on a quantity matching to 1.5e-04.

## One round of self-inflicted irony

The first commit asserted `MUL` directly and so reproduced, in the fix, the defect it was removing. `expect_equal()` divides by `mean(abs(expected))` only when that exceeds `tolerance`; SAS `MUL` is 2.1e-04, below the tolerances set against it, so those comparisons were **absolute** — `MUL = 0` passed, and so did the regression they were added to catch. Caught by `r-reviewer`, verified, and fixed in 9c3c844 by comparing the ratio to 1. Fit 2's pre-existing `MUL` assertion sat 7% above the same branch point and moves to the same form. Two comments that had become false were corrected in the same commit.

## Gates

`document()` clean · `lintr::lint_package()` **0** · `devtools::test()` **3710 pass / 0 fail / 6 skip** (3703 baseline + exactly the 7 new expectations; skips are fixture-availability only) · `spell_check_package()` clean · `R CMD check --as-cran` **with manual** from a clean `git archive` export → **Status: OK**, 228s, inside the 199–245s spread stamped at `fe57e60`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)