### PR TITLE
fix(sas): a PARMS phase is active iff its MU is specified and positive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,32 @@
 
 ## Bug fixes
 
+* **`hzr_translate_sas()` no longer builds a phase that `PROC HAZARD` would
+  not.** A `PARMS` statement names its phases with `MUE`, `MUC` and `MUL`; the
+  shape operands (`THALF`/`NU`/`M` early, `TAU`/`GAMMA`/`ALPHA`/`ETA` late)
+  only shape a phase that already exists. The translator had this the other way
+  round and keyed on the shape operands, so
+  `PARMS MUE=0.2 THALF=1 NU=1 TAU=2 GAMMA=1.5` emitted a two-phase model
+  against `PROC HAZARD`'s one -- carrying an invented `mu` starting value of
+  0.1 for the phase that should not have been there, and offering nothing in
+  `$untranslated` to say so. In the reference C only `setparmno()` sets
+  `C->phase[n]`, and only when that `MU` is greater than zero
+  (`src/hazard/setparmno.c`); the seven shape operands are registered by
+  `setprmf()`, which never touches it. A phase is now built only when its own
+  `MU` was specified and positive -- so a `MUC` of exactly zero no longer
+  builds a constant phase either, where before the translator tested only
+  whether the keyword was present. Shape operands belonging to a phase that
+  never activated are recorded in `$untranslated` rather than dropped, since
+  `PROC HAZARD` zeroes them (`src/hazard/stmtprc.c`) and skips their covariates
+  (`src/hazard/setstat.c`). A `PARMS` that activates no phase at all is now
+  recorded too, because `PROC HAZARD` refuses that job outright
+  (`src/hazard/modterm.c`, `ERROR 1001: No phase selected`) where the
+  translator would previously have emitted a runnable single-distribution fit
+  and reported full coverage. No job in the public `hazard` corpus is affected:
+  the only `PARMS` statement in it that this gate changes is a documentation
+  template with literal `?` placeholders, so this closes a latent divergence
+  rather than changing any translation you have already run.
+
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
   statement specified alongside `WEIBULL`.** The translator read the bare
   `WEIBULL` keyword as a request to constrain the late phase to

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -30,12 +30,11 @@
 
 # hzr_phase() default shape values (mirrored here so the theta starting
 # vector agrees with what hzr_phase() itself defaults to when PARMS did not
-# supply a given shape parameter). mu has no hzr_phase() argument -- its
-# only documented default is .hzr_phase_start()'s mu_start = 0.1, used here
-# for a built phase whose PARMS never supplied its MU value.
+# supply a given shape parameter). There is no matching mu default: a phase is
+# built only when its MU was specified and positive, so every built phase has
+# a real MU to log.
 .hzr_parms_early_default <- c(t_half = 1, nu = 1, m = 0)
 .hzr_parms_late_default  <- c(tau = 1, gamma = 1, alpha = 1, eta = 1)
-.hzr_parms_default_mu_start <- 0.1
 
 # FIX<param> keywords are their own grammar tokens (FIXTHALF, not FIX+THALF),
 # and the R parameter name is not always the lowercased SAS spelling --
@@ -288,7 +287,6 @@
   fixed_early <- intersect(unname(.hzr_parms_early_arg), fixed_early)
   fixed_late <- intersect(unname(.hzr_parms_late_arg), fixed_late)
   mu <- .hzr_parms_ordered(mu, .hzr_parms_mu_order)
-  has_muc <- "MUC" %in% names(mu)
 
   # EARLY/CONSTANT/LATE operand text: comma-separated VAR=VALUE pairs (or
   # bare VARs), optionally followed by a "/ options" tail. Non-numeric values
@@ -323,19 +321,38 @@
     }
   }
 
+  # A phase is active iff its MU was specified and *positive*. That is the
+  # reference rule rather than an inference from it: parmprc.c:13,18,19
+  # registers MUE/MUC/MUL through setparmno(), which sets C->phase[n] = 1 only
+  # under `stmtfld(parmno) > ZERO` (setparmno.c:11-14), while the seven shape
+  # operands go through setprmf() (parmprc.c:14-17,20-23), which never touches
+  # C->phase[] at all. Absence and non-positivity are therefore the same
+  # outcome, which is why this tests the value and not merely the name --
+  # a presence test lets MUE=0 build a phase PROC HAZARD would not.
+  mu_active <- function(key) !is.null(mu[[key]]) && isTRUE(mu[[key]] > 0)
+  has_early <- mu_active("MUE")
+  has_muc <- mu_active("MUC")
+  has_late <- mu_active("MUL")
+
   # Phases are built, and their theta blocks appended, in the same
   # early -> constant -> late order -- .hzr_phase_theta_names() assigns
   # labels by *position* (phases are auto-named "phase_1", "phase_2", ... by
