### PR TITLE
test: reproduce both fits of hz.ce_cardioversion_repeated.ehb against the SAS listing

### DIFF
--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -240,7 +240,12 @@ NULL
 #'   bounds. The measured shares are
 #'   kept on the fit as `fit$fit$phase_share`. Raise it to catch marginal
 #'   phases, set it to 0 to silence the check.
-#' - `reltol`: Relative parameter change tolerance (default 1e-5)
+#' - `reltol`: Relative convergence tolerance on the objective, the negative
+#'   log-likelihood (default 1e-5). BFGS stops when an iteration reduces it by
+#'   less than `reltol * (|objective| + reltol)`, so the stopping gap grows
+#'   with the size of the log-likelihood: about 0.0024 at a log-likelihood of
+#'   -240. On a flat surface a fit can stop that far short of the optimum and
+#'   still report convergence.
 #' - `abstol`: Absolute gradient norm tolerance (default 1e-6)
 #' - `method`: Optimization method: "bfgs" or "nm" (default "bfgs").
 #'   SAS `PROC HAZARD` jobs write `STEEPEST QUASI` together -- steepest

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -294,13 +294,21 @@ and still reports a standard error for.
 **The likelihoods agree at a point, not only at an optimum.** R's log likelihood at the first
 model's `PARMS`, at SAS's final estimates and at R's own optimum is -267.8850808 each time.
 At the second model's final estimates from the listing it is -242.2541227. So a gap in a fit
-can only come from the optimizer, and one did.
+can only come from the optimizer, and one did. The test asserts the log likelihood at the
+listing's estimates for both models, so this holds for as long as the test passes, not only
+on the day it was measured.
 
-**The second model needs `reltol` tightened.** Under default control the translated call
-reports `converged = TRUE` at -242.2675, 0.013 short of the listing. Its estimates are up to
+**The second model needs `reltol` tightened.** With `reltol` at its default, from one start
+or five, the translated call reports `converged = TRUE` at -242.2675, 0.013 short of the listing. Its estimates are up to
 0.16 SE away, and its standard errors up to 10% off. `.hzr_optim_generic()` defaults
 `reltol` to 1e-5, and BFGS stops when an iteration gains less than about `reltol * |LL|`,
-here about 0.0024, which a flat ridge in the late shapes does not provide. With
+here about 0.0024, which a flat ridge in the late shapes does not provide.
+
+The first model passing at the default is not evidence that the default is enough, because
+the two models take different paths. `CONSERVE` fixes one `log_mu`, and with any parameter
+fixed and between 2 and 10 free the engine runs a Nelder-Mead warm-up at `reltol = 1e-10`
+before BFGS (`R/likelihood-multiphase.R`). The second model fixes nothing and goes straight
+to BFGS at 1e-5. With
 `reltol = 1e-12` it reaches the listing's optimum from the same start. The parity test sets
 that explicitly. Whether the default should change is a separate question, because it
 touches every fit and the check-time budget.
@@ -308,8 +316,9 @@ touches every fit and the check-time budget.
 **One start, and why.** The default five starts give the first model the same fit from
 start 1. The perturbed starts end at worse local optima, LL -267.914, -268.175 and -274.368,
 and their Hessians raise the not-invertible warnings, which are about those starts and not
-about the reported fit. The test fits from `PARMS` alone, and agreement rests on the log
-likelihood at SAS's point rather than on `n_starts`.
+about the reported fit. The test fits from `PARMS` alone. For the first model that start is
+SAS's optimum, so the fit alone cannot tell the likelihood from the search; the assertion
+at the listing's estimates can, and agreement rests on it rather than on `n_starts`.
 
 Each tolerance in the test fails the stopped-short fit above: half a unit in the listing's
 third decimal of log likelihood, 1e-3 SE per estimate, 2e-3 relative per standard error.

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -3,7 +3,8 @@
 - **Date:** 2026-09-09
 - **Status:** implemented on this branch. SAS parity verified 2026-09-10 against the reference
   job's log and listing -- see Acceptance. The post-macro step once planned as stage 8 does not
