### PR TITLE
fix(sas): start unspecified PARMS shape operands where PROC HAZARD does

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,19 +42,42 @@
   package's own fixture that moves `gamma`'s standard error from 7.5 to 0.02.
   This replaces an `$untranslated` row with a faithful translation.
 
-* **`hzr_translate_sas()` records, but deliberately does not mirror,
-  `SETG3_verify_ge_2()`.** When `GAMMA * ETA <= 2` and neither is fixed,
-  `setg3.c:907-921` rewrites the free one to `3` over the other -- and the
-  `PROC HAZARD` defaults `gamma = 1`, `eta = 2` land on that boundary exactly,
-  so it applies to every defaulted non-`WEIBULL` late phase. That constraint
-  exists to keep `PROC HAZARD` inside a numerical branch it can evaluate, the
-  same role `g3flag` plays; `hzr_decompos_g3()` carries the general
-  four-parameter form and needs no such restriction, and reaching a late shape
-  the reference implementation cannot is a purpose of this package. The
-  emitted call therefore keeps the general shape, and the divergence is
-  recorded so a SAS parity comparison knows why the starting values differ.
-  No corpus job is affected: every late-phase block there is `WEIBULL`, which
-  returns at `setg3.c:347` before this code runs.
+* **`hzr_translate_sas()` now reports the whole of what `SETG3()` would do to
+  a late phase, and mirrors only the part that has to be mirrored.**
+  `PROC HAZARD` does not optimize from the operands `PARMS` supplies: `SETG3()`
+  rewrites them first, and refuses some jobs outright. The translator now walks
+  that function (`src/model/setg3.c`) and records both, splitting them on a
+  single principle:
+
+  - A rewrite that resolves an **exact non-identifiability** is *mirrored*,
+    because the degeneracy is algebra and is just as real in R. There are two,
+    both in `SETG3_ignore_tau()`: the `TAU` pin and the `ETA` fix, described
+    above.
+  - Every other rewrite keeps `PROC HAZARD` inside a numerical branch it can
+    evaluate -- the role `g3flag` plays, which `hzr_decompos_g3()` does not
+    need because it carries the general four-parameter `G3` form. Copying those
+    would import a SAS limitation into R, and reaching a late shape the
+    reference implementation cannot is a purpose of this package. They are
+    *recorded* in `$untranslated`, so a SAS parity run knows why the starting
+    values differ.
+
+  In practice this covers `SETG3_verify_ge_2()`'s push of `GAMMA * ETA` clear
+  of 2 (which the `PROC HAZARD` defaults `gamma = 1`, `eta = 2` trip exactly,
+  so it applied to every defaulted non-`WEIBULL` late phase), the value
+  substitutions in all eight sign branches, and `SETG3_alpha_fixup()` /
+  `SETG3_alpha_gener()` deriving `ALPHA` from `GAMMA * ETA`.
+
+  Sixteen refusal codes are now recorded rather than emitted as runnable fits,
+  where previously only `SETG3980` was -- and that one only for `alpha = 0`,
+  not for the negative `ALPHA` that raises it too. `ALPHA = 0` **with**
+  `FIXALPHA` is the limiting exponential in both implementations and still
+  translates cleanly; left free, `SETG3` derives an `ALPHA` instead, which is
+  now reported.
+
+  No corpus job is affected: every late-phase block in the public corpus
+  carries `WEIBULL`, which returns at `setg3.c:347` before the sign dispatch,
+  and all of them write `TAU=1 FIXTAU ALPHA=1 FIXALPHA` with a positive `GAMMA`
+  and `ETA`. Verified by running the parser over all of them before and after.
 
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
   statement specified alongside `WEIBULL`.** The translator read the bare

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,9 +30,31 @@
   `$untranslated` to say so. The emitted call now carries `tau = 1` and
   `"tau"` in `fixed`, which identifies `log_mu` again. Jobs whose `PARMS`
   named a different `TAU` additionally record a row, since that value is used
-  by neither `PROC HAZARD` nor the translation. **This changes the emitted
-  call for every job that fixes `ALPHA` at 1**, which is the dominant late-
-  phase shape in the corpus.
+  by neither `PROC HAZARD` nor the translation. No corpus translation changes:
+  every late-phase block in the public corpus already writes `TAU=1 FIXTAU`,
+  so the emitted calls are byte-identical before and after (checked by running
+  the parser over all of them). What changes there is that those jobs no
+  longer need a warning.
+
+  The same branch's `ETA` fix (`setg3.c:405`) is mirrored too: with `GAMMA` and
+  `ETA` both free at `alpha = 1` the pair is exactly singular, and
+  `hzr_phase()` previously left both free and fitted the ridge. On the
+  package's own fixture that moves `gamma`'s standard error from 7.5 to 0.02.
+  This replaces an `$untranslated` row with a faithful translation.
+
+* **`hzr_translate_sas()` records, but deliberately does not mirror,
+  `SETG3_verify_ge_2()`.** When `GAMMA * ETA <= 2` and neither is fixed,
+  `setg3.c:907-921` rewrites the free one to `3` over the other -- and the
+  `PROC HAZARD` defaults `gamma = 1`, `eta = 2` land on that boundary exactly,
+  so it applies to every defaulted non-`WEIBULL` late phase. That constraint
+  exists to keep `PROC HAZARD` inside a numerical branch it can evaluate, the
+  same role `g3flag` plays; `hzr_decompos_g3()` carries the general
+  four-parameter form and needs no such restriction, and reaching a late shape
+  the reference implementation cannot is a purpose of this package. The
+  emitted call therefore keeps the general shape, and the divergence is
+  recorded so a SAS parity comparison knows why the starting values differ.
+  No corpus job is affected: every late-phase block there is `WEIBULL`, which
+  returns at `setg3.c:347` before this code runs.
 
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
   statement specified alongside `WEIBULL`.** The translator read the bare

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,23 @@
 
 ## Bug fixes
 
+* **`hzr_translate_sas()` now starts an unspecified shape parameter where
+  `PROC HAZARD` starts it, not where `hzr_phase()` does.** A `PARMS` statement
+  that named only some of a phase's shape operands had the rest filled from
+  `hzr_phase()`'s defaults, and three of them disagree with the reference C
+  (`src/hazard/stmtprc.c`): `NU` starts at 2 rather than 1, `M` at 1 rather
+  than 0, and `ETA` at 2 rather than 1. Since the multiphase likelihood is
+  multimodal, a different starting vector can reach a different optimum, so
+  this was a fidelity divergence rather than a cosmetic one. The defaults are
+  now `PROC HAZARD`'s, and the emitted `hzr_phase()` call names every shape
+  argument explicitly so that what is printed and what reaches the optimizer
+  cannot disagree. `TAU` is the exception: `SETG3()` starts a non-positive
+  `TAU` at `2*Tmax/3`, which depends on the data and cannot be reproduced at
+  parse time, so such a phase is emitted at `tau = 1` and recorded in
+  `$untranslated` -- unless `SETG3_ignore_tau()` applies, which pins `TAU` at
+  1 anyway. No job in the public corpus is partially specified, so nothing
+  previously translated changes.
+
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
   statement specified alongside `WEIBULL`.** The translator read the bare
   `WEIBULL` keyword as a request to constrain the late phase to

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,20 @@
   `TAU` at `2*Tmax/3`, which depends on the data and cannot be reproduced at
   parse time, so such a phase is emitted at `tau = 1` and recorded in
   `$untranslated` -- unless `SETG3_ignore_tau()` applies, which pins `TAU` at
-  1 anyway. No job in the public corpus is partially specified, so nothing
-  previously translated changes.
+  1 anyway. No job in the *public corpus* is partially specified, so no corpus
+  translation changes; the package's own end-to-end fits test does carry a
+  partial block (`MUE THALF NU MUC`, no `M`), and its early phase now starts at
+  `m = 1`.
+
+* **`hzr_translate_sas()` now reports that `SETG3_ignore_tau()` fixes `TAU`,
+  not merely that it sets it.** When `ALPHA` is fixed at 1, `setg3.c:378-379`
+  sets `TAU` to 1 *and* fixes it; the emitted `hzr_phase()` call left `TAU`
+  free. At `alpha = 1` the `G3` form collapses to `(t/tau)^(gamma*eta)`, so
+  `log_mu` and `log_tau` are exactly aliased -- the fit converges onto a flat
+  ridge and returns no standard errors for either, with nothing in
+  `$untranslated` to say so. Such a job now records a row. This fires whether
+  or not `PARMS` named a `TAU`, because `PROC HAZARD` overwrites the value
+  either way.
 
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
   statement specified alongside `WEIBULL`.** The translator read the bare

--- a/NEWS.md
+++ b/NEWS.md
@@ -67,9 +67,20 @@
   substitutions in all eight sign branches, and `SETG3_alpha_fixup()` /
   `SETG3_alpha_gener()` deriving `ALPHA` from `GAMMA * ETA`.
 
-  Sixteen refusal codes are now recorded rather than emitted as runnable fits,
+  Nine refusal codes can now be recorded rather than emitted as runnable fits,
   where previously only `SETG3980` was -- and that one only for `alpha = 0`,
-  not for the negative `ALPHA` that raises it too. `ALPHA = 0` **with**
+  not for the negative `ALPHA` that raises it too. (All sixteen are mirrored
+  from the C, but seven guard conditions the entry checks at `setg3.c:269-284`
+  have already refused, so no input reaches them; an exhaustive search in the
+  tests pins which nine are live.)
+
+  One correction to a rule this package had recorded wrongly: an **unspecified**
+  `TAU` does not reach `SETG3()` as the value `stmtprc.c` starts it at, 0.
+  `src/hazard/readobs.c:153-154` replaces it with `0.75 * Tmax` on an active
+  late phase, and `readobs()` runs before `SETG3()` (`hazard.c:276` against
+  `:292`). So an absent `TAU` starts at `0.75 * Tmax`, not `2 * Tmax / 3` --
+  that rule (`setg3.c:317`) governs only a `TAU` the job wrote as non-positive
+  -- and a bare `FIXTAU` cannot raise `SETG3900`. `ALPHA = 0` **with**
   `FIXALPHA` is the limiting exponential in both implementations and still
   translates cleanly; left free, `SETG3` derives an `ALPHA` instead, which is
   now reported.

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,15 +21,18 @@
   partial block (`MUE THALF NU MUC`, no `M`), and its early phase now starts at
   `m = 1`.
 
-* **`hzr_translate_sas()` now reports that `SETG3_ignore_tau()` fixes `TAU`,
-  not merely that it sets it.** When `ALPHA` is fixed at 1, `setg3.c:378-379`
-  sets `TAU` to 1 *and* fixes it; the emitted `hzr_phase()` call left `TAU`
-  free. At `alpha = 1` the `G3` form collapses to `(t/tau)^(gamma*eta)`, so
-  `log_mu` and `log_tau` are exactly aliased -- the fit converges onto a flat
-  ridge and returns no standard errors for either, with nothing in
-  `$untranslated` to say so. Such a job now records a row. This fires whether
-  or not `PARMS` named a `TAU`, because `PROC HAZARD` overwrites the value
-  either way.
+* **`hzr_translate_sas()` now pins `TAU` where `SETG3_ignore_tau()` pins it.**
+  When `ALPHA` is fixed at 1, `setg3.c:378-379` sets `TAU` to 1 *and* fixes
+  it; the emitted `hzr_phase()` call mirrored neither, leaving `TAU` free. At
+  `alpha = 1` the `G3` form collapses to `(t/tau)^(gamma*eta)`, so `log_mu`
+  and `log_tau` are exactly aliased: the translated fit converged onto a flat
+  ridge and returned no standard errors for either, with nothing in
+  `$untranslated` to say so. The emitted call now carries `tau = 1` and
+  `"tau"` in `fixed`, which identifies `log_mu` again. Jobs whose `PARMS`
+  named a different `TAU` additionally record a row, since that value is used
+  by neither `PROC HAZARD` nor the translation. **This changes the emitted
+  call for every job that fixes `ALPHA` at 1**, which is the dominant late-
+  phase shape in the corpus.
 
 * **`hzr_translate_sas()` no longer discards the `ALPHA` and `ETA` a `PARMS`
   statement specified alongside `WEIBULL`.** The translator read the bare

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -28,7 +28,7 @@
 .hzr_parms_late_arg  <- c(TAU = "tau", GAMMA = "gamma", ALPHA = "alpha", ETA = "eta")
 .hzr_parms_mu_order  <- c("MUE", "MUC", "MUL")
 
-# PROC HAZARD's OWN shape defaults (stmtprc.c:30-37), used for any shape
+# PROC HAZARD's OWN shape defaults (src/hazard/stmtprc.c:34-37), used for any shape
 # operand a PARMS statement did not name. They are not hzr_phase()'s defaults
 # -- nu, m and eta all differ (SAS 2/1/2 against R 1/0/1) -- and the starting
 # vector is what the emitted call hands the optimizer, so mirroring R's
@@ -259,12 +259,37 @@
   "(SETG33010)" = "ETA is fixed but non-positive, with no GAMMA to derive one from",
   "(SETG33020)" = "GAMMA is fixed but non-positive, with no ETA to derive one from"
 )
+# Deliberately absent, so their omission is not read as an oversight:
+#   SETG3950  (setg3.c:319-321) fires when 2*Tmax/3 itself is <= 0. That is a
+#             property of the data, not of the PARMS block, so it cannot be
+#             decided here -- the TAU row already says the start is
+#             data-dependent.
+#   SETG3940, SETG3990, SETG31000, SETG31010
+#             are reachable only through g_two/ga_two, which FIXGE2/FIXGAE2
+#             drive and .hzr_sas_token() records as unresolved.
+# SEVEN of the sixteen are unreachable in both languages, because each guards a
+# condition the ENTRY checks at setg3.c:269-284 have already refused:
+#   SETG31090, SETG32050, SETG33020  want a non-positive GAMMA that is fixed
+#                                    -- SETG3910 refuses first.
+#   SETG32020, SETG32080, SETG33010  want a non-positive ETA that is fixed
+#                                    -- SETG3930 refuses first.
+#   SETG31070                        wants a fixed ALPHA on a branch where
+#                                    alpha <= 0: negative refuses at SETG3920,
+#                                    and zero sets g3flag = 2 (:332-335) so
+#                                    SETG3_alpha_gener() is never called.
+# They are kept because the C keeps them and because the entry checks are what
+# makes them dead -- change those and these wake up. Nine codes can actually
+# fire, which an exhaustive search in the tests pins rather than asserts.
 
 #' Plain-language gloss for a SETG3 refusal code.
 #' @noRd
 .hzr_setg3_refusal_reason <- function(code) {
-  hit <- .hzr_setg3_refusal[[code]]
-  if (is.null(hit)) "the operand combination is rejected" else hit
+  # `[[` on an unmatched name in a CHARACTER vector throws "subscript out of
+  # bounds" rather than returning NULL, so an is.null() fallback here would be
+  # hollow -- right shape, never reachable, and the parser would error instead
+  # of degrading if a code were ever added to the trace but not the table.
+  hit <- .hzr_setg3_refusal[code]
+  if (is.na(hit)) "the operand combination is rejected" else unname(hit)
 }
 
 #' `alpha` handling shared by several SETG3 branches (setg3.c:815-852).
@@ -290,9 +315,13 @@
 #' Walk `SETG3()` and report what it would do to one late phase.
 #'
 #' @param tau_raw,gamma,alpha,eta The operand values `PARMS` supplied, with
-#'   PROC HAZARD's own initializers for any it did not (`stmtprc.c:33-36`).
-#'   `tau_raw` is 0 when `TAU` was absent -- SAS's initializer, not the 1 the
-#'   emitted call uses as a placeholder.
+#'   PROC HAZARD's own initializers for any it did not
+#'   (`src/hazard/stmtprc.c:34-37`). `tau_raw` is `NA` when `TAU` was absent:
+#'   the `stmtprc.c` initializer of 0 does NOT survive to `SETG3()`, because
+#'   `src/hazard/readobs.c:153-154` replaces an unspecified `TAU` with
+#'   `0.75 * Tmax` on an active late phase, and `readobs()` runs at
+#'   `hazard.c:276`, before `hzrg()` reaches `SETG3()` at `:292`. So an absent
+#'   `TAU` arrives POSITIVE and cannot raise `SETG3900`.
 #' @param fixed Character vector of parameters the job's `FIX*` tokens pinned,
 #'   as the user wrote them: these checks run before SETG3 changes any flag.
 #' @param weibull Whether the job carries the bare `WEIBULL` keyword.
@@ -302,14 +331,21 @@
 #' @noRd
 .hzr_setg3_notes <- function(tau_raw, gamma, alpha, eta, fixed, weibull) {
   fx <- function(p) p %in% fixed
-  refuse <- function(code) list(refusal = code, shape = NULL)
+  # `entry` marks the four checks at setg3.c:269-284, the only ones raised
+  # BEFORE the TAU rules at :309-323. The other twelve codes fire after those
+  # rules have already run, which decides whether a TAU row still applies.
+  refuse <- function(code, entry = FALSE) {
+    list(refusal = code, entry = entry, shape = NULL)
+  }
 
   # setg3.c:269-284. A FIX* on an operand SAS reads as unspecified is fatal,
   # and it is checked before anything else -- including SETG3_ignore_tau().
-  if (isTRUE(tau_raw <= 0) && fx("tau")) return(refuse("(SETG3900)"))
-  if (isTRUE(gamma <= 0) && fx("gamma")) return(refuse("(SETG3910)"))
-  if (isTRUE(alpha < 0) && fx("alpha")) return(refuse("(SETG3920)"))
-  if (isTRUE(eta <= 0) && fx("eta")) return(refuse("(SETG3930)"))
+  # An absent TAU (NA) is 0.75*Tmax by the time SETG3 sees it -- positive, so
+  # only an explicitly non-positive TAU= can refuse here.
+  if (isTRUE(tau_raw <= 0) && fx("tau")) return(refuse("(SETG3900)", TRUE))
+  if (isTRUE(gamma <= 0) && fx("gamma")) return(refuse("(SETG3910)", TRUE))
+  if (isTRUE(alpha < 0) && fx("alpha")) return(refuse("(SETG3920)", TRUE))
+  if (isTRUE(eta <= 0) && fx("eta")) return(refuse("(SETG3930)", TRUE))
 
   # setg3.c:313-315 and 403-421. Reproduced here for the trace only: the
   # emitted call deliberately keeps the user's GAMMA and ETA, because the
@@ -339,7 +375,7 @@
     if (isTRUE(alpha < 0) || (isTRUE(alpha == 0) && g3flag + 2L == 3L)) {
       return(refuse("(SETG3980)"))
     }
-    return(list(refusal = NULL,
+    return(list(refusal = NULL, entry = FALSE,
                 shape = c(gamma = gamma, alpha = alpha, eta = eta)))
   }
 
@@ -366,14 +402,14 @@
       if (is.character(a)) bad <- a else alpha <- a
     }
   } else if (isTRUE(alpha > 0) && isTRUE(eta > 0)) {
-    # gamma <= 0 (setg3.c:533-585)
+    # gamma <= 0 (setg3.c:534-585)
     if (fx("gamma")) return(refuse("(SETG31090)"))
     gamma <- 3 * alpha / eta
     if (isTRUE(gamma * eta <= 2)) gamma <- 3 / eta
     a <- .hzr_setg3_alpha_fixup(gamma, eta, alpha, fx("alpha"), weibull)
     if (is.character(a)) bad <- a else if (!is.null(a)) alpha <- a
   } else if (isTRUE(alpha > 0) && isTRUE(gamma > 0)) {
-    # eta <= 0 (setg3.c:587-636)
+    # eta <= 0 (setg3.c:588-636)
     if (fx("eta")) return(refuse("(SETG32020)"))
     eta <- 3 * alpha / gamma
     if (isTRUE(gamma * eta <= 2)) eta <- 3 / gamma
@@ -396,7 +432,7 @@
       if (is.character(a)) bad <- a else alpha <- a
     }
   } else if (isTRUE(alpha > 0)) {
-    # gamma <= 0, eta <= 0 (setg3.c:716-770)
+    # gamma <= 0, eta <= 0 (setg3.c:717-770)
     if (fx("gamma")) return(refuse("(SETG33020)"))
     if (fx("eta")) return(refuse("(SETG33010)"))
     eta <- 2
@@ -417,7 +453,8 @@
   }
 
   if (!is.null(bad)) return(refuse(bad))
