### PR TITLE
fix(gradient, hessian): keep the m finite-difference stencil on one side of m = 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,25 @@
   `NA` exactly when `"weak_direction_check"` is listed. An object saved by an
   earlier version prints "not recorded" rather than "none".
 
+## Bug fixes
+
+* **The multiphase gradient is now right when an early phase's `m` is near
+  0.** The derivative with respect to `m` is a finite difference, and its
+  stencil, about 6e-6 wide, straddled 0 whenever `|m|` was smaller than
+  that. `hzr_decompos()` changes formula at `m = 0`, and the `m < 0` family
+  meets the `m >= 0` one in a cusp rather than continuing it, so the
+  difference mixed two branches and returned neither side's derivative: +8.4
+  where the true value was -20.2, on a 13-parameter fit that converged to
+  `m = 2.9e-6`. Every other parameter was unaffected. The stencil now keeps
+  the sign of `m`: one-sided on the `m >= 0` side, and no wider than 1% of
+  `|m|` below 0, where the cusp varies on that scale. Likelihood values are
+  unchanged.
+
+  The likelihood itself is still not differentiable at `m = 0`, so a fit
+  whose optimum sits there reports a nonzero gradient. SAS/C never meets the
+  point: it estimates `log|M|` with the sign fixed by the starting value, so
+  `M` cannot reach or cross 0. `hazard()` estimates `m` directly and can.
+
 # TemporalHazard 1.2.10
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,17 +55,25 @@
 
 ## Bug fixes
 
-* **The multiphase gradient is now right when an early phase's `m` is near
-  0.** The derivative with respect to `m` is a finite difference, and its
-  stencil, about 6e-6 wide, straddled 0 whenever `|m|` was smaller than
-  that. `hzr_decompos()` changes formula at `m = 0`, and the `m < 0` family
-  meets the `m >= 0` one in a cusp rather than continuing it, so the
-  difference mixed two branches and returned neither side's derivative: +8.4
-  where the true value was -20.2, on a 13-parameter fit that converged to
-  `m = 2.9e-6`. Every other parameter was unaffected. The stencil now keeps
-  the sign of `m`: one-sided on the `m >= 0` side, and no wider than 1% of
-  `|m|` below 0, where the cusp varies on that scale. Likelihood values are
-  unchanged.
+* **The multiphase gradient and Hessian are now right when an early phase's
+  `m` is near 0.** Both differentiate in `m` by finite differences, and
+  their stencils straddled 0: the gradient's (half-width about 6e-6)
+  whenever `|m|` was smaller than that, the Hessian's (half-width 1.2e-4)
+  whenever `nu > 0` and `|m|` was below 1.2e-4. `hzr_decompos()` changes
+  formula at `m = 0`, and the `m < 0` family meets the `m >= 0` one in a cusp
+  rather than continuing it, so each difference mixed two branches and
+  returned neither side's derivative. The gradient gave +8.4 where the true
+  value was -20.2, on a 13-parameter fit that converged to `m = 2.9e-6`; the
+  Hessian put -4.8e5 on the `m` diagonal where the value is about 0.7, so
+  standard errors of such fits were wrong too. Every other parameter's
+  gradient was unaffected.
+
+  Both stencils now keep the sign of `m`: one-sided on the `m >= 0` side,
+  where the family is smooth. Below 0 the gradient's step is at most 1% of
+  `|m|`, because the cusp varies on that scale, floored at 1e-10 so rounding
+  stays bounded. The Hessian's steps below 0 are one-sided but still 1.2e-4
+  wide, so they stop the branches mixing without resolving the cusp.
+  Likelihood values are unchanged.
 
   The likelihood itself is still not differentiable at `m = 0`, so a fit
   whose optimum sits there reports a nonzero gradient. SAS/C never meets the

--- a/NEWS.md
+++ b/NEWS.md
@@ -58,22 +58,28 @@
 * **The multiphase gradient and Hessian are now right when an early phase's
   `m` is near 0.** Both differentiate in `m` by finite differences, and
   their stencils straddled 0: the gradient's (half-width about 6e-6)
-  whenever `|m|` was smaller than that, the Hessian's (half-width 1.2e-4)
-  whenever `nu > 0` and `|m|` was below 1.2e-4. `hzr_decompos()` changes
-  formula at `m = 0`, and the `m < 0` family meets the `m >= 0` one in a cusp
-  rather than continuing it, so each difference mixed two branches and
-  returned neither side's derivative. The gradient gave +8.4 where the true
-  value was -20.2, on a 13-parameter fit that converged to `m = 2.9e-6`; the
-  Hessian put -4.8e5 on the `m` diagonal where the value is about 0.7, so
-  standard errors of such fits were wrong too. Every other parameter's
-  gradient was unaffected.
+  whenever `|m|` was smaller than that, the analytic Hessian's (half-width
+  1.2e-4) whenever `nu > 0` and `|m|` was below 1.2e-4. `hzr_decompos()`
+  changes formula at `m = 0`, and the `m < 0` family meets the `m >= 0` one
+  in a cusp rather than continuing it, so each difference mixed two
+  branches and returned neither side's derivative. The gradient gave +8.4
+  where the true value was -20.2, on a 13-parameter fit that converged to
+  `m = 2.9e-6`; the Hessian put -4.8e5 on the `m` diagonal where the value
+  is about 0.7, so the standard errors of such fits were wrong too. Every
+  other parameter's gradient was unaffected.
 
-  Both stencils now keep the sign of `m`: one-sided on the `m >= 0` side,
-  where the family is smooth. Below 0 the gradient's step is at most 1% of
-  `|m|`, because the cusp varies on that scale, floored at 1e-10 so rounding
-  stays bounded. The Hessian's steps below 0 are one-sided but still 1.2e-4
-  wide, so they stop the branches mixing without resolving the cusp.
-  Likelihood values are unchanged.
+  Both stencils now keep the sign of `m`, one-sided on the `m >= 0` side,
+  where the family is smooth: there the gradient and the analytic Hessian
+  are now right. Below 0 the gradient's step is at most 1% of `|m|`, because
+  the cusp varies on that scale, floored at 1e-10 so rounding stays bounded.
+  The Hessian's steps below 0 are one-sided but still 1.2e-4 wide: they stop
+  the branches mixing, but for `m` within about 1e-4 below 0 and `nu < 2`
+  they understate the curvature, so the standard error of `m` there is too
+  large (about five times, on the fit the tests use). At `nu = 0` that path
+  used to stop with an error; it now returns these values. Fits whose
+  standard errors come from `numDeriv` -- those with left- or
+  interval-censored rows -- and the score test's information still
+  difference across 0. Likelihood values are unchanged.
 
   The likelihood itself is still not differentiable at `m = 0`, so a fit
   whose optimum sits there reports a nonzero gradient. SAS/C never meets the

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -692,11 +692,28 @@ hzr_phase_cumhaz <- function(time, t_half = 1, nu = 1, m = 0,
     dphi_dnu <- rep(0, n)
   }
 