-  exist as specified -- see Open Items 2.
+  exist as specified -- see Open Items 2. Both of the job's fits reproduce the listing,
+  verified 2026-09-10 -- see Fit parity.
 - **Branch:** `feat/hzr-repeated-events`, cut from `main` at `f93d00c`
 
 ## Purpose
@@ -236,7 +237,7 @@ step, which change no shape. After the job's line 65, the fit input matches the 
 independent tallies exactly: 962 observations, 388 events, 574 right censored, 387 left
 censored, `IV_EVENT` in [0.0001140795, 12.99137] and `IV_START` in
 [0.0001140795, 9.716832]. The exported function raises none of its input warnings on this
-data. Fitting it and reproducing LL -267.885 is out of scope; see below.
+data. The fits on it are recorded under Fit parity, below.
 
 ### PHI constraint
 
@@ -269,6 +270,51 @@ result does not depend on input row order.
 
 Because a gated test prints green when it never ran, it is not evidence. The synthetic
 set must be able to fail on its own.
+
+## Fit parity
+
+Verified 2026-09-10 with the study volume mounted. The job's two `PROC HAZARD` statements
+were put through `hzr_translate_sas()`, and the emitted status and fit calls were evaluated
+over the input above. The translator leaves out only `STEEPEST`, SAS's steepest-descent
+warm-up (#145). Both fits start at the job's `PARMS`.
+
+| | SAS log likelihood | R | largest estimate gap | largest SE gap |
+|---|---|---|---|---|
+| first model: `CONSERVE`, 9 parameters | -267.885 | -267.8850808 | 8.3e-05 SE | 8.9e-04 relative |
+| second: `NOCONSERVE`, `maze_prc` and `iso_pvi` in both phases, 13 parameters | -242.254 | -242.2541227 | 4.0e-05 SE | 5.5e-04 relative |
+
+The comparison is made on SAS's scale. `PROC HAZARD` estimates every shape parameter on the
+log scale (`E3 = Ln(|Nu|)` and so on), so R's `nu`, `m`, `gamma`, `alpha` and `eta` are
+logged, and their standard errors converted by the delta method, `se(x) / |x|`. An estimate
+gap is measured in the listing's own standard errors. The standard errors agree to about
+three figures rather than the seven printed, which is what SAS's numeric Hessian supports.
+For the first model this includes `MUL`, which the listing marks as estimated in closed form
+and still reports a standard error for.
+
+**The likelihoods agree at a point, not only at an optimum.** R's log likelihood at the first
+model's `PARMS`, at SAS's final estimates and at R's own optimum is -267.8850808 each time.
+At the second model's final estimates from the listing it is -242.2541227. So a gap in a fit
+can only come from the optimizer, and one did.
+
+**The second model needs `reltol` tightened.** Under default control the translated call
+reports `converged = TRUE` at -242.2675, 0.013 short of the listing. Its estimates are up to
+0.16 SE away, and its standard errors up to 10% off. `.hzr_optim_generic()` defaults
+`reltol` to 1e-5, and BFGS stops when an iteration gains less than about `reltol * |LL|`,
+here about 0.0024, which a flat ridge in the late shapes does not provide. With
+`reltol = 1e-12` it reaches the listing's optimum from the same start. The parity test sets
+that explicitly. Whether the default should change is a separate question, because it
+touches every fit and the check-time budget.
+
+**One start, and why.** The default five starts give the first model the same fit from
+start 1. The perturbed starts end at worse local optima, LL -267.914, -268.175 and -274.368,
+and their Hessians raise the not-invertible warnings, which are about those starts and not
+about the reported fit. The test fits from `PARMS` alone, and agreement rests on the log
+likelihood at SAS's point rather than on `n_starts`.
+
+Each tolerance in the test fails the stopped-short fit above: half a unit in the listing's
+third decimal of log likelihood, 1e-3 SE per estimate, 2e-3 relative per standard error.
+The fits are in `tests/testthat/test-repeated-events-parity.R` and skip without the volume,
+so CI has never run them.
 
 ## Open items, resolved 2026-09-10
 
@@ -325,5 +371,5 @@ manual from a clean `git archive` export of a **committed** tree.
 - Wiring `hzr_repeated_events()` into `hzr_translate_sas()`. The translator will need to
   recognise a `%repeat` call and emit this function, but that is a separate change with
   its own parity evidence.
-- Running the cardioversion fit itself and reproducing LL -267.885. That is the payoff,
-  and it is the *next* piece of work; this spec covers building the input it needs.
+- Changing the optimizer's default `reltol`. Fit parity shows the default stops the second
+  model short; the fix belongs to the optimizer, not to this function.

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -217,7 +217,12 @@ phase flat across the event times may still be identified through the
 bounds. The measured shares are
 kept on the fit as \code{fit$fit$phase_share}. Raise it to catch marginal
 phases, set it to 0 to silence the check.
-\item \code{reltol}: Relative parameter change tolerance (default 1e-5)
+\item \code{reltol}: Relative convergence tolerance on the objective, the negative
+log-likelihood (default 1e-5). BFGS stops when an iteration reduces it by
+less than \verb{reltol * (|objective| + reltol)}, so the stopping gap grows
+with the size of the log-likelihood: about 0.0024 at a log-likelihood of
+-240. On a flat surface a fit can stop that far short of the optimum and
+still report convergence.
 \item \code{abstol}: Absolute gradient norm tolerance (default 1e-6)
 \item \code{method}: Optimization method: "bfgs" or "nm" (default "bfgs").
 SAS \verb{PROC HAZARD} jobs write \verb{STEEPEST QUASI} together -- steepest

--- a/tests/testthat/test-repeated-events-parity.R
+++ b/tests/testthat/test-repeated-events-parity.R
@@ -101,3 +101,150 @@ test_that("hz.ce_cardioversion_repeated.ehb: the result does not depend on input
     expect_equal(canon(run(shuffled)), base, label = paste("shuffle", k))
   }
 })