-  # .hzr_validate_phases()), so only this order matters, not the names.
+  # .hzr_validate_phases()), so only this order matters, not the names. A
+  # phase that is not built must therefore contribute no theta block either,
+  # or every later block is read against the wrong labels.
+  #
+  # The MU gate is necessary but not sufficient here: an active MU whose phase
+  # has no shape operand is recorded rather than built, because PROC HAZARD
+  # would supply its own shape defaults and they are not this parser's -- see
+  # the orphan branches below.
   phase_calls <- list()
   theta_blocks <- list()
-  if (length(early)) {
+  if (has_early && length(early)) {
     phase_calls[[length(phase_calls) + 1L]] <- .hzr_parms_phase_call(
       "cdf", early, phase_covars$early, fixed_early
     )
-    mu_val <- if (!is.null(mu[["MUE"]])) mu[["MUE"]] else .hzr_parms_default_mu_start
     theta_blocks <- c(theta_blocks,
-      .hzr_parms_theta_block("early", mu_val, early, phase_covar_vals$early)
+      .hzr_parms_theta_block("early", mu[["MUE"]], early, phase_covar_vals$early)
     )
   }
   if (has_muc) {
@@ -346,23 +363,15 @@
       .hzr_parms_theta_block("constant", mu[["MUC"]], list(), phase_covar_vals$constant)
     )
   }
-  if (length(late)) {
+  if (has_late && length(late)) {
     phase_calls[[length(phase_calls) + 1L]] <- .hzr_parms_phase_call(
       "g3", late, phase_covars$late, fixed_late
     )
-    mu_val <- if (!is.null(mu[["MUL"]])) mu[["MUL"]] else .hzr_parms_default_mu_start
     theta_blocks <- c(theta_blocks,
-      .hzr_parms_theta_block("late", mu_val, late, phase_covar_vals$late)
+      .hzr_parms_theta_block("late", mu[["MUL"]], late, phase_covar_vals$late)
     )
   }
 
-  # A MU names its phase. Building a phase only when a *shape* operand
-  # appeared let an orphaned MUE/MUL disappear together with the phase it
-  # scaled -- a one-phase R model against SAS's two, and no untranslated row
-  # to say so. PROC HAZARD would supply its own shape defaults here
-  # (stmtprc.c:30-37: thalf 1, nu 2, m 1; tau = 2*Tmax/3, gamma 1, alpha 1,
-  # eta 2), which are not this parser's defaults, so the MU is recorded
-  # rather than guessed at.
   # SETG3_ignore_tau() (setg3.c:377-424) fires when ALPHA is fixed at 1 --
   # setg3.c:312-314, before the WEIBULL dispatch. It pins TAU at 1 and rewrites
   # the GAMMA/ETA split, which at alpha = 1, tau = 1 is a reparameterisation of
@@ -379,28 +388,12 @@
   # estimates the product as GAMMA alone. That is one fewer estimated parameter
   # than hazard() would use, on a pair that is not separately identifiable --
   # a different model, not a different label for the same one. Recorded.
-  # Both guards describe things SETG3() does, so both require a late phase that
-  # is actually active -- and in PROC HAZARD a phase is active iff its MU was
-  # specified and positive. parmprc.c:19 registers MUL through
-  # setparmno(22, 7, 3, ...) and setparmno.c:14 sets C->phase[3] = 1 only when
-  # stmtfld() > 0; the four shape operands go through setprmf
-  # (parmprc.c:20-23), which never touches C->phase[]. With phase 3 off,
-  # stmtprc.c:113-122 zeroes TAU/GAMMA/ALPHA/ETA and shape.c:31 never calls
-  # SETG3() at all.
   #
-  # So the gate is MUL, not the presence of shape operands: TAU/GAMMA/ETA with
-  # no MUL is not a late phase, and warning about SETG3_ignore_tau() or
-  # SETG3980 there describes code PROC HAZARD never reaches. A false positive
-  # on $untranslated is not harmless -- that frame is how a caller decides
-  # whether a translation can be trusted.
-  #
-  # Note the asymmetry this leaves inside this function, deliberately and
-  # tracked separately: the phase-building block below still keys on shape
-  # operands (`if (length(late))`), so PARMS carrying TAU/GAMMA with no MUL
-  # emits a late phase that PROC HAZARD would not build at all. No corpus job
-  # does that, so it is latent, and changing how phases are built is a wider
-  # change than gating these two warnings.
-  has_late <- !is.null(mu[["MUL"]]) && isTRUE(mu[["MUL"]] > 0)
+  # Both guards describe things SETG3() does, and shape.c:31 calls SETG3() only
+  # under Common.phase[3] == 1, so both require an active late phase. Warning
+  # about them for TAU/GAMMA with no MUL would describe code PROC HAZARD never
+  # reaches, and a false positive on $untranslated is not harmless -- that
+  # frame is how a caller decides whether a translation can be trusted.
   alpha_val <- if (!is.null(late[["alpha"]])) late[["alpha"]] else
     .hzr_parms_late_default[["alpha"]]
   if (has_late && isTRUE(alpha_val == 1) && "alpha" %in% fixed_late &&
@@ -427,14 +420,87 @@
     )
   }
 
