### PR TITLE
fix: keep a masked Weibull vcov on the (mu, nu) scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,22 @@
   not a `PROC HAZARD` refusal, so it is kept apart from the existing
   "selects no phase" stop.
 
+## Bug fixes
+
+* **A Weibull fit with one masked variance reported the others on the wrong
+  scale.** When the Hessian inverse has a non-positive variance, its row and
+  column are set to `NA`. The delta-method transform from the internal
+  `(alpha, psi)` scale to the reported `(mu, nu)` scale was then skipped for
+  the whole matrix, so the surviving standard errors stayed on the internal
+  scale beside `(mu, nu)` estimates, with no error. A masked `alpha` printed
+  `SE(psi)` as the standard error of `nu`, low by a factor of `nu`; a masked
+  `psi` printed `SE(alpha)` as the standard error of `mu`, which depends on
+  `psi` and has no valid standard error there. The transform now runs on the
+  finite block and carries the mask through the Jacobian: a reported
+  parameter is `NA` exactly when it depends on a masked one. Exponential,
+  log-logistic and log-normal fits are unaffected; they report on the scale
+  they are optimised on.
+
 # TemporalHazard 1.2.10
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
   `(alpha, psi)` scale to the reported `(mu, nu)` scale was then skipped for
   the whole matrix, so the surviving standard errors stayed on the internal
   scale beside `(mu, nu)` estimates, with no error. A masked `alpha` printed
-  `SE(psi)` as the standard error of `nu`, low by a factor of `nu`; a masked
+  `SE(psi)` as the standard error of `nu`, off by a factor of `nu`; a masked
   `psi` printed `SE(alpha)` as the standard error of `mu`, which depends on
   `psi` and has no valid standard error there. The transform now runs on the
   finite block and carries the mask through the Jacobian: a reported

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -654,7 +654,11 @@ NULL
     v_int[bad_int, ] <- 0
     v_int[, bad_int] <- 0
     v_nat <- J %*% v_int %*% t(J)
-    bad_nat <- as.vector((J != 0) %*% bad_int) > 0
+    # Dependence is structural, not read off J's values: mu depends on alpha
+    # and psi even where mu_hat underflows to 0 or alpha_hat is exactly 0.
+    depends <- diag(p) != 0
+    depends[1, 2] <- TRUE
+    bad_nat <- as.vector(depends %*% bad_int) > 0
     v_nat[bad_nat, ] <- NA_real_
     v_nat[, bad_nat] <- NA_real_
     result$vcov <- v_nat

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -637,13 +637,27 @@ NULL
   #   dmu/dalpha = mu / nu             dmu/dpsi = -mu alpha / nu
   #   dnu/dalpha = 0                 dnu/dpsi = nu
   #   dbeta/dalpha = 0                 dbeta/dpsi = 0         dbeta/dbeta = I
