### PR TITLE
test: verify hzr_repeated_events() renewal against SAS (ac.reintervention)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,7 +62,7 @@
   returns one row per inter-event segment, with the segment's start time,
   duration and running event count. It reproduces the SAS macro `%repeat`,
   which built this input for the repeated-events `HAZARD` jobs and whose output
-  was never saved, so those jobs can now be run again in R. It refuses input
+  was seldom saved, so those jobs can now be run again in R. It refuses input
   that would otherwise give a plausible but wrong result -- a non-numeric time,
   follow-up or indicator column, a factor `id`, a missing `followup` value, or
   an empty data frame -- and warns, naming the subjects, when an event falls

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -243,8 +243,8 @@ data. Fitting it and reproducing LL -267.885 is out of scope; see below.
 ### Second job: `renewal`, against `ac.reintervention`
 
 The cardioversion job never reads `renewal`. A first search for jobs that call `%repeat` and
-then use its output (2026-09-10) covered only `general/` and `thoracic/`: it silently died
-before reaching `cardiac/`. What it found:
+then use its output (2026-09-10) was read while it was still running, so it covered only
+`general/` and `thoracic/`; it had not yet reached `cardiac/`. What it found:
 - the consulting `tp.*` templates, which read `renewal` but were never run (none of their
   108 listings prints it);
 - several thoracic jobs that print `renewal`.
@@ -262,8 +262,10 @@ was checked against its own output without an R rebuild. Its saved `bd_reop`, 24
 121 subjects, matches its `.lst` table of `renewal` by `ev_reop` cell for cell.
 
 The search tool itself caused two false negatives:
-- **A partial result that looked complete.** `grep` here is ugrep, and the first search died
-  without an error. It came back with zero `cardiac/` callers even though a known one exists.
+- **A partial result that looked complete.** The first search wrote its hit list as it went,
+  and the check for whether it was still running used a mis-escaped `pgrep` pattern that
+  matched nothing. So a list still being written read as final, with zero `cardiac/` callers
+  even though a known one exists.
 - **Silence on SAS listings.** ugrep treats some `.lst` files as binary and then prints
   nothing, not even a zero count, unless given `-a`.
 

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -242,14 +242,33 @@ data. Fitting it and reproducing LL -267.885 is out of scope; see below.
 
 ### Second job: `renewal`, against `ac.reintervention`
 
-The cardioversion job never reads `renewal`. Searching the study volume for jobs that call
-`%repeat` and then use its output (2026-09-10) found three groups:
-- the consulting `tp.*` templates, which read `renewal` but were never run;
-- the cardioversion jobs, which read `iv_seg` and `event_no` only;
+The cardioversion job never reads `renewal`. A first search for jobs that call `%repeat` and
+then use its output (2026-09-10) covered only `general/` and `thoracic/`: it silently died
+before reaching `cardiac/`. What it found:
+- the consulting `tp.*` templates, which read `renewal` but were never run (none of their
+  108 listings prints it);
 - several thoracic jobs that print `renewal`.
 
-Of those, `ac.reintervention.sas` (achalasia; `thoracic/esophagus/benign/achalasia/outcomes/clinical`)
-is the one to use. It prints `ev_rein` by `renewal` directly after the macro, then saves the
+A rescan of `cardiac/` found 1182 callers:
+- 496 read `renewal` in code, and 404 of those have a `.lst`;
+- 9 of those also save `%repeat` output to a library, and 7 of those datasets come from the
+  same run as their listing;
+- the maze cardioversion jobs are among the 1182, and read `iv_seg` and `event_no` only.
+
+So `ac.reintervention` is one usable reference among several, not the only one.
+
+The shones reoperation job (`cardiac/congenital/shones/outcomes/datasets/bd.repeated_reops.sas`)
+was checked against its own output without an R rebuild. Its saved `bd_reop`, 241 rows over
+121 subjects, matches its `.lst` table of `renewal` by `ev_reop` cell for cell.
+
+The search tool itself caused two false negatives:
+- **A partial result that looked complete.** `grep` here is ugrep, and the first search died
+  without an error. It came back with zero `cardiac/` callers even though a known one exists.
+- **Silence on SAS listings.** ugrep treats some `.lst` files as binary and then prints
+  nothing, not even a zero count, unless given `-a`.
+
+`ac.reintervention.sas` (achalasia; `thoracic/esophagus/benign/achalasia/outcomes/clinical`)
+is the one verified here. It prints `ev_rein` by `renewal` directly after the macro, then saves the
 macro's output unchanged as `library.bdrein`. So every returned column can be compared with
 SAS's own, row by row.
 