-  list(refusal = NULL, shape = c(gamma = gamma, alpha = alpha, eta = eta))
+  list(refusal = NULL, entry = FALSE,
+       shape = c(gamma = gamma, alpha = alpha, eta = eta))
 }
 
 #' Map a SAS `PARMS` statement's operands to phases and a starting theta.
@@ -550,7 +587,17 @@
   # pins TAU at 1 (setg3.c:378), exactly the value emitted here.
   # `late` itself is left untouched: `length(late)` is the "did PARMS name a
   # late shape operand" gate below, and a TAU=0 operand still counts as one.
-  tau_defaulted <- is.null(late[["tau"]]) || !isTRUE(late[["tau"]] > 0)
+  #
+  # Absent and explicitly-non-positive are DIFFERENT cases, and conflating
+  # them put a false refusal in $untranslated. PROC HAZARD never sees the
+  # stmtprc.c initializer of 0 for an absent TAU: readobs.c:153-154 replaces
+  # it with 0.75*Tmax on an active late phase, before hzrg() reaches SETG3()
+  # (hazard.c:276 against :292). Only a TAU= the job actually wrote can still
+  # be <= 0 at setg3.c:269, and only that one reaches the 2*Tmax/3 assignment
+  # at :317. Both defaults are data-dependent; they are different data.
+  tau_absent <- is.null(late[["tau"]])
+  tau_nonpositive <- !tau_absent && !isTRUE(late[["tau"]] > 0)
+  tau_defaulted <- tau_absent || tau_nonpositive
   early_full <- .hzr_parms_fill_shape(early, .hzr_parms_early_sas_default)
   late_full <- .hzr_parms_fill_shape(late, .hzr_parms_late_sas_default)
 
@@ -586,7 +633,7 @@
     # is exactly what $untranslated exists to surface.
     late_full[["tau"]] <- 1
     pins <- "tau"
-    # setg3.c:405: with GAMMA and ETA both free, SETG3_ignore_tau() fixes ETA.
+    # setg3.c:406-407: with GAMMA and ETA both free, SETG3_ignore_tau() fixes ETA.
     # Mirrored for the same reason TAU is, and NOT for the reason
     # SETG3_verify_ge_2() is declined below: this one is exact algebra, not a
     # numerical-branch restriction. At alpha = 1 only the product gamma*eta
@@ -595,7 +642,7 @@
     # leaving both free relocates the flat ridge the TAU pin removed rather
     # than exercising a shape SAS cannot reach.
     #
-    # The VALUE rewrite that follows in the C (setg3.c:414-420: gamma <-
+    # The VALUE rewrite that follows in the C (setg3.c:411-415: gamma <-
     # gamma*eta, eta <- 1) is still not mirrored, per the decision recorded
     # above: it is likelihood-equivalent -- both parameterisations span the
     # same exponent -- so it changes what is reported, not what is fitted, and
@@ -678,7 +725,7 @@
   # A MU names its phase. Building a phase only when a *shape* operand
   # appeared let an orphaned MUE/MUL disappear together with the phase it
   # scaled -- a one-phase R model against SAS's two, and no untranslated row
-  # to say so. The shape defaults are now PROC HAZARD's own (stmtprc.c:30-37,
+  # to say so. The shape defaults are now PROC HAZARD's own (src/hazard/stmtprc.c:34-37,
   # see .hzr_parms_early_sas_default), but a phase reconstructed from nothing
   # but a MU would still start from a scale SAS does not use, and its tau would
   # still be data-dependent, so the MU stays recorded rather than guessed at.
@@ -732,7 +779,7 @@
   setg3_refused <- FALSE
   if (length(late) && has_late) {
     setg3 <- .hzr_setg3_notes(
-      tau_raw = if (tau_defaulted) 0 else late[["tau"]],
+      tau_raw = if (tau_absent) NA_real_ else late[["tau"]],
       gamma = late_full[["gamma"]],
       alpha = late_full[["alpha"]],
       eta = late_full[["eta"]],
@@ -740,7 +787,7 @@
       weibull = saw_weibull
     )
     if (!is.null(setg3$refusal)) {
-      setg3_refused <- TRUE
+      setg3_refused <- isTRUE(setg3$entry)
       flag_bad(
         sprintf("GAMMA=%g ALPHA=%g ETA=%g%s", late_full[["gamma"]],
                 late_full[["alpha"]], late_full[["eta"]],
@@ -759,9 +806,18 @@
     } else {
       # At alpha = 1 only the product gamma*eta is identified, and the
       # emitted call deliberately keeps the user's split rather than
-      # SETG3_ignore_tau()'s (setg3.c:414-420) -- likelihood-equivalent, so
+      # SETG3_ignore_tau()'s (setg3.c:411-415) -- likelihood-equivalent, so
       # compare the product there and each operand otherwise. Without this
       # every ignore_tau job would report a rewrite that changes no fit.
+      #
+      # The swap is product-preserving only while that product is POSITIVE.
+      # setg3.c:411-412 and :416-417 carry a fallback -- when gamma*eta <= 0
+      # the C keeps the OTHER operand instead, so gamma = -2, eta = 3 leaves
+      # SAS at gamma = 3, eta = 1, a product of 3 rather than -6. Comparing
+      # products still catches that (the two differ), which is the point: the
+      # comparison must not be read as an assertion that the swap is always
+      # harmless. Such a phase is emitted with a non-positive gamma anyway,
+      # which hzr_phase() rejects outright.
       emitted <- c(gamma = late_full[["gamma"]], alpha = late_full[["alpha"]],
                    eta = late_full[["eta"]])
       got <- setg3$shape
@@ -775,15 +831,36 @@
         function(a, b) isTRUE(all.equal(a, b)), emitted, got
       )]
       if (length(moved)) {
+        # Where the operand is outside hzr_phase()'s own domain the "general
+        # shape kept deliberately" framing is simply false: hzr_phase()
+        # stopifnot()s gamma > 0, eta > 0 and alpha >= 0 (R/phase-spec.R), so
+        # the emitted call cannot even be built. This is the one direction in
+        # which PROC HAZARD is the MORE permissive of the two -- it reads a
+        # non-positive operand as "derive one for me" -- and saying "a parity
+        # run starts elsewhere" would tell the reader the difference is a
+        # starting value when the difference is that R will not run this.
+        unbuildable <- !isTRUE(late_full[["gamma"]] > 0) ||
+          !isTRUE(late_full[["eta"]] > 0) ||
+          !isTRUE(late_full[["alpha"]] >= 0)
         flag_bad(
           paste(sprintf("%s=%g", names(emitted), emitted), collapse = " "),
           paste0("SETG3() optimizes from ",
                  paste(sprintf("%s = %g", moved, got[moved]), collapse = ", "),
-                 ", not the value(s) emitted here: it constrains the late ",
-                 "shape to keep PROC HAZARD inside a numerical branch it can ",
-                 "evaluate. hzr_decompos_g3() carries the general G3 form and ",
-                 "needs no such constraint, so the emitted call keeps it ",
-                 "deliberately -- but a SAS parity run starts elsewhere")
+                 ", not the value(s) emitted here: it ",
+                 if (unbuildable) {
+                   paste0("reads a non-positive GAMMA/ETA (or negative ALPHA) ",
+                          "as a request to derive one. hzr_phase() requires ",
+                          "gamma > 0, eta > 0 and alpha >= 0, so the emitted ",
+                          "call cannot be built at all -- supply the operand ",
+                          "rather than expecting a starting-value difference")
+                 } else {
+                   paste0("constrains the late shape to keep PROC HAZARD ",
+                          "inside a numerical branch it can evaluate. ",
+                          "hzr_decompos_g3() carries the general G3 form and ",
+                          "needs no such constraint, so the emitted call ",
+                          "keeps it deliberately -- but a SAS parity run ",
+                          "starts elsewhere")
+                 })
         )
       }
     }
@@ -794,10 +871,13 @@
   # A job that WROTE a different TAU is a different matter: PROC HAZARD
   # discards that value, and so now does this translator, but a starting value
   # the user typed and neither program uses is worth saying out loud.
-  # A refused job stops inside SETG3 before either TAU rule runs, so neither
-  # row below applies -- reporting them alongside the refusal would describe
-  # code PROC HAZARD never reaches, the same false-positive the MUL gate above
-  # exists to avoid.
+  # Only the four ENTRY refusals (setg3.c:269-284) are raised before the TAU
+  # rules at :309-323; the other twelve fire from :429 onwards, by which point
+  # PROC HAZARD has already applied whichever TAU rule was going to apply. So
+  # the suppression below is keyed on `setg3$entry`, not on "refused at all" --
+  # reporting a TAU rule alongside an entry refusal would describe code PROC
+  # HAZARD never reaches, the same false positive the MUL gate exists to avoid,
+  # while suppressing it for a late refusal would hide one that did run.
   if (length(late) && has_late && !setg3_refused && ignore_tau &&
       !is.null(late[["tau"]]) && !isTRUE(late[["tau"]] == 1)) {
     flag_bad(
@@ -809,6 +889,8 @@
     )
   } else if (length(late) && has_late && !setg3_refused && tau_defaulted &&
              !ignore_tau) {
+    # Which data-dependent default applies depends on whether the job wrote a
+    # TAU at all -- see the tau_absent/tau_nonpositive split above.
     # The other SETG3 branch (setg3.c:316-318), reached only when the
     # ignore_tau branch above was NOT taken -- setg3.c:313-316 is an if/else,
     # so a job that fixes ALPHA at 1 never gets this assignment at all.
@@ -824,13 +906,18 @@
     # `length(late)` because a late phase that was never built is already
     # reported by the MUL guard below, and two rows for one absence is noise.
     flag_bad(
-      if (is.null(late[["tau"]])) "TAU (unspecified)" else
+      if (tau_absent) "TAU (unspecified)" else
         paste0("TAU=", sprintf("%g", late[["tau"]])),
-      paste0("SETG3() starts a non-positive TAU at 2*Tmax/3, which depends ",
-             "on the data and cannot be reproduced at parse time; the ",
-             "emitted phase starts at tau = 1, so this fit begins somewhere ",
-             "PROC HAZARD would not and the multiphase likelihood is ",
-             "multimodal")
+      paste0("PROC HAZARD starts TAU at ",
+             if (tau_absent) {
+               "0.75*Tmax (readobs.c:153-154, applied to an unspecified TAU "
+             } else {
+               "2*Tmax/3 (setg3.c:317, applied to a non-positive TAU "
+             },
+             "before SETG3 runs), which depends on the data and cannot be ",
+             "reproduced at parse time; the emitted phase starts at tau = 1, ",
+             "so this fit begins somewhere PROC HAZARD would not and the ",
+             "multiphase likelihood is multimodal")
     )
   }
 

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -28,13 +28,31 @@
 .hzr_parms_late_arg  <- c(TAU = "tau", GAMMA = "gamma", ALPHA = "alpha", ETA = "eta")
 .hzr_parms_mu_order  <- c("MUE", "MUC", "MUL")
 
-# hzr_phase() default shape values (mirrored here so the theta starting
-# vector agrees with what hzr_phase() itself defaults to when PARMS did not
-# supply a given shape parameter). mu has no hzr_phase() argument -- its
-# only documented default is .hzr_phase_start()'s mu_start = 0.1, used here
-# for a built phase whose PARMS never supplied its MU value.
-.hzr_parms_early_default <- c(t_half = 1, nu = 1, m = 0)
-.hzr_parms_late_default  <- c(tau = 1, gamma = 1, alpha = 1, eta = 1)
+# PROC HAZARD's OWN shape defaults (stmtprc.c:30-37), used for any shape
+# operand a PARMS statement did not name. They are not hzr_phase()'s defaults
+# -- nu, m and eta all differ (SAS 2/1/2 against R 1/0/1) -- and the starting
+# vector is what the emitted call hands the optimizer, so mirroring R's
+# defaults here started a partially-specified job somewhere PROC HAZARD would
+# not have started it. On a multimodal likelihood a different start is a
+# different answer, not a cosmetic difference (AGENTS.md, "n_starts explores a
+# neighbourhood").
+#
+# TAU is the one entry that is NOT SAS's default. stmtprc.c:33 sets it to
+# ZERO, and SETG3() (setg3.c:317) then replaces any non-positive TAU with
+# 2*Tmax/3 -- data-dependent, so unreproducible at parse time. The 1 below is
+# SETG3_ignore_tau()'s pinned value (setg3.c:378), which is right exactly when
+# that branch fires; every other defaulted-TAU late phase gets an untranslated
+# row instead. See the TAU guard in .hzr_parse_parms().
+#
+# mu has no hzr_phase() argument -- its only documented default is
+# .hzr_phase_start()'s mu_start = 0.1, used here for a built phase whose PARMS
+# never supplied its MU value. That is a separate divergence from SAS (SETG1
+# floors a non-positive muE at 1, setg1.c) and, more to the point, a phase
+# whose MU is absent is one PROC HAZARD would not build at all -- the
+# phase-activation asymmetry tracked in the MU comment further down. Left
+# alone here deliberately.
+.hzr_parms_early_sas_default <- c(t_half = 1, nu = 2, m = 1)
+.hzr_parms_late_sas_default  <- c(tau = 1, gamma = 1, alpha = 1, eta = 2)
 .hzr_parms_default_mu_start <- 0.1
 
 # FIX<param> keywords are their own grammar tokens (FIXTHALF, not FIX+THALF),
@@ -119,6 +137,25 @@
   as.call(c(quote(c), as.list(fixed)))
 }
 
+#' Fill a parsed shape list out to every shape parameter of its family.
+#'
+#' The one place a default is applied. Both the emitted `hzr_phase()` call and
+#' the `theta` starting vector are built from this function's result, so they
+#' cannot disagree about what an unspecified operand started at -- filling only
+#' one of the two would be worse than defaulting neither, because the printed
+#' call would then describe a fit that did not happen.
+#'
+#' @param shape Named list of the shape values `PARMS` actually supplied.
+#' @param defaults Named numeric vector of defaults, in canonical argument
+#'   order.
+#' @return A named list carrying every name of `defaults`, in that order.
+#' @noRd
+.hzr_parms_fill_shape <- function(shape, defaults) {
+  out <- as.list(defaults)
+  out[names(shape)] <- shape
+  out[names(defaults)]
+}
+
 #' Build one phase's block of the full interleaved `theta` starting vector.
 #'
 #' Mirrors `.hzr_phase_theta_names()`'s layout exactly: `log_mu`, then (for
@@ -127,8 +164,11 @@
 #' `ALPHA`/`ETA` enter untransformed; `MUE`/`MUC`/`MUL` are always logged.
 #' @param family One of `"early"`, `"constant"`, `"late"`.
 #' @param mu_val Numeric SAS-scale mu starting value for this phase.
-#' @param shape Named list of parsed shape starting values (may omit entries
-#'   PARMS did not supply -- those fall back to the `hzr_phase()` default).
+#' @param shape Named list of shape starting values, already filled out to
+#'   every parameter of the family by `.hzr_parms_fill_shape()`. Completeness
+#'   is asserted rather than defaulted: a short list here would emit a theta
+#'   block of the wrong length, which `.hzr_optim_multiphase()` would either
+#'   reject or, worse, silently mis-align against the phase's parameter names.
 #' @param covar_vals Numeric vector of covariate starting values, `NA` where
 #'   PARMS gave a bare name with no explicit start (defaults to 0, matching
 #'   `.hzr_phase_start()`).