+  # Everything a MU gate discards has to leave a row behind. A phase that is
+  # not built takes its shape operands, its FIX tokens *and* its covariates
+  # with it, and silence on any of them hands back a model a phase short of the
+  # SAS job with nothing to say so -- the failure this package keeps shipping
+  # (see AGENTS.md). PROC HAZARD discards the same material, so the values are
+  # right and only the silence would be wrong: stmtprc.c:101-122 zeroes the
+  # shape operands and clears their status flags, and setstat.c:9-12 returns
+  # early for a phase whose C->phase[] is 0, dropping its covariates.
+  #
   # sprintf("%g"), not format(): format() honours getOption("OutDec"), so a
   # session with OutDec = "," would record "MUE=0,2" and break every grep --
   # the same trap the DELTA reason string above avoids.
-  if (!is.null(mu[["MUE"]]) && !length(early)) {
+  dropped <- function(shape, arg_map, fixed, covars) {
+    sas <- names(arg_map)[match(names(shape), unname(arg_map))]
+    ops <- sprintf("%s=%s", sas, vapply(shape, function(v) sprintf("%g", v), ""))
+    fix <- names(.hzr_parms_fix_map)[match(fixed, unname(.hzr_parms_fix_map))]
+    paste(c(ops, fix, covars), collapse = " ")
+  }
+
+  # (1) A MU that was specified but is not positive. stmtfld(parmno) > ZERO
+  # fails, so the phase never activates; the keyword is not an error and is not
+  # a phase either.
+  for (key in names(mu)) {
+    if (!mu_active(key)) {
+      flag_bad(paste0(key, "=", sprintf("%g", mu[[key]])),
+               paste0(key, " is not positive, so PROC HAZARD leaves that phase ",
+                      "inactive (setparmno.c:11): the phase is not built"))
+    }
+  }
+
+  # (2) Everything belonging to a phase whose MU never activated it.
+  if (!has_early) {
+    gone <- dropped(early, .hzr_parms_early_arg, fixed_early, phase_covars$early)
+    if (nzchar(gone)) {
+      flag_bad(gone, paste0("early phase material with no active MUE: PROC ",
+                            "HAZARD zeroes the shape operands (stmtprc.c:",
+                            "101-112) and skips the covariates (setstat.c:9-12)"))
+    }
+  }
+  if (!has_muc && length(phase_covars$constant)) {
+    flag_bad(paste(phase_covars$constant, collapse = " "),
+             paste0("constant phase covariates with no active MUC: PROC ",
+                    "HAZARD skips them (setstat.c:9-12)"))
+  }
+  if (!has_late) {
+    gone <- dropped(late, .hzr_parms_late_arg, fixed_late, phase_covars$late)
+    if (nzchar(gone)) {
+      flag_bad(gone, paste0("late phase material with no active MUL: PROC ",
+                            "HAZARD zeroes the shape operands (stmtprc.c:",
+                            "113-122) and skips the covariates (setstat.c:9-12)"))
+    }
+  }
+
+  # (3) No phase activated at all. modterm.c:18-22 prints "No phase selected",
+  # sets C->errorno = 1001 and the job does not run. Without this row the
+  # emitted call falls through to hazard()'s default distribution
+  # (sas-parse-job.R:604 omits `dist` when has_phases is FALSE) and
+  # hzr_translate_sas() reports full coverage for a job SAS refuses outright --
+  # the same shape as the SETG3980 guard above. Guarded on PARMS having said
+  # something, so a job with no PARMS at all keeps its existing path.
+  if (!has_early && !has_muc && !has_late &&
+      (length(mu) || length(early) || length(late))) {
+    flag_bad(
+      "PARMS with no positive MUE, MUC or MUL",
+      paste0("PROC HAZARD selects no phase here and refuses the job ",
+             "(modterm.c:18-22 raises ERROR 1001, \"No phase selected\")")
+    )
+  }
+
+  # (4) An active MU whose phase carries no shape operand. PROC HAZARD builds
+  # the phase here, on its own defaults: thalf 1, nu 2, m 1, gamma 1, alpha 1,
+  # eta 2 (stmtprc.c:30-37) and tau = 2*Tmax/3 (setg3.c:317 -- stmtprc.c:34
+  # only zeroes tau; the data-dependent default is set later, in SETG3()).
+  # Those are not this parser's defaults, and tau needs max(time) and so is not
+  # computable at parse time, so the MU is recorded rather than guessed at. A
+  # translation this parser declines is recoverable; one it invents is not.
+  if (has_early && !length(early)) {
     flag_bad(paste0("MUE=", sprintf("%g", mu[["MUE"]])),
              "MUE with no early phase shape operand (THALF/NU/M)")
   }
-  if (!is.null(mu[["MUL"]]) && !length(late)) {
+  if (has_late && !length(late)) {
     flag_bad(paste0("MUL=", sprintf("%g", mu[["MUL"]])),
              "MUL with no late phase shape operand (TAU/GAMMA/ALPHA/ETA)")
   }

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -285,11 +285,18 @@ test_that("the alpha = 1 guard does not fire on a job with no late phase", {
   # flagged about GAMMA and ETA it has no phase for. A false positive on the
   # untranslated frame is not harmless -- that frame is how a caller decides
   # whether a translation is trustworthy.
-  expect_equal(nrow(.hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1",
-                                       "FIXALPHA"))$untranslated), 0L)
-  expect_equal(nrow(.hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1",
-                                       "FIXALPHA", "WEIBULL"))$untranslated), 0L)
-  expect_equal(nrow(.hzr_parse_parms(c("MUC=0.01", "FIXALPHA"))$untranslated), 0L)
+  #
+  # Asserts that no row blames SETG3_ignore_tau(), not that there are no rows:
+  # a stray FIXALPHA on a job with no late phase IS dropped material and earns
+  # its own row (PROC HAZARD clears its status flag at stmtprc.c:118-121). An
+  # nrow == 0 proxy would fail on that unrelated and correct row.
+  no_setg3 <- function(ops) {
+    u <- .hzr_parse_parms(ops)$untranslated
+    expect_false(any(grepl("SETG3|GAMMA\\*ETA|estimates GAMMA", u$reason)))
+  }
+  no_setg3(c("MUE=0.2", "THALF=1", "NU=1", "FIXALPHA"))
+  no_setg3(c("MUE=0.2", "THALF=1", "NU=1", "FIXALPHA", "WEIBULL"))
+  no_setg3(c("MUC=0.01", "FIXALPHA"))
 })
 
 test_that("the alpha = 1 guard still fires when ALPHA was left to default", {
@@ -332,4 +339,148 @@ test_that("both late-phase guards still fire when MUL is present", {
   g2 <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=0",
                            "ETA=1", "WEIBULL"))
   expect_true(any(grepl("SETG3980", g2$untranslated$reason)))
+})
+
+# ---------------------------------------------------------------------------
+# A phase is active iff its MU was specified and positive (setparmno.c:11-14).
+# ---------------------------------------------------------------------------
+
+test_that("late shape operands with no MUL build no phase and are recorded", {
+  # parmprc.c:19-23 registers MUL through setparmno() and TAU/GAMMA/ALPHA/ETA
+  # through setprmf(), and setprmf() never touches C->phase[]. With phase 3
+  # off, stmtprc.c:113-122 zeroes all four operands and shape.c:31 never calls
+  # SETG3(). So this is a one-phase job in PROC HAZARD, and the operands are
+  # discarded -- recorded here rather than dropped silently.
+  got <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "TAU=2", "GAMMA=1.5"))
+  expect_equal(got$phases, quote(list(hzr_phase("cdf", t_half = 1, nu = 1))))
+  expect_equal(got$theta, quote(c(log(0.2), log(1), 1, 0)))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_equal(got$untranslated$construct, "TAU=2 GAMMA=1.5")
+  expect_match(got$untranslated$reason, "no active MUL")
+})
+
+test_that("early shape operands with no MUE build no phase and are recorded", {
+  # The mirror of the above through stmtprc.c:101-112 and shape.c:19.
+  got <- .hzr_parse_parms(c("THALF=1", "NU=1", "MUL=0.05", "TAU=2"))
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("g3", tau = 2)))
+  )
+  expect_equal(got$theta, quote(c(log(0.05), log(2), 1, 1, 1)))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_equal(got$untranslated$construct, "THALF=1 NU=1")
+  expect_match(got$untranslated$reason, "no active MUE")
+})
+
+test_that("a MU of zero is inactive, not merely absent", {
+  # setparmno.c:11 gates on stmtfld(parmno) > ZERO, so MUE=0 registers the
+  # keyword but leaves C->phase[1] at 0. Absence and non-positivity are the
+  # same outcome, and testing only for absence would let this through.
+  got <- .hzr_parse_parms(c("MUE=0", "THALF=1", "NU=1", "MUC=0.001"))
+  expect_equal(got$phases, quote(list(hzr_phase("constant"))))
+  expect_equal(got$theta, quote(c(log(0.001))))
+  expect_true(any(grepl("no active MUE", got$untranslated$reason)))
+})
+
+test_that("MUC gates the constant phase on positivity, not presence", {
+  # shape.c:23 reads Common.phase[2], set by setparmno(21, 6, 2, ...) under the
+  # same > ZERO gate as the other two. A presence test would build this phase.
+  off <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "MUC=0"))
+  expect_equal(off$phases, quote(list(hzr_phase("cdf", t_half = 1, nu = 1))))
+  expect_equal(off$theta, quote(c(log(0.2), log(1), 1, 0)))
+  expect_equal(off$untranslated$construct, "MUC=0")
+
+  # The paired positive case, so the assertion above cannot pass by the phase
+  # never being built at all.
+  on <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "MUC=0.001"))
+  expect_equal(
+    on$phases,
+    quote(list(hzr_phase("cdf", t_half = 1, nu = 1), hzr_phase("constant")))
+  )
+  expect_equal(on$theta, quote(c(log(0.2), log(1), 1, 0, log(0.001))))
+  expect_equal(nrow(on$untranslated), 0L)
+})
+
+test_that("theta drops the block of a phase that was not built", {
+  # .hzr_phase_theta_names() labels theta by *position*, so a phase that is
+  # not built must not leave its block behind: the late block would otherwise
+  # be read as the early phase's shape. Asserts the whole vector, not its
+  # length -- a length check passes on a block of the wrong contents.
+  got <- .hzr_parse_parms(c("THALF=9", "NU=7", "M=5", "MUC=0.001",
+                            "MUL=0.05", "TAU=2", "GAMMA=1.5"))
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("constant"), hzr_phase("g3", tau = 2, gamma = 1.5)))
+  )
+  expect_equal(got$theta, quote(c(log(0.001), log(0.05), log(2), 1.5, 1, 1)))
+})
+
+test_that("a PARMS with no active MU builds nothing and says so", {
+  # The hollow-object case from AGENTS.md: has_phases must be FALSE rather
+  # than the caller receiving an empty list() that looks like a translation.
+  got <- .hzr_parse_parms(c("THALF=1", "NU=1", "TAU=2"))
+  expect_false(got$has_phases)
+  expect_equal(got$phases, quote(list()))
+  expect_setequal(
+    got$untranslated$construct,
+    c("THALF=1 NU=1", "TAU=2", "PARMS with no positive MUE, MUC or MUL")
+  )
+})
+
+test_that("no active MU at all is recorded as the refusal PROC HAZARD raises", {
+  # modterm.c:18-22: with phase[1], phase[2] and phase[3] all 0 the reference
+  # prints "No phase selected", sets C->errorno = 1001 and the job does not
+  # run. Without this row .hzr_parse_job() omits `dist` (sas-parse-job.R:604),
+  # the emitted call falls through to hazard()'s default distribution, and
+  # hzr_translate_sas() reports full coverage for a job SAS refuses -- an
+  # output that looks like a result. Same shape as the SETG3980 guard.
+  got <- .hzr_parse_parms(c("MUE=0", "THALF=1"))
+  expect_false(got$has_phases)
+  expect_true(any(grepl("modterm.c", got$untranslated$reason, fixed = TRUE)))
+
+  # The paired case that must NOT be refused: MUE is positive, so PROC HAZARD
+  # does select phase 1 and does run the job -- this parser declines to
+  # translate it for a different reason (no shape operand), and saying
+  # "no phase selected" there would be a false positive.
+  ok <- .hzr_parse_parms(c("MUE=0.2"))
+  expect_false(any(grepl("modterm.c", ok$untranslated$reason, fixed = TRUE)))
+  expect_equal(ok$untranslated$construct, "MUE=0.2")
+})
+
+test_that("covariates of a phase that is not built are recorded, not dropped", {
+  # setstat.c:9-12 returns early for a phase whose C->phase[] is 0, so PROC
+  # HAZARD drops these too -- the values agree and only silence would be wrong.
+  # This is the hole the MU gate opened: with MUL present the covariate
+  # survives into the emitted formula, so it must not simply vanish without it.
+  got <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "TAU=2"),
+                          covars = list(late = "AGE=1.2, SEX=0.5"))
+  expect_equal(got$phases, quote(list(hzr_phase("cdf", t_half = 1, nu = 1))))
+  expect_equal(got$untranslated$construct, "TAU=2 AGE SEX")
+
+  # The paired built case, so the assertion above cannot pass by the covariates
+  # never having been parsed at all.
+  kept <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "MUL=0.05", "TAU=2"),
+                           covars = list(late = "AGE=1.2, SEX=0.5"))
+  expect_equal(
+    kept$phases,
+    quote(list(hzr_phase("cdf", t_half = 1, nu = 1),
+               hzr_phase("g3", tau = 2, formula = ~AGE + SEX)))
+  )
+  expect_equal(nrow(kept$untranslated), 0L)
+})
+
+test_that("constant phase covariates with no active MUC are recorded", {
+  got <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "MUC=0"),
+                          covars = list(constant = "AGE=1.2"))
+  expect_equal(got$phases, quote(list(hzr_phase("cdf", t_half = 1, nu = 1))))
+  expect_setequal(got$untranslated$construct, c("MUC=0", "AGE"))
+})
+
+test_that("FIX tokens of a phase that is not built are recorded", {
+  # A reader grepping $untranslated for FIXTAU must find it: the token pinned a
+  # parameter in the SAS job and has no effect on the emitted R call.
+  got <- .hzr_parse_parms(c("THALF=1", "NU=1", "FIXTHALF", "MUL=0.05",
+                            "TAU=2", "FIXTAU"))
+  expect_equal(got$phases, quote(list(hzr_phase("g3", tau = 2, fixed = "tau"))))
+  expect_equal(got$untranslated$construct, "THALF=1 NU=1 FIXTHALF")
 })


