### PR TITLE
fix(sas): a job with no PARMS is refused by PROC HAZARD, not defaulted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,21 +20,35 @@
   never activated are recorded in `$untranslated` rather than dropped, since
   `PROC HAZARD` zeroes them (`src/hazard/stmtprc.c`) and skips their covariates
   (`src/hazard/setstat.c`). A job that activates no phase at all is now
-  recorded too -- whether its `PARMS` named no positive `MU`, or it carried no
-  `PARMS` statement whatsoever -- because `PROC HAZARD` refuses that job
-  outright (`src/hazard/modterm.c`, `ERROR 1001: No phase selected`) where the
-  translator would previously have emitted a runnable single-distribution fit
-  and reported full coverage. The two are one state rather than two cases:
-  `stmtprc.c` zeroes all three phases at initialization and only `setparmno()`
-  turns one back on, so a job with no `PARMS` has no active phase for the same
-  reason a `PARMS` naming `MUE=0` does. `modterm()` is reached on every job,
-  not only once a multiphase model has been selected -- its one call site in
-  `outmods()` is unconditional in the procedure's main sequence, and
-  `hazard.c` exits on `ERROR 1001` before any results are computed. No job in
-  the public `hazard` corpus is affected:
-  the only `PARMS` statement in it that this gate changes is a documentation
-  template with literal `?` placeholders, so this closes a latent divergence
-  rather than changing any translation you have already run.
+  **refused** rather than translated -- whether its `PARMS` named no positive
+  `MU`, or it carried no `PARMS` statement whatsoever. `PROC HAZARD` does not
+  run such a job: `src/hazard/modterm.c` raises `ERROR 1001: No phase
+  selected` and the procedure exits before computing any results, so there is
+  no fit for a translation to be faithful to. The translator previously
+  emitted a runnable single-distribution fit and reported full token coverage;
+  it now emits a `stop()` in place of the `hazard()` call, as it already did
+  for `LCENSOR` combined with `ICENSOR`. The two cases are one state rather
+  than two: `src/hazard/stmtprc.c` zeroes all three phases at initialization
+  and only `setparmno()` turns one back on, so a job with no `PARMS` has no
+  active phase for the same reason a `PARMS` naming `MUE=0` does. `modterm()`
+  is reached on every job, not only once a multiphase model has been selected
+  -- its one call site in `outmods()` is unconditional in the procedure's main
+  sequence.
+
+  The refusal fires only when every `PARMS` operand was understood. A
+  statement this parser could not read is recorded, operand by operand, but
+  never refused: `PARMS MUE = 0.2 THALF = 1` (spaces around `=`) parses to
+  nothing here while `PROC HAZARD`'s own lexer discards whitespace and runs
+  the job with an active early phase, so refusing it would stop a job the
+  reference accepts. Relatedly, a second `PARMS` statement now adds to the
+  first rather than replacing it, matching the single field table
+  `parmprc()` reads once after all statements are processed.
+
+  One job in the public `hazard` corpus changes, and only to drop a claim that
+  was wrong: `dist/examples/hm.dthar.TGA.sas` is a documentation template
+  carrying literal `?` placeholders, which the reference would reject as a
+  syntax error rather than as `ERROR 1001`. Its per-operand rows are
+  unchanged. No corpus job is refused.
 
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
   statement specified alongside `WEIBULL`.** The translator read the bare

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,9 +40,9 @@
   never refused: `PARMS MUE = 0.2 THALF = 1` (spaces around `=`) parses to
   nothing here while `PROC HAZARD`'s own lexer discards whitespace and runs
   the job with an active early phase, so refusing it would stop a job the
-  reference accepts. Relatedly, a second `PARMS` statement now adds to the
-  first rather than replacing it, matching the single field table
-  `parmprc()` reads once after all statements are processed.
+  reference accepts. A second `PARMS` statement also now adds to the first
+  rather than replacing it, matching the single field table `parmprc()` reads
+  once after all statements are processed.
 
   One job in the public `hazard` corpus changes, and only to drop a claim that
   was wrong: the second `%HAZARD` block of

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,11 +19,19 @@
   whether the keyword was present. Shape operands belonging to a phase that
   never activated are recorded in `$untranslated` rather than dropped, since
   `PROC HAZARD` zeroes them (`src/hazard/stmtprc.c`) and skips their covariates
-  (`src/hazard/setstat.c`). A `PARMS` that activates no phase at all is now
-  recorded too, because `PROC HAZARD` refuses that job outright
-  (`src/hazard/modterm.c`, `ERROR 1001: No phase selected`) where the
+  (`src/hazard/setstat.c`). A job that activates no phase at all is now
+  recorded too -- whether its `PARMS` named no positive `MU`, or it carried no
+  `PARMS` statement whatsoever -- because `PROC HAZARD` refuses that job
+  outright (`src/hazard/modterm.c`, `ERROR 1001: No phase selected`) where the
   translator would previously have emitted a runnable single-distribution fit