@@ -138,20 +178,13 @@
   block <- list(bquote(log(.(mu_val))))
 
   if (family == "early") {
-    d <- .hzr_parms_early_default
-    t_half <- if (!is.null(shape$t_half)) shape$t_half else d[["t_half"]]
-    nu     <- if (!is.null(shape$nu))     shape$nu     else d[["nu"]]
-    m      <- if (!is.null(shape$m))      shape$m      else d[["m"]]
-    block <- c(block, list(bquote(log(.(t_half)))), list(nu), list(m))
+    stopifnot(all(names(.hzr_parms_early_sas_default) %in% names(shape)))
+    block <- c(block, list(bquote(log(.(shape$t_half)))),
+               list(shape$nu), list(shape$m))
   } else if (family == "late") {
-    d <- .hzr_parms_late_default
-    tau   <- if (!is.null(shape$tau))   shape$tau   else d[["tau"]]
-    gamma <- if (!is.null(shape$gamma)) shape$gamma else d[["gamma"]]
-    alpha <- if (!is.null(shape$alpha)) shape$alpha else d[["alpha"]]
-    eta   <- if (!is.null(shape$eta))   shape$eta   else d[["eta"]]
-    block <- c(block,
-      list(bquote(log(.(tau)))), list(gamma), list(alpha), list(eta)
-    )
+    stopifnot(all(names(.hzr_parms_late_sas_default) %in% names(shape)))
+    block <- c(block, list(bquote(log(.(shape$tau)))),
+               list(shape$gamma), list(shape$alpha), list(shape$eta))
   }
 
   if (length(covar_vals)) {
@@ -290,6 +323,28 @@
   mu <- .hzr_parms_ordered(mu, .hzr_parms_mu_order)
   has_muc <- "MUC" %in% names(mu)
 
+  # Every shape operand PARMS did not name is filled from PROC HAZARD's own
+  # defaults, once, here -- and the same filled list then builds both the
+  # hzr_phase() call and that phase's theta block, so the two cannot describe
+  # different starting values. A partially specified PARMS block therefore
+  # emits a call naming every shape argument explicitly, which is also what
+  # makes the divergence readable: the defaulted values are on the page rather
+  # than hidden in hzr_phase()'s formals.
+  #
+  # TAU is the exception, because SETG3() derives it from the data. Its
+  # predicate is the C one -- tau <= 0, which catches an explicit TAU=0 as well
+  # as an absent TAU (setg3.c:316) -- and it is a divergence only when
+  # SETG3_ignore_tau() does not take the branch above it, since that branch
+  # pins TAU at 1 (setg3.c:378), exactly the value emitted here.
+  # `late` itself is left untouched: `length(late)` is the "did PARMS name a
+  # late shape operand" gate below, and a TAU=0 operand still counts as one.
+  tau_defaulted <- is.null(late[["tau"]]) || !isTRUE(late[["tau"]] > 0)
+  early_full <- .hzr_parms_fill_shape(early, .hzr_parms_early_sas_default)
+  late_full <- .hzr_parms_fill_shape(late, .hzr_parms_late_sas_default)
+  if (tau_defaulted) {
+    late_full[["tau"]] <- .hzr_parms_late_sas_default[["tau"]]
+  }
+
   # EARLY/CONSTANT/LATE operand text: comma-separated VAR=VALUE pairs (or
   # bare VARs), optionally followed by a "/ options" tail. Non-numeric values
   # and the options tail are recorded to untranslated, never guessed at; see
@@ -331,11 +386,11 @@
   theta_blocks <- list()
   if (length(early)) {
     phase_calls[[length(phase_calls) + 1L]] <- .hzr_parms_phase_call(
-      "cdf", early, phase_covars$early, fixed_early
+      "cdf", early_full, phase_covars$early, fixed_early
     )
     mu_val <- if (!is.null(mu[["MUE"]])) mu[["MUE"]] else .hzr_parms_default_mu_start
     theta_blocks <- c(theta_blocks,
-      .hzr_parms_theta_block("early", mu_val, early, phase_covar_vals$early)
+      .hzr_parms_theta_block("early", mu_val, early_full, phase_covar_vals$early)
     )
   }
   if (has_muc) {
@@ -348,21 +403,21 @@
   }
   if (length(late)) {
     phase_calls[[length(phase_calls) + 1L]] <- .hzr_parms_phase_call(
-      "g3", late, phase_covars$late, fixed_late
+      "g3", late_full, phase_covars$late, fixed_late
     )
     mu_val <- if (!is.null(mu[["MUL"]])) mu[["MUL"]] else .hzr_parms_default_mu_start
     theta_blocks <- c(theta_blocks,
-      .hzr_parms_theta_block("late", mu_val, late, phase_covar_vals$late)
+      .hzr_parms_theta_block("late", mu_val, late_full, phase_covar_vals$late)
     )
   }
 
   # A MU names its phase. Building a phase only when a *shape* operand
   # appeared let an orphaned MUE/MUL disappear together with the phase it
   # scaled -- a one-phase R model against SAS's two, and no untranslated row
-  # to say so. PROC HAZARD would supply its own shape defaults here
-  # (stmtprc.c:30-37: thalf 1, nu 2, m 1; tau = 2*Tmax/3, gamma 1, alpha 1,
-  # eta 2), which are not this parser's defaults, so the MU is recorded
-  # rather than guessed at.
+  # to say so. The shape defaults are now PROC HAZARD's own (stmtprc.c:30-37,
+  # see .hzr_parms_early_sas_default), but a phase reconstructed from nothing
+  # but a MU would still start from a scale SAS does not use, and its tau would
+  # still be data-dependent, so the MU stays recorded rather than guessed at.
   # SETG3_ignore_tau() (setg3.c:377-424) fires when ALPHA is fixed at 1 --
   # setg3.c:312-314, before the WEIBULL dispatch. It pins TAU at 1 and rewrites
   # the GAMMA/ETA split, which at alpha = 1, tau = 1 is a reparameterisation of
@@ -401,9 +456,13 @@
   # does that, so it is latent, and changing how phases are built is a wider
   # change than gating these two warnings.
   has_late <- !is.null(mu[["MUL"]]) && isTRUE(mu[["MUL"]] > 0)
-  alpha_val <- if (!is.null(late[["alpha"]])) late[["alpha"]] else
-    .hzr_parms_late_default[["alpha"]]
-  if (has_late && isTRUE(alpha_val == 1) && "alpha" %in% fixed_late &&
+  alpha_val <- late_full[["alpha"]]
+  # setg3.c:312-314's own predicate for taking the SETG3_ignore_tau() branch.
+  # The `g_two && ga_two` disjunct alongside it is driven by PARMS keywords
+  # this parser does not resolve; those are recorded as untranslated, so this
+  # is the half that can be evaluated here.
+  ignore_tau <- isTRUE(alpha_val == 1) && "alpha" %in% fixed_late
+  if (has_late && ignore_tau &&
       !("gamma" %in% fixed_late) && !("eta" %in% fixed_late)) {
     flag_bad(
       "ALPHA=1 FIXALPHA with GAMMA and ETA both estimated",
@@ -424,6 +483,33 @@
       "ALPHA=0 with WEIBULL and no FIXALPHA",
       paste0("PROC HAZARD rejects this: SETG3_weibull() raises SETG3980 for ",
              "alpha = 0 unless ALPHA is fixed, so the job does not run")
+    )
+  }
+
+  # SETG3() replaces a non-positive TAU -- absent from PARMS, or written as
+  # TAU=0 -- with 2*Tmax/3 (setg3.c:317). It is the one shape default that
+  # cannot be reproduced at parse time, because it depends on the data, so the
+  # emitted call starts at tau = 1 and this says so rather than letting the
+  # difference pass as a translation. Emitting `2 * max(<timevar>) / 3` instead
+  # was considered and rejected: SAS's Tmax is taken over the analysis set
+  # after exclusions, not over the raw column, so the expression would look
+  # exact while being a guess.
+  #
+  # Three conditions, each doing work. `length(late)` because a late phase that
+  # was never built is already reported by the MUL guard below, and two rows
+  # for one absence is noise. `has_late` for the same reason the guards above
+  # carry it: with no positive MUL, shape.c never calls SETG3() at all.
+  # `!ignore_tau` because that branch pins TAU at 1 (setg3.c:378) -- exactly
+  # what is emitted -- so there is nothing to report.
+  if (length(late) && has_late && tau_defaulted && !ignore_tau) {
+    flag_bad(
+      if (is.null(late[["tau"]])) "TAU (unspecified)" else
+        paste0("TAU=", sprintf("%g", late[["tau"]])),
+      paste0("SETG3() starts a non-positive TAU at 2*Tmax/3, which depends ",
+             "on the data and cannot be reproduced at parse time; the ",
+             "emitted phase starts at tau = 1, so this fit begins somewhere ",
+             "PROC HAZARD would not and the multiphase likelihood is ",
+             "multimodal")
     )
   }
 

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -341,7 +341,36 @@
   tau_defaulted <- is.null(late[["tau"]]) || !isTRUE(late[["tau"]] > 0)
   early_full <- .hzr_parms_fill_shape(early, .hzr_parms_early_sas_default)
   late_full <- .hzr_parms_fill_shape(late, .hzr_parms_late_sas_default)
-  if (tau_defaulted) {
+
+  # A phase is active in PROC HAZARD iff its MU was specified and positive
+  # (parmprc.c:19 -> setparmno.c:14); with phase 3 off, shape.c never calls
+  # SETG3() and none of what follows happens. This is the gate every SETG3
+  # guard below shares.
+  has_late <- !is.null(mu[["MUL"]]) && isTRUE(mu[["MUL"]] > 0)
+  # setg3.c:312-314's own predicate for taking the SETG3_ignore_tau() branch.
+  # The `g_two && ga_two` disjunct alongside it is driven by PARMS keywords
+  # this parser does not resolve; those are recorded as untranslated, so this
+  # is the half that can be evaluated here.
+  ignore_tau <- isTRUE(late_full[["alpha"]] == 1) && "alpha" %in% fixed_late
+
+  if (has_late && ignore_tau) {
+    # setg3.c:378-379 does TWO things, and mirroring only the first is what
+    # made this branch look harmless: it sets TAU to 1 AND fixes it. Leaving
+    # TAU free is not a spare degree of freedom here but an unidentified one --
+    # at alpha = 1 the G3 form collapses to (t/tau)^(gamma*eta), so mu enters
+    # the likelihood only through log_mu - gamma*eta*log_tau and the two are
+    # exactly aliased. The emitted fit converged onto that ridge and returned
+    # no standard errors for either parameter.
+    #
+    # So the value AND the fix are both mirrored, which is what the C does and
+    # what makes the emitted call identifiable. Where PARMS named a different
+    # TAU this overrides the user's own text, so that case is recorded below --
+    # PROC HAZARD overrides it too, but a silent rewrite of what the job said
+    # is exactly what $untranslated exists to surface.
+    late_full[["tau"]] <- 1
+    fixed_late <- intersect(unname(.hzr_parms_late_arg),
+                            union(fixed_late, "tau"))
+  } else if (tau_defaulted) {
     late_full[["tau"]] <- .hzr_parms_late_sas_default[["tau"]]
   }
 
@@ -455,13 +484,7 @@
   # emits a late phase that PROC HAZARD would not build at all. No corpus job
   # does that, so it is latent, and changing how phases are built is a wider
   # change than gating these two warnings.
-  has_late <- !is.null(mu[["MUL"]]) && isTRUE(mu[["MUL"]] > 0)
   alpha_val <- late_full[["alpha"]]
-  # setg3.c:312-314's own predicate for taking the SETG3_ignore_tau() branch.
-  # The `g_two && ga_two` disjunct alongside it is driven by PARMS keywords
-  # this parser does not resolve; those are recorded as untranslated, so this
-  # is the half that can be evaluated here.
-  ignore_tau <- isTRUE(alpha_val == 1) && "alpha" %in% fixed_late
   if (has_late && ignore_tau &&
       !("gamma" %in% fixed_late) && !("eta" %in% fixed_late)) {
     flag_bad(
@@ -486,36 +509,24 @@
     )
   }
 
-  # SETG3_ignore_tau() does TWO things at setg3.c:378-379, and naming only the
-  # first is what made this look harmless: it sets TAU to 1 AND fixes it. The
-  # emitted call carries only what FIXTAU named, so TAU stays free -- and at
-  # alpha = 1 that is not a spare degree of freedom but an unidentified one.
-  # G3 collapses to (t/tau)^(gamma*eta) there (checked against
-  # hzr_decompos_g3() to 2e-16), so mu enters the likelihood only through
-  # log_mu - gamma*eta*log_tau: the two are exactly aliased, the Hessian is
-  # singular, and hazard() returns NO standard errors for either while still
-  # reporting a fit. That is the shape AGENTS.md opens with, so it is recorded.
-  #
-  # It fires whether or not PARMS named a TAU, because SAS overwrites the value
-  # either way -- a job written TAU=5 runs at tau = 1 in PROC HAZARD. Recorded
-  # rather than rewritten, for the same reason the GAMMA/ETA split above is:
-  # rewriting the emitted call would put it at odds with the user's own PARMS
-  # text. Whether to instead emit `tau = 1, fixed = "tau"` here, which would be
-  # exactly what the C does and would remove the aliasing, is a maintainer
-  # decision -- it changes the emitted call for every corpus block that fires
-  # this branch.
-  if (length(late) && has_late && ignore_tau) {
+  # The emitted call now pins TAU at 1 exactly as SETG3_ignore_tau() does, so
+  # an unspecified (or already-1) TAU translates faithfully and needs no row.
+  # A job that WROTE a different TAU is a different matter: PROC HAZARD
+  # discards that value, and so now does this translator, but a starting value
+  # the user typed and neither program uses is worth saying out loud.
+  if (length(late) && has_late && ignore_tau &&
+      !is.null(late[["tau"]]) && !isTRUE(late[["tau"]] == 1)) {
     flag_bad(
-      if (is.null(late[["tau"]])) "ALPHA=1 FIXALPHA (TAU unspecified)" else
-        paste0("ALPHA=1 FIXALPHA with TAU=", sprintf("%g", late[["tau"]])),
-      paste0("SETG3_ignore_tau() sets TAU to 1 and FIXES it (setg3.c:378-379); ",
-             "the emitted phase leaves TAU free, and at alpha = 1 the G3 form ",
-             "collapses to (t/tau)^(gamma*eta), so log_mu and log_tau are ",
-             "exactly aliased -- the fit converges onto a flat ridge and ",
-             "reports no standard errors for either")
+      paste0("TAU=", sprintf("%g", late[["tau"]])),
+      paste0("SETG3_ignore_tau() discards this TAU and runs at tau = 1, ",
+             "fixed (setg3.c:378-379), because ALPHA is fixed at 1; the ",
+             "emitted phase mirrors that, so the value written here is used ",
+             "by neither PROC HAZARD nor the translation")
     )
-  } else if (length(late) && has_late && tau_defaulted) {
-    # The other SETG3 branch (setg3.c:316-318): a non-positive TAU -- absent
+  } else if (length(late) && has_late && tau_defaulted && !ignore_tau) {
+    # The other SETG3 branch (setg3.c:316-318), reached only when the
+    # ignore_tau branch above was NOT taken -- setg3.c:313-316 is an if/else,
+    # so a job that fixes ALPHA at 1 never gets the 2*Tmax/3 assignment at all.: a non-positive TAU -- absent
     # from PARMS, or written as TAU=0 -- is replaced by 2*Tmax/3. It is the one
     # shape default that cannot be reproduced at parse time, because it depends
     # on the data, so the emitted call starts at tau = 1 and this says so
@@ -525,8 +536,7 @@
     # so the expression would look exact while being a guess.
     #
     # `length(late)` because a late phase that was never built is already
-    # reported by the MUL guard below, and two rows for one absence is noise;
-    # `has_late` because with no positive MUL, shape.c never calls SETG3().
+    # reported by the MUL guard below, and two rows for one absence is noise.
     flag_bad(
       if (is.null(late[["tau"]])) "TAU (unspecified)" else
         paste0("TAU=", sprintf("%g", late[["tau"]])),

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -208,6 +208,218 @@
   as.call(call_args)
 }
 
+# ---------------------------------------------------------------------------
+# SETG3() trace
+# ---------------------------------------------------------------------------
+# PROC HAZARD does not optimize from the operands PARMS supplies: SETG3()
+# (src/model/setg3.c) rewrites them first, and refuses some jobs outright.
+# .hzr_setg3_notes() walks that function and reports what it would do, in the
+# C's own order. It changes nothing about the emitted call.
+#
+# Which of the two happens is a deliberate split, settled once and applied
+# throughout:
+#
+#   * A rewrite that resolves an EXACT non-identifiability is MIRRORED into
+#     the emitted call, because the degeneracy is algebra and is just as real
+#     in R -- SETG3_ignore_tau()'s TAU pin (setg3.c:378-379) and ETA fix
+#     (:405) are the two, both handled at the build site above.
+#   * Every other rewrite here keeps PROC HAZARD inside a numerical branch it
+#     can evaluate -- the role g3flag plays, which hzr_decompos_g3() does not
+#     need because it carries the general four-parameter G3 form. Copying
+#     those would import a SAS limitation into R, and reaching a late shape
+#     the reference cannot is a purpose of this package. They are RECORDED.
+#
+# Refusals are recorded for the reason SETG3980 always was: emitting a
+# runnable fit for a job PROC HAZARD will not run is an answer that looks like
+# a result and is not.
+#
+# g_two/ga_two (the GAMMA*ETA = 2 and GAMMA*ETA/ALPHA = 2 constraint flags)
+# are driven by FIXGE2/FIXGAE2, which .hzr_sas_token() leaves unresolved and
+# records as untranslated -- so a job carrying either is never reported clean,
+# and this trace takes both as FALSE rather than guessing. Every branch below
+# is therefore the !g_two && !ga_two column of the C's own tables.
+
+# What each SETG3 refusal code objects to. The code alone is greppable but
+# opaque; a caller reading $untranslated needs to know which operand to change.
+.hzr_setg3_refusal <- c(
+  "(SETG3900)" = "TAU is fixed at a non-positive value",
+  "(SETG3910)" = "GAMMA is fixed at a non-positive value",
+  "(SETG3920)" = "ALPHA is fixed at a negative value",
+  "(SETG3930)" = "ETA is fixed at a non-positive value",
+  "(SETG3960)" = "WEIBULL requires GAMMA > 0",
+  "(SETG3970)" = "WEIBULL requires ETA > 0",
+  "(SETG3980)" = "WEIBULL rejects a negative ALPHA, and rejects ALPHA = 0 unless ALPHA is fixed",
+  "(SETG31020)" = "GAMMA*ETA <= 2 with both GAMMA and ETA fixed, so neither can be adjusted",
+  "(SETG31040)" = "GAMMA*ETA/ALPHA <= 2 with ALPHA fixed, so ALPHA cannot be adjusted",
+  "(SETG31070)" = "ALPHA is fixed where SETG3 must derive it from GAMMA*ETA",
+  "(SETG31090)" = "GAMMA is fixed but non-positive, so SETG3 cannot derive one from ALPHA and ETA",
+  "(SETG32020)" = "ETA is fixed but non-positive, so SETG3 cannot derive one from ALPHA and GAMMA",
+  "(SETG32050)" = "GAMMA is fixed but non-positive, so SETG3 cannot derive one from ETA",
+  "(SETG32080)" = "ETA is fixed but non-positive, so SETG3 cannot derive one from GAMMA",
+  "(SETG33010)" = "ETA is fixed but non-positive, with no GAMMA to derive one from",
+  "(SETG33020)" = "GAMMA is fixed but non-positive, with no ETA to derive one from"
+)
+
+#' Plain-language gloss for a SETG3 refusal code.
+#' @noRd
+.hzr_setg3_refusal_reason <- function(code) {
+  hit <- .hzr_setg3_refusal[[code]]
+  if (is.null(hit)) "the operand combination is rejected" else hit
+}
+
+#' `alpha` handling shared by several SETG3 branches (setg3.c:815-852).
+#' @return `NULL`, a refusal string, or the substituted alpha.
+#' @noRd
+.hzr_setg3_alpha_fixup <- function(gamma, eta, alpha, alpha_fixed, weibull) {
+  # ga_two is FALSE, so the C falls to the `gteva > TWO || weibul` early
+  # return; under WEIBULL this function is a no-op entirely.
+  if (weibull) return(NULL)
+  if (isTRUE(gamma * eta / alpha > 2)) return(NULL)
+  if (alpha_fixed) return("(SETG31040)")
+  gamma * eta / 3
+}
+
+#' `alpha` handling for the branches that reach SETG3_alpha_gener()
+#' (setg3.c:854-871).
+#' @noRd
+.hzr_setg3_alpha_gener <- function(gamma, eta, alpha_fixed) {
+  if (alpha_fixed) return("(SETG31070)")
+  gamma * eta / 3
+}
+
+#' Walk `SETG3()` and report what it would do to one late phase.
+#'
+#' @param tau_raw,gamma,alpha,eta The operand values `PARMS` supplied, with
+#'   PROC HAZARD's own initializers for any it did not (`stmtprc.c:33-36`).
+#'   `tau_raw` is 0 when `TAU` was absent -- SAS's initializer, not the 1 the
+#'   emitted call uses as a placeholder.
+#' @param fixed Character vector of parameters the job's `FIX*` tokens pinned,
+#'   as the user wrote them: these checks run before SETG3 changes any flag.
+#' @param weibull Whether the job carries the bare `WEIBULL` keyword.
+#' @return `list(refusal = <chr or NULL>, shape = <named numeric or NULL>)`.
+#'   `refusal` names the SAS message code for a job PROC HAZARD will not run;
+#'   otherwise `shape` gives the values SETG3 would optimize from.
+#' @noRd
+.hzr_setg3_notes <- function(tau_raw, gamma, alpha, eta, fixed, weibull) {
+  fx <- function(p) p %in% fixed
+  refuse <- function(code) list(refusal = code, shape = NULL)
+
+  # setg3.c:269-284. A FIX* on an operand SAS reads as unspecified is fatal,
+  # and it is checked before anything else -- including SETG3_ignore_tau().
+  if (isTRUE(tau_raw <= 0) && fx("tau")) return(refuse("(SETG3900)"))
+  if (isTRUE(gamma <= 0) && fx("gamma")) return(refuse("(SETG3910)"))
+  if (isTRUE(alpha < 0) && fx("alpha")) return(refuse("(SETG3920)"))
+  if (isTRUE(eta <= 0) && fx("eta")) return(refuse("(SETG3930)"))
+
+  # setg3.c:313-315 and 403-421. Reproduced here for the trace only: the
+  # emitted call deliberately keeps the user's GAMMA and ETA, because the
+  # swap is likelihood-equivalent. The trace needs SAS's values because the
+  # dispatch below keys on their signs.
+  if (isTRUE(alpha == 1) && fx("alpha")) {
+    if (!fx("gamma") && !fx("eta")) fixed <- union(fixed, "eta")
+    product <- gamma * eta
+    if (fx("eta")) {
+      gamma <- if (isTRUE(product > 0)) product else eta
+      eta <- 1
+    } else {
+      eta <- if (isTRUE(product > 0)) product else gamma
+      gamma <- 1
+    }
+    fixed <- union(fixed, c("tau", "alpha"))
+  }
+
+  # setg3.c:332-335, with ga_two FALSE.
+  g3flag <- if (isTRUE(alpha == 0) && fx("alpha")) 2L else 1L
+
+  if (weibull) {
+    # setg3.c:427-482, then the return at :347. The g_two block is skipped
+    # (see the header), and SETG3_alpha_fixup() is a no-op under WEIBULL.
+    if (isTRUE(gamma <= 0)) return(refuse("(SETG3960)"))
+    if (isTRUE(eta <= 0)) return(refuse("(SETG3970)"))
+    if (isTRUE(alpha < 0) || (isTRUE(alpha == 0) && g3flag + 2L == 3L)) {
+      return(refuse("(SETG3980)"))
+    }
+    return(list(refusal = NULL,
+                shape = c(gamma = gamma, alpha = alpha, eta = eta)))
+  }
+
+  # setg3.c:873-924 with g_two FALSE: push GAMMA*ETA clear of 2.
+  verify_ge_2 <- function() {
+    if (!isTRUE(gamma * eta <= 2)) return(NULL)
+    if (fx("gamma") && fx("eta")) return("(SETG31020)")
+    if (fx("gamma")) eta <<- 3 / gamma else gamma <<- 3 / eta
+    NULL
+  }
+
+  # setg3.c:359-374. Each branch is the !g_two && !ga_two row of its table.
+  bad <- NULL
+  if (isTRUE(alpha > 0) && isTRUE(gamma > 0) && isTRUE(eta > 0)) {
+    bad <- verify_ge_2()
+    if (is.null(bad)) {
+      a <- .hzr_setg3_alpha_fixup(gamma, eta, alpha, fx("alpha"), weibull)
+      if (is.character(a)) bad <- a else if (!is.null(a)) alpha <- a
+    }
+  } else if (isTRUE(gamma > 0) && isTRUE(eta > 0)) {
+    bad <- verify_ge_2()
+    if (is.null(bad) && g3flag == 1L) {
+      a <- .hzr_setg3_alpha_gener(gamma, eta, fx("alpha"))
+      if (is.character(a)) bad <- a else alpha <- a
+    }
+  } else if (isTRUE(alpha > 0) && isTRUE(eta > 0)) {
+    # gamma <= 0 (setg3.c:533-585)
+    if (fx("gamma")) return(refuse("(SETG31090)"))
+    gamma <- 3 * alpha / eta
+    if (isTRUE(gamma * eta <= 2)) gamma <- 3 / eta
+    a <- .hzr_setg3_alpha_fixup(gamma, eta, alpha, fx("alpha"), weibull)
+    if (is.character(a)) bad <- a else if (!is.null(a)) alpha <- a
+  } else if (isTRUE(alpha > 0) && isTRUE(gamma > 0)) {
+    # eta <= 0 (setg3.c:587-636)
+    if (fx("eta")) return(refuse("(SETG32020)"))
+    eta <- 3 * alpha / gamma
+    if (isTRUE(gamma * eta <= 2)) eta <- 3 / gamma
+    a <- .hzr_setg3_alpha_fixup(gamma, eta, alpha, fx("alpha"), weibull)
+    if (is.character(a)) bad <- a else if (!is.null(a)) alpha <- a
+  } else if (isTRUE(eta > 0)) {
+    # alpha <= 0, gamma <= 0 (setg3.c:638-675)
+    if (fx("gamma")) return(refuse("(SETG32050)"))
+    gamma <- 3 / eta
+    if (g3flag == 1L) {
+      a <- .hzr_setg3_alpha_gener(gamma, eta, fx("alpha"))
+      if (is.character(a)) bad <- a else alpha <- a
+    }
+  } else if (isTRUE(gamma > 0)) {
+    # alpha <= 0, eta <= 0 (setg3.c:677-714)
+    if (fx("eta")) return(refuse("(SETG32080)"))
+    eta <- 3 / gamma
+    if (g3flag == 1L) {
+      a <- .hzr_setg3_alpha_gener(gamma, eta, fx("alpha"))
+      if (is.character(a)) bad <- a else alpha <- a
+    }
+  } else if (isTRUE(alpha > 0)) {
+    # gamma <= 0, eta <= 0 (setg3.c:716-770)
+    if (fx("gamma")) return(refuse("(SETG33020)"))
+    if (fx("eta")) return(refuse("(SETG33010)"))
+    eta <- 2
+    gamma <- 1.5 * alpha
+    if (isTRUE(gamma * eta <= 2)) gamma <- 3 / eta
+    a <- .hzr_setg3_alpha_fixup(gamma, eta, alpha, fx("alpha"), weibull)
+    if (is.character(a)) bad <- a else if (!is.null(a)) alpha <- a
+  } else {
+    # all <= 0 (setg3.c:772-812)
+    if (fx("gamma")) return(refuse("(SETG33020)"))
+    if (fx("eta")) return(refuse("(SETG33010)"))
+    gamma <- 1
+    eta <- 3
+    if (g3flag == 1L) {
+      a <- .hzr_setg3_alpha_gener(gamma, eta, fx("alpha"))
+      if (is.character(a)) bad <- a else alpha <- a
+    }
+  }
+
+  if (!is.null(bad)) return(refuse(bad))
+  list(refusal = NULL, shape = c(gamma = gamma, alpha = alpha, eta = eta))
+}
+
 #' Map a SAS `PARMS` statement's operands to phases and a starting theta.
 #'
 #' @param operands Character vector of `PARMS` tokens, e.g.
@@ -352,6 +564,11 @@
   # this parser does not resolve; those are recorded as untranslated, so this
   # is the half that can be evaluated here.
   ignore_tau <- isTRUE(late_full[["alpha"]] == 1) && "alpha" %in% fixed_late
+
+  # SETG3's entry checks (setg3.c:269-284) read the job's OWN FIX* flags,
+  # before SETG3 sets any of its own, so the trace below needs this snapshot
+  # rather than the post-pin set.
+  fixed_late_user <- fixed_late
 
   if (has_late && ignore_tau) {
     # setg3.c:378-379 does TWO things, and mirroring only the first is what
@@ -509,60 +726,67 @@
   # likelihood-equivalent and is documented in hzr_translate_sas() rather than
   # reported per job.
 
-  # SETG3_verify_ge_2() (setg3.c:873-924) rewrites a late phase whose
-  # GAMMA*ETA <= 2: with neither fixed it sets gamma = 3/eta, and with one
-  # fixed it sets the other to 3/(the fixed one). The 3 is not a normalisation
-  # to the boundary but a deliberate push clear of it.
-  #
-  # This is NOT mirrored, and that is a design decision rather than an
-  # omission. The constraint exists so PROC HAZARD stays inside a numerical
-  # branch it can evaluate -- the same reason g3flag exists, which the WEIBULL
-  # branch above notes "has no R counterpart: hzr_decompos_g3() handles the
-  # general form directly". hzr_phase("g3") carries the general four-parameter
-  # shape and is under no such restriction, and exercising a late shape SAS
-  # cannot reach is a goal of this package rather than a defect in it. Copying
-  # the rewrite would import a SAS limitation into R.
-  #
-  # It is recorded because it is still a start-value divergence: a parity run
-  # against a SAS listing will see different GAMMA (or ETA) here, and that
-  # difference should be explained rather than discovered.
-  #
-  # Reached from SETG3_all_gt_0() (setg3.c:499) and SETG3_alpha_le_0() (:523),
-  # i.e. whenever GAMMA > 0 and ETA > 0, whatever ALPHA is -- but never on the
-  # WEIBULL path, which returns at setg3.c:347 before the sign dispatch. Note
-  # the predicate is invariant to SETG3_ignore_tau(): its reparameterisation
-  # (setg3.c:403-421) moves the exponent between GAMMA and ETA but preserves
-  # their PRODUCT, which is all `gte` reads. The g_two half of the function is
-  # driven by FIXGE2/FIXGAE2, which .hzr_sas_token() records as unresolved, so
-  # a job carrying those is never reported clean anyway.
-  gte <- late_full[["gamma"]] * late_full[["eta"]]
-  if (length(late) && has_late && !saw_weibull &&
-      isTRUE(late_full[["gamma"]] > 0) && isTRUE(late_full[["eta"]] > 0) &&
-      isTRUE(gte <= 2) &&
-      !all(c("gamma", "eta") %in% fixed_late)) {
-    flag_bad(
-      sprintf("GAMMA=%g ETA=%g (product %g)", late_full[["gamma"]],
-              late_full[["eta"]], gte),
-      paste0("SETG3_verify_ge_2() rewrites a late phase with GAMMA*ETA <= 2 ",
-             "(setg3.c:907-921), setting the unfixed one to 3 over the other, ",
-             "so PROC HAZARD does not start where this call does; the general ",
-             "G3 shape hzr_phase() carries needs no such constraint and is ",
-             "kept deliberately, but a SAS parity comparison will differ here")
+  # Everything SETG3() would do to this phase, in one place. See the header
+  # of .hzr_setg3_notes() for why a refusal and a rewrite are both recorded
+  # while only the two identifiability fixes are mirrored.
+  setg3_refused <- FALSE
+  if (length(late) && has_late) {
+    setg3 <- .hzr_setg3_notes(
+      tau_raw = if (tau_defaulted) 0 else late[["tau"]],
+      gamma = late_full[["gamma"]],
+      alpha = late_full[["alpha"]],
+      eta = late_full[["eta"]],
+      fixed = fixed_late_user,
+      weibull = saw_weibull
     )
-  }
-
-  alpha_val <- late_full[["alpha"]]
-  # setg3.c:437: SETG3_weibull() rejects alpha == 0 unless ALPHA is fixed
-  # (g3flag == 3 vs 4) and the job does not run. hzr_phase() accepts alpha = 0
-  # as the limiting exponential, so without this the translator would emit a
-  # runnable fit for a job SAS refuses outright.
-  if (has_late && saw_weibull && isTRUE(alpha_val == 0) &&
-      !("alpha" %in% fixed_late)) {
-    flag_bad(
-      "ALPHA=0 with WEIBULL and no FIXALPHA",
-      paste0("PROC HAZARD rejects this: SETG3_weibull() raises SETG3980 for ",
-             "alpha = 0 unless ALPHA is fixed, so the job does not run")
-    )
+    if (!is.null(setg3$refusal)) {
+      setg3_refused <- TRUE
+      flag_bad(
+        sprintf("GAMMA=%g ALPHA=%g ETA=%g%s", late_full[["gamma"]],
+                late_full[["alpha"]], late_full[["eta"]],
+                if (length(fixed_late_user)) {
+                  paste0(" fixed:", paste(fixed_late_user, collapse = ","))
+                } else {
+                  ""
+                }),
+        paste0("PROC HAZARD refuses this job: SETG3 raises ",
+               setg3$refusal, " -- ",
+               .hzr_setg3_refusal_reason(setg3$refusal),
+               ". hzr_phase() would accept it, so without this the ",
+               "translation would emit a runnable fit for a job that does ",
+               "not run")
+      )
+    } else {
+      # At alpha = 1 only the product gamma*eta is identified, and the
+      # emitted call deliberately keeps the user's split rather than
+      # SETG3_ignore_tau()'s (setg3.c:414-420) -- likelihood-equivalent, so
+      # compare the product there and each operand otherwise. Without this
+      # every ignore_tau job would report a rewrite that changes no fit.
+      emitted <- c(gamma = late_full[["gamma"]], alpha = late_full[["alpha"]],
+                   eta = late_full[["eta"]])
+      got <- setg3$shape
+      if (ignore_tau) {
+        emitted <- c(`gamma*eta` = unname(emitted[["gamma"]] * emitted[["eta"]]),
+                     alpha = unname(emitted[["alpha"]]))
+        got <- c(`gamma*eta` = unname(got[["gamma"]] * got[["eta"]]),
+                 alpha = unname(got[["alpha"]]))
+      }
+      moved <- names(emitted)[!mapply(
+        function(a, b) isTRUE(all.equal(a, b)), emitted, got
+      )]
+      if (length(moved)) {
+        flag_bad(
+          paste(sprintf("%s=%g", names(emitted), emitted), collapse = " "),
+          paste0("SETG3() optimizes from ",
+                 paste(sprintf("%s = %g", moved, got[moved]), collapse = ", "),
+                 ", not the value(s) emitted here: it constrains the late ",
+                 "shape to keep PROC HAZARD inside a numerical branch it can ",
+                 "evaluate. hzr_decompos_g3() carries the general G3 form and ",
+                 "needs no such constraint, so the emitted call keeps it ",
+                 "deliberately -- but a SAS parity run starts elsewhere")
+        )
+      }
+    }
   }
 
   # The emitted call now pins TAU at 1 exactly as SETG3_ignore_tau() does, so
@@ -570,7 +794,11 @@
   # A job that WROTE a different TAU is a different matter: PROC HAZARD
   # discards that value, and so now does this translator, but a starting value
   # the user typed and neither program uses is worth saying out loud.
-  if (length(late) && has_late && ignore_tau &&
+  # A refused job stops inside SETG3 before either TAU rule runs, so neither
+  # row below applies -- reporting them alongside the refusal would describe
+  # code PROC HAZARD never reaches, the same false-positive the MUL gate above
+  # exists to avoid.
+  if (length(late) && has_late && !setg3_refused && ignore_tau &&
       !is.null(late[["tau"]]) && !isTRUE(late[["tau"]] == 1)) {
     flag_bad(
       paste0("TAU=", sprintf("%g", late[["tau"]])),
@@ -579,7 +807,8 @@
              "emitted phase mirrors that, so the value written here is used ",
              "by neither PROC HAZARD nor the translation")
     )
-  } else if (length(late) && has_late && tau_defaulted && !ignore_tau) {
+  } else if (length(late) && has_late && !setg3_refused && tau_defaulted &&
+             !ignore_tau) {
     # The other SETG3 branch (setg3.c:316-318), reached only when the
     # ignore_tau branch above was NOT taken -- setg3.c:313-316 is an if/else,
     # so a job that fixes ALPHA at 1 never gets this assignment at all.

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -368,8 +368,26 @@
     # PROC HAZARD overrides it too, but a silent rewrite of what the job said
     # is exactly what $untranslated exists to surface.
     late_full[["tau"]] <- 1
+    pins <- "tau"
+    # setg3.c:405: with GAMMA and ETA both free, SETG3_ignore_tau() fixes ETA.
+    # Mirrored for the same reason TAU is, and NOT for the reason
+    # SETG3_verify_ge_2() is declined below: this one is exact algebra, not a
+    # numerical-branch restriction. At alpha = 1 only the product gamma*eta
+    # enters the likelihood, so the pair is exactly singular in R too -- the
+    # general G3 shape hzr_phase() carries is genuinely degenerate here, and
+    # leaving both free relocates the flat ridge the TAU pin removed rather
+    # than exercising a shape SAS cannot reach.
+    #
+    # The VALUE rewrite that follows in the C (setg3.c:414-420: gamma <-
+    # gamma*eta, eta <- 1) is still not mirrored, per the decision recorded
+    # above: it is likelihood-equivalent -- both parameterisations span the
+    # same exponent -- so it changes what is reported, not what is fitted, and
+    # rewriting it would put the emitted call at odds with the user's PARMS.
+    if (!("gamma" %in% fixed_late) && !("eta" %in% fixed_late)) {
+      pins <- c(pins, "eta")
+    }
     fixed_late <- intersect(unname(.hzr_parms_late_arg),
-                            union(fixed_late, "tau"))
+                            union(fixed_late, pins))
   } else if (tau_defaulted) {
     late_full[["tau"]] <- .hzr_parms_late_sas_default[["tau"]]
   }
@@ -484,18 +502,56 @@
   # emits a late phase that PROC HAZARD would not build at all. No corpus job
   # does that, so it is latent, and changing how phases are built is a wider
   # change than gating these two warnings.
-  alpha_val <- late_full[["alpha"]]
-  if (has_late && ignore_tau &&
-      !("gamma" %in% fixed_late) && !("eta" %in% fixed_late)) {
+  # The GAMMA*ETA divergence this block used to record is gone: setg3.c:405's
+  # ETA fix is now mirrored above, so hazard() estimates the same number of
+  # free parameters as PROC HAZARD on this branch. What remains unmirrored is
+  # the value rewrite (gamma <- gamma*eta, eta <- 1), which is
+  # likelihood-equivalent and is documented in hzr_translate_sas() rather than
+  # reported per job.
+
+  # SETG3_verify_ge_2() (setg3.c:873-924) rewrites a late phase whose
+  # GAMMA*ETA <= 2: with neither fixed it sets gamma = 3/eta, and with one
+  # fixed it sets the other to 3/(the fixed one). The 3 is not a normalisation
+  # to the boundary but a deliberate push clear of it.
+  #
+  # This is NOT mirrored, and that is a design decision rather than an
+  # omission. The constraint exists so PROC HAZARD stays inside a numerical
+  # branch it can evaluate -- the same reason g3flag exists, which the WEIBULL
+  # branch above notes "has no R counterpart: hzr_decompos_g3() handles the
+  # general form directly". hzr_phase("g3") carries the general four-parameter
+  # shape and is under no such restriction, and exercising a late shape SAS
+  # cannot reach is a goal of this package rather than a defect in it. Copying
+  # the rewrite would import a SAS limitation into R.
+  #
+  # It is recorded because it is still a start-value divergence: a parity run
+  # against a SAS listing will see different GAMMA (or ETA) here, and that
+  # difference should be explained rather than discovered.
+  #
+  # Reached from SETG3_all_gt_0() (setg3.c:499) and SETG3_alpha_le_0() (:523),
+  # i.e. whenever GAMMA > 0 and ETA > 0, whatever ALPHA is -- but never on the
+  # WEIBULL path, which returns at setg3.c:347 before the sign dispatch. Note
+  # the predicate is invariant to SETG3_ignore_tau(): its reparameterisation
+  # (setg3.c:403-421) moves the exponent between GAMMA and ETA but preserves
+  # their PRODUCT, which is all `gte` reads. The g_two half of the function is
+  # driven by FIXGE2/FIXGAE2, which .hzr_sas_token() records as unresolved, so
+  # a job carrying those is never reported clean anyway.
+  gte <- late_full[["gamma"]] * late_full[["eta"]]
+  if (length(late) && has_late && !saw_weibull &&
+      isTRUE(late_full[["gamma"]] > 0) && isTRUE(late_full[["eta"]] > 0) &&
+      isTRUE(gte <= 2) &&
+      !all(c("gamma", "eta") %in% fixed_late)) {
     flag_bad(
-      "ALPHA=1 FIXALPHA with GAMMA and ETA both estimated",
-      paste0("SETG3_ignore_tau() estimates GAMMA*ETA as a single parameter ",
-             "here (it fixes ETA); hazard() would estimate both, which is one ",
-             "more free parameter than PROC HAZARD on a product that is not ",
-             "separately identifiable at alpha = 1")
+      sprintf("GAMMA=%g ETA=%g (product %g)", late_full[["gamma"]],
+              late_full[["eta"]], gte),
+      paste0("SETG3_verify_ge_2() rewrites a late phase with GAMMA*ETA <= 2 ",
+             "(setg3.c:907-921), setting the unfixed one to 3 over the other, ",
+             "so PROC HAZARD does not start where this call does; the general ",
+             "G3 shape hzr_phase() carries needs no such constraint and is ",
+             "kept deliberately, but a SAS parity comparison will differ here")
     )
   }
 
+  alpha_val <- late_full[["alpha"]]
   # setg3.c:437: SETG3_weibull() rejects alpha == 0 unless ALPHA is fixed
   # (g3flag == 3 vs 4) and the job does not run. hzr_phase() accepts alpha = 0
   # as the limiting exponential, so without this the translator would emit a
@@ -526,8 +582,9 @@
   } else if (length(late) && has_late && tau_defaulted && !ignore_tau) {
     # The other SETG3 branch (setg3.c:316-318), reached only when the
     # ignore_tau branch above was NOT taken -- setg3.c:313-316 is an if/else,
-    # so a job that fixes ALPHA at 1 never gets the 2*Tmax/3 assignment at all.: a non-positive TAU -- absent
-    # from PARMS, or written as TAU=0 -- is replaced by 2*Tmax/3. It is the one
+    # so a job that fixes ALPHA at 1 never gets this assignment at all.
+    # A non-positive TAU -- absent from PARMS, or written as TAU=0 -- is
+    # replaced by 2*Tmax/3. It is the one
     # shape default that cannot be reproduced at parse time, because it depends
     # on the data, so the emitted call starts at tau = 1 and this says so
     # rather than letting the difference pass as a translation. Emitting

--- a/R/sas-parse-parms.R
+++ b/R/sas-parse-parms.R
@@ -486,22 +486,47 @@
     )
   }
 
-  # SETG3() replaces a non-positive TAU -- absent from PARMS, or written as
-  # TAU=0 -- with 2*Tmax/3 (setg3.c:317). It is the one shape default that
-  # cannot be reproduced at parse time, because it depends on the data, so the
-  # emitted call starts at tau = 1 and this says so rather than letting the
-  # difference pass as a translation. Emitting `2 * max(<timevar>) / 3` instead
-  # was considered and rejected: SAS's Tmax is taken over the analysis set
-  # after exclusions, not over the raw column, so the expression would look
-  # exact while being a guess.
+  # SETG3_ignore_tau() does TWO things at setg3.c:378-379, and naming only the
+  # first is what made this look harmless: it sets TAU to 1 AND fixes it. The
+  # emitted call carries only what FIXTAU named, so TAU stays free -- and at
+  # alpha = 1 that is not a spare degree of freedom but an unidentified one.
+  # G3 collapses to (t/tau)^(gamma*eta) there (checked against
+  # hzr_decompos_g3() to 2e-16), so mu enters the likelihood only through
+  # log_mu - gamma*eta*log_tau: the two are exactly aliased, the Hessian is
+  # singular, and hazard() returns NO standard errors for either while still
+  # reporting a fit. That is the shape AGENTS.md opens with, so it is recorded.
   #
-  # Three conditions, each doing work. `length(late)` because a late phase that
-  # was never built is already reported by the MUL guard below, and two rows
-  # for one absence is noise. `has_late` for the same reason the guards above
-  # carry it: with no positive MUL, shape.c never calls SETG3() at all.
-  # `!ignore_tau` because that branch pins TAU at 1 (setg3.c:378) -- exactly
-  # what is emitted -- so there is nothing to report.
-  if (length(late) && has_late && tau_defaulted && !ignore_tau) {
+  # It fires whether or not PARMS named a TAU, because SAS overwrites the value
+  # either way -- a job written TAU=5 runs at tau = 1 in PROC HAZARD. Recorded
+  # rather than rewritten, for the same reason the GAMMA/ETA split above is:
+  # rewriting the emitted call would put it at odds with the user's own PARMS
+  # text. Whether to instead emit `tau = 1, fixed = "tau"` here, which would be
+  # exactly what the C does and would remove the aliasing, is a maintainer
+  # decision -- it changes the emitted call for every corpus block that fires
+  # this branch.
+  if (length(late) && has_late && ignore_tau) {
+    flag_bad(
+      if (is.null(late[["tau"]])) "ALPHA=1 FIXALPHA (TAU unspecified)" else
+        paste0("ALPHA=1 FIXALPHA with TAU=", sprintf("%g", late[["tau"]])),
+      paste0("SETG3_ignore_tau() sets TAU to 1 and FIXES it (setg3.c:378-379); ",
+             "the emitted phase leaves TAU free, and at alpha = 1 the G3 form ",
+             "collapses to (t/tau)^(gamma*eta), so log_mu and log_tau are ",
+             "exactly aliased -- the fit converges onto a flat ridge and ",
+             "reports no standard errors for either")
+    )
+  } else if (length(late) && has_late && tau_defaulted) {
+    # The other SETG3 branch (setg3.c:316-318): a non-positive TAU -- absent
+    # from PARMS, or written as TAU=0 -- is replaced by 2*Tmax/3. It is the one
+    # shape default that cannot be reproduced at parse time, because it depends
+    # on the data, so the emitted call starts at tau = 1 and this says so
+    # rather than letting the difference pass as a translation. Emitting
+    # `2 * max(<timevar>) / 3` instead was considered and rejected: SAS's Tmax
+    # is taken over the analysis set after exclusions, not over the raw column,
+    # so the expression would look exact while being a guess.
+    #
+    # `length(late)` because a late phase that was never built is already
+    # reported by the MUL guard below, and two rows for one absence is noise;
+    # `has_late` because with no positive MUL, shape.c never calls SETG3().
     flag_bad(
       if (is.null(late[["tau"]])) "TAU (unspecified)" else
         paste0("TAU=", sprintf("%g", late[["tau"]])),

--- a/tests/testthat/test-sas-parse-hazard.R
+++ b/tests/testthat/test-sas-parse-hazard.R
@@ -37,17 +37,18 @@ test_that("a LATE statement with comma-separated VAR=VALUE operands parses", {
   got <- .hzr_parse_hazard(.hzr_sas_blocks(txt)[[1L]])
   expect_equal(
     got$call[["phases"]],
-    quote(list(hzr_phase("g3", tau = 2, gamma = 1.5,
+    quote(list(hzr_phase("g3", tau = 2, gamma = 1.5, alpha = 1, eta = 2,
                           formula = ~NOPREVTE + NOTEE)))
   )
-  # log_mu, log_tau, gamma, alpha (defaulted), eta (defaulted), then the two
-  # covariate starts in the order they appear on the LATE statement. Compare
-  # evaluated: a parsed `-0.3680751` literal is a unary-minus call, not the
-  # plain double the translator builds, so quote()-comparing the call would
-  # spuriously differ in representation.
+  # log_mu, log_tau, gamma, alpha (defaulted to PROC HAZARD's 1), eta
+  # (defaulted to PROC HAZARD's 2, NOT hzr_phase()'s 1), then the two covariate
+  # starts in the order they appear on the LATE statement. Compare evaluated: a
+  # parsed `-0.3680751` literal is a unary-minus call, not the plain double the
+  # translator builds, so quote()-comparing the call would spuriously differ in
+  # representation.
   expect_equal(
     eval(got$call[["theta"]]),
-    c(log(0.01), log(2), 1.5, 1, 1, 2.653528, -0.3680751)
+    c(log(0.01), log(2), 1.5, 1, 2, 2.653528, -0.3680751)
   )
 })
 

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -472,22 +472,27 @@ test_that("an incomplete shape list fails loudly in the theta block", {
 })
 
 test_that("a late phase with no TAU records the data-dependent SAS default", {
-  # setg3.c:317 starts a non-positive TAU at 2*Tmax/3, which is unreproducible
-  # at parse time. The emitted phase starts at tau = 1, so the difference is
-  # recorded rather than passed off as a translation.
+  # An UNSPECIFIED TAU is 0.75*Tmax (readobs.c:153-154), not setg3.c:317's
+  # 2*Tmax/3 -- readobs() has already replaced it before SETG3 runs, so the
+  # tau <= 0 branch there is never reached for an absent TAU. This assertion
+  # named the wrong rule and the wrong number until that was checked; the
+  # explicit-TAU=0 case below is the one setg3.c:317 governs.
   got <- .hzr_parse_parms(c("MUL=0.01", "GAMMA=2"))
   expect_equal(nrow(got$untranslated), 1L)
   expect_equal(got$untranslated$construct, "TAU (unspecified)")
-  expect_match(got$untranslated$reason, "2\\*Tmax/3")
+  expect_match(got$untranslated$reason, "0\\.75\\*Tmax")
+  expect_false(grepl("2*Tmax/3", got$untranslated$reason, fixed = TRUE))
   expect_equal(got$phases,
                quote(list(hzr_phase("g3", tau = 1, gamma = 2, alpha = 1,
                                     eta = 2))))
 })
 
-test_that("an explicit TAU = 0 takes the same SETG3 branch and is recorded", {
-  # The C predicate is tau <= 0, not "absent", and hzr_phase() would reject
-  # tau = 0 outright -- so without this the translator emitted a call that
-  # errored where SAS supplies a default and runs.
+test_that("an explicit TAU = 0 takes SETG3's own branch and is recorded", {
+  # setg3.c:316-317's predicate is tau <= 0, and only a TAU the job WROTE can
+  # still be non-positive there -- readobs.c:153-154 has already replaced an
+  # absent one. hzr_phase() would reject tau = 0 outright, so without this the
+  # translator emitted a call that errored where SAS supplies a default and
+  # runs. Different rule and different constant from the absent case above.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=0", "GAMMA=2"))
   expect_equal(got$untranslated$construct, "TAU=0")
   expect_match(got$untranslated$reason, "2\\*Tmax/3")
@@ -599,9 +604,11 @@ test_that("the verify_ge_2 row does not fire above the boundary or on WEIBULL", 
 test_that("the product SETG3_verify_ge_2 reads survives the ignore_tau swap", {
   # setg3.c:403-421 moves the exponent between GAMMA and ETA but preserves
   # their PRODUCT, which is all `gte` reads -- so the boundary test is the same
-  # whether or not that branch ran. This is what lets one predicate serve both
-  # paths; if the reparameterisation ever stops being product-preserving, the
-  # guard silently starts testing the wrong quantity.
+  # whether or not that branch ran.
+  #
+  # Only while the product is positive, though: setg3.c:411-412 falls back to
+  # the other operand when gamma*eta <= 0, and the product then changes. That
+  # case is covered by the test below, not here.
   # gamma * eta = 3, above the boundary, in both orderings: 0.5 * 6 straight,
   # and 1 * 3 after the swap. Neither may record the rewrite.
   a <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=0.5", "ETA=6"))
@@ -675,7 +682,10 @@ test_that("each SETG3 entry refusal is recorded with its own code", {
     expect_equal(nrow(got$untranslated), 1L, info = paste(ops, collapse = " "))
     got$untranslated$reason
   }
-  expect_match(refusal(c("MUL=0.01", "FIXTAU", "GAMMA=2", "ETA=2")),
+  # TAU=0 explicitly, NOT a bare FIXTAU: an unspecified TAU never reaches
+  # setg3.c:269 as 0 (see the readobs.c test below), so a bare FIXTAU cannot
+  # raise SETG3900. This assertion said otherwise until that was checked.
+  expect_match(refusal(c("MUL=0.01", "TAU=0", "FIXTAU", "GAMMA=2", "ETA=2")),
                "SETG3900")
   expect_match(refusal(c("MUL=0.01", "TAU=1", "GAMMA=0", "FIXGAMMA", "ETA=2")),
                "SETG3910")
@@ -689,19 +699,45 @@ test_that("each SETG3 entry refusal is recorded with its own code", {
 test_that("a refusal names the operand, not just the SAS message code", {
   # The code alone is greppable but opaque; a caller reading $untranslated has
   # to know which operand to change.
-  got <- .hzr_parse_parms(c("MUL=0.01", "FIXTAU", "GAMMA=2", "ETA=2"))
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=0", "FIXTAU", "GAMMA=2",
+                            "ETA=2"))
   expect_match(got$untranslated$reason, "TAU is fixed at a non-positive value")
   expect_match(got$untranslated$construct, "fixed:tau")
 })
 
-test_that("a refused job records only the refusal, not the TAU rules too", {
-  # SETG3 returns at :271 before either TAU rule runs, so reporting the
-  # 2*Tmax/3 divergence alongside would describe code PROC HAZARD never
-  # reaches -- the same false positive the MUL gate exists to avoid. This
-  # input has no TAU operand, so the 2*Tmax/3 row would otherwise fire.
-  got <- .hzr_parse_parms(c("MUL=0.01", "FIXTAU", "GAMMA=2", "ETA=2"))
-  expect_equal(nrow(got$untranslated), 1L)
-  expect_false(any(grepl("Tmax", got$untranslated$reason, fixed = TRUE)))
+test_that("an ENTRY refusal suppresses the TAU row but a later one does not", {
+  # setg3.c:269-284 returns before the TAU rules at :309-323, so a TAU row
+  # there would describe code PROC HAZARD never reaches. The other twelve
+  # codes fire from :429 onwards, by which point the TAU rule HAS run --
+  # suppressing the row for those would hide a divergence that happened.
+  # Keying the suppression on "refused at all" gets the second case wrong.
+  entry <- .hzr_parse_parms(c("MUL=0.01", "TAU=0", "FIXTAU", "GAMMA=2",
+                              "ETA=2"))
+  expect_equal(nrow(entry$untranslated), 1L)
+  expect_false(any(grepl("Tmax", entry$untranslated$reason, fixed = TRUE)))
+  late <- .hzr_parse_parms(c("MUL=0.01", "GAMMA=1", "FIXGAMMA", "ETA=2",
+                             "FIXETA"))
+  expect_true(any(grepl("SETG31020", late$untranslated$reason)))
+  expect_true(any(grepl("Tmax", late$untranslated$reason, fixed = TRUE)))
+})
+
+test_that("an unspecified TAU is 0.75*Tmax, not the stmtprc.c initializer", {
+  # readobs.c:153-154 replaces an unspecified TAU with 0.75*Tmax whenever the
+  # late phase is active, and readobs() runs at hazard.c:276, before hzrg()
+  # reaches SETG3() at :292. So the stmtprc.c initializer of 0 never arrives
+  # at setg3.c:269 -- an absent TAU is POSITIVE there, cannot raise SETG3900,
+  # and never reaches the 2*Tmax/3 assignment at :317 either.
+  #
+  # Conflating "absent" with "non-positive" put a refusal in $untranslated for
+  # a job PROC HAZARD runs, which is this package's signature defect inverted:
+  # a finding that looks like one and is not.
+  absent <- .hzr_parse_parms(c("MUL=0.01", "FIXTAU", "GAMMA=2", "ETA=2"))
+  expect_equal(nrow(absent$untranslated), 1L)
+  expect_match(absent$untranslated$reason, "0\\.75\\*Tmax")
+  expect_false(any(grepl("SETG3900", absent$untranslated$reason)))
+  # An explicit non-positive TAU is the other rule, and a different number.
+  written <- .hzr_parse_parms(c("MUL=0.01", "TAU=0", "GAMMA=2", "ETA=2"))
+  expect_match(written$untranslated$reason, "2\\*Tmax/3")
 })
 
 test_that("WEIBULL's own refusals are recorded, including a negative ALPHA", {
@@ -740,6 +776,10 @@ test_that("a non-positive GAMMA or ETA is a rewrite SAS makes and R cannot", {
   # recording it says which operand to supply.
   g <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "GAMMA=0", "ETA=2", "ALPHA=1"))
   expect_match(g$untranslated$reason, "optimizes from gamma = 1\\.5")
+  # The claim above, made load-bearing: the emitted call really cannot be
+  # built, so the row must not describe the difference as a starting value.
+  expect_error(eval(g$phases), "gamma must be a positive scalar")
+  expect_match(g$untranslated$reason, "cannot be built at all")
   e <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "GAMMA=2", "ETA=0", "ALPHA=1"))
   expect_match(e$untranslated$reason, "optimizes from .*eta = 1\\.5")
 })
@@ -771,4 +811,129 @@ test_that("the SETG3 trace is gated on an active late phase", {
                                        "ETA=2"))$untranslated), 0L)
   expect_equal(nrow(.hzr_parse_parms(c("MUL=0", "FIXTAU",
                                        "GAMMA=2"))$untranslated), 0L)
+})
+
+test_that("the ignore_tau swap is NOT product-preserving when the product is <= 0", {
+  # setg3.c:411-412: `if(Late.gamma<=ZERO) Late.gamma = HZRstr.l.eta;`. With
+  # gamma = -2 and eta = 3 the C does not carry -6 across -- it keeps eta,
+  # leaving gamma = 3, eta = 1 and a product of 3. The trace has to reproduce
+  # the fallback rather than the arithmetic, and the comparison has to notice.
+  # Stated as an invariant without this exception, "the swap preserves the
+  # product" is the kind of half-read claim that put a wrong assertion in this
+  # file once already.
+  tr <- .hzr_setg3_notes(tau_raw = 1, gamma = -2, alpha = 1, eta = 3,
+                         fixed = "alpha", weibull = FALSE)
+  expect_equal(unname(tr$shape[["gamma"]]), 3)
+  expect_equal(unname(tr$shape[["eta"]]), 1)
+  expect_false(isTRUE(all.equal(
+    tr$shape[["gamma"]] * tr$shape[["eta"]], -2 * 3
+  )))
+  # And the divergence is reported rather than absorbed by the product test.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=-2",
+                            "ETA=3", "FIXALPHA"))
+  expect_match(got$untranslated$reason, "optimizes from gamma\\*eta = 3")
+  # The positive case still preserves it, so the two halves are distinguished.
+  pos <- .hzr_setg3_notes(tau_raw = 1, gamma = 2, alpha = 1, eta = 3,
+                          fixed = "alpha", weibull = FALSE)
+  expect_equal(unname(pos$shape[["gamma"]] * pos$shape[["eta"]]), 6)
+})
+
+test_that("the four remaining sign branches use SETG3's own constants", {
+  # setg3.c:638-812. These are the branches with the distinctive substitutions,
+  # and none was covered: mutating `eta <- 3` to 2 in all_le_0, or
+  # `gamma <- 1.5 * alpha` to `alpha` in alpha_gt_0, produced no failure.
+  # Asserted through .hzr_setg3_notes() directly so the values are visible
+  # rather than inferred from a reason string.
+  fx <- character(0)
+  # eta_gt_0 (:638): alpha <= 0, gamma <= 0, eta > 0 -> gamma = 3/eta, then
+  # alpha_gener derives alpha = gamma*eta/3 = 1.
+  a <- .hzr_setg3_notes(1, gamma = 0, alpha = 0, eta = 3, fixed = fx,
+                        weibull = FALSE)
+  expect_equal(unname(a$shape[["gamma"]]), 1)
+  expect_equal(unname(a$shape[["alpha"]]), 1)
+  # gamma_gt_0 (:678): alpha <= 0, gamma > 0, eta <= 0 -> eta = 3/gamma.
+  b <- .hzr_setg3_notes(1, gamma = 2, alpha = 0, eta = 0, fixed = fx,
+                        weibull = FALSE)
+  expect_equal(unname(b$shape[["eta"]]), 1.5)
+  # alpha_gt_0 (:717): alpha > 0, gamma <= 0, eta <= 0 -> eta = 2,
+  # gamma = 1.5*alpha.
+  cc <- .hzr_setg3_notes(1, gamma = 0, alpha = 2, eta = 0, fixed = fx,
+                         weibull = FALSE)
+  expect_equal(unname(cc$shape[["eta"]]), 2)
+  expect_equal(unname(cc$shape[["gamma"]]), 3)
+  # all_le_0 (:772): gamma = 1, eta = 3.
+  d <- .hzr_setg3_notes(1, gamma = 0, alpha = 0, eta = 0, fixed = fx,
+                        weibull = FALSE)
+  expect_equal(unname(d$shape[["gamma"]]), 1)
+  expect_equal(unname(d$shape[["eta"]]), 3)
+})
+
+test_that("the reachable refusal codes are exactly the nine, by exhaustive search", {
+  # Sixteen codes are mirrored from the C, but only NINE can fire. The other
+  # seven each guard a condition the ENTRY checks at setg3.c:269-284 already
+  # refused: SETG31090/32050/33020 want a non-positive GAMMA that is fixed
+  # (SETG3910), SETG32020/32080/33010 a non-positive ETA that is fixed
+  # (SETG3930), and SETG31070 a fixed ALPHA on a branch where alpha <= 0 --
+  # negative refuses at SETG3920, and zero sets g3flag = 2 so alpha_gener is
+  # never called. That is a property of PROC HAZARD, not of this port, and it
+  # is why they have no individual tests: an input that reaches them does not
+  # exist.
+  #
+  # Searched rather than argued. Reasoning about reachability through three
+  # files is how the SETG3900 claim went wrong; a grid says what is true.
+  skip_on_cran()
+  parms <- c("tau", "gamma", "alpha", "eta")
+  subsets <- unlist(lapply(0:4, function(k) utils::combn(parms, k, simplify = FALSE)),
+                    recursive = FALSE)
+  seen <- character(0)
+  for (tau in c(NA, -1, 0, 1, 5)) {
+    for (g in c(-2, 0, 1, 2, 3)) {
+      for (a in c(-2, 0, 1, 2, 3)) {
+        for (e in c(-2, 0, 1, 2, 3)) {
+          for (fx in subsets) {
+            for (w in c(TRUE, FALSE)) {
+              tr <- .hzr_setg3_notes(tau, g, a, e, fx, w)
+              if (!is.null(tr$refusal)) seen <- union(seen, tr$refusal)
+            }
+          }
+        }
+      }
+    }
+  }
+  expect_setequal(seen, c("(SETG3900)", "(SETG3910)", "(SETG3920)",
+                          "(SETG3930)", "(SETG3960)", "(SETG3970)",
+                          "(SETG3980)", "(SETG31020)", "(SETG31040)"))
+})
+
+test_that("the two non-entry refusals that ARE reachable fire on named inputs", {
+  # SETG31020 (verify_ge_2, both operands fixed at or below the boundary) and
+  # SETG31040 (alpha_fixup, ALPHA fixed with GAMMA*ETA/ALPHA <= 2) are the only
+  # refusals raised after the entry checks. Both need positive operands, which
+  # is exactly why they survive where the other seven do not.
+  both <- .hzr_setg3_notes(1, gamma = 1, alpha = 1, eta = 2,
+                           fixed = c("gamma", "eta"), weibull = FALSE)
+  expect_equal(both$refusal, "(SETG31020)")
+  expect_false(isTRUE(both$entry))
+  pinned <- .hzr_setg3_notes(1, gamma = 2, alpha = 3, eta = 2,
+                             fixed = "alpha", weibull = FALSE)
+  expect_equal(pinned$refusal, "(SETG31040)")
+})
+
+test_that("every code in the refusal table has its own gloss", {
+  # The table is kept complete against the C even where a code is unreachable,
+  # so nothing may fall through to the generic text.
+  for (code in names(.hzr_setg3_refusal)) {
+    expect_false(identical(.hzr_setg3_refusal_reason(code),
+                           "the operand combination is rejected"),
+                 info = code)
+  }
+})
+
+test_that("an unknown refusal code degrades instead of erroring", {
+  # `[[` on an unmatched name in a character vector throws rather than
+  # returning NULL, so the is.null() fallback this replaced was hollow: right
+  # shape, unreachable, and the parser would have errored if a code were ever
+  # added to the trace but not the table.
+  expect_equal(.hzr_setg3_refusal_reason("(SETG39999)"),
+               "the operand combination is rejected")
 })

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -578,8 +578,8 @@ test_that("SETG3_verify_ge_2's GAMMA rewrite is recorded, not mirrored", {
   # form and needs no such restriction, and reaching a late shape SAS cannot
   # is a goal here. Recorded so a parity run knows why the starts differ.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=3"))
-  expect_equal(got$untranslated$construct, "GAMMA=1 ETA=2 (product 2)")
-  expect_match(got$untranslated$reason, "GAMMA\\*ETA <= 2")
+  expect_equal(got$untranslated$construct, "gamma=1 alpha=1 eta=2")
+  expect_match(got$untranslated$reason, "optimizes from gamma = 1\\.5")
   expect_equal(
     got$phases,
     quote(list(hzr_phase("g3", tau = 3, gamma = 1, alpha = 1, eta = 2)))
@@ -593,7 +593,7 @@ test_that("the verify_ge_2 row does not fire above the boundary or on WEIBULL", 
   above <- .hzr_parse_parms(c("MUL=0.01", "TAU=3", "GAMMA=2", "ETA=2"))
   expect_equal(nrow(above$untranslated), 0L)
   weib <- .hzr_parse_parms(c("MUL=0.01", "TAU=3", "GAMMA=1", "ETA=2", "WEIBULL"))
-  expect_false(any(grepl("GAMMA\\*ETA", weib$untranslated$reason)))
+  expect_equal(nrow(weib$untranslated), 0L)
 })
 
 test_that("the product SETG3_verify_ge_2 reads survives the ignore_tau swap", {
@@ -608,11 +608,11 @@ test_that("the product SETG3_verify_ge_2 reads survives the ignore_tau swap", {
   expect_equal(nrow(a$untranslated), 0L)
   b <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=0.5", "ETA=6",
                           "ALPHA=1", "FIXALPHA", "FIXGAMMA"))
-  expect_false(any(grepl("GAMMA\\*ETA <= 2", b$untranslated$reason)))
+  expect_false(any(grepl("optimizes from", b$untranslated$reason)))
   # And the same product BELOW the boundary does record, so the pair above is
   # not passing merely because the guard never fires on these shapes.
   lo <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=0.5", "ETA=3"))
-  expect_true(any(grepl("GAMMA\\*ETA <= 2", lo$untranslated$reason)))
+  expect_true(any(grepl("optimizes from gamma", lo$untranslated$reason)))
 })
 
 test_that("the aliasing that motivates pinning TAU is real, not asserted", {
@@ -648,4 +648,127 @@ test_that("a MUL with no late shape operand records the MU, not TAU as well", {
   got <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "MUL=0.05"))
   expect_equal(nrow(got$untranslated), 1L)
   expect_match(got$untranslated$reason, "no late phase")
+})
+
+# ---------------------------------------------------------------------------
+# The rest of the SETG3() chain (.hzr_setg3_notes()).
+#
+# Two kinds of divergence, both recorded and neither mirrored, per the split
+# documented on that function: a REFUSAL is a job PROC HAZARD will not run, and
+# a REWRITE is SETG3 constraining the late shape to stay inside a numerical
+# branch it can evaluate. Only the two alpha = 1 identifiability fixes are
+# mirrored, and those are tested above.
+#
+# None of this fires on the public corpus: every late-phase PARMS block there
+# carries WEIBULL, which returns at setg3.c:347 before the sign dispatch, and
+# all of them write TAU=1 FIXTAU ALPHA=1 FIXALPHA with a positive GAMMA and
+# ETA. These tests therefore carry the whole behaviour.
+# ---------------------------------------------------------------------------
+
+test_that("each SETG3 entry refusal is recorded with its own code", {
+  # setg3.c:269-284, checked before anything else -- including
+  # SETG3_ignore_tau(). A FIX* on an operand SAS reads as unspecified is
+  # fatal, and the value SAS reads is the job's own, so FIXTAU with no TAU
+  # operand refuses on the stmtprc.c initializer of 0.
+  refusal <- function(ops) {
+    got <- .hzr_parse_parms(ops)
+    expect_equal(nrow(got$untranslated), 1L, info = paste(ops, collapse = " "))
+    got$untranslated$reason
+  }
+  expect_match(refusal(c("MUL=0.01", "FIXTAU", "GAMMA=2", "ETA=2")),
+               "SETG3900")
+  expect_match(refusal(c("MUL=0.01", "TAU=1", "GAMMA=0", "FIXGAMMA", "ETA=2")),
+               "SETG3910")
+  expect_match(refusal(c("MUL=0.01", "TAU=1", "GAMMA=2", "ETA=2",
+                         "ALPHA=-1", "FIXALPHA")),
+               "SETG3920")
+  expect_match(refusal(c("MUL=0.01", "TAU=1", "GAMMA=2", "ETA=0", "FIXETA")),
+               "SETG3930")
+})
+
+test_that("a refusal names the operand, not just the SAS message code", {
+  # The code alone is greppable but opaque; a caller reading $untranslated has
+  # to know which operand to change.
+  got <- .hzr_parse_parms(c("MUL=0.01", "FIXTAU", "GAMMA=2", "ETA=2"))
+  expect_match(got$untranslated$reason, "TAU is fixed at a non-positive value")
+  expect_match(got$untranslated$construct, "fixed:tau")
+})
+
+test_that("a refused job records only the refusal, not the TAU rules too", {
+  # SETG3 returns at :271 before either TAU rule runs, so reporting the
+  # 2*Tmax/3 divergence alongside would describe code PROC HAZARD never
+  # reaches -- the same false positive the MUL gate exists to avoid. This
+  # input has no TAU operand, so the 2*Tmax/3 row would otherwise fire.
+  got <- .hzr_parse_parms(c("MUL=0.01", "FIXTAU", "GAMMA=2", "ETA=2"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_false(any(grepl("Tmax", got$untranslated$reason, fixed = TRUE)))
+})
+
+test_that("WEIBULL's own refusals are recorded, including a negative ALPHA", {
+  # setg3.c:429-440. The pre-existing guard covered only alpha == 0; a
+  # negative ALPHA raises the same SETG3980 and was emitted as a runnable fit.
+  neg <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=-2",
+                            "ETA=1", "WEIBULL"))
+  expect_match(neg$untranslated$reason, "SETG3980")
+  g <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=0", "ETA=1", "WEIBULL"))
+  expect_match(g$untranslated$reason, "SETG3960")
+  e <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ETA=0",
+                          "WEIBULL"))
+  expect_match(e$untranslated$reason, "SETG3970")
+})
+
+test_that("ALPHA = 0 is faithful when fixed and a rewrite when free", {
+  # setg3.c:332-335: alpha == 0 with FIXALPHA sets g3flag = 2, the limiting
+  # exponential, which is exactly what hzr_phase() fits at alpha = 0 -- so
+  # that job translates cleanly. Left free, SETG3_alpha_gener() (:854) instead
+  # derives alpha = gamma*eta/3, and the emitted call would fit the
+  # exponential SAS did not choose. The pair distinguishes the two; asserting
+  # only the second would pass for a guard that fired on every ALPHA = 0.
+  fixed <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "GAMMA=2", "ETA=2",
+                              "ALPHA=0", "FIXALPHA"))
+  expect_equal(nrow(fixed$untranslated), 0L)
+  free <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "GAMMA=2", "ETA=2",
+                             "ALPHA=0"))
+  expect_match(free$untranslated$reason, "optimizes from alpha = 1\\.33333")
+})
+
+test_that("a non-positive GAMMA or ETA is a rewrite SAS makes and R cannot", {
+  # setg3.c:533-585 and :587-636 treat a non-positive operand as "derive one
+  # for me" -- gamma = 3*alpha/eta, then 3/eta if the product still sits at or
+  # below 2. hzr_phase() requires gamma > 0 and would reject the emitted call
+  # outright, so this is the one place SAS is the more permissive of the two;
+  # recording it says which operand to supply.
+  g <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "GAMMA=0", "ETA=2", "ALPHA=1"))
+  expect_match(g$untranslated$reason, "optimizes from gamma = 1\\.5")
+  e <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "GAMMA=2", "ETA=0", "ALPHA=1"))
+  expect_match(e$untranslated$reason, "optimizes from .*eta = 1\\.5")
+})
+
+test_that("SETG3_alpha_fixup's refusal and its substitution are distinguished", {
+  # setg3.c:838-851: with GAMMA*ETA/ALPHA <= 2 the C either derives
+  # alpha = gamma*eta/3, or refuses with SETG31040 when ALPHA is fixed and it
+  # cannot. Same operands, one FIXALPHA apart.
+  free <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2", "ETA=2",
+                             "ALPHA=3"))
+  expect_match(free$untranslated$reason, "optimizes from alpha = 1\\.33333")
+  pinned <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2", "ETA=2",
+                               "ALPHA=3", "FIXALPHA"))
+  expect_match(pinned$untranslated$reason, "SETG31040")
+})
+
+test_that("a late shape SETG3 leaves alone records nothing", {
+  # The other side of every guard above, so none of them can be satisfied by
+  # firing unconditionally: GAMMA*ETA = 4 > 2 and GAMMA*ETA/ALPHA = 4 > 2, so
+  # verify_ge_2 and alpha_fixup are both no-ops and the translation is exact.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=3", "GAMMA=2", "ETA=2"))
+  expect_equal(nrow(got$untranslated), 0L)
+})
+
+test_that("the SETG3 trace is gated on an active late phase", {
+  # Same gate as every other SETG3 guard: with no positive MUL, shape.c never
+  # calls SETG3(), so neither a refusal nor a rewrite can happen.
+  expect_equal(nrow(.hzr_parse_parms(c("GAMMA=0", "FIXGAMMA",
+                                       "ETA=2"))$untranslated), 0L)
+  expect_equal(nrow(.hzr_parse_parms(c("MUL=0", "FIXTAU",
+                                       "GAMMA=2"))$untranslated), 0L)
 })

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -250,11 +250,10 @@ test_that("alpha = 1 fixed with GAMMA and ETA both free is recorded", {
   # 2026-09-08); the 16 that fire SETG3_ignore_tau() all fix GAMMA.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=2",
                             "ETA=3", "FIXALPHA"))
-  expect_true(any(grepl("estimates GAMMA\\*ETA", got$untranslated$reason)))
-  # The same branch also leaves TAU free where SAS fixes it; that is a second,
-  # separate row (see the SETG3_ignore_tau TAU tests below), so assert this
-  # guard by its reason rather than by the row count.
-  expect_equal(nrow(got$untranslated), 2L)
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_match(got$untranslated$reason, "estimates GAMMA\\*ETA")
+  # TAU=1 is what the branch pins anyway, so it contributes no second row.
+  expect_true("tau" %in% eval(got$phases)[[1L]]$fixed)
 })
 
 test_that("alpha = 1 fixed with GAMMA fixed is not recorded", {
@@ -472,37 +471,73 @@ test_that("a positive TAU is not recorded", {
   expect_equal(nrow(got$untranslated), 0L)
 })
 
-test_that("SETG3_ignore_tau() fixing TAU, not just setting it, is recorded", {
-  # This test previously asserted ZERO untranslated rows here, on the grounds
-  # that setg3.c:378 pins tau at 1 -- "exactly what is emitted, so there is
-  # nothing to report". That read half the function. Line 379 is
-  # hzr_parm_set_fixed(HZ_TAU): SAS fixes TAU as well, and the emitted call
-  # does not. At alpha = 1 that is not a spare parameter but an unidentified
-  # one, and the fit below is the reason this matters -- it converges and
-  # reports no standard errors on the two aliased parameters, which is the
-  # exact shape AGENTS.md opens with. FIXGAMMA keeps the GAMMA*ETA guard quiet
-  # so the surviving row can only be the TAU one.
+test_that("SETG3_ignore_tau() pins TAU at 1 AND fixes it, and so does the call", {
+  # setg3.c:378-379 is two statements: Late.tau = ONE, then
+  # hzr_parm_set_fixed(HZ_TAU). An earlier version of this test read only the
+  # first, concluded "exactly what is emitted, so there is nothing to report",
+  # and asserted ZERO untranslated rows over a fit that returns no standard
+  # errors. Both halves are now mirrored, so the translation is faithful and
+  # there is genuinely nothing to report -- but assert the emitted `fixed=`,
+  # not just the row count, or this reverts to the assertion that could not
+  # fail.
   got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
                             "FIXALPHA", "FIXGAMMA"))
-  expect_equal(nrow(got$untranslated), 1L)
-  expect_match(got$untranslated$reason, "exactly aliased")
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("g3", tau = 1, gamma = 1, alpha = 1, eta = 1.32,
+                         fixed = c("tau", "gamma", "alpha"))))
+  )
+  expect_equal(nrow(got$untranslated), 0L)
 })
 