### PR DESCRIPTION
**Stacked on #235.** Base is `fix/sas-parms-weibull-generalized`, not `main`, so the diff stays one commit — retarget to `main` once #235 merges.

## The divergence

`.hzr_parse_parms()` decided whether to emit a phase from whether that phase's *shape* operands appeared in PARMS (`if (length(early))`, `has_muc <- "MUC" %in% names(mu)`, `if (length(late))`). The reference C keys on the MU instead, and I read each of these rather than inferring them:

| Reference | What it establishes |
|---|---|
| `parmprc.c:13,18,19` | MUE/MUC/MUL are registered through `setparmno()` |
| `setparmno.c:11-14` | sets `C->phase[n] = 1` only under `stmtfld(parmno) > ZERO` |
| `setprmf.c` | registers the seven shape operands; contains no reference to `phase` at all |
| `stmtprc.c:101-122` | an inactive phase has its shape operands zeroed and status flags cleared |
| `setstat.c:9-12` | returns before `*phasevar = 1` for an inactive phase — its covariates are never registered |
| `shape.c:19,23,31` | `SETG1()`, the `muC` branch and `SETG3()` all gate on `Common.phase[1..3]` |
| `modterm.c:18-22` | all three phases off → `ERROR 1001: No phase selected`, job refused |