-  and reported full coverage. No job in the public `hazard` corpus is affected:
+  and reported full coverage. The two are one state rather than two cases:
+  `stmtprc.c` zeroes all three phases at initialization and only `setparmno()`
+  turns one back on, so a job with no `PARMS` has no active phase for the same
+  reason a `PARMS` naming `MUE=0` does. `modterm()` is reached on every job,
+  not only once a multiphase model has been selected -- its one call site in
+  `outmods()` is unconditional in the procedure's main sequence, and
+  `hazard.c` exits on `ERROR 1001` before any results are computed. No job in
+  the public `hazard` corpus is affected:
   the only `PARMS` statement in it that this gate changes is a documentation
   template with literal `?` placeholders, so this closes a latent divergence
   rather than changing any translation you have already run.

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,9 +45,11 @@
   `parmprc()` reads once after all statements are processed.
 
   One job in the public `hazard` corpus changes, and only to drop a claim that
-  was wrong: `dist/examples/hm.dthar.TGA.sas` is a documentation template
-  carrying literal `?` placeholders, which the reference would reject as a
-  syntax error rather than as `ERROR 1001`. Its per-operand rows are
+  was wrong: the second `%HAZARD` block of
+  `dist/examples/hm.dthar.TGA.sas` is a documentation template carrying
+  literal `?` placeholders, which the reference would reject as a syntax
+  error rather than as `ERROR 1001`. (That file's first block is a valid
+  `PARMS` activating two phases and is unaffected.) Its per-operand rows are
   unchanged. No corpus job is refused.
 
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -508,7 +508,13 @@
       LCENSOR    = statements$LCENSOR <- ops[[1L]],
       RCENSOR    = statements$RCENSOR <- ops[[1L]],
       WEIGHT     = statements$WEIGHT <- ops[[1L]],
-      PARAMETERS = parms_ops <- ops,
+      # Accumulate rather than overwrite: PROC HAZARD keeps its PARMS fields
+      # in one table that parmprc() reads once, after every statement has been
+      # processed (stmtprc.c), so a second PARMS statement adds to the first
+      # rather than replacing it. Overwriting also made the no-phase refusal
+      # below fire on `PARMS MUE=0.2 THALF=1; PARMS FIXNU;` -- a job the
+      # reference runs -- because only the trailing statement survived.
+      PARAMETERS = parms_ops <- c(parms_ops, ops),
       STEPWISE   = sel_ops <- ops,
       EARLY      = covars$early <- ops_text,
       CONSTANT   = covars$constant <- ops_text,
@@ -542,6 +548,34 @@
         "so one column cannot express both and any translation would fit ",
         "the interval-censored rows as at risk from time 0. Translate this ",
         "job by hand (#155)."