-test_that("the SETG3_ignore_tau TAU row fires on a TAU the job did specify", {
-  # SAS overwrites the value either way, so a job written TAU=5 runs at
-  # tau = 1, fixed. Keying the row on "TAU was defaulted" would have missed
-  # this entirely -- the emitted call starts at 5, free.
+test_that("pinning TAU restores standard errors on the aliased log_mu", {
+  # The point of the pin, executed rather than argued. With TAU free this fit
+  # converges onto the log_mu/log_tau ridge and vcov() gives NA for both; with
+  # TAU fixed as SAS fixes it, log_mu is identified again. An assertion on the
+  # emitted `fixed=` alone would not show that.
+  skip_on_cran()
+  got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
+                            "FIXALPHA", "FIXGAMMA"))
+  set.seed(1)
+  n <- 400
+  d <- data.frame(t = stats::rexp(n, 0.3), s = rep(c(1, 0), length.out = n))
+  fit <- suppressWarnings(hazard(
+    time = d$t, status = d$s, dist = "multiphase",
+    phases = eval(got$phases), theta = eval(got$theta), fit = TRUE
+  ))
+  se <- sqrt(diag(stats::vcov(fit)))
+  expect_true(is.finite(se[["phase_1.log_mu"]]))
+})
+
+test_that("a TAU the ignore_tau branch discards is recorded", {
+  # PROC HAZARD overrides the value, and so now does the translator -- but a
+  # starting value the job wrote and neither program uses is worth saying out
+  # loud, which is what $untranslated is for.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=5", "ALPHA=1", "GAMMA=1",
                             "ETA=1.32", "FIXALPHA", "FIXGAMMA"))