-  if (is.matrix(result$vcov) && !anyNA(result$vcov)) {
+  #
+  # .hzr_safe_solve() masks a non-positive variance by setting its row and
+  # column to NA. Transform the finite block and carry the mask through J: a
+  # reported parameter is unavailable when it depends on any masked internal
+  # one. Skipping the transform instead would leave the surviving entries on
+  # the (alpha, psi) scale beside (mu, nu) estimates.
+  if (is.matrix(result$vcov)) {
     J <- diag(p)
     J[1, 1] <- mu_hat / nu_hat
     J[1, 2] <- -mu_hat * alpha_hat / nu_hat
     J[2, 1] <- 0
     J[2, 2] <- nu_hat
-    result$vcov <- J %*% result$vcov %*% t(J)
+    bad_int <- !is.finite(diag(result$vcov))
+    v_int <- result$vcov
+    v_int[bad_int, ] <- 0
+    v_int[, bad_int] <- 0
+    v_nat <- J %*% v_int %*% t(J)
+    bad_nat <- as.vector((J != 0) %*% bad_int) > 0
+    v_nat[bad_nat, ] <- NA_real_
+    v_nat[, bad_nat] <- NA_real_
+    result$vcov <- v_nat
   }
 
   result

--- a/tests/testthat/test-weibull-hessian.R
+++ b/tests/testthat/test-weibull-hessian.R
@@ -134,28 +134,28 @@ test_that("a masked internal variance keeps the weibull vcov on the (mu, nu) sca
     hazard(survival::Surv(time, status) ~ z, data = dat, dist = "weibull",
            theta = c(mu = 1, nu = 1, z = 0), fit = TRUE)
   }
-  se_ref <- unname(sqrt(diag(fit_weibull()$fit$vcov)))
+  v_ref <- unname(fit_weibull()$fit$vcov)
   real_solve <- .hzr_safe_solve
-  se_masked <- function(k) {
+  vcov_masked <- function(k) {
     local_mocked_bindings(.hzr_safe_solve = function(H, ...) {
       res <- real_solve(H, ...)
       res$vcov[k, ] <- NA_real_
       res$vcov[, k] <- NA_real_
       res
     })
-    unname(sqrt(diag(fit_weibull()$fit$vcov)))
+    unname(fit_weibull()$fit$vcov)
   }
 
-  # alpha masked: nu = exp(psi) depends on psi alone, so SE(nu) survives and
-  # must equal the unmasked value, not SE(psi) = SE(nu) / nu.
-  se1 <- se_masked(1)
-  expect_equal(is.na(se1), c(TRUE, FALSE, FALSE))
-  expect_equal(se1[2:3], se_ref[2:3])
+  # alpha masked: nu = exp(psi) depends on psi alone, so the (nu, z) block
+  # survives and must equal the unmasked one -- SE(nu), not SE(psi) = SE(nu) / nu.
+  v1 <- vcov_masked(1)
+  expect_equal(is.na(v1), outer(1:3, 1:3, function(i, j) i == 1 | j == 1))
+  expect_equal(v1[2:3, 2:3], v_ref[2:3, 2:3])
 
   # psi masked: mu depends on psi through dmu/dpsi, so it is masked as well.
-  se2 <- se_masked(2)
-  expect_equal(is.na(se2), c(TRUE, TRUE, FALSE))
-  expect_equal(se2[3], se_ref[3])
+  v2 <- vcov_masked(2)
+  expect_equal(is.na(v2), outer(1:3, 1:3, function(i, j) i <= 2 | j <= 2))
+  expect_equal(v2[3, 3], v_ref[3, 3])
 })
 
 test_that("weibull SEs are invariant to covariate rescaling", {

--- a/tests/testthat/test-weibull-hessian.R
+++ b/tests/testthat/test-weibull-hessian.R
@@ -119,6 +119,45 @@ test_that("weibull fit vcov uses the analytic Hessian (matches numDeriv+delta)",
   expect_true(isTRUE(fit$fit$pd))
 })
 
+test_that("a masked internal variance keeps the weibull vcov on the (mu, nu) scale", {
+  # .hzr_safe_solve() NAs the row and column of a non-positive variance. The
+  # delta-method transform used to be skipped whenever the vcov held any NA,
+  # leaving the surviving SEs on the (alpha, psi) scale beside (mu, nu)
+  # estimates. Force the mask on a healthy fit and compare to the unmasked SEs.
+  set.seed(25)
+  n <- 500
+  z <- rnorm(n)
+  time <- rweibull(n, shape = 1.5, scale = exp(-0.5 * z / 1.5)) + 0.01
+  status <- rbinom(n, 1, 0.85)
+  dat <- data.frame(time, status, z)
+  fit_weibull <- function() {
+    hazard(survival::Surv(time, status) ~ z, data = dat, dist = "weibull",
+           theta = c(mu = 1, nu = 1, z = 0), fit = TRUE)
+  }
+  se_ref <- unname(sqrt(diag(fit_weibull()$fit$vcov)))
+  real_solve <- .hzr_safe_solve
+  se_masked <- function(k) {
+    local_mocked_bindings(.hzr_safe_solve = function(H, ...) {
+      res <- real_solve(H, ...)
+      res$vcov[k, ] <- NA_real_
+      res$vcov[, k] <- NA_real_
+      res
+    })
+    unname(sqrt(diag(fit_weibull()$fit$vcov)))
+  }
+
+  # alpha masked: nu = exp(psi) depends on psi alone, so SE(nu) survives and
+  # must equal the unmasked value, not SE(psi) = SE(nu) / nu.
+  se1 <- se_masked(1)
+  expect_equal(is.na(se1), c(TRUE, FALSE, FALSE))
+  expect_equal(se1[2:3], se_ref[2:3])
+
+  # psi masked: mu depends on psi through dmu/dpsi, so it is masked as well.
+  se2 <- se_masked(2)
+  expect_equal(is.na(se2), c(TRUE, TRUE, FALSE))
+  expect_equal(se2[3], se_ref[3])
+})
+
 test_that("weibull SEs are invariant to covariate rescaling", {
   set.seed(26)
   n <- 600


### PR DESCRIPTION
## The defect

`.hzr_optim_weibull()` optimises on `(alpha, psi, beta)` and reports `(mu, nu, beta)`, converting the covariance with the delta method, `J V Jᵀ`. That transform sat behind `!anyNA(result$vcov)`. `.hzr_safe_solve()` (`R/hessian-invert.R:66-73`) handles a non-positive variance by setting that row and column to `NA` and still returning a matrix. So once one row was masked, the transform was skipped for the whole matrix. The surviving standard errors stayed on the internal scale, printed beside `(mu, nu)` estimates, with no error. It is a result-shaped output that is not a result.

Found by the whole-branch review of `feat/degraded-record` (#244). Re-measured on `origin/main` at `df54da3` before any change: the guard was still at `R/likelihood-weibull.R:640`.

## Reproduction (seed 25, n = 500, one covariate; on `main`)

I forced the mask by wrapping the real `.hzr_safe_solve()` and setting row and column `k` of its vcov to `NA`.

| Masked internal row | Reported SE | Value on `main` | Correct |
|---|---|---|---|
| none | SE(nu) | 0.0557 | 0.0557 |
| 1 (`alpha`) | SE(nu) | **0.0376** (= SE(psi)) | 0.0557 (= nu · SE(psi), nu = 1.480) |
| 2 (`psi`) | SE(mu) | **0.0512** (= SE(alpha)) | `NA`: mu depends on psi through dmu/dpsi |

That is two distinct wrong answers: a standard error on the wrong scale, and a standard error printed for a parameter that has none.

## The fix

- Zero the masked internal rows and columns, which are identified by a non-finite diagonal.
- Compute `J V Jᵀ`.
- Mask every reported parameter that depends on a masked internal one.

The dependence pattern is **structural**, not read off `J`'s values. Otherwise an underflowed `mu_hat`, which zeroes all of `J`'s first row, would report SE(mu) = 0 for a masked `alpha`. The unmasked path is bit-identical to the old code, including the absence of dimnames.

## Other families

Exponential, log-logistic and log-normal do not share the pattern. Their optimisers return `.hzr_optim_generic()`'s result unchanged, on the scale they are optimised on (`log_lambda`; `log_alpha`, `log_beta`; `mu`, `log_sigma`). Multiphase pads a free-parameter vcov out to full size with `NA`, but applies no transform that could be skipped.

## Test

`tests/testthat/test-weibull-hessian.R`: "a masked internal variance keeps the weibull vcov on the (mu, nu) scale". It uses `local_mocked_bindings()` on `.hzr_safe_solve`, the same pattern as `test-hessian-unavailable.R`, and asserts values rather than presence:

- the full `NA` pattern of the reported vcov for each mask;
- the surviving covariance block against an unmasked fit of the same data.

The test runs under `R CMD check` (no `skip_on_cran()`).

- **On unfixed `main`:** fails with SE(nu) 0.038 against 0.056, and SE(mu) not `NA`.
- **Mutation check:** deleting the column-mask line fails it too.

## Review

The `r-reviewer` agent was run over the diff.

- **Taken:**
  - the structural dependence mask;
  - "off by a factor of nu", not "low" (it is high when nu < 1);
  - comparing the covariance block rather than only SEs.
- **Declined:** its suggestion to mask any row holding a non-finite cell. Masking row and column `k` puts an `NA` in *every* row, so that test masks everything; I hit exactly that in a first draft. The case it guards, a NaN off-diagonal with finite diagonals, cannot come out of `.hzr_safe_solve()` from a finite Hessian. If it ever did, the NaN would fill the whole matrix, which is loud rather than silent.

## Downstream

Masked-fit confidence limits change. `.hzr_free_vcov()` (`R/predict-cl.R`) used to feed the internal-scale submatrix into the natural-scale Weibull Jacobian; the new limits are the correct ones. With `psi` masked, `summary()` now shows `NA` for mu where it used to show SE(alpha).

**Interaction with #244, which merged at 19:00 EDT, after this branch was cut.** `main` has been merged in. #244's `standard_errors` degraded entry names the estimated parameters that have no finite positive variance, so it reads the vcov this fix produces:

- **Masked `alpha`:** it still names `mu` alone, which is what #244's own `mask_first_variance()` test asserts. The difference is that `nu`'s SE beside it is now on the right scale.
- **Masked `psi`:** it now names `mu` and `nu` both. Before this fix it named `nu` alone, while printing a wrong-scale SE(alpha) as mu's.

## Gates

**At `3a45d89`** (this branch with `main` merged in, including #244):

- `devtools::document()`: no changes to `man/` or `NAMESPACE`.
- `lintr::lint_package()`: 0 lints.
- `spelling::spell_check_package()`: clean.
- #244's `test-degraded-fits.R`: 38/38 pass. `test-weibull-hessian.R`: 17/17 pass.
- `devtools::test()` with `NOT_CRAN=true`: **4192 pass, 0 fail, 0 error, 6 skip**. The 6 skips are the local fixture skips.
- `R CMD check --as-cran` with the manual, from a clean `git archive` export: **Status: OK**.
  - Tarball 3.12 MB; no `CLAUDE`/`AGENTS` files in it.
  - Wall time 5m 36s: tests 151s, vignettes 74s, PDF manual 11s. These are **not** comparable to the `AGENTS.md` series, because this branch's full local suite was running on the same machine throughout.

**At `976a8c6`** (before the merge):

- Suite: **4058 pass, 0 fail, 0 error, 6 skip**.
- Check: **Status: OK**. Tarball 3.11 MB, no dev files.
- Wall time 6m 22s, tests 193s. **Not** comparable to the `AGENTS.md` series: two full `devtools::test()` runs shared the machine, this branch's and a sibling session's (worktree `unruffled-lalande-50aa45`).

The new test was confirmed to **fail on unfixed `main`**.

No version bump: this lands under the unreleased 1.2.11, which is untagged, alongside #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