@@ -281,6 +300,10 @@ But renewal gives the same answer on this data from stale flags or fresh ones:
   they have `event_no = 1`. The first-row bump needs `event_no = 0`.
 - **The 39 stale `last` rows** are each subject's last event, so they have `event = 1`. The
   last-row bump needs `event = 0`.
+
+Shones shows the same from SAS's own saved columns. Stale and fresh flags differ on 122 of
+its 241 rows, and the bump rule gives identical `renewal` either way; SAS matches both. That
+makes two production jobs, and 705 rows, where the stale-flag branch changes nothing.
 
 So the stale-flag branch of `renewal` is still pinned only by the synthetic fixture below.
 

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -255,6 +255,9 @@ A rescan of `cardiac/` found 1182 callers:
   same run as their listing;
 - the maze cardioversion jobs are among the 1182, and read `iv_seg` and `event_no` only.
 
+A scan of `vascular/` found 45 more callers: 32 read `renewal`, 24 of those have a `.lst`,
+and 5 also save the macro output.
+
 So `ac.reintervention` is one usable reference among several, not the only one.
 
 The shones reoperation job (`cardiac/congenital/shones/outcomes/datasets/bd.repeated_reops.sas`)

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -109,8 +109,10 @@ change.
 **`renewal` is in scope for v1.** It is two lines inside a stage we write regardless,
 and the hard part — the stale `first`/`last` carry-forward, below — must be implemented
 correctly whether or not the column is returned. Omitting the column while keeping the
-machinery would be the worst of both. It also makes the corpus renewal variant
-(`hz.te123.OMC.renewal`) a second parity target at no extra cost.
+machinery would be the worst of both. (This paragraph first named the corpus job
+`hz.te123.OMC.renewal` as a second parity target. It is not one: the OMC jobs never call
+`%repeat`, and their renewal fit reads a `NOPREVTE` count from the raw input. The SAS
+evidence for `renewal` is `ac.reintervention`; see Acceptance.)
 
 ## Missing-value semantics
 
@@ -238,6 +240,50 @@ censored, `IV_EVENT` in [0.0001140795, 12.99137] and `IV_START` in
 [0.0001140795, 9.716832]. The exported function raises none of its input warnings on this
 data. Fitting it and reproducing LL -267.885 is out of scope; see below.
 