+      )),
+      status_call = NULL, outhaz = outhaz, untranslated = untr,
+      tokens_seen = seen, tokens_mapped = mapped
+    ))
+  }
+
+  # The second refusal, and for the same reason as the LCENSOR + ICENSOR one
+  # above: PROC HAZARD does not run this job at all. With no active phase
+  # modterm.c:18-22 raises ERROR 1001 ("No phase selected") and hazard.c:299-302
+  # exits via hzfxit("SEMANTIC") BEFORE results(), so the reference produces no
+  # estimates -- there is no fit here for a translation to be faithful to. An
+  # $untranslated row alone leaves the fit chunk in place, and a reader who
+  # renders past the callout gets a converged single-distribution fit with a
+  # populated summary standing in for a job that produced nothing.
+  #
+  # Placed AFTER the censoring refusal so a job carrying both keeps that one's
+  # more specific message, matching the precedence already established there.
+  if (isTRUE(parms$refused)) {
+    return(list(
+      call = quote(stop(
+        "This PROC HAZARD job selects no phase: no PARMS statement named a ",
+        "positive MUE, MUC or MUL. PROC HAZARD refuses such a job outright -- ",
+        "modterm.c raises ERROR 1001, \"No phase selected\", and the ",
+        "procedure exits before computing any results -- so there is no fit ",
+        "to translate. Add the PARMS statement naming the phase(s) this ",
+        "model needs, or fit it by hand as a single-distribution model if ",
+        "that is what you intend.",
+        call. = FALSE
       )),
       status_call = NULL, outhaz = outhaz, untranslated = untr,
       tokens_seen = seen, tokens_mapped = mapped

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -525,9 +525,13 @@
   refused <- !has_early && !has_muc && !has_late && !unreadable
   if (refused) {
     flag_bad(
-      # Keyed on `operands`, not on mu/early/late: dist/examples/
-      # hm.dthar.TGA.sas is a template carrying literal `MUE=? THALF=? NU=?`,
-      # which leaves all three empty while the statement plainly existed.
+      # Keyed on `operands`, not on mu/early/late: the SECOND %HAZARD block
+      # of dist/examples/hm.dthar.TGA.sas (line 110; its PARMS at 122) carries
+      # literal `MUE=? THALF=? NU=?` for the reader to fill in from the
+      # stepwise output, which leaves all three empty while the statement
+      # plainly existed. The file's FIRST block (line 70, PARMS at 74) is a
+      # valid `MUE=0.2 THALF=0.08 NU=1 M=1 FIXM MUC=0.001` activating phases 1
+      # and 2 -- so this is a property of that one block, not of the file.
       # (It is unreadable, so it no longer reaches here -- but the wording
       # must not depend on that gate to be true.) A bare `PARMS;` cannot
       # occur: hazard_y.y:133-135 requires at least one parmsopt, so it is a

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -473,19 +473,49 @@
     }
   }
 
-  # (3) No phase activated at all. modterm.c:18-22 prints "No phase selected",
-  # sets C->errorno = 1001 and the job does not run. Without this row the
-  # emitted call falls through to hazard()'s default distribution
-  # (sas-parse-job.R:604 omits `dist` when has_phases is FALSE) and
-  # hzr_translate_sas() reports full coverage for a job SAS refuses outright --
-  # the same shape as the SETG3980 guard above. Guarded on PARMS having said
-  # something, so a job with no PARMS at all keeps its existing path.
-  if (!has_early && !has_muc && !has_late &&
-      (length(mu) || length(early) || length(late))) {
+  # (3) No phase activated at all -- including the job carrying no PARMS
+  # statement whatsoever, which arrives here with `operands` empty. PROC
+  # HAZARD does not distinguish the two: stmtprc.c:87 zeroes all three phases
+  # at init, and the only write that turns one back on is setparmno.c:14,
+  # reached from parmprc.c:13,18,19 for MUE/MUC/MUL alone and only under
+  # `stmtfld(parmno) > ZERO`. The seven shape operands go through setprmf()
+  # (parmprc.c:14-17,20-23), which never touches C->phase[] at all. So "no
+  # PARMS" and "PARMS naming no positive MU" are one state, not two cases.
+  #
+  # That state is refused, not merely defaulted, and modterm() is reached for
+  # every job rather than only for a selected multiphase model: its single
+  # call site is outmods.c:91, and outmods() sits in main's straight-line
+  # sequence (hazard.c:296) with the no-phase test as one of the three
+  # disjuncts at outmods.c:89 that fire the call. hazard.c:298-301 then routes
+  # errorno 1001 to hzfxit("SEMANTIC"), which exits BEFORE results() -- so the
+  # job prints no estimates and never fits.
+  #
+  # Without this row the emitted call falls through to hazard()'s default
+  # distribution (sas-parse-job.R:604 omits `dist` when has_phases is FALSE)
+  # and hzr_translate_sas() reports FULL coverage for a job SAS refuses
+  # outright -- the same shape as the SETG3980 guard above. The no-PARMS half
+  # is latent rather than shipped: 0 of the 29 hazard() fits the public corpus
+  # emits lack dist = "multiphase" (measured 2026-09-09). Latent is why this
+  # is a `flag_bad()` and not a corpus-visible regression, not a reason to
+  # leave the path reporting full coverage for a model that has no phases.
+  # The wording keys on `operands`, not on mu/early/late: a PARMS statement
+  # whose every operand failed to parse (dist/examples/hm.dthar.TGA.sas is a
+  # template carrying literal `MUE=? THALF=? NU=?`) leaves all three empty
+  # while the statement plainly existed, and calling that "no PARMS" would be
+  # a confident wrong annotation in the frame a caller reads to decide whether
+  # the translation can be trusted. A bare `PARMS;` is genuinely
+  # indistinguishable from an absent one here -- both arrive as character(0) --
+  # so the absent wording is phrased to be true of either.
+  if (!has_early && !has_muc && !has_late) {
     flag_bad(
-      "PARMS with no positive MUE, MUC or MUL",
+      if (length(operands)) {
+        "PARMS with no positive MUE, MUC or MUL"
+      } else {
+        "no PARMS operands (no MUE, MUC or MUL)"
+      },
       paste0("PROC HAZARD selects no phase here and refuses the job ",
-             "(modterm.c:18-22 raises ERROR 1001, \"No phase selected\")")
+             "(modterm.c:18-22 raises ERROR 1001, \"No phase selected\"; ",
+             "hazard.c:298-301 then exits before results())")
     )
   }
 

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -182,10 +182,16 @@
 #'   `list(early = c("X1", "X2"), constant = , late = )`, from the operands of
 #'   the `EARLY` / `CONSTANT` / `LATE` statements.
 #' @return `list(phases = <call>, theta = <call>, has_phases = <logical>,
-#'   untranslated = <data.frame>)`. `has_phases` is `TRUE` only when at least
-#'   one phase was actually built from the operands (i.e. `phases` is not the
-#'   empty `list()` call) -- callers use it to decide whether the job
-#'   qualifies as multiphase at all.
+#'   refused = <logical>, untranslated = <data.frame>)`. `has_phases` is
+#'   `TRUE` only when at least one phase was actually built from the operands
+#'   (i.e. `phases` is not the empty `list()` call) -- callers use it to decide
+#'   whether the job qualifies as multiphase at all. `refused` is `TRUE` only
+#'   when no phase is active AND every operand was understood, meaning
+#'   `PROC HAZARD` would raise `ERROR 1001` and run nothing
+#'   (`src/hazard/modterm.c`); the caller emits a `stop()` in place of the fit.
+#'   It is deliberately narrower than `!has_phases`: a statement this parser
+#'   could not read is recorded but not refused, because the refusal is a
+#'   claim about the reference and not about this parser.
 #' @noRd
 .hzr_parse_parms <- function(operands, covars = list()) {
   mu <- list()
@@ -196,6 +202,14 @@
   saw_weibull <- FALSE
   bad_construct <- character(0)
   bad_reason <- character(0)
+  # Set when an operand could not be read at all -- an unresolved keyword, a
+  # non-numeric value, or a keyword with no phase target. It gates the "no
+  # phase selected" refusal below, which is a claim about what PROC HAZARD
+  # would do and is only sound when this parser actually understood the whole
+  # statement. Distinct from `bad_construct`, which also collects the later
+  # SEMANTIC guards: `MUE=0 THALF=1` is fully readable and genuinely selects
+  # no phase, so it must still refuse even though it flags THALF=1.
+  unreadable <- FALSE
 
   flag_bad <- function(construct, reason) {
     bad_construct <<- c(bad_construct, construct)
@@ -210,8 +224,10 @@
       val <- suppressWarnings(as.numeric(substr(op, eq + 1L, nchar(op))))
       token <- .hzr_sas_token(key, "HAZARD", "PARM")
       if (is.na(token)) {
+        unreadable <- TRUE
         flag_bad(op, "unresolved PARMS keyword")
       } else if (is.na(val)) {
+        unreadable <- TRUE
         flag_bad(op, sprintf("PARMS value for %s is not numeric", key))
       } else if (token %in% .hzr_parms_mu_order) {
         mu[[token]] <- val
@@ -239,6 +255,7 @@
           ))
         }
       } else {
+        unreadable <- TRUE
         flag_bad(op, "PARMS keyword has no phase target")
       }
       next
@@ -246,6 +263,7 @@
 
     token <- .hzr_sas_token(op, "HAZARD", "PARM")
     if (is.na(token)) {
+      unreadable <- TRUE
       flag_bad(op, "unresolved PARMS keyword")
     } else if (token == "WEIBULL") {
       # setopt(6) -> SETG3_weibull() (setg3.c:427) is the GENERALIZED Weibull:
@@ -486,28 +504,35 @@
   # every job rather than only for a selected multiphase model: its single
   # call site is outmods.c:91, and outmods() sits in main's straight-line
   # sequence (hazard.c:296) with the no-phase test as one of the three
-  # disjuncts at outmods.c:89 that fire the call. hazard.c:298-301 then routes
+  # disjuncts at outmods.c:89 that fire the call. hazard.c:299-302 then routes
   # errorno 1001 to hzfxit("SEMANTIC"), which exits BEFORE results() -- so the
-  # job prints no estimates and never fits.
+  # job prints no estimates and never fits. `refused` therefore propagates to
+  # .hzr_parse_job(), which emits a stop() in place of the hazard() call: an
+  # $untranslated row alone still renders a populated fit, and a fit standing
+  # in for a job that produced no result is this package's signature defect.
   #
-  # Without this row the emitted call falls through to hazard()'s default
-  # distribution (sas-parse-job.R:604 omits `dist` when has_phases is FALSE)
-  # and hzr_translate_sas() reports FULL coverage for a job SAS refuses
-  # outright -- the same shape as the SETG3980 guard above. The no-PARMS half
-  # is latent rather than shipped: 0 of the 29 hazard() fits the public corpus
-  # emits lack dist = "multiphase" (measured 2026-09-09). Latent is why this
-  # is a `flag_bad()` and not a corpus-visible regression, not a reason to
-  # leave the path reporting full coverage for a model that has no phases.
-  # The wording keys on `operands`, not on mu/early/late: a PARMS statement
-  # whose every operand failed to parse (dist/examples/hm.dthar.TGA.sas is a
-  # template carrying literal `MUE=? THALF=? NU=?`) leaves all three empty
-  # while the statement plainly existed, and calling that "no PARMS" would be
-  # a confident wrong annotation in the frame a caller reads to decide whether
-  # the translation can be trusted. A bare `PARMS;` is genuinely
-  # indistinguishable from an absent one here -- both arrive as character(0) --
-  # so the absent wording is phrased to be true of either.
-  if (!has_early && !has_muc && !has_late) {
+  # `unreadable` is the gate that keeps this from being a FALSE POSITIVE, and
+  # it is load bearing now that the outcome is a hard stop. Testing only the
+  # three has_* flags conflates "PARMS selected no phase" with "this parser
+  # could not read PARMS". `PARMS MUE = 0.2 THALF = 1` is the case that bites:
+  # .hzr_parse_hazard() splits operands on " ", so it yields "MUE", "=", "0.2"
+  # and nothing parses -- while HAZARD's own lexer discards whitespace
+  # unconditionally (hazard_l.l:32 `ws [ \t\n\r\)]+`, rule at :50), making
+  # that a well-formed parmsopt (hazard_y.y:138) whose job RUNS with an active
+  # early phase. Refusing it would stop a job PROC HAZARD accepts. The
+  # per-operand rows still record what was not understood; only the refusal,
+  # which is a claim about the reference, requires having understood it all.
+  refused <- !has_early && !has_muc && !has_late && !unreadable
+  if (refused) {
     flag_bad(
+      # Keyed on `operands`, not on mu/early/late: dist/examples/
+      # hm.dthar.TGA.sas is a template carrying literal `MUE=? THALF=? NU=?`,
+      # which leaves all three empty while the statement plainly existed.
+      # (It is unreadable, so it no longer reaches here -- but the wording
+      # must not depend on that gate to be true.) A bare `PARMS;` cannot
+      # occur: hazard_y.y:133-135 requires at least one parmsopt, so it is a
+      # HAZARD syntax error, and character(0) here means the statement was
+      # genuinely absent.
       if (length(operands)) {
         "PARMS with no positive MUE, MUC or MUL"
       } else {
@@ -515,7 +540,7 @@
       },
       paste0("PROC HAZARD selects no phase here and refuses the job ",
              "(modterm.c:18-22 raises ERROR 1001, \"No phase selected\"; ",
-             "hazard.c:298-301 then exits before results())")
+             "hazard.c:299-302 then exits before results())")
     )
   }
 
@@ -539,6 +564,7 @@
     phases = as.call(c(quote(list), phase_calls)),
     theta = as.call(c(quote(c), theta_blocks)),
     has_phases = length(phase_calls) > 0L,
+    refused = refused,
     untranslated = .hzr_untranslated_frame(
       line = rep(NA_integer_, length(bad_construct)),
       construct = bad_construct,

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -488,9 +488,12 @@ test_that("operands this parser cannot read are recorded but never refused", {
 })
 
 test_that("a PARMS template with `?` placeholders is not refused as no-phase", {
-  # dist/examples/hm.dthar.TGA.sas is a template carrying literal
-  # `PARMS MUE=? THALF=? NU=? M=1 FIXM MUC=?;` for the reader to fill in from
-  # the stepwise output above it. Every value is non-numeric, so no MU is
+  # The SECOND %HAZARD block of dist/examples/hm.dthar.TGA.sas (line 110,
+  # PARMS at 122) carries literal `PARMS MUE=? THALF=? NU=? M=1 FIXM MUC=?;`
+  # for the reader to fill in from the stepwise output above it. The file's
+  # FIRST block (line 70, PARMS at 74) is fully valid and activates phases 1
+  # and 2, so grepping the file for a valid PARMS will find one -- the shape
+  # under test here belongs to the second block alone. Every value is non-numeric, so no MU is
   # active -- but that is this parser failing to read the statement, not PROC
   # HAZARD selecting no phase, and the reference would reject `?` as a SYNTAX
   # error long before modterm.c's ERROR 1001. Claiming "No phase selected"

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -454,29 +454,55 @@ test_that("a job with no PARMS operands at all is refused, not defaulted", {
   # stay at their stmtprc.c:87 zero, and modterm.c:18-22 raises ERROR 1001.
   # modterm() is universal rather than multiphase-only: its single call site
   # is outmods.c:91, outmods() is unconditional in main (hazard.c:296), and
-  # hazard.c:298-301 routes 1001 to hzfxit("SEMANTIC") BEFORE results(). The
+  # hazard.c:299-302 routes 1001 to hzfxit("SEMANTIC") BEFORE results(). The
   # job never fits, so a translation that emits one is a wrong answer.
   got <- .hzr_parse_parms(character(0))
   expect_false(got$has_phases)
+  expect_true(got$refused)
   expect_equal(got$untranslated$construct,
                "no PARMS operands (no MUE, MUC or MUL)")
   expect_true(any(grepl("modterm.c", got$untranslated$reason, fixed = TRUE)))
 })
 
-test_that("a PARMS whose operands all fail to parse is not called 'no PARMS'", {
+test_that("operands this parser cannot read are recorded but never refused", {
+  # `refused` drives a stop() in place of the fit, so it is a claim about what
+  # PROC HAZARD does and is sound only when the whole statement was understood.
+  # .hzr_parse_hazard() splits on " ", so `PARMS MUE = 0.2` arrives as separate
+  # "MUE", "=", "0.2" operands and nothing parses -- while HAZARD's lexer drops
+  # whitespace unconditionally (hazard_l.l:32, rule at :50) and RUNS that job
+  # with an active early phase. Refusing it would stop a job the reference
+  # accepts, so the gate must key on comprehension, not on has_phases.
+  spaced <- .hzr_parse_parms(c("MUE", "=", "0.2", "THALF", "=", "1"))
+  expect_false(spaced$has_phases)
+  expect_false(spaced$refused)
+  expect_false(any(grepl("modterm.c", spaced$untranslated$reason, fixed = TRUE)))
+  # Not refusing is not the same as declaring it fine -- the operands are still
+  # reported, so this cannot pass by the parser having silently accepted them.
+  expect_true("MUE" %in% spaced$untranslated$construct)
+
+  # The paired readable case, so the assertions above cannot pass merely
+  # because nothing ever refuses: MUE=0 is understood AND selects no phase.
+  read <- .hzr_parse_parms(c("MUE=0", "THALF=1"))
+  expect_false(read$has_phases)
+  expect_true(read$refused)
+})
+
+test_that("a PARMS template with `?` placeholders is not refused as no-phase", {
   # dist/examples/hm.dthar.TGA.sas is a template carrying literal
   # `PARMS MUE=? THALF=? NU=? M=1 FIXM MUC=?;` for the reader to fill in from
-  # the stepwise output above it. Every value is non-numeric, so mu, early and
-  # late all stay empty while the statement plainly existed. $untranslated is
-  # the frame a caller reads to decide whether a translation can be trusted,
-  # so keying the wording on mu/early/late rather than on `operands` would
-  # annotate that job "no PARMS" -- wrong, and confidently so.
-  got <- .hzr_parse_parms(c("MUE=?", "MUC=?"))
+  # the stepwise output above it. Every value is non-numeric, so no MU is
+  # active -- but that is this parser failing to read the statement, not PROC
+  # HAZARD selecting no phase, and the reference would reject `?` as a SYNTAX
+  # error long before modterm.c's ERROR 1001. Claiming "No phase selected"
+  # here would attribute the wrong refusal to the reference, and now that
+  # `refused` emits a stop() it would also replace the fit on that basis.
+  got <- .hzr_parse_parms(c("MUE=?", "THALF=?", "M=1", "FIXM", "MUC=?"))
   expect_false(got$has_phases)
-  expect_true("PARMS with no positive MUE, MUC or MUL" %in%
-                got$untranslated$construct)
-  expect_false("no PARMS operands (no MUE, MUC or MUL)" %in%
-                 got$untranslated$construct)
+  expect_false(got$refused)
+  expect_false(any(grepl("modterm.c", got$untranslated$reason, fixed = TRUE)))
+  # The unreadable operands are each still reported by name, so the assertions
+  # above cannot pass by the whole statement having been silently dropped.
+  expect_true(all(c("MUE=?", "THALF=?", "MUC=?") %in% got$untranslated$construct))
 })
 
 test_that("covariates of a phase that is not built are recorded, not dropped", {

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -447,6 +447,38 @@ test_that("no active MU at all is recorded as the refusal PROC HAZARD raises", {
   expect_equal(ok$untranslated$construct, "MUE=0.2")
 })
 
+test_that("a job with no PARMS operands at all is refused, not defaulted", {
+  # The wider half of the same modterm.c rule. A PROC HAZARD job carrying no
+  # PARMS statement reaches here with operands = character(0), so no
+  # setparmno() call ever fires (parmprc.c:13,18,19), all three C->phase[]
+  # stay at their stmtprc.c:87 zero, and modterm.c:18-22 raises ERROR 1001.
+  # modterm() is universal rather than multiphase-only: its single call site
+  # is outmods.c:91, outmods() is unconditional in main (hazard.c:296), and
+  # hazard.c:298-301 routes 1001 to hzfxit("SEMANTIC") BEFORE results(). The
+  # job never fits, so a translation that emits one is a wrong answer.
+  got <- .hzr_parse_parms(character(0))
+  expect_false(got$has_phases)
+  expect_equal(got$untranslated$construct,
+               "no PARMS operands (no MUE, MUC or MUL)")
+  expect_true(any(grepl("modterm.c", got$untranslated$reason, fixed = TRUE)))
+})
+
+test_that("a PARMS whose operands all fail to parse is not called 'no PARMS'", {
+  # dist/examples/hm.dthar.TGA.sas is a template carrying literal
+  # `PARMS MUE=? THALF=? NU=? M=1 FIXM MUC=?;` for the reader to fill in from
+  # the stepwise output above it. Every value is non-numeric, so mu, early and
+  # late all stay empty while the statement plainly existed. $untranslated is
+  # the frame a caller reads to decide whether a translation can be trusted,
+  # so keying the wording on mu/early/late rather than on `operands` would
+  # annotate that job "no PARMS" -- wrong, and confidently so.
+  got <- .hzr_parse_parms(c("MUE=?", "MUC=?"))
+  expect_false(got$has_phases)
+  expect_true("PARMS with no positive MUE, MUC or MUL" %in%
+                got$untranslated$construct)
+  expect_false("no PARMS operands (no MUE, MUC or MUL)" %in%
+                 got$untranslated$construct)
+})
+
 test_that("covariates of a phase that is not built are recorded, not dropped", {
   # setstat.c:9-12 returns early for a phase whose C->phase[] is 0, so PROC
   # HAZARD drops these too -- the values agree and only silence would be wrong.

--- a/tests/testthat/test-translate-sas.R
+++ b/tests/testthat/test-translate-sas.R
@@ -230,23 +230,74 @@ test_that("a corpus round-trip on hz.te123.OMC.sas preserves both HAZARD and bot
   expect_true(all(c("pred_haz", "pred_haz_2") %in% names(job$calls)))
 })
 
-test_that("a PROC HAZARD job with no PARMS surfaces the modterm.c refusal", {
-  # End to end, because the unit assertion in test-sas-parse-parms.R proves
-  # only that .hzr_parse_parms() built the row -- not that it survives into
-  # what a caller of hzr_translate_sas() actually reads. Before this guard the
-  # job below translated with an EMPTY $untranslated frame and full token
-  # coverage, emitting a runnable single-distribution fit for a job PROC
-  # HAZARD refuses outright (modterm.c:18-22, ERROR 1001 "No phase selected";
-  # hazard.c:298-301 exits before results()). The coverage assertion is the
-  # point: it is exactly what made the defect invisible.
+# The translator emits its fit as `fit <- hazard(...)`, so the call head is
+# `<-` and a naive identical(x[[1]], quote(hazard)) never matches -- an
+# assertion that "no fit was emitted" would then pass unconditionally.
+.is_hazard_fit <- function(x) {
+  if (!is.call(x)) return(FALSE)
+  if (identical(x[[1L]], quote(`<-`)) && is.call(x[[3L]])) x <- x[[3L]]
+  identical(x[[1L]], quote(hazard))
+}
+
+test_that("a PROC HAZARD job with no PARMS is refused, not fitted", {
+  # PROC HAZARD does not run this job: with no active phase modterm.c:18-22
+  # raises ERROR 1001 and hazard.c:299-302 exits via hzfxit("SEMANTIC") before
+  # results(). Before this guard the job translated with an EMPTY $untranslated
+  # frame and full token coverage, emitting a runnable single-distribution fit
+  # for a job the reference refuses outright.
+  #
+  # The assertion that carries the weight is the absence of a hazard() call:
+  # an $untranslated row alone leaves the fit chunk in place, so a reader who
+  # renders past the callout still gets a converged fit with a populated
+  # summary standing in for a job that produced no result at all.
   f <- withr::local_tempfile(fileext = ".sas")
   writeLines(c("PROC HAZARD DATA=D;", "  TIME FU;", "  EVENT DEAD;", "RUN;"), f)
   job <- suppressWarnings(hzr_translate_sas(f))
 
-  expect_true(any(grepl("modterm.c", job$untranslated$reason, fixed = TRUE)))
+  expect_false(any(vapply(job$calls, .is_hazard_fit, logical(1))))
+  says_refused <- function(x) {
+    any(grepl("No phase selected", as.character(x), fixed = TRUE))
+  }
+  expect_true(any(vapply(job$calls, says_refused, logical(1))))
   expect_equal(job$untranslated$construct,
                "no PARMS operands (no MUE, MUC or MUL)")
-  # Coverage still reports every token mapped -- the counters cannot express
-  # this defect, which is why the row has to.
-  expect_equal(job$coverage$tokens_seen, job$coverage$tokens_mapped)
+})
+
+test_that("a PARMS this parser cannot read is recorded but NOT refused", {
+  # The false positive the refusal gate exists to prevent, and it is not
+  # hypothetical: .hzr_parse_hazard() splits operands on " ", so `MUE = 0.2`
+  # yields "MUE", "=", "0.2" and nothing parses -- while HAZARD's own lexer
+  # discards whitespace unconditionally (hazard_l.l:32, rule at :50), making
+  # this a well-formed parmsopt (hazard_y.y:138) whose job RUNS with an active
+  # early phase. Refusing it would stop a job PROC HAZARD accepts, which is
+  # worse than translating it imperfectly: $untranslated still records every
+  # operand that was not understood.
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste("PROC HAZARD DATA=D; TIME FU; EVENT DEAD;",
+                   "PARMS MUE = 0.2 THALF = 1 NU = 1; RUN;"), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+
+  expect_false(any(grepl("No phase selected", job$untranslated$reason,
+                         fixed = TRUE)))
+  expect_true(any(vapply(job$calls, .is_hazard_fit, logical(1))))
+  # ... and the operands it could not read are still reported, so declining to
+  # refuse is not the same as declaring the job fine.
+  expect_true("MUE" %in% job$untranslated$construct)
+})
+
+test_that("a second PARMS statement adds to the first rather than replacing it", {
+  # PROC HAZARD keeps its PARMS fields in one table that parmprc() reads once,
+  # after every statement is processed, so `PARMS MUE=0.2 ...; PARMS FIXNU;`
+  # runs with an active early phase. Overwriting parms_ops dropped MUE and made
+  # the no-phase guard refuse a job the reference accepts.
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(paste("PROC HAZARD DATA=D; TIME FU; EVENT DEAD;",
+                   "PARMS MUE=0.2 THALF=1 NU=1; PARMS FIXNU; RUN;"), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+
+  expect_false(any(grepl("No phase selected", job$untranslated$reason,
+                         fixed = TRUE)))
+  fit <- Filter(.is_hazard_fit, job$calls)
+  expect_length(fit, 1L)
+  expect_equal(fit[[1L]][[3L]]$dist, "multiphase")
 })

--- a/tests/testthat/test-translate-sas.R
+++ b/tests/testthat/test-translate-sas.R
@@ -229,3 +229,24 @@ test_that("a corpus round-trip on hz.te123.OMC.sas preserves both HAZARD and bot
   # four minimum kinds.
   expect_true(all(c("pred_haz", "pred_haz_2") %in% names(job$calls)))
 })
+
+test_that("a PROC HAZARD job with no PARMS surfaces the modterm.c refusal", {
+  # End to end, because the unit assertion in test-sas-parse-parms.R proves
+  # only that .hzr_parse_parms() built the row -- not that it survives into
+  # what a caller of hzr_translate_sas() actually reads. Before this guard the
+  # job below translated with an EMPTY $untranslated frame and full token
+  # coverage, emitting a runnable single-distribution fit for a job PROC
+  # HAZARD refuses outright (modterm.c:18-22, ERROR 1001 "No phase selected";
+  # hazard.c:298-301 exits before results()). The coverage assertion is the
+  # point: it is exactly what made the defect invisible.
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(c("PROC HAZARD DATA=D;", "  TIME FU;", "  EVENT DEAD;", "RUN;"), f)
+  job <- suppressWarnings(hzr_translate_sas(f))
+
+  expect_true(any(grepl("modterm.c", job$untranslated$reason, fixed = TRUE)))
+  expect_equal(job$untranslated$construct,
+               "no PARMS operands (no MUE, MUC or MUL)")
+  # Coverage still reports every token mapped -- the counters cannot express
+  # this defect, which is why the row has to.
+  expect_equal(job$coverage$tokens_seen, job$coverage$tokens_mapped)
+})


### PR DESCRIPTION
Stacked on #237 — **please merge that first**; the base is `fix/sas-parms-phase-keyed-on-mu`, so this diff is two commits.

## The question this had to settle first

#237's MU gate records a `PARMS` statement that activates no phase, but deliberately scoped itself out of the older and wider case: a `PROC HAZARD` job carrying **no `PARMS` statement at all**. Whether that is a defect or correct-as-is turns entirely on one question about the reference C — *is `modterm()` reached for every job, or only once a multiphase model has been selected?*

**It is universal.** Verified against `~/Documents/GitHub/hazard`:

- `modterm()` has exactly one call site, `outmods.c:91`.
- `outmods()` sits in `main`'s straight-line sequence at `hazard.c:296` — no enclosing conditional, no early return between `hzrg()` and it.
- The no-phase test is not a filter that could hide the call; it is one of the three disjuncts at `outmods.c:89` that *fire* it.
- `hazard.c:299-302` routes `errorno = 1001` to `hzfxit("SEMANTIC")`, which exits **before** `results()`.

So the job prints no estimates and never fits.

The other half holds too. Across all of `src/hazard`, `C->phase[]` is written in exactly two places: `stmtprc.c:87` zeroes all three at init, and `setparmno.c:14` sets one to `1` — reachable only from `parmprc.c:13,18,19` (MUE/MUC/MUL) and only under `stmtfld(parmno) > ZERO`. The seven shape operands go through `setprmf()`, which never touches it. (`hzpe.c` also writes `phase[]`, but that is `hazpred`/`libhazp` — a different program.)

"No `PARMS`" and "`PARMS` naming no positive MU" are therefore **one state, not two cases**.

## What was wrong

On `main`, a minimal no-PARMS job translated to:

```r
fit <- hazard(data = D, time = FU, status = .hzr_status, fit = TRUE,
              theta = c(), weights = ifelse(DEAD > 0, DEAD, 1))
```

**0 untranslated rows, 3/3 token coverage** — a runnable single-distribution fit, reported as fully translated, for a job SAS refuses outright. `theta = c()` is the tell: the hollow-object shape, which defeats both `is.null` and a length check on the wrapper.

The corpus test could not catch this. `test-sas-translate-corpus.R:20` asserts `tokens_seen > 0` and `seen >= mapped` — coverage counters, which a wrong-but-runnable fit satisfies cleanly.

## The change

**Refused, not recorded.** `.hzr_parse_parms()` returns `refused`, and `.hzr_parse_job()` emits a `stop()` in place of the `hazard()` call, mirroring the `LCENSOR` + `ICENSOR` path at `sas-parse-job.R:536`. An `$untranslated` row alone leaves the fit chunk in place, so a reader who renders past the callout still gets a converged fit with a populated summary standing in for a job that produced no result.

**Refusal requires comprehension.** It fires only when every operand was understood. `PARMS MUE = 0.2 THALF = 1` (spaces around `=`) parses to nothing here, because `.hzr_parse_hazard()` splits on `" "` — while HAZARD's lexer discards whitespace unconditionally (`hazard_l.l:32`, rule at `:50`), making it a well-formed `parmsopt` (`hazard_y.y:138`) whose job **runs**. Refusing that would stop a job the reference accepts. The per-operand rows still record what was not understood; only the refusal, which is a claim about the reference, requires having understood it all.

**A second `PARMS` accumulates** rather than replacing the first, matching the single field table `parmprc()` reads once after all statements are processed. Overwriting made `PARMS MUE=0.2 THALF=1 NU=1; PARMS FIXNU;` refuse a job that runs.

## Corpus effect

Re-measured A/B across all 110 `.sas` files: **exactly 1 of 57** translated jobs differs from #237, and only by **dropping a false claim**. the **second** `%HAZARD` block of `dist/examples/hm.dthar.TGA.sas` (line 110, its `PARMS` at 122) is a documentation template carrying literal `?` placeholders; #237 annotates it as refused by `ERROR 1001`, but the reference would reject `?` as a **syntax error** long before `modterm.c`. That file's *first* block (line 70, `PARMS` at 74) is a valid `MUE=0.2 THALF=0.08 NU=1 M=1 FIXM MUC=0.001` activating phases 1 and 2 and is unaffected — the template shape belongs to one block, not to the file. Its per-operand rows are unchanged, and **no corpus job is refused**.

An earlier text-matching scan suggested 11 affected jobs; every one was a false positive — matches inside comments, or blocks whose `PARMS` arrives via `%hmmodel;` macro expansion. Matching on the *call head* rather than deparsed text gives the figures above.

## Verification

Tests were mutation-checked rather than reasoned about — restoring #237's narrow scoping and keying the wording on `mu`/`early`/`late` each produce failures. One assertion had to be rewritten because `identical(x[[1]], quote(hazard))` passes unconditionally against the emitted `fit <- hazard(...)`; the helper now unwraps the assignment.

Gates, in AGENTS.md order:

- `devtools::document()` — clean, no `man/`/`NAMESPACE` diff
- `lintr::lint_package()` — **0 lints**
- `devtools::test()` with `NOT_CRAN=true` — **0 failures**, 6 skips, **3789 passes** (skips unchanged from the AGENTS.md baseline)
- `R CMD check --as-cran` from a clean `git archive` export, with the manual — **`Status: OK`**

The `r-reviewer` findings and how each was resolved are in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
