### PR TITLE
ci: run the SAS parity and translator corpus tests on ubuntu-release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,6 +61,11 @@ jobs:
           fi
 
   R-CMD-check:
+    # Named explicitly: without this, GitHub appends every matrix value to the
+    # job name, so sas_corpus turns the ubuntu-release job into
+    # "R-CMD-check (ubuntu-latest, release, true)" and the ruleset's required
+    # "R-CMD-check (ubuntu-latest, release)" never reports.
+    name: R-CMD-check (${{ matrix.config.os }}, ${{ matrix.config.r }})
     needs: changes
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -101,13 +106,21 @@ jobs:
           persist-credentials: false
 
       # Fail here if the files the tests look for are not where they look,
-      # rather than letting every one of those tests skip and pass.
+      # rather than letting every one of those tests skip and pass. The list
+      # is every fixture test-sas-parity.R reads, because each test there
+      # skips on its own file: a pin that keeps a few sentinels but drops one
+      # of these would turn that test green over nothing.
       - if: needs.changes.outputs.run == 'true' && matrix.config.sas_corpus
         shell: bash
         run: |
           mv hazard-corpus "$RUNNER_TEMP/hazard"
           for f in examples/hz.death.AVC.lst examples/hz.deadp.KUL.lst \
-                   examples/hz.te123.OMC.sas; do
+                   examples/hm.death.patient.lst examples/hm.death.AVC.deciles.lst \
+                   examples/ac.death.AVC.lst examples/hp.death.AVC.lst \
+                   examples/bs.death.AVC.lst examples/hp.death.AVC.hm1.lst \
+                   examples/hp.death.AVC.hm2.lst examples/hs.death.AVC.hm1.lst \
+                   examples/hz.te123.OMC.lst examples/hz.tm123.OMC.lst \
+                   examples/hz.te123.OMC.sas examples/data/omc; do
             test -f "$RUNNER_TEMP/hazard/$f" || { echo "missing: $f"; exit 1; }
           done
           echo "HAZARD_REPO=$RUNNER_TEMP/hazard" >> "$GITHUB_ENV"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-latest, r: 'devel'}
-          - {os: ubuntu-latest, r: 'release'}
+          - {os: ubuntu-latest, r: 'release', sas_corpus: true}
           - {os: ubuntu-latest, r: 'oldrel-1'}
           - {os: macos-latest,  r: 'release'}
           - {os: windows-latest, r: 'release'}
@@ -79,6 +79,39 @@ jobs:
     steps:
       - if: needs.changes.outputs.run == 'true'
         uses: actions/checkout@v4