+
+# The fits. The job's PROC HAZARD statements go through hzr_translate_sas(),
+# and the calls it emits are evaluated over the rebuilt input, so the model
+# specification comes from the translator rather than from this file.
+
+cardioversion_job <- function(dir) {
+  path <- file.path(dirname(dir), "distributions", "hz.ce_cardioversion_repeated.ehb.sas")
+  testthat::skip_if_not(file.exists(path), "cardioversion job not found beside the datasets")
+  # STEEPEST, in both blocks, is the one construct the translator leaves out:
+  # SAS's steepest-descent warm-up (issue #145). Nothing else may go missing.
+  expect_warning(job <- hzr_translate_sas(path), "STEEPEST")
+  expect_equal(job$untranslated$construct, c("STEEPEST", "STEEPEST"))
+  job
+}
+
+# The fit input: %repeat and then the job's line 65, as in the first test,
+# which checks it against the listing's tallies.
+cardioversion_events <- function(dir) {
+  events <- hzr_repeated_events(.hzr_derive_bd_card(dir), "ccfid", "iv_event", "iv_end", "ce_card")
+  nudge <- which(events$iv_start >= events$iv_event)
+  events$iv_event[nudge] <- events$iv_event[nudge] + 0.0001141553
+  events
+}
+
+# Evaluates one emitted status chunk and fit chunk, changing only the control
+# entries named in `control`. SAS names are case-insensitive, and the
+# translator writes them in upper case.
+fit_translated <- function(job, events, fit_slot, status_slot, control) {
+  env <- new.env()
+  env$EVENTS <- stats::setNames(events, toupper(names(events)))
+  eval(job$calls[[status_slot]], env)
+  cl <- job$calls[[fit_slot]][[3L]]
+  cl$control[names(control)] <- control
+  eval(cl, env)
+}
+
+# Row coverage: the fit saw what the listing's Initial Summary counted. The
+# two status counts sum to 962, so no row carries any other code.
+expect_listing_rows <- function(fit) {
+  d <- fit$data
+  expect_equal(length(d$time), 962L)
+  expect_equal(sum(d$status == 1), 388L)
+  expect_equal(sum(d$status == 0), 574L)
+  expect_equal(sum(d$time_lower > 0), 387L)
+}
+
+# `sas` is the listing's Parameter Estimate Summary in R's theta order, named
+# by R's parameter names. SAS estimates every shape on the log scale, so for
+# the rows marked `logged` R's estimate is logged and its standard error
+# converted by the delta method, se(log|x|) = se(x) / |x|.
+#
+# Tolerances, all measured 2026-09-10 against a fit that stopped short (model
+# 2 under default control, 0.013 below the listing's log likelihood), which
+# fails every one of them:
+# - log likelihood: half a unit in the listing's third decimal;
+# - estimates: 1e-3 of the listing's standard error. Both optimizers stop on a
+#   tolerance on a flat surface, so the printed digits are not all fixed by
+#   the data; a thousandth of a standard error is agreement for any purpose.
+# - standard errors: 2e-3 relative. SAS's Hessian is numeric.
+expect_matches_listing <- function(fit, sas, ll) {
+  f <- fit$fit
+  # Not a hollow fit: .hzr_optim_generic() clamps a non-finite objective to
+  # 1e10 and still reports convergence, so the log likelihood is checked
+  # against the listing, never taken from `converged`.
+  expect_true(f$converged)
+  expect_lt(abs(f$objective - ll), 5e-4)
+  expect_equal(names(f$theta), row.names(sas))
+  expect_true(is.matrix(f$vcov))
+  se <- sqrt(diag(f$vcov))
+  expect_true(all(is.finite(se) & se > 0))
+  est <- ifelse(sas$logged, log(abs(f$theta)), f$theta)
+  se <- ifelse(sas$logged, se / abs(f$theta), se)
+  expect_lt(max(abs(est - sas$est) / sas$se), 1e-3)
+  expect_lt(max(abs(se / sas$se - 1)), 2e-3)
+}
+
+sas_table <- function(names, logged, est, se) {
+  data.frame(logged = logged, est = est, se = se, row.names = names)
+}
+
+test_that("hz.ce_cardioversion_repeated.ehb: the first model reproduces the listing", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("haven")
+  dir <- skip_if_no_maze_datasets()
+  job <- cardioversion_job(dir)
+
+  # One start, at the job's PARMS. SAS's iteration 0 already sits at the
+  # optimum, and the listing's LL is from that point. The default five starts
+  # return this same fit from start 1, but the perturbed starts end at worse
+  # local optima (LL -267.914, -268.175, -274.368) and their Hessians warn --
+  # noise that says nothing about this fit.
+  expect_no_warning(
+    fit <- fit_translated(job, cardioversion_events(dir), "fit", "status", list(n_starts = 1L))
+  )
+  expect_listing_rows(fit)
+  # CONSERVE: "Conservation of events: Invoked at each iteration".
+  expect_true(fit$spec$control$conserve_applied)
+
+  # .lst lines 100 and 116-125.
+  sas <- sas_table(
+    c("phase_1.log_mu", "phase_1.log_t_half", "phase_1.nu", "phase_1.m",
+      "phase_2.log_mu", "phase_2.log_tau", "phase_2.gamma", "phase_2.alpha", "phase_2.eta"),
+    logged = c(FALSE, FALSE, TRUE, TRUE, FALSE, FALSE, TRUE, TRUE, TRUE),
+    #      E0        E2        E3        E4        L0         L1        L2        L3        L4
+    est = c(-1.19976, -4.56749, -1.76693, 1.761105, -1.40628, -0.609944, 1.863922, 0.916978,
+            -1.99124),
+    se = c(0.09400547, 0.06371024, 0.2689927, 0.3089678, 0.2012175, 0.3764006, 0.6892761,
+           0.3171719, 0.8600162)
+  )
+  expect_matches_listing(fit, sas, ll = -267.885)
+})
+
+test_that("hz.ce_cardioversion_repeated.ehb: the stratified model reproduces the listing", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("haven")
+  dir <- skip_if_no_maze_datasets()
+  job <- cardioversion_job(dir)
+  events <- cardioversion_events(dir)
+  expect_false(anyNA(events[c("maze_prc", "iso_pvi")]))
+
+  # reltol is tightened on purpose. Under the default (1e-5) BFGS stops at LL
+  # -242.2675 and reports convergence; R's log likelihood at the listing's own
+  # estimates is -242.2541, so the likelihoods agree and the default optimizer
+  # tolerance stopped 0.013 short on a flat ridge in the late shapes.
+  ctl <- list(n_starts = 1L, reltol = 1e-12, maxit = 5000L)
+  expect_no_warning(fit <- fit_translated(job, events, "fit_2", "status_2", ctl))
+  expect_listing_rows(fit)
+  # NOCONSERVE: "Conservation of events: Not invoked".
+  expect_false(fit$spec$control$conserve_applied)
+
+  # .lst lines 2760 and 2772-2793.
+  sas <- sas_table(
+    c("phase_1.log_mu", "phase_1.log_t_half", "phase_1.nu", "phase_1.m",
+      "phase_1.MAZE_PRC", "phase_1.ISO_PVI",
+      "phase_2.log_mu", "phase_2.log_tau", "phase_2.gamma", "phase_2.alpha", "phase_2.eta",
+      "phase_2.MAZE_PRC", "phase_2.ISO_PVI"),
+    logged = c(FALSE, FALSE, TRUE, TRUE, FALSE, FALSE,
+               FALSE, FALSE, TRUE, TRUE, TRUE, FALSE, FALSE),
+    #      E0        E2        E3        E4        MAZE_PRC  ISO_PVI
+    est = c(-1.02384, -4.56614, -1.77136, 1.770403, -0.54922, 0.1504561,
+            #  L0        L1         L2        L3         L4        MAZE_PRC   ISO_PVI
+            -1.16547, -0.692292, 2.014376, 0.7332091, -2.11007, -0.938336, -0.461191),
+    se = c(0.1162237, 0.06331743, 0.2646996, 0.3068885, 0.1807944, 0.2205966,
+           0.2346658, 0.3799748, 0.8113678, 0.2687002, 0.9540579, 0.1622002, 0.2525617)
+  )
+  expect_matches_listing(fit, sas, ll = -242.254)
+})