-  # Derivative w.r.t. m
+  # Derivative w.r.t. m.  hzr_decompos() changes formula at m = 0, and the two
+  # sides do not join smoothly: m >= 0 is one smooth family (Case 1L is the
+  # m -> 0+ limit of Case 1), while Case 2 meets it in a |m|^nu cusp.  A
+  # stencil straddling 0 differences two branches and returns neither side's
+  # derivative -- +8.4 against a true -20.2 at m = 2.9e-6.  SAS/C never meets
+  # this: it estimates log|M| with the sign fixed at setup (hzd_early_t2p.c),
+  # so M cannot reach or cross 0.  Here the stencil keeps the sign of m
+  # instead.  For m < 0 the step is capped at 1% of |m|, because the cusp
+  # varies on the scale of |m|; for m >= 0 near 0 a one-sided second-order
+  # stencil is used, and m = 0 itself takes the m >= 0 side.
   h_m <- eps_rel * max(abs(m), 1)
+  if (m < 0) h_m <- min(h_m, 0.01 * abs(m))
+  forward_m <- m >= 0 && m - h_m < 0
   d_plus  <- perturb_decompos(t_half, nu, m + h_m)
-  d_minus <- perturb_decompos(t_half, nu, m - h_m)
-  if (!is.null(d_plus) && !is.null(d_minus)) {
+  d_minus <- if (forward_m) NULL else perturb_decompos(t_half, nu, m - h_m)
+  d_plus2 <- if (forward_m) perturb_decompos(t_half, nu, m + 2 * h_m) else NULL
+  if (!is.null(d_plus) && !is.null(d_plus2)) {
+    e_plus  <- extract(d_plus, type)
+    e_plus2 <- extract(d_plus2, type)
+    dPhi_dm <- (-3 * base$Phi + 4 * e_plus$Phi - e_plus2$Phi) / (2 * h_m)
+    dphi_dm <- (-3 * base$phi + 4 * e_plus$phi - e_plus2$phi) / (2 * h_m)
+  } else if (!is.null(d_plus) && !is.null(d_minus)) {
     e_plus  <- extract(d_plus, type)
     e_minus <- extract(d_minus, type)
     dPhi_dm <- (e_plus$Phi - e_minus$Phi) / (2 * h_m)

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -700,19 +700,31 @@ hzr_phase_cumhaz <- function(time, t_half = 1, nu = 1, m = 0,
   # this: it estimates log|M| with the sign fixed at setup (hzd_early_t2p.c),
   # so M cannot reach or cross 0.  Here the stencil keeps the sign of m
   # instead.  For m < 0 the step is capped at 1% of |m|, because the cusp
-  # varies on the scale of |m|; for m >= 0 near 0 a one-sided second-order
-  # stencil is used, and m = 0 itself takes the m >= 0 side.
+  # varies on the scale of |m|, and floored at 1e-10 so rounding stays
+  # bounded as m -> 0-.  A stencil that would still reach 0 goes one-sided
+  # and second order: forward from m >= 0 (m = 0 itself takes that side),
+  # backward from m < 0.
   h_m <- eps_rel * max(abs(m), 1)
-  if (m < 0) h_m <- min(h_m, 0.01 * abs(m))
-  forward_m <- m >= 0 && m - h_m < 0
-  d_plus  <- perturb_decompos(t_half, nu, m + h_m)
-  d_minus <- if (forward_m) NULL else perturb_decompos(t_half, nu, m - h_m)
-  d_plus2 <- if (forward_m) perturb_decompos(t_half, nu, m + 2 * h_m) else NULL
-  if (!is.null(d_plus) && !is.null(d_plus2)) {
-    e_plus  <- extract(d_plus, type)
-    e_plus2 <- extract(d_plus2, type)
-    dPhi_dm <- (-3 * base$Phi + 4 * e_plus$Phi - e_plus2$Phi) / (2 * h_m)
-    dphi_dm <- (-3 * base$phi + 4 * e_plus$phi - e_plus2$phi) / (2 * h_m)
+  if (m < 0) h_m <- min(h_m, max(0.01 * abs(m), 1e-10))
+  # +1: forward from m >= 0; -1: backward from m < 0; 0: central.
+  side <- if (m >= 0 && m - h_m < 0) {
+    1
+  } else if (m < 0 && m + h_m >= 0) {
+    -1
+  } else {
+    0
+  }
+  d_plus  <- if (side < 0) NULL else perturb_decompos(t_half, nu, m + h_m)
+  d_minus <- if (side > 0) NULL else perturb_decompos(t_half, nu, m - h_m)
+  d_far   <- if (side != 0) {
+    perturb_decompos(t_half, nu, m + 2 * side * h_m)
+  }
+  d_near  <- if (side > 0) d_plus else d_minus
+  if (side != 0 && !is.null(d_near) && !is.null(d_far)) {
+    e_near  <- extract(d_near, type)
+    e_far   <- extract(d_far, type)
+    dPhi_dm <- side * (-3 * base$Phi + 4 * e_near$Phi - e_far$Phi) / (2 * h_m)
+    dphi_dm <- side * (-3 * base$phi + 4 * e_near$phi - e_far$phi) / (2 * h_m)
   } else if (!is.null(d_plus) && !is.null(d_minus)) {
     e_plus  <- extract(d_plus, type)
     e_minus <- extract(d_minus, type)

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -571,8 +571,14 @@ hzr_phase_cumhaz <- function(time, t_half = 1, nu = 1, m = 0,
 #' Derivatives of phase cumulative and instantaneous hazard w.r.t. shape params
 #'
 #' Computes \eqn{\Phi_j(t)}, \eqn{\phi_j(t)}, and their derivatives with
-#' respect to `t_half`, `nu`, and `m` using central finite differences on
-#' [hzr_decompos()].  The `log_t_half` derivative is obtained via the chain
+#' respect to `t_half`, `nu`, and `m` using finite differences on
+#' [hzr_decompos()]: central in `t_half` and `nu`, and in `m` central except
+#' near `m = 0`, where the stencil keeps the sign of `m`.  [hzr_decompos()]
+#' changes formula at `m = 0` and the two sides meet in a cusp, so for
+#' `m >= 0` a stencil that would reach 0 becomes one-sided forward (second
+#' order), and for `m < 0` the step is capped at 1% of `|m|` (floored at
+#' 1e-10) and becomes one-sided backward if it would still reach 0.  The
+#' `log_t_half` derivative is obtained via the chain
 #' rule: \eqn{d\Phi/d(\log t_{1/2}) = t_{1/2} \cdot d\Phi/dt_{1/2}}.
 #'
 #' @param time Numeric vector of positive times.

--- a/R/hessian-multiphase.R
+++ b/R/hessian-multiphase.R
@@ -154,8 +154,9 @@ NULL
   }
 
   # nu / m cross: corners (nu_p, m_p), (nu_p, m_m), (nu_m, m_p), (nu_m, m_m).
-  # Under m_boundary, use forward-in-m / central-in-nu (nu_m is valid here --
-  # only m is boundary-restricted). Under nu_boundary, use forward-in-nu /
+  # Under m_boundary, use one-sided-in-m (toward m_dir) / central-in-nu (nu_m
+  # is valid here -- only m is boundary-restricted). Under nu_boundary, use
+  # forward-in-nu /
   # central-in-m (m_m is valid here -- only nu is boundary-restricted). Under
   # both, step one-sided in each: forward in nu, toward m_dir in m.
   if (m_boundary && nu_boundary) {

--- a/R/hessian-multiphase.R
+++ b/R/hessian-multiphase.R
@@ -21,7 +21,10 @@ NULL
 #' Computes the six unique mixed second partial derivatives of
 #' \eqn{\Phi_j(t)} (cumulative shape) and \eqn{\phi_j(t)} (instantaneous
 #' shape) with respect to the internal shape parameters
-#' \eqn{\{log\_t\_half, \nu, m\}} via second-order central differences.
+#' \eqn{\{log\_t\_half, \nu, m\}} via second-order central differences,
+#' except where a stencil would cross into an undefined region or reach
+#' across \eqn{m = 0}: there it steps one-sided, forward from \eqn{m \ge 0}
+#' and backward from \eqn{m < 0}.
 #'
 #' This is the second-derivative analogue of \code{.hzr_phase_derivatives()}.
 #'
@@ -61,7 +64,9 @@ NULL
   # they only stop the two branches being mixed. The two conditions hold
   # together only for m just below 0 with nu in [0, h), where the nu / m
   # cross term steps one-sided in both.
-  m_dir <- if (m >= 0 && m < h) 1 else if (m < 0 && m > -h) -1 else 0
+  # Inclusive below, as in the gradient (`m + h_m >= 0`): at m = -h exactly a
+  # central stencil would put m + h on 0 itself, the m >= 0 family.
+  m_dir <- if (m >= 0 && m < h) 1 else if (m < 0 && m >= -h) -1 else 0
   m_boundary  <- m_dir != 0
   nu_boundary <- m  < 0 && abs(nu) < h
 

--- a/R/hessian-multiphase.R
+++ b/R/hessian-multiphase.R
@@ -50,10 +50,19 @@ NULL
   # step below would probe the OTHER parameter's -h side, which crosses into
   # that undefined region. Detect it and fall back to a forward-only
   # (one-sided) difference in just that one direction; every other
-  # direction/pair keeps the ordinary central-difference formula. (The two
-  # conditions can't both hold: that would require m < 0 && nu < 0
-  # simultaneously, which d00 above would already have rejected.)
-  m_boundary  <- nu < 0 && abs(m)  < h
+  # direction/pair keeps the ordinary central-difference formula.
+  #
+  # m's stencil must not reach across m = 0 whatever the sign of nu, either:
+  # hzr_decompos() changes formula there, and the m < 0 family meets the
+  # m >= 0 one in a cusp, so a central difference mixes two branches. It put
+  # -4.8e5 on the m diagonal at m = 5e-6, where the value is O(1). m_dir is
+  # the side the one-sided stencil steps to: forward from m >= 0, backward
+  # from m < 0. Backward steps of h cannot resolve the cusp when |m| << h;
+  # they only stop the two branches being mixed. The two conditions hold
+  # together only for m just below 0 with nu in [0, h), where the nu / m
+  # cross term steps one-sided in both.
+  m_dir <- if (m >= 0 && m < h) 1 else if (m < 0 && m > -h) -1 else 0
+  m_boundary  <- m_dir != 0
   nu_boundary <- m  < 0 && abs(nu) < h
 
   # Perturbed values on each internal scale:
@@ -63,7 +72,8 @@ NULL
   t_m  <- t_half * exp(-h)
   nu_p <- nu + h
   nu_m <- if (nu_boundary) NA_real_ else nu - h
-  m_p  <- m  + h
+  # Under m_boundary, m_p is the near point on the m_dir side.
+  m_p  <- if (m_boundary) m + m_dir * h else m + h
   m_m  <- if (m_boundary)  NA_real_ else m  - h
 
   # Six single-parameter perturbations for diagonal second differences
@@ -77,9 +87,10 @@ NULL
 
   h2 <- h * h
 
-  # Diagonal second differences. At a boundary, use the forward second
-  # difference (f(x+2h) - 2f(x+h) + f(x)) / h^2 -- valid but O(h) rather
-  # than O(h^2) locally, exactly at these two named limiting cases.
+  # Diagonal second differences. At a boundary, use the one-sided second
+  # difference (f(x+2sh) - 2f(x+sh) + f(x)) / h^2, s = +1 except for a
+  # backward step in m (s = m_dir) -- valid but O(h) rather than O(h^2)
+  # locally, and used only at the boundaries above.
   d2Phi_tt <- (d_tp$Phi - 2 * d00$Phi + d_tm$Phi) / h2
   d2phi_tt <- (d_tp$phi - 2 * d00$phi + d_tm$phi) / h2
 
@@ -93,7 +104,7 @@ NULL
   }
 
   if (m_boundary) {
-    d_mp2 <- eval_at(t_half, nu, m + 2 * h)
+    d_mp2 <- eval_at(t_half, nu, m + 2 * m_dir * h)
     d2Phi_mm_ <- (d_mp2$Phi - 2 * d_mp$Phi + d00$Phi) / h2
     d2phi_mm_ <- (d_mp2$phi - 2 * d_mp$phi + d00$phi) / h2
   } else {
@@ -122,16 +133,17 @@ NULL
   }
 
   # t_half / m cross: corners (t_p, m_p), (t_p, m_m), (t_m, m_p), (t_m, m_m).
-  # Under m_boundary, use forward-in-m / central-in-t_half instead (drops
-  # the m_m corners).
+  # Under m_boundary, use one-sided-in-m (toward m_dir) / central-in-t_half
+  # instead (drops the m_m corners); m_dir restores the sign of a backward
+  # step.
   if (m_boundary) {
     # d_tp/d_tm (= eval_at(t_p/t_m, nu, m)) already computed above
     e_tm_pp <- eval_at(t_p, nu, m_p)
     e_tm_mp <- eval_at(t_m, nu, m_p)
-    d2_tm_Phi <- ((e_tm_pp$Phi - d_tp$Phi) -
-                    (e_tm_mp$Phi - d_tm$Phi)) / (2 * h2)
-    d2_tm_phi <- ((e_tm_pp$phi - d_tp$phi) -
-                    (e_tm_mp$phi - d_tm$phi)) / (2 * h2)
+    d2_tm_Phi <- m_dir * ((e_tm_pp$Phi - d_tp$Phi) -
+                            (e_tm_mp$Phi - d_tm$Phi)) / (2 * h2)
+    d2_tm_phi <- m_dir * ((e_tm_pp$phi - d_tp$phi) -
+                            (e_tm_mp$phi - d_tm$phi)) / (2 * h2)
   } else {
     e_tm_pp <- eval_at(t_p, nu, m_p)
     e_tm_pm <- eval_at(t_p, nu, m_m)
@@ -144,15 +156,20 @@ NULL
   # nu / m cross: corners (nu_p, m_p), (nu_p, m_m), (nu_m, m_p), (nu_m, m_m).
   # Under m_boundary, use forward-in-m / central-in-nu (nu_m is valid here --
   # only m is boundary-restricted). Under nu_boundary, use forward-in-nu /
-  # central-in-m (m_m is valid here -- only nu is boundary-restricted).
-  if (m_boundary) {
+  # central-in-m (m_m is valid here -- only nu is boundary-restricted). Under
+  # both, step one-sided in each: forward in nu, toward m_dir in m.
+  if (m_boundary && nu_boundary) {
+    e_nm_pp <- eval_at(t_half, nu_p, m_p)
+    d2_nm_Phi <- m_dir * (e_nm_pp$Phi - d_np$Phi - d_mp$Phi + d00$Phi) / h2
+    d2_nm_phi <- m_dir * (e_nm_pp$phi - d_np$phi - d_mp$phi + d00$phi) / h2
+  } else if (m_boundary) {
     # d_np/d_nm (= eval_at(t_half, nu_p/nu_m, m)) already computed above
     e_nm_pp <- eval_at(t_half, nu_p, m_p)
     e_nm_mp <- eval_at(t_half, nu_m, m_p)
-    d2_nm_Phi <- ((e_nm_pp$Phi - d_np$Phi) -
-                    (e_nm_mp$Phi - d_nm$Phi)) / (2 * h2)
-    d2_nm_phi <- ((e_nm_pp$phi - d_np$phi) -
-                    (e_nm_mp$phi - d_nm$phi)) / (2 * h2)
+    d2_nm_Phi <- m_dir * ((e_nm_pp$Phi - d_np$Phi) -
+                            (e_nm_mp$Phi - d_nm$Phi)) / (2 * h2)
+    d2_nm_phi <- m_dir * ((e_nm_pp$phi - d_np$phi) -
+                            (e_nm_mp$phi - d_nm$phi)) / (2 * h2)
   } else if (nu_boundary) {
     # d_mp/d_mm (= eval_at(t_half, nu, m_p/m_m)) already computed above
     e_nm_pp <- eval_at(t_half, nu_p, m_p)

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -772,9 +772,10 @@
 #' Gradient of the multiphase log-likelihood
 #'
 #' Computes the score vector \eqn{d\ell / d\theta} using analytic chain-rule
-#' formulas for `log_mu` and `beta` parameters, and central-difference
+#' formulas for `log_mu` and `beta` parameters, and finite-difference
 #' derivatives (via `.hzr_phase_derivatives()`) for shape parameters
-#' (`log_t_half`, `nu`, `m`).
+#' (`log_t_half`, `nu`, `m`): central, except that the `m` stencil stays on
+#' the side of `m` near `m = 0`, where the phase family has a cusp.
 #'
 #' @inheritParams .hzr_logl_multiphase
 #' @return Numeric vector of length `length(theta)` -- the gradient.

--- a/man/dot-hzr_gradient_multiphase.Rd
+++ b/man/dot-hzr_gradient_multiphase.Rd
@@ -51,8 +51,9 @@ Returns a zero vector if any component is non-finite (guards optimizer).
 }
 \description{
 Computes the score vector \eqn{d\ell / d\theta} using analytic chain-rule
-formulas for \code{log_mu} and \code{beta} parameters, and central-difference
+formulas for \code{log_mu} and \code{beta} parameters, and finite-difference
 derivatives (via \code{.hzr_phase_derivatives()}) for shape parameters
-(\code{log_t_half}, \code{nu}, \code{m}).
+(\code{log_t_half}, \code{nu}, \code{m}): central, except that the \code{m} stencil stays on
+the side of \code{m} near \code{m = 0}, where the phase family has a cusp.
 }
 \keyword{internal}

--- a/man/dot-hzr_phase_derivatives.Rd
+++ b/man/dot-hzr_phase_derivatives.Rd
@@ -38,8 +38,14 @@ Named list:
 }
 \description{
 Computes \eqn{\Phi_j(t)}, \eqn{\phi_j(t)}, and their derivatives with
-respect to \code{t_half}, \code{nu}, and \code{m} using central finite differences on
-\code{\link[=hzr_decompos]{hzr_decompos()}}.  The \code{log_t_half} derivative is obtained via the chain
+respect to \code{t_half}, \code{nu}, and \code{m} using finite differences on
+\code{\link[=hzr_decompos]{hzr_decompos()}}: central in \code{t_half} and \code{nu}, and in \code{m} central except
+near \code{m = 0}, where the stencil keeps the sign of \code{m}.  \code{\link[=hzr_decompos]{hzr_decompos()}}
+changes formula at \code{m = 0} and the two sides meet in a cusp, so for
+\code{m >= 0} a stencil that would reach 0 becomes one-sided forward (second
+order), and for \code{m < 0} the step is capped at 1\% of \verb{|m|} (floored at
+1e-10) and becomes one-sided backward if it would still reach 0.  The
+\code{log_t_half} derivative is obtained via the chain
 rule: \eqn{d\Phi/d(\log t_{1/2}) = t_{1/2} \cdot d\Phi/dt_{1/2}}.
 }
 \keyword{internal}

--- a/tests/testthat/test-multiphase-gradient.R
+++ b/tests/testthat/test-multiphase-gradient.R
@@ -232,6 +232,105 @@ test_that(".hzr_phase_derivatives works for all 6 decomposition cases", {
   }
 })
 
+# ============================================================================
+# The m derivative near m = 0
+# ============================================================================
+#
+# hzr_decompos() changes formula at m = 0, and Case 2 (m < 0) meets the
+# m >= 0 family in a |m|^nu cusp, so a difference stencil that straddles 0
+# mixes two branches. numerical_gradient() above straddles too -- its step is
+# eps^(1/3) * max(|theta|, 1), about 6e-6 for any |m| < 1 -- so it cannot be
+# the reference here. This one keeps every stencil point on the side of `x`
+# (the step is at most 1% of |x|) and Richardson-extrapolates; at x = 0 it
+# differences forward, the m >= 0 side.
+onside_derivative <- function(f, x, base = NULL) {
+  if (x == 0) {
+    h <- 1e-4 * 2^-(0:5)
+    d <- sapply(h, function(hh) (f(hh) - f(0)) / hh)
+    for (k in 1:4) d <- (2^k * d[-1] - d[-length(d)]) / (2^k - 1)
+    return(d[length(d)])
+  }
+  if (is.null(base)) base <- 1e-2 * abs(x)
+  h <- base * 2^-(0:3)
+  d <- sapply(h, function(hh) (f(x + hh) - f(x - hh)) / (2 * hh))
+  for (k in 1:3) d <- (4^k * d[-1] - d[-length(d)]) / (4^k - 1)
+  d[length(d)]
+}
+
+test_that(".hzr_phase_derivatives dPhi/dm does not straddle m = 0", {
+  t_grid <- c(0.05, 0.3, 2, 10)
+  t_half <- 0.28
+  for (nu in c(0.5, 0.905, 2)) for (m in c(-5e-6, 0, 5e-6)) {
+    for (type in c("cdf", "hazard")) {
+      pd <- .hzr_phase_derivatives(t_grid, t_half = t_half, nu = nu, m = m,
+                                   type = type)
+      cumhaz_at <- function(tt, z) {
+        hzr_phase_cumhaz(tt, t_half = t_half, nu = nu, m = z, type = type)
+      }
+      hazard_at <- function(tt, z) {
+        hzr_phase_hazard(tt, t_half = t_half, nu = nu, m = z, type = type)
+      }
+      ref_Phi <- sapply(t_grid, function(tt) {
+        onside_derivative(function(z) cumhaz_at(tt, z), m)
+      })
+      ref_phi <- sapply(t_grid, function(tt) {
+        onside_derivative(function(z) hazard_at(tt, z), m)
+      })
+      lab <- sprintf("nu = %g, m = %g, %s", nu, m, type)
+      # Relative to the largest reference entry: a straddling stencil misses
+      # by 10% to 100000% on this grid, the one-sided one by at most 7e-5.
+      expect_lt(max(abs(pd$dPhi_dm - ref_Phi)) / max(abs(ref_Phi)), 1e-3,
+                label = paste("dPhi/dm error,", lab))
+      expect_lt(max(abs(pd$dphi_dm - ref_phi)) / max(abs(ref_phi)), 1e-3,
+                label = paste("dphi/dm error,", lab))
+    }
+  }
+})
+
+test_that("multiphase gradient is right for m within 1e-5 of 0, both signs", {
+  set.seed(42)
+  n <- 200
+  time   <- rexp(n, rate = 0.3) + 0.01
+  status <- sample(0:1, n, replace = TRUE, prob = c(0.3, 0.7))
+  x_mat  <- matrix(rnorm(n * 2), ncol = 2, dimnames = list(NULL, c("age", "sex")))
+  phases <- list(
+    early = hzr_phase("cdf",    t_half = 0.3, nu = 0.9, m = 0),
+    late  = hzr_phase("hazard", t_half = 5,   nu = 1,   m = 1)
+  )
+  covariate_counts <- c(early = 2L, late = 2L)
+  x_list <- list(early = x_mat, late = x_mat)
+  ll <- function(th) {
+    .hzr_logl_multiphase(
+      th, time, status,
+      phases = phases, covariate_counts = covariate_counts, x_list = x_list
+    )
+  }
+
+  for (m in c(-5e-6, 5e-6)) {
+    # [log_mu, log_t_half, nu, m, beta1, beta2] per phase; early m is index 4.
+    theta <- c(log(0.1), log(0.3), 0.9, m, 0.5, -0.3,
+               log(0.01), log(5), 1, 1, 0.1, 0.2)
+    grad <- .hzr_gradient_multiphase(
+      theta, time, status,
+      phases = phases, covariate_counts = covariate_counts, x_list = x_list
+    )
+    ref <- vapply(seq_along(theta), function(i) {
+      f <- function(z) {
+        th <- theta
+        th[i] <- z
+        ll(th)
+      }
+      onside_derivative(f, theta[i],
+                        base = if (i == 4L) NULL else 1e-3 * max(abs(theta[i]), 1))
+    }, numeric(1))
+    # Per component, so one wrong entry cannot hide behind the others.
+    expect_true(all(abs(grad - ref) <= 1e-4 * pmax(abs(ref), 1)),
+                label = sprintf("gradient at m = %g; worst component %d, error %.3g",
+                                m, which.max(abs(grad - ref) / pmax(abs(ref), 1)),
+                                max(abs(grad - ref))))
+  }
+})
+
 
 # ============================================================================
 # Full gradient tests on KUL dataset

--- a/tests/testthat/test-multiphase-gradient.R
+++ b/tests/testthat/test-multiphase-gradient.R
@@ -441,6 +441,45 @@ test_that("Hessian second derivatives step backward, not across, below m = 0", {
   expect_true(within(sd2$d2Phi_dlog_thalf_dm, ref_tm),
               label = "d2Phi/dlog_thalf dm")
   expect_true(within(sd2$d2Phi_dnu_dm, ref_nm), label = "d2Phi/dnu dm")
+
+  # The same three terms for phi, which for the cdf type is the density g.
+  g <- function(th, n, mm) hzr_decompos(t_grid, th, n, mm)$g
+  gref_mm <- (g(t_half, nu, m + hm) - 2 * g(t_half, nu, m) +
+                g(t_half, nu, m - hm)) / hm^2
+  gref_tm <- (g(t_half * exp(ht), nu, m + hm) - g(t_half * exp(ht), nu, m - hm) -
+                g(t_half * exp(-ht), nu, m + hm) +
+                g(t_half * exp(-ht), nu, m - hm)) / (4 * ht * hm)
+  gref_nm <- (g(t_half, nu + hn, m + hm) - g(t_half, nu + hn, m - hm) -
+                g(t_half, nu - hn, m + hm) + g(t_half, nu - hn, m - hm)) /
+    (4 * hn * hm)
+  expect_true(within(sd2$d2phi_dm2, gref_mm), label = "d2phi/dm2")
+  expect_true(within(sd2$d2phi_dlog_thalf_dm, gref_tm),
+              label = "d2phi/dlog_thalf dm")
+  expect_true(within(sd2$d2phi_dnu_dm, gref_nm), label = "d2phi/dnu dm")
+})
+
+test_that("the Hessian's m stencil never reaches 0 from below, m = -h included", {
+  # At m = -h exactly a central stencil puts m + h on 0 itself, which belongs
+  # to the m >= 0 family. Record every m the Hessian evaluates Phi at and
+  # require all of them below 0. (A value comparison cannot see this: at
+  # nu = 2 both stencils are accurate there.)
+  h <- .hzr_h2
+  real <- .hzr_phase_derivatives
+  seen <- numeric(0)
+  testthat::local_mocked_bindings(
+    .hzr_phase_derivatives = function(time, t_half, nu, m, type) {
+      seen <<- c(seen, m)
+      real(time, t_half = t_half, nu = nu, m = m, type = type)
+    }
+  )
+  for (m in c(-h, -h / 2, -2 * h)) {
+    seen <- numeric(0)
+    .hzr_phase_second_derivatives(c(0.3, 2), t_half = 0.28, nu = 2, m = m,
+                                  type = "cdf")
+    expect_true(length(seen) > 0 && all(seen < 0),
+                label = sprintf("stencil points below 0 at m = %g; max %g",
+                                m, max(seen)))
+  }
 })
 
 test_that("Hessian second derivatives are finite with m and nu both at a boundary", {

--- a/tests/testthat/test-multiphase-gradient.R
+++ b/tests/testthat/test-multiphase-gradient.R
@@ -260,30 +260,64 @@ onside_derivative <- function(f, x, base = NULL) {
 test_that(".hzr_phase_derivatives dPhi/dm does not straddle m = 0", {
   t_grid <- c(0.05, 0.3, 2, 10)
   t_half <- 0.28
-  for (nu in c(0.5, 0.905, 2)) for (m in c(-5e-6, 0, 5e-6)) {
-    for (type in c("cdf", "hazard")) {
-      pd <- .hzr_phase_derivatives(t_grid, t_half = t_half, nu = nu, m = m,
-                                   type = type)
-      cumhaz_at <- function(tt, z) {
-        hzr_phase_cumhaz(tt, t_half = t_half, nu = nu, m = z, type = type)
-      }
-      hazard_at <- function(tt, z) {
-        hzr_phase_hazard(tt, t_half = t_half, nu = nu, m = z, type = type)
-      }
-      ref_Phi <- sapply(t_grid, function(tt) {
-        onside_derivative(function(z) cumhaz_at(tt, z), m)
-      })
-      ref_phi <- sapply(t_grid, function(tt) {
-        onside_derivative(function(z) hazard_at(tt, z), m)
-      })
-      lab <- sprintf("nu = %g, m = %g, %s", nu, m, type)
-      # Relative to the largest reference entry: a straddling stencil misses
-      # by 10% to 100000% on this grid, the one-sided one by at most 7e-5.
-      expect_lt(max(abs(pd$dPhi_dm - ref_Phi)) / max(abs(ref_Phi)), 1e-3,
-                label = paste("dPhi/dm error,", lab))
-      expect_lt(max(abs(pd$dphi_dm - ref_phi)) / max(abs(ref_phi)), 1e-3,
-                label = paste("dphi/dm error,", lab))
+  # nu = -1 is Case 3L at m = 0 and Case 3 above it; m < 0 is undefined there.
+  # Only the cdf type: the hazard type's Phi = -log(1 - G) loses digits to
+  # cancellation at large t when nu < 0, which is a property of Phi, not of
+  # the stencil.
+  grid <- rbind(
+    expand.grid(nu = c(0.5, 0.905, 2), m = c(-5e-6, 0, 5e-6),
+                type = c("cdf", "hazard"), stringsAsFactors = FALSE),
+    expand.grid(nu = -1, m = c(0, 5e-6), type = "cdf",
+                stringsAsFactors = FALSE)
+  )
+  # Per entry, so a wrong small entry cannot hide behind a large one; the
+  # floor stops an entry near zero demanding more than the reference can
+  # deliver. A straddling stencil misses by 10% to 100000% on this grid.
+  within <- function(v, r) {
+    all(abs(v - r) <= 1e-3 * pmax(abs(r), 1e-2 * max(abs(r))))
+  }
+  for (k in seq_len(nrow(grid))) {
+    nu <- grid$nu[k]
+    m <- grid$m[k]
+    type <- grid$type[k]
+    pd <- .hzr_phase_derivatives(t_grid, t_half = t_half, nu = nu, m = m,
+                                 type = type)
+    cumhaz_at <- function(tt, z) {
+      hzr_phase_cumhaz(tt, t_half = t_half, nu = nu, m = z, type = type)
     }
+    hazard_at <- function(tt, z) {
+      hzr_phase_hazard(tt, t_half = t_half, nu = nu, m = z, type = type)
+    }
+    ref_Phi <- sapply(t_grid, function(tt) {
+      onside_derivative(function(z) cumhaz_at(tt, z), m)
+    })
+    ref_phi <- sapply(t_grid, function(tt) {
+      onside_derivative(function(z) hazard_at(tt, z), m)
+    })
+    lab <- sprintf("nu = %g, m = %g, %s", nu, m, type)
+    expect_true(within(pd$dPhi_dm, ref_Phi), label = paste("dPhi/dm,", lab))
+    expect_true(within(pd$dphi_dm, ref_phi), label = paste("dphi/dm,", lab))
+  }
+})
+
+test_that(".hzr_phase_derivatives dPhi/dm stays bounded as m -> 0 from below", {
+  # For m < 0 the step is 1% of |m|, floored at 1e-10. Without the floor,
+  # rounding grew without bound: dPhi/dm was 36 at m = -1e-15 where it should
+  # be 0.151, and NA at -1e-300. At nu = 2 the derivative is flat in m this
+  # close to 0, so it must hold its value. At nu = 0.9 it grows like
+  # |m|^(nu - 1) toward the cusp, so it is only required to stay finite.
+  d_at <- function(nu, m) {
+    .hzr_phase_derivatives(c(0.05, 2), t_half = 0.28, nu = nu, m = m,
+                           type = "cdf")$dPhi_dm
+  }
+  ref <- d_at(2, -1e-8)
+  for (m in c(-1e-10, -1e-13, -1e-15)) {
+    expect_true(all(abs(d_at(2, m) - ref) <= 1e-2 * abs(ref)),
+                label = sprintf("nu = 2, m = %g", m))
+  }
+  for (m in c(-1e-13, -1e-15, -1e-300)) {
+    expect_true(all(is.finite(d_at(0.9, m))),
+                label = sprintf("nu = 0.9, m = %g", m))
   }
 })
 
@@ -328,6 +362,47 @@ test_that("multiphase gradient is right for m within 1e-5 of 0, both signs", {
                 label = sprintf("gradient at m = %g; worst component %d, error %.3g",
                                 m, which.max(abs(grad - ref) / pmax(abs(ref), 1)),
                                 max(abs(grad - ref))))
+  }
+})
+
+test_that("multiphase Hessian m row does not straddle m = 0", {
+  set.seed(42)
+  n <- 200
+  time   <- rexp(n, rate = 0.3) + 0.01
+  status <- sample(0:1, n, replace = TRUE, prob = c(0.3, 0.7))
+  x_mat  <- matrix(rnorm(n * 2), ncol = 2, dimnames = list(NULL, c("age", "sex")))
+  phases <- list(
+    early = hzr_phase("cdf",    t_half = 0.3, nu = 0.9, m = 0),
+    late  = hzr_phase("hazard", t_half = 5,   nu = 1,   m = 1)
+  )
+  covariate_counts <- c(early = 2L, late = 2L)
+  x_list <- list(early = x_mat, late = x_mat)
+
+  for (m in c(0, 5e-6)) {
+    theta <- c(log(0.1), log(0.3), 0.9, m, 0.5, -0.3,
+               log(0.01), log(5), 1, 1, 0.1, 0.2)
+    H <- .hzr_hessian_multiphase(
+      theta, time = time, status = status, time_lower = NULL,
+      time_upper = NULL, x = NULL, weights = NULL, phases = phases,
+      covariate_counts = covariate_counts, x_list = x_list
+    )
+    # H is the Hessian of the negative log-likelihood, so its m row is minus
+    # the derivative of the score in m. m >= 0 is the smooth side, so the
+    # reference differences the (corrected) score forward from m.
+    score_at <- function(z) {
+      th <- theta
+      th[4] <- m + z
+      .hzr_gradient_multiphase(
+        th, time, status,
+        phases = phases, covariate_counts = covariate_counts, x_list = x_list
+      )
+    }
+    ref <- -vapply(seq_along(theta), function(j) {
+      onside_derivative(function(z) score_at(z)[j], 0)
+    }, numeric(1))
+    expect_true(all(abs(H[4, ] - ref) <= 1e-2 * pmax(abs(ref), 1)),
+                label = sprintf("Hessian m row at m = %g; worst error %.3g",
+                                m, max(abs(H[4, ] - ref))))
   }
 })
 

--- a/tests/testthat/test-multiphase-gradient.R
+++ b/tests/testthat/test-multiphase-gradient.R
@@ -260,7 +260,9 @@ onside_derivative <- function(f, x, base = NULL) {
 test_that(".hzr_phase_derivatives dPhi/dm does not straddle m = 0", {
   t_grid <- c(0.05, 0.3, 2, 10)
   t_half <- 0.28
-  # nu = -1 is Case 3L at m = 0 and Case 3 above it; m < 0 is undefined there.
+  # nu = -1 is Case 3L at m = 0 and Case 3 above it; m < 0 is undefined there,
+  # so the old stencil already fell back to a forward difference and these
+  # rows guard the new one-sided stencil rather than the original straddle.
   # Only the cdf type: the hazard type's Phi = -log(1 - G) loses digits to
   # cancellation at large t when nu < 0, which is a property of Phi, not of
   # the stencil.
@@ -403,6 +405,54 @@ test_that("multiphase Hessian m row does not straddle m = 0", {
     expect_true(all(abs(H[4, ] - ref) <= 1e-2 * pmax(abs(ref), 1)),
                 label = sprintf("Hessian m row at m = %g; worst error %.3g",
                                 m, max(abs(H[4, ] - ref))))
+  }
+})
+
+test_that("Hessian second derivatives step backward, not across, below m = 0", {
+  # At m = -5e-5 the Hessian's 1.2e-4 step would cross 0, so it steps
+  # backward (m_dir = -1). At nu = 2 the m < 0 side is smooth enough for that
+  # to be accurate, which makes it the place to pin the sign of every m term:
+  # dropping or flipping m_dir errs by about 200% here. (At nu < 2 the cusp
+  # varies on the scale of |m| and a 1.2e-4 step understates the curvature;
+  # that limit is documented, not tested.) The references difference Phi with
+  # an m step of 0.1 * |m|, so they stay below 0.
+  t_grid <- c(0.3, 2)
+  t_half <- 0.28
+  nu <- 2
+  m <- -5e-5
+  P <- function(th, n, mm) hzr_decompos(t_grid, th, n, mm)$G
+  hm <- 0.1 * abs(m)
+  ht <- 1e-3
+  hn <- 1e-3
+  ref_mm <- (P(t_half, nu, m + hm) - 2 * P(t_half, nu, m) +
+               P(t_half, nu, m - hm)) / hm^2
+  ref_tm <- (P(t_half * exp(ht), nu, m + hm) - P(t_half * exp(ht), nu, m - hm) -
+               P(t_half * exp(-ht), nu, m + hm) +
+               P(t_half * exp(-ht), nu, m - hm)) / (4 * ht * hm)
+  ref_nm <- (P(t_half, nu + hn, m + hm) - P(t_half, nu + hn, m - hm) -
+               P(t_half, nu - hn, m + hm) + P(t_half, nu - hn, m - hm)) /
+    (4 * hn * hm)
+  sd2 <- .hzr_phase_second_derivatives(t_grid, t_half = t_half, nu = nu,
+                                       m = m, type = "cdf")
+  within <- function(v, r) {
+    all(abs(v - r) <= 0.05 * pmax(abs(r), 1e-2 * max(abs(r))))
+  }
+  expect_true(within(sd2$d2Phi_dm2, ref_mm), label = "d2Phi/dm2")
+  expect_true(within(sd2$d2Phi_dlog_thalf_dm, ref_tm),
+              label = "d2Phi/dlog_thalf dm")
+  expect_true(within(sd2$d2Phi_dnu_dm, ref_nm), label = "d2Phi/dnu dm")
+})
+
+test_that("Hessian second derivatives are finite with m and nu both at a boundary", {
+  # m just below 0 with nu in [0, h): the nu / m cross term steps one-sided
+  # in both. Only finiteness is checked -- the cusp below 0 is not resolved
+  # at this step size (see above) -- but before this branch existed the same
+  # point read a nu - h corner that does not exist.
+  for (nu in c(0, .hzr_h2 / 2)) {
+    sd2 <- .hzr_phase_second_derivatives(c(0.3, 2), t_half = 0.28, nu = nu,
+                                         m = -5e-6, type = "cdf")
+    expect_true(all(vapply(sd2, function(v) all(is.finite(v)), logical(1))),
+                label = sprintf("all second derivatives finite at nu = %g", nu))
   }
 })
 


### PR DESCRIPTION
## What was wrong

The multiphase gradient and the analytic Hessian differentiate in the early phase's shape `m` by finite differences, and both stencils straddled `m = 0`:

- gradient, `.hzr_phase_derivatives()`: central step `eps^(1/3) * max(|m|, 1)` (half-width about 6e-6), so any `|m| < 6e-6`;
- Hessian, `.hzr_phase_second_derivatives()`: step `eps^(1/4)` (1.2e-4), one-sided only when `nu < 0`, so any `nu > 0` with `|m| < 1.2e-4`.

`hzr_decompos()` changes formula at `m = 0` (Case 1 / 1L / 2), and the `m < 0` family does not continue the `m >= 0` one: it meets it in a `|m|^nu` cusp. Profiling logL across `m = 0` shows it: slope -20.2, steady from `m = 1e-8` to `1e-4` on the right; on the left, slopes that grow as `m -> 0-` (46, 60, 79, 103, 170), with `G(-h) - G(0)` proportional to `h^nu`. A stencil across that point returns neither side's derivative.

Found while investigating the default optimizer tolerance (synthetic early-CDF + late-G3 fit, 13 free parameters, `conserve = FALSE`, optimum at `m = 2.9e-6`):

| | analytic | true (on-side) |
|---|---|---|
| gradient, `d logL / d m` | +8.4 | -20.2 |
| Hessian, `H[m, m]` at `m = 5e-6` | -4.8e5 | about 0.69 |

The likelihood values were never wrong; only the derivatives, and through the Hessian, standard errors.

SAS/C never meets this point: `hzd_early_t2p.c:59-61` estimates `log|M|` with the sign fixed by `g1flag` at setup (`setg1.c`), so `M` cannot reach or cross 0. `hazard()` estimates `m` on its natural scale and can. Changing that parameterization is out of scope (likelihood-level); this PR keeps each stencil on the side of `m` instead.

## The fix

- **Gradient.** `m >= 0` with a stencil that would reach 0 (includes `m = 0`, where Case 1L is the smooth `m -> 0+` limit of Case 1): one-sided forward, second order. `m < 0`: step `min(h, max(0.01 |m|, 1e-10))`, and one-sided backward if it would still reach 0. Validated against an on-side Richardson reference over `m` in [-1, 0.5], `nu` in {-1, -0.5, 0.5, 0.905, 2}, cdf and hazard: no worse anywhere; 3.6 -> 1.9e-8 at `m = 0`, 0.73 -> 1.1e-5 at `m = 5e-6`, 7.9e-2 -> 2.3e-6 at `m = -5e-6` (nu = 0.905).
- **Hessian.** The existing one-sided path is keyed on the stencil reaching 0 for any `nu` (`m_dir`: forward from `m >= 0`, backward from `m < 0`), cross terms signed by `m_dir`, plus a branch for `m` and `nu` both on a boundary. Away from `|m| < 1.2e-4` the Hessian is bit-identical to `main` (checked by r-reviewer at `m` = ±0.5, ±2, 1e-3, ±1.3e-4).

## What is still not right (stated in NEWS and the code)

- **Hessian just below 0.** For `m` within about 1e-4 below 0 and `nu < 2`, the backward 1.2e-4 step stops the branches mixing but cannot resolve the cusp: `d2Phi/dm2` is 42 against about 1100 at `nu = 0.9, m = -5e-6`; SE(m) about 5x too large on the test model. At `nu = 2` it is accurate. At `nu = 0` that path used to stop with an error (so the analytic Hessian declined); it now returns these values.
- **numDeriv paths untouched.** Fits with left- or interval-censored rows (Hessian from `numDeriv`, `R/likelihood-multiphase.R`) and the score test's information (`R/score-test.R`) still difference across 0.
- **`hzr_decompos()` itself** overflows in Case 2 for `nu = 2` below `|m|` about 1e-155 (`G = NA`); the derivative inherits it. Value-level, left alone.

## Tests

In `test-multiphase-gradient.R`, all against on-side references (the file's existing `numerical_gradient()` helper straddles 0 the same way, so it could not be the reference):

- `.hzr_phase_derivatives()` d/dm at `m` in {-5e-6, 0, 5e-6} x `nu` in {0.5, 0.905, 2} x cdf/hazard, plus `nu = -1` (cdf), per entry;
- `.hzr_gradient_multiphase()` at `m = ±5e-6` with covariates, per component (the brief's test);
- bounded as `m -> 0-` (the 1e-10 floor);
- Hessian `m` row at `m` in {0, 5e-6} against minus the forward derivative of the corrected score;
- Hessian backward branch at `nu = 2, m = -5e-5` (diagonal and both cross terms); both-boundary smoke test.

Mutation evidence: against `main`'s code the new tests fail 24/36 (phase level), 2/2 (gradient), 2/2 (Hessian row). Dropping `m_dir` from either Hessian cross term, or flipping the backward direction, each fails the backward-branch test.

## Gates

- `devtools::document()`: no changes. `lintr::lint_package()`: 0.
- `devtools::test()` (`NOT_CRAN=true`) on the merge commit `2f56d79`: **4247 passed, 0 failed, 6 skipped, 0 errors**.
- `spelling::spell_check_package()`: clean.
- `R CMD check --as-cran` with the manual, from `git archive` of `e2a254a` (before merging `main`, which brought in #245 and #246 and a NEWS conflict, resolved by keeping both bullets): **Status: OK** (0/0/0), overall 211 s, tests 90 s, vignettes 47 s, tarball 3.13 MB, no `CLAUDE`/`AGENTS` files in it. An earlier check on `ab04b71` measured 221 s. The tarball was 2.93 MB at `bd75f9f` per AGENTS.md; the growth predates this branch.
- `r-reviewer`: two passes; every finding verified and either fixed or recorded above.

Follow-up: the optimizer-tolerance investigation that surfaced this (BFGS `reltol = 1e-5` stopping short with `converged = TRUE`) becomes a separate PR stacked on this one, adding SAS/C's relative-gradient acceptance test with an `nlm()` polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