+
+      # The SAS reference corpus (ehrlinger/hazard, public) that the SAS
+      # parity tests and the translator corpus test read. Without it those
+      # tests skip, and a green run says nothing about them.
+      #
+      # One runner only: they add minutes, and Windows is already the slowest
+      # job. Pinned to a commit, so a change there cannot move this package's
+      # CI unannounced; moving the pin is a deliberate PR, and the corpus
+      # test's floors were measured against this commit.
+      #
+      # Checked out beside the package, then moved out of the workspace:
+      # anything left in the package root is packed into the tarball by
+      # R CMD build.
+      - if: needs.changes.outputs.run == 'true' && matrix.config.sas_corpus
+        uses: actions/checkout@v4
+        with:
+          repository: ehrlinger/hazard
+          ref: dad7978277c2c60e258be3cd78029d4f4093e557
+          path: hazard-corpus
+          persist-credentials: false
+
+      # Fail here if the files the tests look for are not where they look,
+      # rather than letting every one of those tests skip and pass.
+      - if: needs.changes.outputs.run == 'true' && matrix.config.sas_corpus
+        shell: bash
+        run: |
+          mv hazard-corpus "$RUNNER_TEMP/hazard"
+          for f in examples/hz.death.AVC.lst examples/hz.deadp.KUL.lst \
+                   examples/hz.te123.OMC.sas; do
+            test -f "$RUNNER_TEMP/hazard/$f" || { echo "missing: $f"; exit 1; }
+          done
+          echo "HAZARD_REPO=$RUNNER_TEMP/hazard" >> "$GITHUB_ENV"
+          echo "HAZARD_EXAMPLES_DIR=$RUNNER_TEMP/hazard/examples" >> "$GITHUB_ENV"
 
       - if: needs.changes.outputs.run == 'true'
         uses: r-lib/actions/setup-r@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,8 +168,22 @@ That matters mostly for how you read a red CI. The previous text here claimed CI
 those tests, which would lead you to dismiss a CI-only test failure as impossible --- and the
 CI-only failures are the valuable ones, because they are the platform differences a single
 machine cannot show you. CI does skip more than the local run (42 against 6 on that
-commit), but those are the SAS fixture-availability skips: the local machine has the
-checkouts under `~/Documents/GitHub/hazard` and the runners do not.
+commit). Most of those were SAS fixture-availability skips: the local machine has the
+checkouts under `~/Documents/GitHub/hazard`, and the runners did not.
+
+**Since 2026-09-10, one runner has them.** The **ubuntu-latest / release** job checks out
+`ehrlinger/hazard` at a pinned commit and points `HAZARD_REPO` and `HAZARD_EXAMPLES_DIR` at
+it (`R-CMD-check.yaml`), so the SAS parity tests and the translator corpus test run there,
+and only there. The other four platforms still skip them. Moving the pin is a deliberate PR,
+because the corpus test's floors are measured against that commit. A step fails the job if
+the files those tests read are missing, so a moved path fails CI instead of turning back
+into silent skips.
+
+The remaining CI-only skips are ones no runner can satisfy:
+- the `bh.dead` parity helpers, which live in `inst/dev/`, and the built tarball excludes it;
+- the C `hazard` binary;
+- the private maze datasets;
+- the generated weighted-parity fixture.
 
 CI is still not a substitute for the local suite, for the opposite reason to the one
 previously given: it exercises *more* of the suite than a local `--as-cran` check does, and