So `PARMS MUE=0.2 THALF=1 NU=1 TAU=2 GAMMA=1.5` was a two-phase model in R against PROC HAZARD's one — and the phantom carried an invented `mu` start of 0.1 at the head of its theta block, shifting every later block against `.hzr_phase_theta_names()`'s positional labels. Nothing appeared in `$untranslated`.

## What changed

A phase is built iff its own MU was specified and **positive**. That also fixes the constant phase, which was not in the original scope: `has_muc` tested *presence*, so `MUC=0` built a phase PROC HAZARD leaves inactive. `.hzr_parms_default_mu_start` is removed — nothing can now build a phase without a real MU to log, and it was emitting `log(0) = -Inf` into theta for `MUE=0`.

Everything a closed gate discards now leaves a row: a non-positive MU; a phase's shape operands, `FIX` tokens and covariates; and the case where nothing activates at all. That last one matters — without it `sas-parse-job.R:604` omits `dist`, the call falls through to `hazard()`'s default distribution, and `hzr_translate_sas()` reports **5/5 coverage for a job SAS will not run**.

The MU gate is necessary but not sufficient: an active MU whose phase has no shape operand is still *recorded* rather than built, because SAS's defaults are not this parser's and `tau = 2*Tmax/3` (`setg3.c:317`) needs `max(time)`. Unchanged from 82210d4.