--- a/tests/testthat/test-repeated-events-parity.R
+++ b/tests/testthat/test-repeated-events-parity.R
@@ -171,6 +171,20 @@ expect_matches_listing <- function(fit, sas, ll) {
   expect_true(is.matrix(f$vcov))
   se <- sqrt(diag(f$vcov))
   expect_true(all(is.finite(se) & se > 0))
+
+  # The log likelihood at the listing's own estimates, with no optimizer
+  # involved, so a failure here is the likelihood and not the search. log|x|
+  # drops the sign; every logged parameter in this job is positive.
+  expect_true(all(f$theta[sas$logged] > 0))
+  d <- fit$data
+  ll_at_sas <- .hzr_logl_multiphase( # nolint: object_usage_linter.
+    theta = ifelse(sas$logged, exp(sas$est), sas$est),
+    time = d$time, status = d$status, time_lower = d$time_lower,
+    time_upper = d$time_upper, weights = d$weights,
+    phases = f$phases, covariate_counts = f$covariate_counts, x_list = f$x_list
+  )
+  expect_lt(abs(ll_at_sas - ll), 5e-4)
+
   est <- ifelse(sas$logged, log(abs(f$theta)), f$theta)
   se <- ifelse(sas$logged, se / abs(f$theta), se)
   expect_lt(max(abs(est - sas$est) / sas$se), 1e-3)


### PR DESCRIPTION
Follows #241, which rebuilt this job's `%repeat` fit input exactly. This fits it.

## What it does

The job's two `PROC HAZARD` statements go through `hzr_translate_sas()`, and the emitted status and `hazard()` calls are evaluated over the rebuilt input, starting at the job's `PARMS`. The only construct left untranslated is `STEEPEST` (#145), and the test asserts that nothing else is.

| | SAS LL | R LL | worst estimate gap | worst SE gap |
|---|---|---|---|---|
| First model: `CONSERVE`, 9 parameters | -267.885 | -267.8850808 | 8.3e-05 SE | 8.9e-04 relative |
| Stratified model: `NOCONSERVE`, `maze_prc` and `iso_pvi`, 13 parameters | -242.254 | -242.2541227 | 4.0e-05 SE | 5.5e-04 relative |

The comparison is made on SAS's log scale, with SEs converted by the delta method. Row coverage (962 / 388 / 574 / 387) is asserted before any fitted value. The test also evaluates R's log likelihood at the listing's own estimates, with no optimizer involved, and it matches for both models. That makes the likelihood's agreement independent of the search.

## Finding: the default `reltol` stops the stratified model short

With `reltol` at its default of 1e-5, the translated call reports `converged = TRUE` at **-242.2675**, 0.013 below the listing. At that point its estimates are up to 0.16 SE off and its SEs up to 10% off. BFGS stops once a step gains less than about `reltol * |LL|` (≈ 0.0024 here). The late shapes sit on a flat ridge where steps never gain more than that. With `reltol = 1e-12` the fit reaches the listing's optimum from the same start. The test sets that explicitly and says why.

The default is **left alone**, because changing it touches every fit and the check-time budget. The first model passing at the default is not evidence that the default is enough: `CONSERVE` fixes one `log_mu`, which sends it through a Nelder-Mead warm-up at 1e-10 first. All of this is recorded in `inst/dev/REPEATED-EVENTS-DESIGN.md` under "Fit parity".

Every tolerance in the test (log likelihood to 5e-4, estimates to 1e-3 SE, SEs to 2e-3 relative) fails that stopped-short fit, so none of these assertions is unable to fail.

## `reltol` documentation (3795ebe)

`hazard()`'s roxygen called `reltol` a "relative parameter change tolerance". Every `hazard()` path passes `use_bounds = FALSE`, so `reltol` always reaches `stats::optim`'s BFGS. There it bounds the relative reduction in the negative log-likelihood, and the stopping gap therefore grows with |LL|. The entry now says that, with the ~0.0024-at-240 figure. `R CMD check --as-cran` passes with the manual, including the PDF step.

Not changed here: `abstol` is documented as an "absolute gradient norm tolerance", but it reaches `optim` only on the bounded L-BFGS-B path (as `pgtol`), and no caller takes that path. So the setting currently has no effect. That is for the separate `reltol`-default work.

## Evidence

⚠️ **CI cannot run these tests.** The data are PHI and live only on the study volume, so the new tests skip on every runner, and a green CI run says nothing about parity. The results below are from local runs with the volume mounted. `main` (#244) was merged in first, and the results are from the merged base (967943d).

- `devtools::document()`: no changes
- `lintr::lint_package()`: 0 lints
- `spelling::spell_check_package()`: clean
- the parity file with `NOT_CRAN=true`: 55 passes, 0 failures, 0 skips, 0 warnings
- the full suite with `NOT_CRAN=true`: 4858 passes, 0 failures, 6 skips
- `R CMD check --as-cran` with the manual, built from `git archive`: Status OK (0/0/0). Tests took 150s and the vignette rebuild 78s, but that run overlapped the full suite, so the timings are not a clean measurement.

`r-reviewer` was run over the diff. It found four issues and all were verified against the code. The missing likelihood-at-SAS's-point assertion, the imprecise wording about the optimizer paths and the stale base are fixed here. The roxygen wording is noted above. Only a test and a dev doc changed, nothing user-facing, so there is no NEWS entry or version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