+### Second job: `renewal`, against `ac.reintervention`
+
+The cardioversion job never reads `renewal`. Searching the study volume for jobs that call
+`%repeat` and then use its output (2026-09-10) found three groups:
+- the consulting `tp.*` templates, which read `renewal` but were never run;
+- the cardioversion jobs, which read `iv_seg` and `event_no` only;
+- several thoracic jobs that print `renewal`.
+
+Of those, `ac.reintervention.sas` (achalasia; `thoracic/esophagus/benign/achalasia/outcomes/clinical`)
+is the one to use. It prints `ev_rein` by `renewal` directly after the macro, then saves the
+macro's output unchanged as `library.bdrein`. So every returned column can be compared with
+SAS's own, row by row.
+
+Verified 2026-09-10 with the volume mounted, by `.hzr_derive_bdmult1()` and
+`tests/testthat/test-repeated-events-renewal-parity.R`:
+- **Rebuild:** `pndil1` 29 x 7, `reint1` 15 x 7, `cmb` 44 x 9, `bdmult` 425 x 218 and
+  `bdmult1` 425 x 219, each as the `.log` records it.
+- **`%repeat` stages:** 425 x 220 through stage 3, then 464 x 222 at stages 4 and 5 and
+  464 x 228 at stages 6 and 7 (SAS; R's widths differ as the test states).
+- **Crosstab:** the `.lst` table of `ev_rein` by `renewal`, cell for cell.
+- **`bdrein`:** 464 rows over 420 subjects, in the same order, with no mismatch in
+  `iv_rein`, `iv_fup`, `iv_start`, `iv_seg`, `event`, `rcensor`, `event_no`, `renewal`,
+  `first` or `last`.
+
+Two points of detail:
+- **The job aliases the indicator.** It passes `event=ev_rein`, the same column as
+  `eventype=`, so SAS overwrites its input indicator. R's `event` is compared with SAS's
+  `ev_rein`.
+- **One input line names a patient.** The job overrides `iv_fup` for one subject named by
+  `ccfid`, and that subject has an event. The helper reads the identifier from the job's
+  source on the volume at run time, so it never enters the repository.
+
+What this settles, and what it does not. `bdrein`'s saved `first` and `last` are the
+stage-4 flags, and they differ from recomputed flags on 75 rows. R matches SAS on all 75,
+which is SAS evidence that the flags are carried forward.
+
+But renewal gives the same answer on this data from stale flags or fresh ones:
+- **The 36 stale `first` rows** are censored rows appended after a subject's only event, so
+  they have `event_no = 1`. The first-row bump needs `event_no = 0`.
+- **The 39 stale `last` rows** are each subject's last event, so they have `event = 1`. The
+  last-row bump needs `event = 0`.
+
+So the stale-flag branch of `renewal` is still pinned only by the synthetic fixture below.
+
 ### PHI constraint
 
 The cardioversion data is PHI. It stays on the study volume and never enters the repo.
@@ -266,6 +312,12 @@ unless the maze study datasets are mounted (overridable with `HAZARD_MAZE_DATASE
 `haven` is installed. It rebuilds `bd_card`, asserts every shape in the table under
 Acceptance **before** comparing any value, then the tallies and ranges, then that the
 result does not depend on input row order.
+
+**Volume-gated `renewal` parity test** (`tests/testthat/test-repeated-events-renewal-parity.R`):
+it skips unless the achalasia datasets are mounted (overridable with
+`HAZARD_ACHALASIA_DIR`). It rebuilds `bdmult1`, asserts every shape, then the `.lst`
+crosstab, then `library.bdrein` row by row. Its failure output is counts only: no row and no
+`ccfid`.
 
 Because a gated test prints green when it never ran, it is not evidence. The synthetic
 set must be able to fail on its own.

--- a/inst/sas-parity/helper-sas-parity.R
+++ b/inst/sas-parity/helper-sas-parity.R
@@ -1312,3 +1312,117 @@
   row.names(b) <- NULL
   b
 }
+
+# ---------------------------------------------------------------------------
+# Achalasia reintervention: bdmult1 derivation
+# ---------------------------------------------------------------------------
+# ac.reintervention.sas builds bdmult1 -- the input to its %repeat call -- in
+# SAS WORK, then saves the macro's output unchanged as library.bdrein. That
+# saved dataset is SAS's own renewal column, row by row, and it is the only
+# SAS evidence for renewal in the job corpus: the maze cardioversion job never
+# reads the column.
+#
+# PHI, as above: the directory is found at run time and is NA when not mounted.
+
+.hzr_achalasia_dir <- function() {
+  env <- Sys.getenv("HAZARD_ACHALASIA_DIR", "")
+  if (nzchar(env) && dir.exists(env)) return(env)
+  default <- "/Volumes/qhsstudies/thoracic/esophagus/benign/achalasia/outcomes/clinical"
+  if (dir.exists(default)) return(default)
+  NA_character_
+}
+
+# The job overrides iv_fup for one subject named by ccfid. Copying that line
+# would put a patient identifier in the repository, and unlike the maze job's
+# duraf line it changes the answer: the subject has an event. So the
+# identifier is read from the job's own source on the volume, and nothing is
+# returned unless exactly one such line is found. The error never names it.
+.hzr_achalasia_override_id <- function(root) {
+  src <- readLines(file.path(root, "distributions", "ac.reintervention.sas"), warn = FALSE)
+  pat <- "^\\s*if\\s+ccfid\\s*=\\s*'([^']+)'\\s+then\\s+iv_fup\\s*=\\s*iv_rein\\s*\\+\\s*\\.0001\\s*;"
+  hit <- grep(pat, src, ignore.case = TRUE, perl = TRUE)
+  if (length(hit) != 1L) {
+    stop(sprintf("Expected one iv_fup override line in ac.reintervention.sas, found %d.",
+                 length(hit)), call. = FALSE)
+  }
+  sub(paste0(pat, ".*"), "\\1", src[hit], ignore.case = TRUE, perl = TRUE)
+}
+
+# Reproduces the job's statements from `data pndil` through `data bdmult1`
+# (library.reops is read by the job but never used, so it is not read here).
+# Returns every intermediate whose shape the .log records, so each can be
+# checked, with lower-case names.
+.hzr_derive_bdmult1 <- function(root) {
+  read <- function(member) {
+    d <- haven::read_sas(file.path(root, "datasets", paste0(member, ".sas7bdat")))
+    d <- as.data.frame(haven::zap_labels(haven::zap_formats(d)))
+    names(d) <- tolower(names(d))
+    d
+  }
+  # SAS subtracts day counts. R's Date counts from a different origin, which
+  # cancels in every difference taken here.
+  day <- function(x) as.numeric(x)
+  built <- read("built")
+
+  # data pndil; set library.bdrpndil; ev_rein = 1;
+  # data pndil1; set pndil; where sz_dilator_pneum_dilations >= 30;
+  #   rename dt_rpndil = dt_rein; keep ...;
+  pndil <- read("bdrpndil")
+  pndil$ev_rein <- 1
+  pndil <- pndil[!is.na(pndil$sz_dilator_pneum_dilations) &
+                   pndil$sz_dilator_pneum_dilations >= 30, , drop = FALSE]
+  names(pndil)[names(pndil) == "dt_rpndil"] <- "dt_rein"
+  pndil1 <- pndil[c("ccfid", "dt_surg", "dt_rein", "ev_rein", "rec_id", "record_id", "iv_rpndil")]
+
+  # data reint; set library.bdreinv; ev_rein = 1;
+  # data reint1; set reint; rename dt_reinv = dt_rein; keep ...;
+  # The keep list also names `o`, which does not exist (a .log WARNING).
+  reint <- read("bdreinv")
+  reint$ev_rein <- 1
+  names(reint)[names(reint) == "dt_reinv"] <- "dt_rein"
+  reint1 <- reint[c("ccfid", "dt_surg", "dt_rein", "ev_rein", "rec_id", "record_id", "iv_reinv")]
+
+  # data cmb; set pndil1 reint1; iv_rein = max(iv_reinv, iv_rpndil);
+  # SET stacks the two and fills each one's missing column with missing; SAS
+  # max() skips missing values.
+  pndil1$iv_reinv <- NA_real_
+  reint1$iv_rpndil <- NA_real_
+  cmb <- rbind(pndil1, reint1[names(pndil1)])
+  cmb$iv_rein <- pmax(cmb$iv_reinv, cmb$iv_rpndil, na.rm = TRUE)
+  row.names(cmb) <- NULL
+
+  # proc sql: select * from built as a left join cmb as d
+  #   on a.ccfid = d.ccfid and a.dt_surg = d.dt_surg;
+  # A left join keeps every built row, once per match. select * keeps the
+  # first of a duplicated name, so cmb's ccfid, dt_surg and rec_id are dropped
+  # (the .log's three "already exists" warnings).
+  key_built <- paste(built$ccfid, day(built$dt_surg))
+  key_cmb <- paste(cmb$ccfid, day(cmb$dt_surg))
+  if (anyDuplicated(key_built)) {
+    stop("library.built has duplicate (ccfid, dt_surg) keys; the job's join would not be one-to-many.",
+         call. = FALSE)
+  }
+  hits <- lapply(key_built, function(k) which(key_cmb == k))
+  bi <- rep(seq_along(hits), pmax(lengths(hits), 1L))
+  ci <- unlist(lapply(hits, function(h) if (length(h)) h else NA_integer_))
+  bdmult <- cbind(built[bi, , drop = FALSE],
+                  cmb[ci, setdiff(names(cmb), names(built)), drop = FALSE])
+  row.names(bdmult) <- NULL
+
+  # data bdmult1; set bdmult;
+  #   iv_fup = (dt_fup - dt_surg)/365.2425 + .0001;
+  #   if dt_fup = . then iv_fup = (dt_disch - dt_surg)/365.2425 + .0001;
+  #   if ccfid = <one subject> then iv_fup = iv_rein + .0001;
+  bdmult1 <- bdmult
+  bdmult1$iv_fup <- (day(bdmult1$dt_fup) - day(bdmult1$dt_surg)) / 365.2425 + .0001
+  no_fup <- is.na(bdmult1$dt_fup)
+  bdmult1$iv_fup[no_fup] <- (day(bdmult1$dt_disch[no_fup]) - day(bdmult1$dt_surg[no_fup])) /
+    365.2425 + .0001
+  over <- bdmult1$ccfid == .hzr_achalasia_override_id(root)
+  if (!any(over)) stop("The iv_fup override matches no subject in library.built.", call. = FALSE)
+  bdmult1$iv_fup[over] <- bdmult1$iv_rein[over] + .0001
+
+  list(pndil1 = pndil1[setdiff(names(pndil1), "iv_reinv")],
+       reint1 = reint1[setdiff(names(reint1), "iv_rpndil")],
+       cmb = cmb, bdmult = bdmult, bdmult1 = bdmult1)
+}

--- a/tests/testthat/test-repeated-events-renewal-parity.R
+++ b/tests/testthat/test-repeated-events-renewal-parity.R
@@ -1,0 +1,113 @@
+# Parity with SAS for ac.reintervention (achalasia): the renewal column.
+#
+# The maze cardioversion job (test-repeated-events-parity.R) never reads
+# renewal. This job does -- it prints ev_rein by renewal -- and it saved the
+# macro's output, unchanged, as library.bdrein. So every column
+# hzr_repeated_events() returns can be compared with SAS's own, row by row.
+# Every expected value below comes from the job's .log, its .lst or bdrein --
+# none from the R code.
+#
+# The data are PHI and live only on the study volume. This test skips when the
+# volume is not mounted, which is every CI runner, so a green CI run is NOT
+# evidence of parity. Failure output is counts only: no row and no ccfid is
+# ever printed.
+
+skip_if_no_achalasia <- function() {
+  d <- .hzr_achalasia_dir() # nolint: object_usage_linter.
+  testthat::skip_if(is.na(d), "achalasia study datasets not mounted")
+  d
+}
+
+test_that("ac.reintervention: %repeat reproduces the SAS log, the .lst and library.bdrein", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("haven")
+  root <- skip_if_no_achalasia()
+
+  r <- .hzr_derive_bdmult1(root)
+  # The rebuild, against the .log: WORK.PNDIL1 29 x 7, WORK.REINT1 15 x 7,
+  # WORK.CMB 44 x 9, WORK.BDMULT 425 rows and 218 columns, WORK.BDMULT1 425 x 219.
+  expect_equal(unname(vapply(r, dim, integer(2))),
+               matrix(c(29L, 7L, 15L, 7L, 44L, 9L, 425L, 218L, 425L, 219L), nrow = 2))
+  bdmult1 <- r$bdmult1
+
+  id <- "ccfid"
+  tm <- "iv_rein"
+  fu <- "iv_fup"
+  ind <- "ev_rein"
+  s1 <- .hzr_re_stage1(bdmult1)
+  s2 <- .hzr_re_stage2(s1, id, tm, ind)
+  s3 <- .hzr_re_stage3(s2, id, tm, fu, ind)
+  s4 <- .hzr_re_stage4(s3, id, tm, fu, ind)
+  s5 <- .hzr_re_stage5(s4, ind)
+  s6 <- .hzr_re_stage6(s5, id, tm, fu)
+  s7 <- .hzr_re_stage7(s6, id, tm, ind)
+
+  # Row coverage first: the macro's thirteen DATA and SORT steps (.log lines
+  # 349-443) give 425 x 220 through stage 3, 464 x 222 at stages 4 and 5, and
+  # 464 x 228 at stages 6 and 7. From stage 5 R is one column wider: the job
+  # passes event=ev_rein, the same column as eventype=, so SAS overwrites its
+  # indicator where R adds `event`. Stages 6 and 7 also drop lag_iv and number,
+  # the macro's loop counters.
+  shapes <- rbind(dim(s1), dim(s2), dim(s3), dim(s4), dim(s5), dim(s6), dim(s7))
+  expect_equal(shapes[, 1], c(425L, 425L, 425L, 464L, 464L, 464L, 464L))
+  expect_equal(shapes[, 2], c(220L, 220L, 220L, 222L, 222L + 1L, 228L - 2L + 1L, 228L - 2L + 1L))
+
+  # This data trips none of the function's input warnings. Those warnings name
+  # subjects, so they are counted here, never printed; and the comparison with
+  # the stages reports a bare FALSE rather than a diff of patient rows.
+  warned <- testthat::capture_warnings(events <- hzr_repeated_events(bdmult1, id, tm, fu, ind))
+  expect_length(warned, 0L)
+  expect_true(isTRUE(all.equal(events, `row.names<-`(s7, NULL))))
+
+  # The .lst's "Table of ev_rein by renewal".
+  tab <- table(events$event, events$renewal)
+  expect_equal(unname(dimnames(tab)), list(c("0", "1"), c("1", "2", "3", "4", "5")))
+  expect_equal(as.vector(tab), c(381L, 39L, 36L, 3L, 2L, 1L, 0L, 1L, 1L, 0L))
+
+  # library.bdrein, row by row. Coverage before any value: the .log's shape
+  # (LIBRARY.BDREIN has 464 observations and 228 variables), then the same
+  # subjects in the same order.
+  sas <- haven::read_sas(file.path(root, "datasets", "bdrein.sas7bdat"))
+  sas <- as.data.frame(haven::zap_labels(haven::zap_formats(sas)))
+  names(sas) <- tolower(names(sas))
+  expect_equal(dim(sas), c(464L, 228L))
+  expect_equal(nrow(events), nrow(sas))
+  expect_equal(sum(events$ccfid != sas$ccfid), 0L)
+
+  # R's `event` and `rcensor` are the job's ev_rein and cn_rein.
+  pairs <- c(iv_rein = "iv_rein", iv_fup = "iv_fup", iv_start = "iv_start", iv_seg = "iv_seg",
+             event = "ev_rein", rcensor = "cn_rein", event_no = "event_no",
+             renewal = "renewal", first = "first", last = "last")
+  for (v in names(pairs)) {
+    got <- events[[v]]
+    want <- sas[[pairs[[v]]]]
+    # A missing column would make both sums below zero-length, and so zero.
+    expect_length(got, nrow(sas))
+    # A constant column would match whatever the code did.
+    expect_gt(length(unique(want)), 1L, label = paste(v, "distinct values in SAS"))
+    expect_equal(sum(is.na(got) != is.na(want)), 0L, label = paste(v, "missingness mismatches"))
+    # Elementwise and relative, so a small value is not waved through by an
+    # absolute tolerance; a zero must be exactly zero.
+    bad <- abs(got - want) > 1e-9 * abs(want)
+    expect_equal(sum(bad, na.rm = TRUE), 0L, label = paste(v, "value mismatches"))
+  }
+
+  # bdrein's first and last are the stage-4 flags, carried stale into the
+  # renewal step. On 75 rows they are not the subject's first or last row of
+  # the output, and R matches SAS on every one of them above: SAS evidence that
+  # the flags are carried forward, not recomputed.
+  #
+  # What this data cannot show is renewal reading them. The 36 stale `first`
+  # rows are the censored rows appended after a subject's only event, which
+  # copy that event's first = 1; they have event_no = 1, and the first-row bump
+  # needs event_no = 0. The 39 stale `last` rows are each subject's last event;
+  # they have event = 1, and the last-row bump needs event = 0. So renewal is
+  # the same from stale flags or fresh ones here, and that branch is pinned
+  # only by the hand-traced fixtures in test-repeated-events.R.
+  fresh <- .hzr_re_flags(events$ccfid)
+  stale_first <- fresh$first != (events$first == 1)
+  stale_last <- fresh$last != (events$last == 1)
+  expect_equal(c(sum(stale_first), sum(stale_last)), c(36L, 39L))
+  expect_equal(unique(events$event_no[stale_first]), 1)
+  expect_equal(unique(events$event[stale_last]), 1)
+})


### PR DESCRIPTION
## What this does

Adds the first SAS evidence for the `renewal` column of `hzr_repeated_events()`.

The maze cardioversion job used for #241's parity check never reads `renewal`. Its fit uses `LCENSOR IV_START`. So until now the column's expected values came only from a hand-trace of the macro.

`ac.reintervention.sas` (achalasia, `thoracic/esophagus/benign/achalasia/outcomes/clinical`) does read it:
- It prints `ev_rein` by `renewal` directly after `%repeat`.
- It then saves the macro's output unchanged as `library.bdrein`, so every column the function returns can be compared with SAS's own, row by row.

## Finding the target

The design doc named `hz.te123.OMC.renewal` as a candidate. It is not one: the OMC jobs never call `%repeat`, and their renewal fit reads a `NOPREVTE` count from the raw input. I searched the study volume for jobs that call `%repeat(` and then use its output:
- **`general/consulting`:** 74 hits, all never-run `tp.*` templates, with no `.lst`.
- **`thoracic`:** 33 real jobs, several of which print `renewal`.
- **`cardiac`:** the cardioversion jobs read `iv_seg` and `event_no`, but not `renewal`.

Of the areas that search covered (`general` and `thoracic`), `ac.reintervention` is the only job whose `%repeat` output survives as a dataset.

**Correction (2026-09-10):** that first search was read while it was still running: a mis-escaped `pgrep` made it look finished, and it had not yet reached `cardiac/`. A rescan found **1182** `%repeat` callers there. **496** read `renewal` in code and **404** of those have a `.lst`. **9** also save `%repeat` output to a library, and **7** of those datasets come from the same run as their `.lst`. A scan of `vascular/` found 45 more callers: 32 read `renewal`, 24 of those have a `.lst`, and 5 also save the macro output. So `ac.reintervention` is one of several jobs that save the output, not the only one.

One of them, `cardiac/congenital/shones/./bd.repeated_reops.sas`, is a complete second reference. Its saved `bd_reop` (241 rows over 121 subjects, `renewal` running from 1 to 5) matches its `.lst` crosstab cell for cell. Like achalasia, it cannot tell stale flags from fresh: they differ on 122 of its 241 rows, yet `renewal` comes out identical both ways, and SAS matches both. None of this changes the result below.

## Verified (volume mounted, 2026-09-10)

- **Rebuild:** `.hzr_derive_bdmult1()` reproduces every input shape in the `.log`: `pndil1` 29×7, `reint1` 15×7, `cmb` 44×9, `bdmult` 425×218 and `bdmult1` 425×219.
- **`%repeat` stages:** all seven shapes match (425×220 up to 464×228 in SAS; R's documented width differences are asserted, not hidden).
- **Crosstab:** the `.lst` table of `ev_rein` by `renewal` matches cell for cell.
- **`bdrein`:** 464 rows over 420 subjects, in the same order. There is no mismatch in `iv_rein`, `iv_fup`, `iv_start`, `iv_seg`, `event`, `rcensor`, `event_no`, `renewal`, `first` or `last`.

## What it does not settle

`bdrein`'s saved `first` and `last` are the stale stage-4 flags. They differ from recomputed flags on 75 rows, and R matches SAS on all 75. That is SAS evidence that the flags are carried forward.

But on this data `renewal` gives the same answer from stale flags or fresh ones. All 75 rows fail the bump condition either way:
- **36 rows** are censored rows appended after a subject's only event, so they have `event_no = 1`. The bump needs `event_no = 0`.
- **39 rows** are each subject's last event, so they have `event = 1`. The bump needs `event = 0`.

So the stale-flag branch of `renewal` is still pinned only by the synthetic fixtures in `test-repeated-events.R`. The test and the design doc both say this.

Mutation check. I broke `R/repeated-events.R` three ways, each in a scratch copy:

| Mutation | New test |
|---|---|
| drop `renewal`'s bump | **fails** (3 assertions) |
| recompute `first`/`last` at stage 6 | **fails** (5 assertions) |
| `renewal` reads fresh flags | passes, which is the documented limit |

## PHI

- **The data stays on the volume.** The test skips when it is not mounted, which is every CI runner, so **a green CI run is not evidence of parity**.
- **The job's input names one patient.** It overrides `iv_fup` for one subject named by `ccfid`, and that subject has an event, so the override changes the answer and has to be reproduced. The helper reads the identifier from the job's `.sas` at run time. It is not in the repository, the tests or the commit.
- **Failure output is counts only.** After the `r-reviewer` pass, input warnings are captured rather than printed, since they name subjects. The stage comparison reports a bare `FALSE`, not a waldo diff. I checked both paths with a planted identifier, and neither printed it.

## Also

- **Design doc:** corrects the OMC claim and adds this job to "Acceptance" and "Test structure".
- **NEWS:** says `%repeat` output was "never saved", which this job contradicts, so it now says "seldom". This is a user-facing sentence; please check it.
- **Not in this PR:** the existing maze parity test (`test-repeated-events-parity.R:49–50`) has the same two ID-printing failure paths. It is flagged as a separate task.

## Gates

- `devtools::document()`: no diff in `man/`, `NAMESPACE` or `DESCRIPTION`.
- `lintr::lint_package()`: 0 lints.
- `spelling::spell_check_package()`: clean.
- `devtools::test()` with `NOT_CRAN=true`: 0 failures, 6 skips, 4241 passes. This ran before the reviewer fixes, which touched only the new test file; that test was re-run afterwards (53/53).
- New test with the volume mounted: 53 passed, 0 skipped.
- `R CMD check --as-cran` with the manual, from a `git archive` of `ad90216`: Status: OK (0 errors, 0 warnings, 0 notes), and the tarball contains no `CLAUDE`/`AGENTS` files. The run took 312s wall, with tests at 153s and vignettes at 64s. That run overlapped the full test suite on the same machine, so the times are recorded, not interpreted.
- `r-reviewer`: two PHI leaks and one assertion that could pass vacuously. All three fixed; the rest of the helper and test was found sound.

No version bump: this is test and documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