-  expect_equal(got$untranslated$construct, "ALPHA=1 FIXALPHA with TAU=5")
-  expect_match(got$untranslated$reason, "exactly aliased")
+  expect_equal(got$untranslated$construct, "TAU=5")
+  expect_match(got$untranslated$reason, "discards this TAU")
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("g3", tau = 1, gamma = 1, alpha = 1, eta = 1.32,
+                         fixed = c("tau", "gamma", "alpha"))))
+  )
 })
 
-test_that("the aliasing the ignore_tau row describes is real, not asserted", {
-  # The row claims G3 collapses to (t/tau)^(gamma*eta) at alpha = 1, which is
-  # why log_mu and log_tau cannot both be identified. Compute it rather than
-  # restate it: a wrong claim in an $untranslated reason is a wrong claim a
-  # caller acts on.
+test_that("the ignore_tau branch suppresses the 2*Tmax/3 row, not just reorders it", {
+  # setg3.c:313-316 is an if/else: a job that fixes ALPHA at 1 never reaches
+  # the 2*Tmax/3 assignment, so an absent TAU there is not a data-dependent
+  # default. The first cut of this fell through to that row and reported a
+  # divergence PROC HAZARD does not have.
+  got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
+                            "FIXALPHA", "FIXGAMMA"))
+  expect_false(any(grepl("Tmax", got$untranslated$reason, fixed = TRUE)))
+})
+
+test_that("the aliasing that motivates pinning TAU is real, not asserted", {
+  # The comment justifying the pin claims G3 collapses to (t/tau)^(gamma*eta)
+  # at alpha = 1, which is why log_mu and log_tau cannot both be identified.
+  # Compute it rather than restate it.
   tt <- c(0.5, 1, 2, 5, 10)
   g <- hzr_decompos_g3(tt, tau = 2, gamma = 1.3, alpha = 1, eta = 1.7)$G
   expect_equal(g, (tt / 2)^(1.3 * 1.7))

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -19,15 +19,14 @@ test_that("an early-plus-constant PARMS maps to two phases and a theta", {
 test_that("WEIBULL leaves unspecified ALPHA and ETA at their defaults, free", {
   # PARMS ... WEIBULL is setopt(6) -> SETG3_weibull (setg3.c:427), the
   # generalized Weibull, which admits all positive parameter values. With
-  # ALPHA and ETA absent from PARMS they take hzr_phase()'s defaults of 1 --
-  # so they are omitted from the emitted call -- and stay estimated. Only the
+  # ALPHA and ETA absent from PARMS they take PROC HAZARD's defaults
+  # (stmtprc.c:30-37: alpha = 1, eta = 2) and stay estimated. Only the
   # explicit FIXTAU/FIXGAMMA pin anything.
   #
-  # Note those are *R's* defaults, not SAS's: stmtprc.c:30-37 starts an
-  # unspecified late phase at gamma = 1, alpha = 1, eta = 2 (and tau at
-  # 2*Tmax/3, data-dependent). This test pins the translator's behaviour, not
-  # start-value parity with PROC HAZARD -- a separate, pre-existing gap that
-  # WEIBULL jobs now share with every other path.
+  # Those defaults are emitted explicitly rather than left to hzr_phase(),
+  # whose own eta default is 1. Omitting them would put the printed call and
+  # the theta vector into disagreement the moment the two default tables
+  # differ, which is what this test guards: assert $theta as well as $phases.
   #
   # This test previously asserted alpha = eta = 1, fixed. That was the
   # translator's behaviour, not SAS's: it read WEIBULL as a constraint to the
@@ -40,9 +39,11 @@ test_that("WEIBULL leaves unspecified ALPHA and ETA at their defaults, free", {
   expect_equal(
     got$phases,
     quote(list(
-      hzr_phase("g3", tau = 2, gamma = 1.5, fixed = c("tau", "gamma"))
+      hzr_phase("g3", tau = 2, gamma = 1.5, alpha = 1, eta = 2,
+                fixed = c("tau", "gamma"))
     ))
   )
+  expect_equal(got$theta, quote(c(log(0.01), log(2), 1.5, 1, 2)))
 })
 
 test_that("phase covariates become a formula on the owning phase", {
@@ -52,7 +53,7 @@ test_that("phase covariates become a formula on the owning phase", {
   expect_equal(
     got$phases,
     quote(list(
-      hzr_phase("cdf", t_half = 1, nu = 1, formula = ~AGE + SEX),
+      hzr_phase("cdf", t_half = 1, nu = 1, m = 1, formula = ~AGE + SEX),
       hzr_phase("constant", formula = ~AGE)
     ))
   )
@@ -73,7 +74,8 @@ test_that("a raw EARLY VAR=value operand list produces a formula from names only
   )
   expect_equal(
     got$phases,
-    quote(list(hzr_phase("cdf", t_half = 1, nu = 1, formula = ~NYHA + I_PATH)))
+    quote(list(hzr_phase("cdf", t_half = 1, nu = 1, m = 1,
+                         formula = ~NYHA + I_PATH)))
   )
 })
 
@@ -82,7 +84,7 @@ test_that("a non-numeric phase-statement value is untranslated, not guessed", {
   got <- .hzr_parse_parms(ops, covars = list(early = "NOBS=NUM"))
   expect_equal(
     got$phases,
-    quote(list(hzr_phase("cdf", t_half = 1, nu = 1)))
+    quote(list(hzr_phase("cdf", t_half = 1, nu = 1, m = 1)))
   )
   expect_true("NOBS=NUM" %in% got$untranslated$construct)
 })
@@ -92,7 +94,7 @@ test_that("a phase '/ options' tail is untranslated, not parsed", {
   got <- .hzr_parse_parms(ops, covars = list(early = "AGE=1.2 / EXCLUDE=(SEX)"))
   expect_equal(
     got$phases,
-    quote(list(hzr_phase("cdf", t_half = 1, nu = 1, formula = ~AGE)))
+    quote(list(hzr_phase("cdf", t_half = 1, nu = 1, m = 1, formula = ~AGE)))
   )
   expect_true(any(grepl("phase options", got$untranslated$reason, fixed = TRUE)))
 })
@@ -102,11 +104,12 @@ test_that("phase covariate starting values map into theta, in covariate order", 
   got <- .hzr_parse_parms(ops, covars = list(
     early = "NYHA=1.121142, I_PATH=0.9513664, INC_SURG=1.375285"
   ))
-  # log_mu, log_t_half, nu, m (defaulted, PARMS gave none), then the three
-  # covariate starts in the order they appear on the EARLY statement.
+  # log_mu, log_t_half, nu, m (defaulted to PROC HAZARD's 1, PARMS gave none),
+  # then the three covariate starts in the order they appear on the EARLY
+  # statement.
   expect_equal(
     got$theta,
-    quote(c(log(0.2), log(1), 1, 0, 1.121142, 0.9513664, 1.375285))
+    quote(c(log(0.2), log(1), 1, 1, 1.121142, 0.9513664, 1.375285))
   )
   expect_false(any(grepl(
     "not yet mapped to theta", got$untranslated$reason, fixed = TRUE
@@ -332,4 +335,146 @@ test_that("both late-phase guards still fire when MUL is present", {
   g2 <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=0",
                            "ETA=1", "WEIBULL"))
   expect_true(any(grepl("SETG3980", g2$untranslated$reason)))
+})
+
+# ---------------------------------------------------------------------------
+# Shape defaults for a partially specified PARMS block (PROC HAZARD's, not
+# hzr_phase()'s). stmtprc.c:30-37 starts an unspecified early phase at
+# thalf 1, nu 2, m 1 and an unspecified late phase at gamma 1, alpha 1,
+# eta 2; hzr_phase() defaults nu 1, m 0, eta 1. theta is what reaches the
+# optimizer, so mirroring R's defaults started a partially specified job
+# somewhere PROC HAZARD would not have, and the multiphase likelihood is
+# multimodal -- a different start is a different answer.
+#
+# No public-corpus PARMS block is partially specified (0 of 38 measured
+# 2026-09-08; every live block gives MUE + THALF + NU + M together), so
+# these tests carry the whole burden of the behaviour.
+# ---------------------------------------------------------------------------
+
+test_that("an unspecified early NU and M start at PROC HAZARD's values", {
+  got <- .hzr_parse_parms(c("MUE=0.2", "THALF=0.5"))
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("cdf", t_half = 0.5, nu = 2, m = 1)))
+  )
+  expect_equal(got$theta, quote(c(log(0.2), log(0.5), 2, 1)))
+})
+
+test_that("an unspecified late GAMMA, ALPHA and ETA start at SAS's values", {
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=3"))
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("g3", tau = 3, gamma = 1, alpha = 1, eta = 2)))
+  )
+  expect_equal(got$theta, quote(c(log(0.01), log(3), 1, 1, 2)))
+})
+
+test_that("the emitted defaults are SAS's and differ from hzr_phase()'s", {
+  # Without this the two tests above would keep passing if the values were
+  # silently re-derived from hzr_phase()'s formals -- which is the state this
+  # change exists to leave. Reads the formals rather than restating them, so
+  # it fails loudly if hzr_phase()'s own defaults are ever changed to match
+  # (at which point emitting them explicitly stops being load bearing and
+  # this whole block should be revisited, not quietly deleted).
+  f <- formals(hzr_phase)
+  expect_false(identical(eval(f$nu), unname(.hzr_parms_early_sas_default[["nu"]])))
+  expect_false(identical(eval(f$m), unname(.hzr_parms_early_sas_default[["m"]])))
+  expect_false(identical(eval(f$eta), unname(.hzr_parms_late_sas_default[["eta"]])))
+  expect_equal(.hzr_parms_early_sas_default, c(t_half = 1, nu = 2, m = 1))
+  expect_equal(.hzr_parms_late_sas_default,
+               c(tau = 1, gamma = 1, alpha = 1, eta = 2))
+})
+
+test_that("the emitted phases call and the theta vector agree, defaults included", {
+  # The failure this change had to avoid: filling theta from SAS's defaults
+  # while the hzr_phase() call kept omitting them, so the printed call would
+  # describe a fit that did not happen. Asserting both literals side by side
+  # would share the generator's assumptions, so EXECUTE both instead --
+  # evaluate the emitted call and rebuild theta from the resulting phase
+  # objects through .hzr_phase_start(), the same route hazard() takes when no
+  # theta is supplied. A disagreement of any kind fails here.
+  cases <- list(
+    c("MUE=0.2", "THALF=0.5"),
+    c("MUE=0.2", "THALF=0.5", "NU=1.4"),
+    c("MUL=0.01", "TAU=3"),
+    c("MUL=0.01", "TAU=3", "GAMMA=2.5", "ALPHA=0.5", "ETA=1.25"),
+    c("MUE=0.3", "THALF=0.1", "M=4", "MUC=0.002", "MUL=0.05", "TAU=2",
+      "ETA=0.5")
+  )
+  mu_of <- function(ops, key) {
+    hit <- grep(paste0("^", key, "="), ops, value = TRUE)
+    if (!length(hit)) return(NULL)
+    as.numeric(sub("^[^=]+=", "", hit))
+  }
+  for (ops in cases) {
+    got <- .hzr_parse_parms(ops)
+    phases <- eval(got$phases)
+    expect_gt(length(phases), 0L)
+    mus <- Filter(Negate(is.null),
+                  lapply(c("MUE", "MUC", "MUL"), function(k) mu_of(ops, k)))
+    expect_equal(length(mus), length(phases))
+    from_phases <- unlist(Map(
+      function(ph, mu) .hzr_phase_start(ph, n_covariates = 0L, mu_start = mu),
+      phases, mus
+    ))
+    expect_equal(eval(got$theta), from_phases, info = paste(ops, collapse = " "))
+  }
+})
+
+test_that("a late phase with no TAU records the data-dependent SAS default", {
+  # setg3.c:317 starts a non-positive TAU at 2*Tmax/3, which is unreproducible
+  # at parse time. The emitted phase starts at tau = 1, so the difference is
+  # recorded rather than passed off as a translation.
+  got <- .hzr_parse_parms(c("MUL=0.01", "GAMMA=2"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_equal(got$untranslated$construct, "TAU (unspecified)")
+  expect_match(got$untranslated$reason, "2\\*Tmax/3")
+  expect_equal(got$phases,
+               quote(list(hzr_phase("g3", tau = 1, gamma = 2, alpha = 1,
+                                    eta = 2))))
+})
+
+test_that("an explicit TAU = 0 takes the same SETG3 branch and is recorded", {
+  # The C predicate is tau <= 0, not "absent", and hzr_phase() would reject
+  # tau = 0 outright -- so without this the translator emitted a call that
+  # errored where SAS supplies a default and runs.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=0", "GAMMA=2"))
+  expect_equal(got$untranslated$construct, "TAU=0")
+  expect_match(got$untranslated$reason, "2\\*Tmax/3")
+  expect_equal(got$phases,
+               quote(list(hzr_phase("g3", tau = 1, gamma = 2, alpha = 1,
+                                    eta = 2))))
+})
+
+test_that("a positive TAU is not recorded", {
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2"))
+  expect_equal(nrow(got$untranslated), 0L)
+})
+
+test_that("the TAU guard does not fire where SETG3_ignore_tau() pins tau at 1", {
+  # setg3.c:312-316: the ignore_tau branch runs INSTEAD of the 2*Tmax/3
+  # assignment, and setg3.c:378 pins tau at 1 -- exactly what is emitted, so
+  # there is nothing to report. FIXGAMMA keeps the separate GAMMA*ETA guard
+  # quiet so a surviving row could only be the TAU one.
+  got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
+                            "FIXALPHA", "FIXGAMMA"))
+  expect_equal(nrow(got$untranslated), 0L)
+})
+
+test_that("the TAU guard does not fire without a positive MUL", {
+  # Same gate as the other two SETG3 guards: with phase 3 off, shape.c never
+  # calls SETG3(), so no TAU default is ever applied.
+  got <- .hzr_parse_parms(c("GAMMA=2", "ETA=3"))
+  expect_false(any(grepl("Tmax", got$untranslated$reason, fixed = TRUE)))
+  got0 <- .hzr_parse_parms(c("MUL=0", "GAMMA=2"))
+  expect_false(any(grepl("Tmax", got0$untranslated$reason, fixed = TRUE)))
+})
+
+test_that("a MUL with no late shape operand records the MU, not TAU as well", {
+  # The whole phase is missing and the MUL row already says so; a second row
+  # about that phase's TAU would be noise on $untranslated, which is how a
+  # caller decides whether a translation can be trusted.
+  got <- .hzr_parse_parms(c("MUE=0.2", "THALF=1", "NU=1", "MUL=0.05"))
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_match(got$untranslated$reason, "no late phase")
 })

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -236,24 +236,52 @@ test_that("a MUE with no early shape operand is recorded, not dropped", {
   expect_match(got$untranslated$reason, "no early phase")
 })
 
-test_that("alpha = 1 fixed with GAMMA and ETA both free is recorded", {
+test_that("alpha = 1 fixed with GAMMA and ETA both free fixes ETA, as SAS does", {
   # setg3.c:312-314 routes alpha == 1 && FIXALPHA into SETG3_ignore_tau(),
-  # which at setg3.c:405-406 does `if(hzr_parms_ge_estim()) set_fixed(ETA)`:
-  # with both shape parameters free, SAS fixes ETA and estimates the product
-  # gamma*eta as gamma alone. At alpha = 1, tau = 1 the G3 form collapses to
-  # t^(gamma*eta), so gamma and eta are not separately identifiable and SAS is
-  # resolving that. hazard() would leave both free and fit the ridge -- one
-  # more estimated parameter than PROC HAZARD, with different standard errors.
-  # A model difference, not a reporting one, so it is recorded.
+  # which at setg3.c:405 does `if(hzr_parms_ge_estim()) set_fixed(ETA)`: with
+  # both shape parameters free, SAS fixes ETA. At alpha = 1, tau = 1 the G3
+  # form collapses to t^(gamma*eta), so the pair is not separately
+  # identifiable and SAS is resolving that.
   #
-  # No corpus job reaches this today (0 of 38 live PARMS blocks, measured
-  # 2026-09-08); the 16 that fire SETG3_ignore_tau() all fix GAMMA.
+  # This was previously RECORDED rather than mirrored, which left hazard()
+  # fitting the flat ridge with one more free parameter than PROC HAZARD. It
+  # is now mirrored: unlike SETG3_verify_ge_2()'s GAMMA rewrite, this is exact
+  # algebra rather than a numerical-branch restriction, so mirroring it costs
+  # none of the general G3 shape hzr_phase() carries -- that shape is
+  # genuinely degenerate at alpha = 1.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=2",
                             "ETA=3", "FIXALPHA"))
-  expect_equal(nrow(got$untranslated), 1L)
-  expect_match(got$untranslated$reason, "estimates GAMMA\\*ETA")
-  # TAU=1 is what the branch pins anyway, so it contributes no second row.
-  expect_true("tau" %in% eval(got$phases)[[1L]]$fixed)
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("g3", tau = 1, gamma = 2, alpha = 1, eta = 3,
+                         fixed = c("tau", "alpha", "eta"))))
+  )
+  expect_equal(nrow(got$untranslated), 0L)
+})
+
+test_that("fixing ETA at alpha = 1 is what makes GAMMA estimable", {
+  # Two-sided, because "the standard error is finite" alone could come from
+  # anything: fit the SAME phase with ETA left free and show the ridge. The
+  # emitted (fixed) form gives gamma an SE around 0.02; leaving ETA free gives
+  # 7.5 on gamma and 13.7 on eta -- the flat direction, not a tighter fit.
+  skip_on_cran()
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=2",
+                            "ETA=3", "FIXALPHA"))
+  set.seed(1)
+  n <- 400
+  d <- data.frame(t = stats::rexp(n, 0.3), s = rep(c(1, 0), length.out = n))
+  fit_one <- function(phases) {
+    f <- suppressWarnings(hazard(
+      time = d$t, status = d$s, dist = "multiphase",
+      phases = phases, theta = eval(got$theta), fit = TRUE
+    ))
+    sqrt(diag(stats::vcov(f)))[["phase_1.gamma"]]
+  }
+  se_fixed <- fit_one(eval(got$phases))
+  se_free <- fit_one(list(hzr_phase("g3", tau = 1, gamma = 2, alpha = 1,
+                                    eta = 3, fixed = c("tau", "alpha"))))
+  expect_true(is.finite(se_fixed))
+  expect_lt(se_fixed, se_free / 100)
 })
 
 test_that("alpha = 1 fixed with GAMMA fixed is not recorded", {
@@ -297,13 +325,15 @@ test_that("the alpha = 1 guard does not fire on a job with no late phase", {
   expect_equal(nrow(.hzr_parse_parms(c("MUC=0.01", "FIXALPHA"))$untranslated), 0L)
 })
 
-test_that("the alpha = 1 guard still fires when ALPHA was left to default", {
+test_that("ETA is fixed even when ALPHA was left to its default", {
   # The other half of the same boundary: a late phase exists, PARMS never named
   # ALPHA, and FIXALPHA pins it at the default of 1 with GAMMA and ETA free.
-  # SAS fixes ETA here, so this must still be recorded -- the scope fix above
-  # must not buy its way out of the guard by requiring an explicit ALPHA.
+  # SAS fixes ETA here too, so the mirror must not buy its way out by
+  # requiring an explicit ALPHA operand.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2", "ETA=3", "FIXALPHA"))
-  expect_true(any(grepl("estimates GAMMA\\*ETA", got$untranslated$reason)))
+  expect_true("eta" %in% eval(got$phases)[[1L]]$fixed)
+  # TAU=2 is discarded by the same branch, which is the one row here.
+  expect_equal(got$untranslated$construct, "TAU=2")
 })
 
 test_that("the alpha = 1 guard does not fire without MUL", {
@@ -318,7 +348,7 @@ test_that("the alpha = 1 guard does not fire without MUL", {
   # Gating on shape operands instead of MUL got this wrong: TAU/GAMMA/ETA with
   # no MUL is not a late phase at all.
   got <- .hzr_parse_parms(c("TAU=2", "GAMMA=2", "ETA=3", "FIXALPHA"))
-  expect_false(any(grepl("estimates GAMMA", got$untranslated$reason)))
+  expect_false("eta" %in% eval(got$phases)[[1L]]$fixed)
 })
 
 test_that("the ALPHA = 0 WEIBULL guard does not fire without MUL", {
@@ -332,7 +362,7 @@ test_that("the ALPHA = 0 WEIBULL guard does not fire without MUL", {
 test_that("both late-phase guards still fire when MUL is present", {
   # The other side of the gate, so it cannot be satisfied by never firing.
   g1 <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2", "ETA=3", "FIXALPHA"))
-  expect_true(any(grepl("estimates GAMMA", g1$untranslated$reason)))
+  expect_true("eta" %in% eval(g1$phases)[[1L]]$fixed)
   g2 <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=1.5", "ALPHA=0",
                            "ETA=1", "WEIBULL"))
   expect_true(any(grepl("SETG3980", g2$untranslated$reason)))
@@ -480,8 +510,11 @@ test_that("SETG3_ignore_tau() pins TAU at 1 AND fixes it, and so does the call",
   # there is genuinely nothing to report -- but assert the emitted `fixed=`,
   # not just the row count, or this reverts to the assertion that could not
   # fail.
+  # WEIBULL matches every late-phase block in the corpus, and keeps this test
+  # on the tau pin alone: without it GAMMA*ETA = 1.32 <= 2 also trips the
+  # SETG3_verify_ge_2 row, which is a separate divergence tested below.
   got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
-                            "FIXALPHA", "FIXGAMMA"))
+                            "FIXALPHA", "FIXGAMMA", "WEIBULL"))
   expect_equal(
     got$phases,
     quote(list(hzr_phase("g3", tau = 1, gamma = 1, alpha = 1, eta = 1.32,
@@ -497,7 +530,7 @@ test_that("pinning TAU restores standard errors on the aliased log_mu", {
   # emitted `fixed=` alone would not show that.
   skip_on_cran()
   got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
-                            "FIXALPHA", "FIXGAMMA"))
+                            "FIXALPHA", "FIXGAMMA", "WEIBULL"))
   set.seed(1)
   n <- 400
   d <- data.frame(t = stats::rexp(n, 0.3), s = rep(c(1, 0), length.out = n))
@@ -514,7 +547,7 @@ test_that("a TAU the ignore_tau branch discards is recorded", {
   # starting value the job wrote and neither program uses is worth saying out
   # loud, which is what $untranslated is for.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=5", "ALPHA=1", "GAMMA=1",
-                            "ETA=1.32", "FIXALPHA", "FIXGAMMA"))
+                            "ETA=1.32", "FIXALPHA", "FIXGAMMA", "WEIBULL"))
   expect_equal(got$untranslated$construct, "TAU=5")
   expect_match(got$untranslated$reason, "discards this TAU")
   expect_equal(
@@ -530,8 +563,56 @@ test_that("the ignore_tau branch suppresses the 2*Tmax/3 row, not just reorders 
   # default. The first cut of this fell through to that row and reported a
   # divergence PROC HAZARD does not have.
   got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
-                            "FIXALPHA", "FIXGAMMA"))
+                            "FIXALPHA", "FIXGAMMA", "WEIBULL"))
   expect_false(any(grepl("Tmax", got$untranslated$reason, fixed = TRUE)))
+})
+
+test_that("SETG3_verify_ge_2's GAMMA rewrite is recorded, not mirrored", {
+  # setg3.c:907-921 pushes a late phase with GAMMA*ETA <= 2 clear of the
+  # boundary -- gamma = 3/eta with neither fixed. The SAS defaults gamma = 1,
+  # eta = 2 land on GAMMA*ETA = 2 exactly, so this fires on every defaulted
+  # non-WEIBULL late phase: PROC HAZARD would start at gamma = 1.5.
+  #
+  # It is deliberately NOT mirrored. The constraint keeps PROC HAZARD inside a
+  # numerical branch it can evaluate; hzr_decompos_g3() carries the general
+  # form and needs no such restriction, and reaching a late shape SAS cannot
+  # is a goal here. Recorded so a parity run knows why the starts differ.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=3"))
+  expect_equal(got$untranslated$construct, "GAMMA=1 ETA=2 (product 2)")
+  expect_match(got$untranslated$reason, "GAMMA\\*ETA <= 2")
+  expect_equal(
+    got$phases,
+    quote(list(hzr_phase("g3", tau = 3, gamma = 1, alpha = 1, eta = 2)))
+  )
+})
+
+test_that("the verify_ge_2 row does not fire above the boundary or on WEIBULL", {
+  # GAMMA*ETA > 2 is untouched by setg3.c:907, and the WEIBULL path returns at
+  # setg3.c:347 before the sign dispatch reaches SETG3_verify_ge_2() at all --
+  # which is why no corpus job trips this (every late block there is WEIBULL).
+  above <- .hzr_parse_parms(c("MUL=0.01", "TAU=3", "GAMMA=2", "ETA=2"))
+  expect_equal(nrow(above$untranslated), 0L)
+  weib <- .hzr_parse_parms(c("MUL=0.01", "TAU=3", "GAMMA=1", "ETA=2", "WEIBULL"))
+  expect_false(any(grepl("GAMMA\\*ETA", weib$untranslated$reason)))
+})
+
+test_that("the product SETG3_verify_ge_2 reads survives the ignore_tau swap", {
+  # setg3.c:403-421 moves the exponent between GAMMA and ETA but preserves
+  # their PRODUCT, which is all `gte` reads -- so the boundary test is the same
+  # whether or not that branch ran. This is what lets one predicate serve both
+  # paths; if the reparameterisation ever stops being product-preserving, the
+  # guard silently starts testing the wrong quantity.
+  # gamma * eta = 3, above the boundary, in both orderings: 0.5 * 6 straight,
+  # and 1 * 3 after the swap. Neither may record the rewrite.
+  a <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=0.5", "ETA=6"))
+  expect_equal(nrow(a$untranslated), 0L)
+  b <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=0.5", "ETA=6",
+                          "ALPHA=1", "FIXALPHA", "FIXGAMMA"))
+  expect_false(any(grepl("GAMMA\\*ETA <= 2", b$untranslated$reason)))
+  # And the same product BELOW the boundary does record, so the pair above is
+  # not passing merely because the guard never fires on these shapes.
+  lo <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=0.5", "ETA=3"))
+  expect_true(any(grepl("GAMMA\\*ETA <= 2", lo$untranslated$reason)))
 })
 
 test_that("the aliasing that motivates pinning TAU is real, not asserted", {

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -250,8 +250,11 @@ test_that("alpha = 1 fixed with GAMMA and ETA both free is recorded", {
   # 2026-09-08); the 16 that fire SETG3_ignore_tau() all fix GAMMA.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=2",
                             "ETA=3", "FIXALPHA"))
-  expect_equal(nrow(got$untranslated), 1L)
-  expect_match(got$untranslated$reason, "estimates GAMMA\\*ETA")
+  expect_true(any(grepl("estimates GAMMA\\*ETA", got$untranslated$reason)))
+  # The same branch also leaves TAU free where SAS fixes it; that is a second,
+  # separate row (see the SETG3_ignore_tau TAU tests below), so assert this
+  # guard by its reason rather than by the row count.
+  expect_equal(nrow(got$untranslated), 2L)
 })
 
 test_that("alpha = 1 fixed with GAMMA fixed is not recorded", {
@@ -260,7 +263,7 @@ test_that("alpha = 1 fixed with GAMMA fixed is not recorded", {
   # to report. Distinguishes the guard above from "any fixed alpha = 1".
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=1",
                             "ETA=1.32", "FIXALPHA", "FIXGAMMA", "WEIBULL"))
-  expect_equal(nrow(got$untranslated), 0L)
+  expect_false(any(grepl("estimates GAMMA", got$untranslated$reason)))
 })
 
 test_that("ALPHA = 0 under WEIBULL without FIXALPHA is recorded", {
@@ -301,8 +304,7 @@ test_that("the alpha = 1 guard still fires when ALPHA was left to default", {
   # SAS fixes ETA here, so this must still be recorded -- the scope fix above
   # must not buy its way out of the guard by requiring an explicit ALPHA.
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=2", "GAMMA=2", "ETA=3", "FIXALPHA"))
-  expect_equal(nrow(got$untranslated), 1L)
-  expect_match(got$untranslated$reason, "estimates GAMMA\\*ETA")
+  expect_true(any(grepl("estimates GAMMA\\*ETA", got$untranslated$reason)))
 })
 
 test_that("the alpha = 1 guard does not fire without MUL", {
@@ -347,8 +349,13 @@ test_that("both late-phase guards still fire when MUL is present", {
 # multimodal -- a different start is a different answer.
 #
 # No public-corpus PARMS block is partially specified (0 of 38 measured
-# 2026-09-08; every live block gives MUE + THALF + NU + M together), so
-# these tests carry the whole burden of the behaviour.
+# 2026-09-08; every live block gives MUE + THALF + NU + M together). That is
+# NOT the same as "nothing exercises this": test-sas-translate-fits.R's
+# end-to-end fit uses `MUE THALF NU MUC` with no M, so its early phase moved
+# from m = 0 to m = 1 under this change. It needed no edit only because its
+# assertions are on class, dist and theta LENGTH -- none of which can see a
+# start-value change -- which is the reason these tests carry the burden of
+# the behaviour, not the absence of a caller.
 # ---------------------------------------------------------------------------
 
 test_that("an unspecified early NU and M start at PROC HAZARD's values", {
@@ -421,6 +428,20 @@ test_that("the emitted phases call and the theta vector agree, defaults included
   }
 })
 
+test_that("an incomplete shape list fails loudly in the theta block", {
+  # .hzr_parms_theta_block()'s roxygen claims completeness is asserted rather
+  # than defaulted. Reachable only by calling it directly, since the one
+  # in-package caller always passes a .hzr_parms_fill_shape() result -- so
+  # without this the claim is untested and the stopifnot() has never been seen
+  # to fire.
+  expect_error(
+    .hzr_parms_theta_block("late", 0.1, list(tau = 1), numeric(0))
+  )
+  expect_error(
+    .hzr_parms_theta_block("early", 0.1, list(t_half = 1, nu = 2), numeric(0))
+  )
+})
+
 test_that("a late phase with no TAU records the data-dependent SAS default", {
   # setg3.c:317 starts a non-positive TAU at 2*Tmax/3, which is unreproducible
   # at parse time. The emitted phase starts at tau = 1, so the difference is
@@ -451,23 +472,57 @@ test_that("a positive TAU is not recorded", {
   expect_equal(nrow(got$untranslated), 0L)
 })
 
-test_that("the TAU guard does not fire where SETG3_ignore_tau() pins tau at 1", {
-  # setg3.c:312-316: the ignore_tau branch runs INSTEAD of the 2*Tmax/3
-  # assignment, and setg3.c:378 pins tau at 1 -- exactly what is emitted, so
-  # there is nothing to report. FIXGAMMA keeps the separate GAMMA*ETA guard
-  # quiet so a surviving row could only be the TAU one.
+test_that("SETG3_ignore_tau() fixing TAU, not just setting it, is recorded", {
+  # This test previously asserted ZERO untranslated rows here, on the grounds
+  # that setg3.c:378 pins tau at 1 -- "exactly what is emitted, so there is
+  # nothing to report". That read half the function. Line 379 is
+  # hzr_parm_set_fixed(HZ_TAU): SAS fixes TAU as well, and the emitted call
+  # does not. At alpha = 1 that is not a spare parameter but an unidentified
+  # one, and the fit below is the reason this matters -- it converges and
+  # reports no standard errors on the two aliased parameters, which is the
+  # exact shape AGENTS.md opens with. FIXGAMMA keeps the GAMMA*ETA guard quiet
+  # so the surviving row can only be the TAU one.
   got <- .hzr_parse_parms(c("MUL=0.01", "ALPHA=1", "GAMMA=1", "ETA=1.32",
                             "FIXALPHA", "FIXGAMMA"))
-  expect_equal(nrow(got$untranslated), 0L)
+  expect_equal(nrow(got$untranslated), 1L)
+  expect_match(got$untranslated$reason, "exactly aliased")
+})
+
+test_that("the SETG3_ignore_tau TAU row fires on a TAU the job did specify", {
+  # SAS overwrites the value either way, so a job written TAU=5 runs at
+  # tau = 1, fixed. Keying the row on "TAU was defaulted" would have missed
+  # this entirely -- the emitted call starts at 5, free.
+  got <- .hzr_parse_parms(c("MUL=0.01", "TAU=5", "ALPHA=1", "GAMMA=1",
+                            "ETA=1.32", "FIXALPHA", "FIXGAMMA"))
+  expect_equal(got$untranslated$construct, "ALPHA=1 FIXALPHA with TAU=5")
+  expect_match(got$untranslated$reason, "exactly aliased")
+})
+
+test_that("the aliasing the ignore_tau row describes is real, not asserted", {
+  # The row claims G3 collapses to (t/tau)^(gamma*eta) at alpha = 1, which is
+  # why log_mu and log_tau cannot both be identified. Compute it rather than
+  # restate it: a wrong claim in an $untranslated reason is a wrong claim a
+  # caller acts on.
+  tt <- c(0.5, 1, 2, 5, 10)
+  g <- hzr_decompos_g3(tt, tau = 2, gamma = 1.3, alpha = 1, eta = 1.7)$G
+  expect_equal(g, (tt / 2)^(1.3 * 1.7))
+  # And it does NOT collapse away from alpha = 1, so the guard's scope is right.
+  g2 <- hzr_decompos_g3(tt, tau = 2, gamma = 1.3, alpha = 1.5, eta = 1.7)$G
+  expect_false(isTRUE(all.equal(g2, (tt / 2)^(1.3 * 1.7))))
 })
 
 test_that("the TAU guard does not fire without a positive MUL", {
   # Same gate as the other two SETG3 guards: with phase 3 off, shape.c never
   # calls SETG3(), so no TAU default is ever applied.
+  #
+  # MUL=0 deliberately does NOT appear here. It is SAS's own "phase off"
+  # marker, but this parser still builds the phase and emits log(0) = -Inf as
+  # its starting log_mu with no untranslated row -- a pre-existing gap in the
+  # phase-activation asymmetry noted in .hzr_parse_parms(), not something this
+  # guard should be read as blessing. Asserting the TAU row is absent there
+  # would pass over the -Inf and quietly certify it.
   got <- .hzr_parse_parms(c("GAMMA=2", "ETA=3"))
   expect_false(any(grepl("Tmax", got$untranslated$reason, fixed = TRUE)))
-  got0 <- .hzr_parse_parms(c("MUL=0", "GAMMA=2"))
-  expect_false(any(grepl("Tmax", got0$untranslated$reason, fixed = TRUE)))
 })
 
 test_that("a MUL with no late shape operand records the MU, not TAU as well", {


### PR DESCRIPTION
## What

`.hzr_parse_parms()` filled any shape parameter a SAS `PARMS` statement did not name from **`hzr_phase()`'s** defaults. Three of those disagree with the reference C (`src/hazard/stmtprc.c:30-37`):

| | `NU` | `M` | `ETA` |
|---|---|---|---|
| `hzr_phase()` | 1 | 0 | 1 |
| `PROC HAZARD` | **2** | **1** | **2** |

The emitted call always carries `theta`, and `.hzr_optim_multiphase()` only falls back to `.hzr_phase_start()` when `theta_start` is `NULL` — so these were the values that actually reached the optimizer. The multiphase likelihood is multimodal, so a different start is a different answer, not a cosmetic difference.

## How the call and theta are kept in agreement

Switching only the theta table would have made the printed `hzr_phase()` call describe a fit that did not happen — worse than defaulting neither. So the fill happens **once**, in a new `.hzr_parms_fill_shape()`, and the same list builds both. A partially specified block now names every shape argument explicitly rather than leaving some to `hzr_phase()`'s formals. `.hzr_parms_theta_block()` no longer carries a default table at all — it asserts completeness, so a short list fails loudly instead of emitting a mis-aligned block.

## TAU

`TAU` cannot be reproduced at parse time: `stmtprc.c` sets it to zero and `SETG3()` (`setg3.c:317`) then derives `2*Tmax/3` from the data. Emitting `2 * max(<timevar>) / 3` was considered and rejected — SAS's `Tmax` is over the analysis set after exclusions, so the expression would look exact while being a guess. Such a phase is emitted at `tau = 1` and recorded in `$untranslated`. The predicate is the C one (`tau <= 0`, which also catches an explicit `TAU=0` that `hzr_phase()` would have rejected outright).

## The second defect, found in review

`SETG3_ignore_tau()` at `setg3.c:378-379` is **two** statements:

```c
Late.tau = ONE;
hzr_parm_set_fixed(HZ_TAU);
```

The first version of this PR read only the first, concluded "nothing to report", and shipped a test asserting `nrow($untranslated) == 0` on that branch. SAS fixes `TAU`; the emitted call left it free. At `alpha = 1` that is not a spare degree of freedom but an **unidentified** one — `G3` collapses to `(t/tau)^(gamma*eta)` (verified against `hzr_decompos_g3()` to 2e-16, now a test rather than a claim), so `mu` enters the likelihood only through `log_mu - gamma*eta*log_tau`. The translated fit converged onto that ridge and `vcov()` returned `NA` for both.

The emitted call now carries `tau = 1` and `"tau"` in `fixed=`, mirroring the C. On the test fixture that moves `log_mu`'s standard error from `NA` to 0.12 — asserted by fitting, not by inspecting the call.

⚠️ **This changes the emitted call for every job that fixes `ALPHA` at 1**, which is the dominant late-phase shape in the corpus. Deliberate, and flagged in `NEWS.md`.

## Two claims corrected

- "nothing previously translated changes" was **wrong**. `test-sas-translate-fits.R`'s end-to-end fit uses `MUE THALF NU MUC` with no `M` — a partial block. Its early phase moved from `m = 0` to `m = 1`. It needed no edit only because its assertions are on class, `dist` and theta *length*, none of which can see a start-value change.
- `MUL=0` was dropped from the "no positive MUL" test: that input emits `log(0) = -Inf` as its starting `log_mu` with no untranslated row, and asserting only that the TAU row is absent passed over the `-Inf` and quietly certified it. Tracked separately, not blessed here.

## Not in scope (reported, not folded in)

- `MUL=0` emitting `-Inf`, and shape operands with no `MUL` fabricating a whole phase `PROC HAZARD` would not build — both return zero untranslated rows. These belong with the phase-activation asymmetry the file already tracks.
- `mu`'s own default (`0.1` vs `SETG1`'s floor of 1) — same reason.

## Verification

- `devtools::document()` clean; `lintr::lint_package()` **0 lints**; `spelling::spell_check_package()` clean
- `devtools::test()` with `NOT_CRAN=true`: **0 failures**, 6 skips (SAS weighted-parity fixtures absent locally)
- `R CMD check --as-cran` from a clean `git archive`, with the manual: **Status: OK** (0/0/0)
- Two deliberate mutations confirmed the new call/theta agreement test can fail (8 and 7 failures)

One process note: the first `R CMD check` on the final commit reported `1 ERROR` with `getcwd: cannot access parent directories`. That was a collision on the shared per-user `$TMPDIR` — `AGENTS.md`'s recipe hardcodes `$TMPDIR/tree` and `$TMPDIR/TemporalHazard.Rcheck`, so a concurrent session running the same recipe deletes them underneath. Re-running in a unique directory gave `Status: OK`. That run's wall-clock is contended and is **not** quoted as a timing measurement; the uncontended runs earlier on this branch were 198s and 201s overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)