### PR TITLE
test: keep maze parity failure output to counts only

### DIFF
--- a/tests/testthat/test-repeated-events-parity.R
+++ b/tests/testthat/test-repeated-events-parity.R
@@ -45,9 +45,12 @@ test_that("hz.ce_cardioversion_repeated.ehb: %repeat reproduces the SAS log and 
   expect_equal(shapes[, 2], c(358L, 358L, 358L, 360L, 361L, 367L - 2L, 367L - 2L))
 
   # The exported function is the same seven stages, and this data trips none of
-  # its input warnings.
-  expect_no_warning(events <- hzr_repeated_events(bd_card, id, tm, fu, ind))
-  expect_equal(events, `row.names<-`(s7, NULL))
+  # its input warnings. Those warnings name subjects, so they are counted here,
+  # never printed; and the comparison with the stages reports a bare FALSE
+  # rather than a diff of patient rows.
+  warned <- testthat::capture_warnings(events <- hzr_repeated_events(bd_card, id, tm, fu, ind))
+  expect_length(warned, 0L)
+  expect_true(isTRUE(all.equal(events, `row.names<-`(s7, NULL))))
 
   # The job's line 65, after the macro. It moves an event time that does not
   # exceed its start; it removes no rows (.log line 315: 962 in, 962 out).
@@ -94,10 +97,16 @@ test_that("hz.ce_cardioversion_repeated.ehb: the result does not depend on input
     row.names(x) <- NULL
     x
   }
-  run <- function(d) hzr_repeated_events(d, "ccfid", "iv_event", "iv_end", "ce_card")
+  # Its warnings name subjects, and would print without failing the test.
+  run <- function(d) {
+    warned <- testthat::capture_warnings(out <- hzr_repeated_events(d, "ccfid", "iv_event", "iv_end", "ce_card"))
+    expect_length(warned, 0L)
+    out
+  }
   base <- canon(run(bd_card))
+  # `canon()` keeps ccfid, so a failure must not print a diff.
   for (k in 1:5) {
     shuffled <- withr::with_seed(k, bd_card[sample(nrow(bd_card)), , drop = FALSE])
-    expect_equal(canon(run(shuffled)), base, label = paste("shuffle", k))
+    expect_true(isTRUE(all.equal(canon(run(shuffled)), base)), label = paste("shuffle", k))
   }
 })


### PR DESCRIPTION
## What this does

`tests/testthat/test-repeated-events-parity.R` runs `hzr_repeated_events()` on PHI from the maze study volume. Four places in it could print patient identifiers. This makes their output counts only.

| Where | Before | Why it leaked | After |
|---|---|---|---|
| test 1, line 49 | `expect_no_warning(events <- hzr_repeated_events(...))` | the failure message quotes the warning, and the function's input warnings name subjects via `.hzr_re_subject_list()` | `warned <- testthat::capture_warnings(...)` then `expect_length(warned, 0L)` |
| test 1, line 50 | `expect_equal(events, s7)` | a waldo diff prints differing cells, including `ccfid` and dates | `expect_true(isTRUE(all.equal(...)))` |
| test 2, `run()` | called `hzr_repeated_events()` six times without capturing warnings | testthat prints warnings **without failing the test**, so it would pass while printing IDs | `run()` captures the warnings and asserts there are none |
| test 2, shuffle check | `expect_equal(canon(run(shuffled)), base, ...)` | the same diff problem, since `canon()` keeps `ccfid` | `expect_true(isTRUE(all.equal(...)), label = paste("shuffle", k))` |

The remaining assertions compare dimensions, counts, sums and ratios of aggregates, so they cannot print a row or an identifier.

This uses the same pattern as `test-repeated-events-renewal-parity.R` (#248). That PR settled on `capture_warnings()` rather than a hand-rolled `withCallingHandlers()` counter because it is simpler and equally silent.

## Verified

- **The test still passes with data behind it.** With the maze volume mounted and `NOT_CRAN=true`: 26 passed, 0 skipped, 0 warnings. That is 14 in the first block and 12 in the second, which gained 6 `expect_length()` checks from `run()`.
- **Failures print no data.** I forced each new assertion form to fail on a planted identifier. `capture_warnings()` + `expect_length()` printed only the length. `expect_true(isTRUE(all.equal()))` printed only `FALSE`, with or without `label =`. Neither printed the identifier.
- **The comparison is not weakened.** Per `r-reviewer`, `all.equal()` uses the same default tolerance and mean-relative-difference rule as edition-3 `expect_equal()`, and still checks names, row names and attributes. What changes is diagnosis only: a failure now says `FALSE` and nothing about where.

## Known and left alone

- `canon()` builds its call with `do.call(order, ...)`, which puts the column values into the call. If `order()` ever errored, the backtrace could print the start of the `ccfid` vector. `order()` does not error on this data, so I noted it rather than restructured it.
- **#247 has the same leak.** Its new `cardioversion_events()` helper calls `hzr_repeated_events()` without capturing warnings, and in the stratified-model test it runs outside any warning assertion. It should get the same treatment in that PR.

## Merge with #247

Both PRs edit this file. #247 appends new tests after line 103, below every line changed here. `git merge-tree` of this head (`f7c1bb5`) with #247's (`967943d`) merges cleanly, with no conflicts.

## Gates

- `devtools::document()`: no diff in `man/`, `NAMESPACE` or `DESCRIPTION`.
- `lintr::lint_package()`: 0 lints.
- `spelling::spell_check_package()`: clean.
- `devtools::test()` with `NOT_CRAN=true`: 0 failures, 6 skips, 4194 passes. This ran before the `run()` fix, which touched only this test file; that file was re-run afterwards with the volume mounted (26/26, 0 warnings).
- `R CMD check --as-cran` with the manual, from a `git archive` of the commit: Status: OK (0 errors, 0 warnings, 0 notes) on `f7c1bb5`, and the tarball contains no `CLAUDE`/`AGENTS` files.
- `r-reviewer`: found the `run()` leak (fixed here) and the `do.call` edge case (noted above). It found the rewritten assertions sound.

Test-only. No version bump, no NEWS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