## Corpus impact: none

No job in the public `hazard` corpus is affected — the only PARMS statement this gate changes is a documentation template with literal `?` placeholders. This closes a latent divergence rather than changing any translation already run.

> I could not reproduce the "38 live PARMS blocks" figure cited in #235's test comments; three counting methods give 16, 22 and 38. The "0 affected" conclusion holds under all three, so NEWS names the single affected item instead of asserting a denominator.

## One test rewritten

A #235 test asserted *"the alpha = 1 guard does not fire on a job with no late phase"* via `nrow(untranslated) == 0` — a proxy that held only because nothing else could produce a row. A stray `FIXALPHA` there is real dropped material (`stmtprc.c:118-121` clears its status flag) and now earns one, so the assertion was rewritten to test its stated intent.

## Gate

- `devtools::document()` — no diff in `man/`, `NAMESPACE`, `DESCRIPTION`
- `lintr::lint_package()` — **0**
- `spelling::spell_check_package()` — 0
- `devtools::test()` (`NOT_CRAN=true`) — **0 FAIL / 6 SKIP / 3766 PASS** (skips are SAS fixture availability only)
- `R CMD check --as-cran` with the manual, from a clean `git archive` — **Status: OK**, 3m 25s, tarball 2.9 MB, tests 84s, vignettes 45s, under-check 2742 passes
- Ten mutants killed across two rounds, including a false-positive guard: firing the `modterm.c` refusal when a MU *is* active breaks 3 tests

## Deliberately out of scope (filed separately)

1. `.hzr_parms_early_default` is `nu = 1, m = 0` (R's `hzr_phase()` defaults) but SAS's are `nu = 2, m = 1` (`stmtprc.c:30-37`). Any *partially* specified phase gets a different starting vector. Zero corpus blocks are partially specified, so latent.
2. `has_phases == FALSE` was already reachable via the no-PARMS path (`sas-parse-job.R:598-603`). Read with `modterm.c`, a job with no PARMS has no active phase either — so that older path may also emit runnable fits for jobs SAS rejects. Needs the C question settled first (is `modterm()` universal or multiphase-only?) before anything changes.

Also worth a maintainer decision: this makes the no-phase-selected case **visible** in `$untranslated` rather than emitting `stop()` as the LCENSOR+ICENSOR path does at `sas-parse-job.R:527-540`. A hard refusal would have to change job-level code that also governs (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)