--- a/tests/testthat/test-sas-translate-corpus.R
+++ b/tests/testthat/test-sas-translate-corpus.R
@@ -5,6 +5,10 @@ test_that("every public-corpus job either translates or fails loudly", {
 
   fs <- list.files(path.expand(repo), pattern = "[.]sas$",
                    recursive = TRUE, full.names = TRUE)
+  # dist/ is a local `make install --prefix=./dist` tree, gitignored by the
+  # hazard repo: not public corpus, and absent from a clean checkout such as
+  # the one CI uses. Counting it makes a local run measure a different corpus.
+  fs <- fs[!startsWith(fs, file.path(path.expand(repo), "dist", ""))]
   skip_if(length(fs) == 0L, "no .sas files found")
 
   out <- withr::local_tempdir()
@@ -22,10 +26,11 @@ test_that("every public-corpus job either translates or fails loudly", {
     n_ok <- n_ok + 1L
   }
   # Warn loudly if nothing translated: a pass over zero jobs is not a pass.
-  # Measured 2026-08-20: 57 successful translations across 110 .sas files (26
-  # distinct .qmd outputs -- fewer than 57 because examples/, dist/examples/
-  # and tests/ hold duplicate copies of the same jobs). A drop below this
+  # Measured 2026-09-10 on a clean checkout of the hazard commit CI pins
+  # (dad7978): 37 successful translations across 66 .sas files. examples/
+  # and tests/ hold duplicate copies of the same jobs. A drop below this
   # threshold that isn't explained by a corpus change is a real regression.
+  # (The 2026-08-20 figure, 57 across 110, also counted a local dist/ tree.)
   expect_gt(n_ok, 20L)
 })
 
@@ -38,6 +43,8 @@ test_that("public-corpus jobs that translate also render", {
   skip_if_not(dir.exists(path.expand(corpus)), "hazard checkout not available")
   fs <- list.files(path.expand(corpus),
                    pattern = "[.]sas$", full.names = TRUE, recursive = TRUE)
+  # Same exclusion as above: dist/ is a local install tree, not corpus.
+  fs <- fs[!startsWith(fs, file.path(path.expand(corpus), "dist", ""))]
   skip_if(length(fs) == 0L, "no .sas corpus available")
 
   n_trans <- 0L        # .sas files that translated at all
@@ -53,10 +60,10 @@ test_that("public-corpus jobs that translate also render", {
     if (is.null(job)) next
     n_trans <- n_trans + 1L
 
-    # The corpus holds the same jobs under examples/, dist/examples/ and
-    # tests/, so 57 translations are 22 distinct documents. Fitting each
-    # one once keeps the file inside its time budget; the duplicates would
-    # exercise byte-identical calls.
+    # The corpus holds the same jobs under examples/ and tests/, so 37
+    # translations are 21 distinct documents. Fitting each one once keeps
+    # the file inside its time budget; the duplicates would exercise
+    # byte-identical calls.
     key <- paste(vapply(job$calls, function(x) paste(deparse(x), collapse = " "), ""),
                  collapse = " ;; ")
     if (!is.null(seen[[key]])) next
@@ -131,13 +138,15 @@ test_that("public-corpus jobs that translate also render", {
   # quietly reducing what is tested. Floors, not equalities, so a corpus
   # that grows does not fail.
   #
-  # Re-measured 2026-09-10: 10 eligible, 12 partial. The eleventh eligible
-  # job, hm.dthar.TGA.sas, never rendered a fit: its second PARMS is a `?`
-  # template, so fit_2 was hazard(fit = TRUE, theta = c()) and bound an
-  # unfitted object, which this test counted as rendered. The translator
-  # now emits a stop() there, which makes the job partial.
+  # Re-measured 2026-09-10 on a clean checkout of the hazard commit CI pins
+  # (dad7978), dist/ excluded above: 37 translations, 21 distinct
+  # documents, 10 eligible and all 10 rendering, 11 partial. The 2026-08-22
+  # figures also counted a local dist/ install tree. That tree is the only
+  # place hm.dthar.TGA.sas exists, the job whose `?` PARMS template now emits
+  # a stop() instead of an unfitted fit; that shape is tested without the
+  # corpus in test-sas-translate-fits.R.
   expect_gt(n_trans, 20L)
   expect_gte(n_eligible, 10L)
-  expect_gte(n_partial, 12L)
+  expect_gte(n_partial, 11L)
   expect_equal(n_rendered, n_eligible)
 })


### PR DESCRIPTION
## What

The **ubuntu-latest / release** job in `R-CMD-check.yaml` now checks out the public SAS reference corpus, [`ehrlinger/hazard`](https://github.com/ehrlinger/hazard), pinned at `dad7978`. It points `HAZARD_REPO` and `HAZARD_EXAMPLES_DIR` at it, so the SAS parity tests and the translator corpus test run on CI instead of skipping.

Until now they ran only on a machine with `~/Documents/GitHub/hazard`. A green CI run said nothing about them, and the corpus test is the one that caught #243's translator issue.

## Design

- **One runner only.** The added tests take about 110s (`test-sas-parity.R`) plus 23–30s (the corpus test) locally, and more on a runner. Windows is already the slowest job, at about 45 min. ubuntu-release is already a required check, so these tests now block merges with no ruleset change.
- **Pinned to a commit.** A change in `hazard` can't move this package's CI unannounced. Moving the pin is a deliberate PR, because the corpus test's floors are measured against it.
- **Checked out beside the package, then moved to `$RUNNER_TEMP`.** Anything left in the package root would be packed into the tarball by `R CMD build`.
- **Fails loudly if the fixtures are missing.** A step checks for `examples/hz.death.AVC.lst`, `hz.deadp.KUL.lst` and `hz.te123.OMC.sas` and fails the job if any is absent. A moved path therefore turns CI red instead of back into silent, green skips.
- No `pull_request_target` or event data is involved. `ref` is a literal SHA, and `persist-credentials: false` is set.

## What the local proof found: the corpus test was measuring a local build artefact

Before pushing, I ran the four affected test files against a **fresh clone at the pin**. `HOME` pointed at an empty directory, so the `~/Documents/GitHub/hazard` default couldn't satisfy anything. The env vars work: the tests read the clone, and the control run without them skips.

**But the corpus test failed** (`n_partial` 11 < 12). The local checkout matches `dad7978` according to `git status`, but it also holds **`dist/`, a gitignored `make install --prefix=./dist` tree from April** with 44 extra `.sas` files. The corpus test lists `.sas` files recursively, so its floors had been measured over files that exist only on this machine:

| Tree | `.sas` files | translations | distinct | eligible | partial | rendered |
|---|---|---|---|---|---|---|
| clean clone at `dad7978` (what CI sees) | 66 | 37 | 21 | 10 | 11 | 10 |
| local, before this PR (`dist/` counted) | 110 | 57 | 22 | 10 | **12** | 10 |
| local, with this PR (`dist/` excluded) | 68 | 39 | 21 | 10 | 11 | 10 |

**Correction to #243.** The corpus job that #243 turned from "rendered" into "partial", `hm.dthar.TGA.sas`, **exists only in that `dist/` tree**. It isn't tracked anywhere in `hazard`. The comment I wrote in #243 cited it as corpus evidence, which was wrong. The translator fix is still tested on CI, without the corpus, in `test-sas-translate-fits.R`.

**Fix in `test-sas-translate-corpus.R`:**
- Both tests exclude the top-level `dist/`, so a local run and CI measure the same corpus (the distinct/eligible/partial/rendered counts now match).
- The partial floor is 11, the clean-tree count.
- The measurement comments are corrected and dated.

The test now passes on all three trees: 142 passes on the clean pin, 146 locally, 0 failures.

## Coverage: before and after

On the latest green `main` run (`34517773078`), ubuntu-release skipped 44–45 tests against 6 locally. This PR should recover **21** of them:
- 17 in `test-sas-parity.R`;
- 3 "hazard checkout not available" (the corpus and grammar tests);
- 1 `hz.te123.OMC.sas` round-trip.

What stays CI-only, because no runner can satisfy it:
- the `bh.dead` helpers (they live in `inst/dev/`, which the built tarball excludes);
- the C `hazard` binary;
- the private maze datasets;
- the generated weighted-parity fixture.

`AGENTS.md` describes the mechanism. I'll stamp the measured ubuntu-release skip count there from this PR's own CI run.

## Gates

| Gate | Result |
|---|---|
| `actionlint` on `R-CMD-check.yaml` | clean |
| `lintr::lint()` on the changed test | 0 lints |
| Corpus test vs a fresh clone at `dad7978`, with `HOME` redirected so the default path cannot help | 0 failed, 142 passed |
| Corpus test vs the local checkout (with its `dist/`) | 0 failed, 146 passed |
| All four `HAZARD_REPO` / `HAZARD_EXAMPLES_DIR` test files vs the fresh clone | read the clone; the control without the env vars skips |
| `NOT_CRAN=true devtools::test()` | **0 failed, 6 skipped, 4149 passed** |

**Not run, and why:**
- **`devtools::document()`:** no roxygen changed.
- **`spelling`:** it doesn't cover `AGENTS.md`.
- **Local `R CMD check --as-cran`:** the only tarball change is `tests/testthat/test-sas-translate-corpus.R`, and that file is skipped under `--as-cran` (`skip_on_cran()`). `.github/` and `AGENTS.md` are `.Rbuildignore`d.

The real evidence for this PR is its own CI run: ubuntu-release has to show the SAS tests running, not skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
