### PR TITLE
docs: PROC SORT keeps tied rows in input order (repeated-events design)

### DIFF
--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -197,12 +197,14 @@ names as this package's signature defect.
 
 ### Sort stability at tied times
 
-Every stage re-runs `proc sort by &id &iv_event`, and R's `order()` is stable. From memory,
-`PROC SORT`'s default is `EQUALS`, which keeps tied rows in their input order; if so, an
-earlier draft of this document was wrong to call SAS's sort unstable. That default has not
-been checked against SAS's documentation here, and nothing below rests on it. What matters
-is the order rows *reach* the first sort, and in the reference job that comes out of a
-`PROC SQL` join whose output order is not guaranteed.
+Every stage re-runs `proc sort by &id &iv_event`, and R's `order()` is stable. So is
+`PROC SORT` by default: `EQUALS` is its default, and for observations with identical BY
+values it keeps their relative order from the input data set ([SAS 9.3 Base Procedures
+Guide, PROC SORT statement](https://support.sas.com/documentation/cdl/en/proc/65145/HTML/default/p02bhn81rn4u64n1b6l00ftdnxge.htm),
+checked 2026-09-10; the reference job ran on SAS 8.2). An earlier draft of this document
+called SAS's sort unstable, which was wrong. What matters is the order rows *reach* the
+first sort, and in the reference job that comes out of a `PROC SQL` join whose output
+order is not guaranteed.
 
 That caveat is not inert for this job: 2845 of `bd_card`'s 3246 rows sit in 545 tied
 `(ccfid, iv_event)` groups. It is nonetheless harmless, and the parity test shows it rather


### PR DESCRIPTION
Corrects one claim in `inst/dev/REPEATED-EVENTS-DESIGN.md`. The sort-stability section said, from memory and unverified, that `PROC SORT`'s default might be `EQUALS`. SAS's documentation confirms it: `EQUALS` is the default, and it keeps the relative order of observations with identical BY values ([SAS 9.3 Base Procedures Guide, PROC SORT statement](https://support.sas.com/documentation/cdl/en/proc/65145/HTML/default/p02bhn81rn4u64n1b6l00ftdnxge.htm)). The section now says so with the source. The real ordering risk stays where it was: the `PROC SQL` join that feeds the macro, which the parity test's shuffle check covers.

Documentation only, in a file excluded from the build, so nothing in the package, its tests or its check changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)