### PR TITLE
docs: fix the content flagged in #252, each claim checked by running code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,13 @@
   log-logistic and log-normal fits are unaffected; they report on the scale
   they are optimised on.
 
+* **`hzr_argument_mapping()` listed DELTA as implemented.** Its
+  `implementation_status` was `"implemented"` and its `r_parameter` read
+  "(absorbed by decompos)", while the row's own notes say a non-zero DELTA
+  is refused or flagged and never fitted (#181). The row is now
+  `"planned"` with `r_parameter` "(not implemented)", so
+  `hzr_argument_mapping(include_planned = FALSE)` no longer includes it.
+
 # TemporalHazard 1.2.10
 
 ## New features

--- a/R/argument_mapping.R
+++ b/R/argument_mapping.R
@@ -72,7 +72,7 @@ hzr_argument_mapping <- function(include_planned = TRUE) {
     "time", "status", "theta", "dist",
     # Multiphase
     "phases (list of hzr_phase())", "mu (via exp(log_mu) in theta)",
-    "hzr_phase(t_half=)", "hzr_phase(nu=)", "hzr_phase(m=)", "(absorbed by decompos)",
+    "hzr_phase(t_half=)", "hzr_phase(nu=)", "hzr_phase(m=)", "(not implemented)",
     "hzr_phase('constant')",
     "hzr_phase('g3', tau=)", "hzr_phase('g3', gamma=)", "hzr_phase('g3', alpha=)", "hzr_phase('g3', eta=)"
   ),
@@ -105,7 +105,7 @@ hzr_argument_mapping <- function(include_planned = TRUE) {
     "maps directly to hzr_phase(t_half=) starting value",
     "maps directly to hzr_phase(nu=) starting value",
     "maps directly to hzr_phase(m=) starting value",
-    "time transform B(t) = (exp(delta*t)-1)/delta absorbed into decompos shape",
+    "time transform B(t) = (exp(delta*t)-1)/delta; drops out at DELTA = 0, non-zero DELTA not implemented",
     "hzr_phase('constant') with no shape parameters",
     "maps directly to hzr_phase('g3', tau=) for late phase",
     "maps directly to hzr_phase('g3', gamma=) for late phase",
@@ -117,7 +117,7 @@ hzr_argument_mapping <- function(include_planned = TRUE) {
     "implemented", "implemented", "implemented", "implemented", "planned", "implemented",
     # Multiphase
     "implemented", "implemented",
-    "implemented", "implemented", "implemented", "implemented",
+    "implemented", "implemented", "implemented", "planned",
     "implemented",
     "implemented", "implemented", "implemented", "implemented"
   ),

--- a/R/candidate-score.R
+++ b/R/candidate-score.R
@@ -61,11 +61,11 @@
 }
 
 
-#' Score a stepwise candidate under Wald or AIC criterion
+#' Score a stepwise candidate under the score, Wald or AIC criterion
 #'
 #' Produces a unified "smaller is better" score for either adding new
 #' coefficients to a model (`mode = "entry"`) or dropping coefficients
-#' from the current model (`mode = "drop"`), under a Wald or AIC
+#' from the current model (`mode = "drop"`), under the score, Wald or AIC
 #' criterion.
 #'
 #' @param criterion One of `"score"`, `"wald"`, or `"aic"`.  `"score"` is

--- a/R/data.R
+++ b/R/data.R
@@ -8,7 +8,8 @@
 #' @format A data frame with 310 rows and 11 variables:
 #' \describe{
 #'   \item{study}{Patient identifier}
-#'   \item{status}{NYHA functional class (1--4)}
+#'   \item{status}{NYHA functional class (1--4). A covariate, not a censoring
+#'     status: the event indicator is `dead`.}
 #'   \item{inc_surg}{Surgical grade of AV valve incompetence}
 #'   \item{opmos}{Date of operation (months since January 1967)}
 #'   \item{age}{Age at repair (months)}
@@ -101,9 +102,8 @@ utils::globalVariables("cabgkul")
 #' OMC: Open Mitral Commissurotomy
 #'
 #' Data for 339 patients who underwent open mitral commissurotomy at the
-#' University of Alabama Birmingham. Contains repeated thromboembolic events
-#' (up to 3 per patient) with left censoring, exercising the interval
-#' censoring likelihood.
+#' University of Alabama Birmingham. Records repeated thromboembolic events
+#' (up to 3 per patient) as indicators; the event dates are not included.
 #'
 #' @format A data frame with 339 rows and 7 variables:
 #' \describe{

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -105,8 +105,9 @@
 #'
 #' Computes the cumulative distribution \eqn{G(t)}, density \eqn{g(t)}, and
 #' hazard \eqn{h(t) = g(t)/(1 - G(t))} for the parametric family defined by
-#' half-life, time exponent, and shape.  This single function generates all
-#' temporal phase shapes used in multiphase hazard models.
+#' half-life, time exponent, and shape.  It supplies the `"cdf"` and
+#' `"hazard"` phase shapes of a multiphase hazard model; the `"g3"` late phase
+#' comes from [hzr_decompos_g3()], and the `"constant"` phase is linear in time.
 #'
 #' @section Parameter mapping from SAS/C HAZARD:
 #'

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -112,8 +112,10 @@
 #' @section Parameter mapping from SAS/C HAZARD:
 #'
 #' The original C code used separate parameterizations for early (DELTA,
-#' RHO/THALF, NU, M) and late (TAU, GAMMA, ALPHA, ETA) phases.  Both
-#' collapse onto the three parameters here.  See
+#' RHO/THALF, NU, M) and late (TAU, GAMMA, ALPHA, ETA) phases.  The early
+#' phase maps onto the three parameters here: DELTA must be 0, and RHO is
+#' fixed by THALF, NU and M.  The late phase does not: it is a separate
+#' four-parameter shape computed by [hzr_decompos_g3()].  See
 #' [hzr_argument_mapping()] for the full translation table.
 #'
 #' @section Valid parameter combinations:

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -304,14 +304,30 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #'   \item The parametric survival and cumulative hazard from the fitted
 #'     model (and per-phase components for multiphase models).
 #'   \item Cumulative observed events vs. cumulative expected events
-#'     (sum of individual cumulative hazards for those exiting the risk
-#'     set at each time).
+#'     (the parametric cumulative hazard at each time, times the number
+#'     of observations leaving the risk set then).
 #'   \item The running residual (expected minus observed).
 #' }
 #'
-#' Perfect model fit implies the expected and observed event counts track
-#' each other (residual near zero).  This is the conservation-of-events
-#' principle.
+#' For an intercept-only model every patient shares one curve, so the
+#' expected count is the sum of each patient's cumulative hazard at their
+#' own exit time.  At the maximum likelihood estimate that sum equals the
+#' number of observed events (the conservation-of-events identity): the
+#' final residual is zero and the printed "Conservation ratio (E/O)" is 1.
+#'
+#' A model with covariates is different.  The parametric curve, and so the
+#' expected count, is evaluated at the covariate means, one "mean patient"
+#' standing in for everyone.  The mean patient's cumulative hazard is not
+#' the average of the patients' cumulative hazards, so the printed E/O is
+#' not the conservation-of-events identity and need not be near 1 at a
+#' correct fit.  Read it as a mean-patient check: how closely the curve
+#' for a patient with average covariates follows the whole cohort.
+#'
+#' To check conservation of events for a covariate model, sum each
+#' patient's own cumulative hazard at their follow-up time and compare the
+#' total with the event count.  Pass the covariate columns plus a `time`
+#' column to [predict.hazard()] with `type = "cumulative_hazard"`; the
+#' Examples show how.
 #'
 #' @param object A fitted `hazard` object (with `fit = TRUE`).
 #' @param time_grid Optional numeric vector of time points at which to
@@ -328,11 +344,14 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #'   \item{km_surv}{Kaplan-Meier survival estimate.}
 #'   \item{km_cumhaz}{Kaplan-Meier cumulative hazard
 #'     (\eqn{-\log(\text{km\_surv})}).}
-#'   \item{par_surv}{Parametric survival from the fitted model.}
-#'   \item{par_cumhaz}{Parametric cumulative hazard.}
+#'   \item{par_surv}{Parametric survival from the fitted model, at the
+#'     covariate means for a model with covariates.}
+#'   \item{par_cumhaz}{Parametric cumulative hazard, at the covariate
+#'     means for a model with covariates.}
 #'   \item{cum_observed}{Cumulative observed events to this time.}
-#'   \item{cum_expected}{Cumulative expected events (sum of individual
-#'     cumulative hazards for observations exiting the risk set).}
+#'   \item{cum_expected}{Cumulative expected events: \code{par_cumhaz}
+#'     times the number of observations exiting the risk set, summed to
+#'     this time.}
 #'   \item{residual}{Expected minus observed
 #'     (\code{cum_expected - cum_observed}).}
 #' }
@@ -356,6 +375,14 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' )
 #' gof <- hzr_gof(fit)
 #' print(gof)
+#'
+#' # With covariates, hzr_gof() uses the covariate means, so its E/O is a
+#' # mean-patient check.  The conservation-of-events check sums each
+#' # patient's own cumulative hazard at their follow-up time:
+#' nd <- avc[, c("age", "mal")]
+#' nd$time <- avc$int_dead
+#' c(expected = sum(predict(fit, newdata = nd, type = "cumulative_hazard")),
+#'   observed = sum(avc$dead))
 #'
 #' # Plot observed vs expected events
 #' if (requireNamespace("ggplot2", quietly = TRUE)) {

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -106,18 +106,23 @@ NULL
 #'
 #' @param time Numeric follow-up time vector.
 #' @param status Numeric or logical event indicator vector.
-#' @param time_lower Optional numeric vector with two distinct roles, selected
-#'   by `status`. Supplying it explicitly is **not** a no-op.
+#' @param time_lower Optional numeric vector whose role depends on `status`.
+#'   Supplying it explicitly is **not** a no-op.
 #'   * `status == 2` (interval-censored): the lower bound of the censoring
-#'     interval, defaulting to `time`.
+#'     interval, defaulting to `time`. Every `dist` reads it this way.
 #'   * `status %in% c(0, 1)` (right-censored or event): the counting-process
 #'     **entry time**, so the row contributes `H(time) - H(time_lower)`.
-#'     Left `NULL`, the entry time is **`0`**, not `time`.
+#'     Only `dist = "weibull"` and `dist = "multiphase"` use this role, and
+#'     `"weibull"` only where `time_lower < time`. The `"exponential"`,
+#'     `"loglogistic"` and `"lognormal"` families ignore `time_lower` on these
+#'     rows. Left `NULL`, the entry time is **`0`**, not `time`.
+#'   * `status == -1` (left-censored): not used; the bound is `time_upper`.
 #'
 #'   Passing `time_lower = time` therefore states that every subject entered
-#'   the risk set at the instant it left, which contributes nothing and
-#'   removes the row from the likelihood. That is a valid specification and
-#'   the fit will not converge to anything meaningful; it warns.
+#'   the risk set at the instant it left. `hazard()` accepts it with a
+#'   warning. Under `"multiphase"` those rows lose their cumulative-hazard
+#'   term and the fit it returns is meaningless; `"weibull"` reads them as
+#'   entering at time 0, and the other families ignore the argument there.
 #' @param time_upper Optional numeric upper bound vector for censoring intervals.
 #'   Used when `status %in% c(-1, 2)`; defaults to `time` if NULL.
 #' @param x Optional design matrix (or data frame coercible to matrix).
@@ -622,8 +627,10 @@ hazard <- function(formula = NULL,
 
   # For status 0/1 rows `time_lower` is the counting-process ENTRY time, not a
   # censoring bound, so `time_lower >= time` says the subject left the risk set
-  # at or before it entered.  Such a row contributes H(time) - H(time_lower),
-  # which is zero or negative: it drops out of the likelihood, or worse.  With
+  # at or before it entered.  Under "multiphase" such a row contributes
+  # H(time) - H(time_lower), which is zero or negative: it drops out of the
+  # likelihood, or worse ("weibull" reads it as entry at 0, and the other
+  # families ignore time_lower on status 0/1 rows; issue #253).  With
   # every row like that the objective is unbounded above and the optimizer
   # returns a large positive "log-likelihood", converged = TRUE and rcond = 0,
   # with nothing naming the cause.  Reported as issue #136, where the argument
@@ -632,12 +639,15 @@ hazard <- function(formula = NULL,
     degenerate <- status %in% c(0, 1) & time_lower >= time
     if (any(degenerate)) {
       warning(sum(degenerate), " of ", n, " row(s) have 'time_lower' >= 'time' ",
-              "with status 0 or 1. For those rows 'time_lower' is the ",
-              "counting-process entry time, so they enter the risk set at or ",
-              "after they leave it and contribute nothing to the likelihood ",
-              "(it is not a censoring bound outside status 2). If you meant ",
-              "the default -- entry at time 0 -- leave 'time_lower' as NULL; ",
-              "passing 'time_lower = time' is not the same thing.",
+              "with status 0 or 1. On these rows 'time_lower' is not a ",
+              "censoring bound (that role belongs to status 2). ",
+              "dist = \"multiphase\" reads it as the counting-process entry ",
+              "time, so the rows enter the risk set at or after they leave ",
+              "it, their cumulative-hazard term vanishes or turns negative, ",
+              "and the fit is meaningless. dist = \"weibull\" treats them as ",
+              "entering at time 0, and the other families ignore ",
+              "'time_lower' on these rows. For entry at time 0, leave ",
+              "'time_lower' as NULL.",
               call. = FALSE)
     }
   }

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -251,7 +251,9 @@ NULL
 #'   -240. On a flat surface a fit can stop that far short of the optimum and
 #'   still report convergence.
 #' - `abstol`: Absolute gradient norm tolerance (default 1e-6)
-#' - `method`: Optimization method: "bfgs" or "nm" (default "bfgs").
+#' - `method`: Recorded but not used. The optimizer is always BFGS (a
+#'   multiphase fit may run a Nelder-Mead warm-up first); the entry is
+#'   accepted so that translated SAS jobs (`QUASI`) run unchanged.
 #'   SAS `PROC HAZARD` jobs write `STEEPEST QUASI` together (steepest
 #'   descent first, then quasi-Newton). `QUASI`/`QUASINEWTON` is `"bfgs"`;
 #'   **there is no steepest-descent option and no two-stage strategy**. The

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -145,10 +145,9 @@ NULL
 #'   vector (the way a wrapper forwarding its own argument by name does),
 #'   such a name raises a warning naming the symbol and the argument.
 #'   Masked arguments are validated like any other, so an `NA` in a
-#'   masked column now errors: an `NA` count on the SAS `ICENSOR`
+#'   masked column errors: an `NA` count on the SAS `ICENSOR`
 #'   path reaches `weights` and stops with `'weights' must be
-#'   non-negative and finite`, where it was previously accepted
-#'   silently.
+#'   non-negative and finite`.
 #' @param time_windows Optional numeric vector of strictly positive cut points for
 #'   piecewise time-varying coefficients. When provided, each predictor column in
 #'   `x` is expanded into one column per time window so each window gets its own
@@ -270,7 +269,9 @@ NULL
 #'
 #'   Read `fit$spec$control$conserve_applied`, not
 #'   `fit$spec$control$conserve`: the latter says only what you asked for.
-#' - `nocov`, `nocor`: Suppress covariance/correlation output (legacy; no-op in M2)
+#' - `nocov`, `nocor`: Accepted for compatibility with the SAS `PROC HAZARD`
+#'   options of the same names. They change neither the fitted object nor its
+#'   printed summary.
 #'
 #' Censoring status coding:
 #' - 1: Exact event at time

--- a/R/likelihood-exponential.R
+++ b/R/likelihood-exponential.R
@@ -36,7 +36,7 @@ NULL
 
 #' Log-likelihood for exponential hazard with covariates
 #'
-#' Computes the negative log-likelihood for right-censored data under the exponential
+#' Computes the log-likelihood for right-censored data under the exponential
 #' parametric hazard model with optional linear-predictor covariates.
 #'
 #' @param theta Vector of parameters:
@@ -73,7 +73,7 @@ NULL
 #' \deqn{\ell(\theta) = \sum_{i: \delta_i = 1} [\log\lambda + \eta_i]
 #'   - \lambda \sum_i t_i \exp(\eta_i)}
 #'
-#' Reparameterization: \u03b8\[1\] = log(\u03bb) avoids constrained optimization.
+#' Reparameterization: theta\[1\] = log(lambda) avoids constrained optimization.
 #'
 #' Mixed censoring status coding:
 #' - 1: exact event at time

--- a/R/likelihood-loglogistic.R
+++ b/R/likelihood-loglogistic.R
@@ -51,7 +51,7 @@ NULL
 
 #' Log-likelihood for log-logistic hazard with covariates
 #'
-#' Computes the negative log-likelihood for right-censored data under the log-logistic
+#' Computes the log-likelihood for right-censored data under the log-logistic
 #' parametric hazard model with optional linear-predictor covariates.
 #'
 #' @param theta Vector of parameters:
@@ -74,12 +74,13 @@ NULL
 #' @details
 #' The log-logistic hazard model is parameterized as:
 #'
-#' \deqn{h(t | x) = \frac{\alpha \beta t^{\beta - 1}}{1 + \alpha t^{\beta} \exp(\eta)}}
+#' \deqn{h(t | x) = \frac{\alpha \beta t^{\beta - 1} \exp(\eta)}{1 + \alpha t^{\beta} \exp(\eta)}}
 #'
 #' where:
 #' - \eqn{\alpha > 0} is scale parameter
 #' - \eqn{\beta > 0} is shape parameter
-#' - \eqn{\eta = x \beta} is covariate effect (linear on log-scale)
+#' - \eqn{\eta = x b} is covariate effect (linear on log-scale), with
+#'   coefficient vector \eqn{b} = theta\[3:length\], not the shape \eqn{\beta}
 #'
 #' The survival function is:
 #'
@@ -92,10 +93,10 @@ NULL
 #' The log-likelihood for right-censored data is:
 #'
 #' \deqn{\ell(\theta) = \sum_{\delta_i = 1} [\log(\alpha \beta) + (\beta - 1)
-#'   \log(t_i) - \log(1 + \alpha t_i^{\beta} \exp(\eta_i))] + \sum_{i}
+#'   \log(t_i) + \eta_i - \log(1 + \alpha t_i^{\beta} \exp(\eta_i))] - \sum_{i}
 #'   \log(1 + \alpha t_i^{\beta} \exp(\eta_i))}
 #'
-#' Reparameterization: \u03b8\[1\] = log(\u03b1), \u03b8\[2\] = log(\u03b2) avoids constrained optimization.
+#' Reparameterization: theta\[1\] = log(alpha), theta\[2\] = log(beta) avoids constrained optimization.
 #'
 #' Mixed censoring status coding:
 #' - 1: exact event at time
@@ -235,25 +236,20 @@ NULL
 #'
 #' Computes the score vector of the log-logistic log-likelihood w.r.t. all parameters.
 #'
-#' The log-likelihood is:
+#' The log-likelihood, with term_i = alpha*t_i^beta*exp(eta_i), is:
 #'   \eqn{L = \sum(\delta_i * [\log(\alpha) + \log(\beta) + (\beta-1)
-#'   *\log(t_i)]) - \sum(\log(1 + \alpha*t_i^\beta*\exp(\eta_i)))}
+#'   *\log(t_i) + \eta_i]) - \sum((1 + \delta_i) * \log(1 + term_i))}
 #'
-#' Let p_i = alpha*t_i^beta*exp(eta_i) / (1 + alpha*t_i^beta*exp(eta_i)) = probability of event at t_i
+#' Let p_i = term_i / (1 + term_i) and w_i = (1 + delta_i) * p_i. An event
+#' carries log(1 + term_i) twice, once from log h and once from log S.
 #'
 #' Derivatives (using chain rule and reparameterization):
-#' dL/d(log alpha) = sum(delta_i) - alpha * sum(t_i^beta * exp(eta_i) / (1 + alpha*t_i^beta*exp(eta_i)))
-#'             = sum(delta_i) - sum(alpha * t_i^beta * exp(eta_i) / (1 + term))
+#' dL/d(log alpha) = sum(delta_i) - sum(w_i)
 #'
-#' dL/d(log beta) = sum(delta_i) + sum(delta_i * log(t_i))
-#'                  - beta * sum(alpha*t_i^beta*log(t_i)*exp(eta_i)
-#'                                 /(1 + alpha*t_i^beta*exp(eta_i)))
-#'                = sum(delta_i) + sum(delta_i * log(t_i))
-#'                  - beta * sum(t_i^beta*log(t_i)
-#'                                 /(1 + 1/(alpha*t_i^beta*exp(eta_i))))
+#' dL/d(log beta) = sum(delta_i)
+#'                  + beta * [sum(delta_i * log(t_i)) - sum(w_i * log(t_i))]
 #'
-#' dL/dbeta_j = sum(delta_i * x_ij) - sum(alpha*t_i^beta*exp(eta_i)*x_ij / (1 + alpha*t_i^beta*exp(eta_i)))
-#'         = t(X) %*% (delta - p)
+#' dL/db_j = sum(delta_i * x_ij) - sum(w_i * x_ij) = t(X) %*% (delta - w)
 #'
 #' @noRd
 .hzr_gradient_loglogistic <- function(

--- a/R/likelihood-lognormal.R
+++ b/R/likelihood-lognormal.R
@@ -96,7 +96,7 @@ NULL
 #' \deqn{\ell(\theta) = \sum_{\delta_i=1} [\log \phi(z_i) - \log \sigma - \log t_i]
 #'   + \sum_{\delta_i=0} \log \Phi(-z_i)}
 #'
-#' Reparameterization: \u03b8\[1\] = \u03bc, \u03b8\[2\] = log(\u03c3) avoids constraints.
+#' Reparameterization: theta\[1\] = mu, theta\[2\] = log(sigma) avoids constraints.
 #'
 #' Mixed censoring status coding:
 #' - 1: exact event at time

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -37,7 +37,7 @@ NULL
 
 #' Log-likelihood for Weibull hazard with covariates
 #'
-#' Computes the negative log-likelihood for a sample under the Weibull
+#' Computes the log-likelihood for a sample under the Weibull
 #' parametric hazard model with optional linear-predictor covariates.
 #'
 #' @param theta Vector of parameters:
@@ -75,9 +75,9 @@ NULL
 #' The log-likelihood for right-censored data is:
 #'
 #' \deqn{\ell(\theta) = \sum_{i: \delta_i = 1} \log h(t_i | x_i)
-#'   - \sum_i S(t_i | x_i)}
+#'   - \sum_i H(t_i | x_i)}
 #'
-#' where S is the survival function (1 - CDF).
+#' where H is the cumulative hazard, \eqn{H = -\log S}.
 #'
 #' Mixed censoring status coding:
 #' - 1: exact event at time
@@ -234,9 +234,6 @@ NULL
 #'
 #' Computes the score vector (gradient) of the Weibull log-likelihood w.r.t. all parameters.
 #'
-#' @param time_lower Optional lower bounds for interval-censored rows.
-#' @param time_upper Optional upper bounds for left/interval-censored rows.
-#'
 #' The log-likelihood is:
 #'   L = sum(delta_i * log h(t_i)) - sum(H(t_i))
 #'
@@ -247,6 +244,9 @@ NULL
 #' dL/dnu  = sum(delta_i / nu) + sum(delta_i) * log(mu) + sum(delta_i * log(t_i))
 #'           - sum(log(mu * t_i) * H(t_i))
 #' dL/dbeta_j = sum(delta_i * x_ij) - sum(H(t_i) * x_ij)  = t(X) %*% (delta - H)
+#'
+#' @param time_lower Optional lower bounds for interval-censored rows.
+#' @param time_upper Optional upper bounds for left/interval-censored rows.
 #'
 #' @noRd
 .hzr_gradient_weibull <- function(

--- a/R/likelihood-weibull.R
+++ b/R/likelihood-weibull.R
@@ -72,12 +72,15 @@ NULL
 #' - \eqn{\nu > 0} is shape (NU)
 #' - \eqn{\eta = x \beta} is log-relative-hazard (covariates)
 #'
-#' The log-likelihood for right-censored data is:
+#' The log-likelihood for right-censored data, with optional
+#' counting-process entry times, is:
 #'
 #' \deqn{\ell(\theta) = \sum_{i: \delta_i = 1} \log h(t_i | x_i)
-#'   - \sum_i H(t_i | x_i)}
+#'   - \sum_i \left[H(t_i | x_i) - H(s_i | x_i)\right]}
 #'
-#' where H is the cumulative hazard, \eqn{H = -\log S}.
+#' where H is the cumulative hazard, \eqn{H = -\log S}, and \eqn{s_i} is
+#' the entry time: `time_lower` on a status 0 or 1 row with
+#' `time_lower < time`, and 0 otherwise (so \eqn{H(s_i) = 0}).
 #'
 #' Mixed censoring status coding:
 #' - 1: exact event at time
@@ -235,17 +238,20 @@ NULL
 #' Computes the score vector (gradient) of the Weibull log-likelihood w.r.t. all parameters.
 #'
 #' The log-likelihood is:
-#'   L = sum(delta_i * log h(t_i)) - sum(H(t_i))
+#'   L = sum(delta_i * log h(t_i)) - sum(H(t_i) - H(s_i))
 #'
-#' where h(t) = nu * mu^nu * t^(nu-1) * exp(eta) and H(t) = (mu*t)^nu * exp(eta)
-#' (so log h = log(nu) + nu*log(mu) + (nu-1)*log(t) + eta). Derivatives are:
+#' where h(t) = nu * mu^nu * t^(nu-1) * exp(eta), H(t) = (mu*t)^nu * exp(eta)
+#' (so log h = log(nu) + nu*log(mu) + (nu-1)*log(t) + eta), and s_i is the
+#' entry time: time_lower on a status 0/1 row with time_lower < time, else 0.
+#' Terms at s_i = 0 are zero. Derivatives are:
 #'
-#' dL/dmu  = (nu / mu) * sum(delta_i) - (nu / mu) * sum(H(t_i))
+#' dL/dmu  = (nu / mu) * sum(delta_i) - (nu / mu) * sum(H(t_i) - H(s_i))
 #' dL/dnu  = sum(delta_i / nu) + sum(delta_i) * log(mu) + sum(delta_i * log(t_i))
-#'           - sum(log(mu * t_i) * H(t_i))
-#' dL/dbeta_j = sum(delta_i * x_ij) - sum(H(t_i) * x_ij)  = t(X) %*% (delta - H)
+#'           - sum(log(mu * t_i) * H(t_i) - log(mu * s_i) * H(s_i))
+#' dL/dbeta_j = sum(delta_i * x_ij) - sum((H(t_i) - H(s_i)) * x_ij)
 #'
-#' @param time_lower Optional lower bounds for interval-censored rows.
+#' @param time_lower Optional: the entry time on status 0/1 rows (when less
+#'   than `time`), and the lower bound on interval-censored rows.
 #' @param time_upper Optional upper bounds for left/interval-censored rows.
 #'
 #' @noRd

--- a/R/phase-spec.R
+++ b/R/phase-spec.R
@@ -351,11 +351,11 @@ is_hzr_phase <- function(x) {
 
 #' Number of shape parameters for a phase
 #'
-#' Returns 3 (t_half, nu, m) for `"cdf"` and `"hazard"` phases, 0 for
-#' `"constant"`.
+#' Returns 3 (t_half, nu, m) for `"cdf"` and `"hazard"` phases, 4 (tau,
+#' gamma, alpha, eta) for `"g3"`, and 0 for `"constant"`.
 #'
 #' @param phase An `hzr_phase` object.
-#' @return Integer: 3 or 0.
+#' @return Integer: 3, 4 or 0.
 #' @keywords internal
 .hzr_phase_n_shape <- function(phase) {
   stopifnot(is_hzr_phase(phase))
@@ -374,6 +374,7 @@ is_hzr_phase <- function(x) {
 #'
 #' \itemize{
 #'   \item For `"cdf"`/`"hazard"`: `[log_mu, log_t_half, nu, m, beta_1, ..., beta_p]`
+#'   \item For `"g3"`:             `[log_mu, log_tau, gamma, alpha, eta, beta_1, ..., beta_p]`
 #'   \item For `"constant"`:       `[log_mu, beta_1, ..., beta_p]`
 #' }
 #'
@@ -564,12 +565,14 @@ hzr_theta_names <- function(phases, covariates = NULL) {
 #' Extract starting values from a phase specification
 #'
 #' Returns initial theta sub-vector on the estimation (internal) scale:
-#' log(mu), log(t_half), nu, m, followed by zeros for covariate coefficients.
+#' log(mu), then log(t_half), nu, m for `"cdf"`/`"hazard"` phases or
+#' log(tau), gamma, alpha, eta for `"g3"` (nothing for `"constant"`),
+#' followed by zeros for covariate coefficients.
 #'
 #' @param phase An `hzr_phase` object.
 #' @param n_covariates Integer; number of covariate columns.
 #' @param mu_start Numeric scalar; initial scale parameter (default 0.1).
-#' @return Named numeric vector of starting values.
+#' @return Unnamed numeric vector of starting values.
 #' @keywords internal
 .hzr_phase_start <- function(phase, n_covariates = 0L, mu_start = 0.1) {
   stopifnot(is_hzr_phase(phase))

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -160,8 +160,9 @@
 #' no expression that serves: `time_lower` is one column carrying two
 #' meanings, so gating it on status hands the interval rows their lower bound
 #' and thereby drops their entry time, fitting a left-truncated
-#' interval-censored subject as at risk from time `0`. That converges and
-#' reports plausibly, the exact failure mode this package exists to refuse.
+#' interval-censored subject as at risk from time `0`. That fit converges
+#' and looks plausible, which is the failure mode this package exists to
+#' refuse.
 #' The reference implementation carries three distinct times (`TIME`, `CTIME`,
 #' `STIME`) and subtracts `H(STIME)` for every row, interval rows included, so
 #' translating it faithfully needs an entry-time argument [hazard()] does not

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -138,8 +138,8 @@
 
 #' Log-likelihood / gradient entry points for a single distribution
 #'
-#' SIGN CONVENTION: both return the POSITIVE log-likelihood scale, despite
-#' what some of their roxygen blocks say. `.hzr_optim_generic()` is what negates
+#' SIGN CONVENTION: both return the POSITIVE log-likelihood scale, as their
+#' roxygen blocks say. `.hzr_optim_generic()` is what negates
 #' them for minimisation, and the analytic `hessian_fn` hook it takes is on the
 #' negated (objective) scale. So the observed information is a Hessian of
 #' `-logl_fn`, not of `logl_fn`. Getting this backwards yields a negative

--- a/R/stepwise-formula.R
+++ b/R/stepwise-formula.R
@@ -212,13 +212,12 @@
 #' \code{formula[[3L]]}) and returns \code{TRUE} if any call node has a
 #' function symbol that exactly matches one of \code{phase_names}.
 #'
-#' This is stricter than a string-regex approach: a phase named \code{"log"}
-#' will NOT produce a false positive when the formula contains \code{log(age)},
-#' because \code{log} would also appear in \code{phase_names} only if the user
-#' deliberately named a phase \code{"log"}.  Conversely, the function only
-#' fires when the call head is an exact match to a known phase name; standard
-#' R functions that happen to share names with phases do not trigger the check
-#' unless those names are actually phase names.
+#' This is stricter than a string-regex approach.  A call such as
+#' \code{log(age)} triggers the check only when a phase is actually named
+#' \code{"log"}; with phases named \code{"early"} and \code{"constant"} it
+#' does not.  The function fires only when a call head exactly matches a
+#' known phase name, so a variable such as \code{early_age}, or a bare
+#' symbol \code{early} that is not called, does not trigger it.
 #'
 #' @param rhs  A language object (the RHS of a formula, typically
 #'   \code{formula[[3L]]}).

--- a/R/stepwise-step.R
+++ b/R/stepwise-step.R
@@ -144,7 +144,8 @@
 #'   \item{score}{Winning score (p or dAIC), or `NA_real_`.}
 #'   \item{p_value}{Winning p-value.}
 #'   \item{delta_aic}{Winning dAIC.}
-#'   \item{stat, df}{Wald statistic / df of the winner.}
+#'   \item{stat, stat_type, df}{Test statistic of the winner, what it is
+#'     (`"score_q"`, `"wald_z"` or `"wald_chisq"`), and its df.}
 #'   \item{all_scores}{Tibble-like data frame of every candidate
 #'     considered and its score.}
 #'   \item{refit_failures}{Character vector of `"var@phase"` tokens for

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -141,12 +141,11 @@
 #'       an unscored candidate as a bad one: `information_indefinite` marks
 #'       candidates whose effect is too large for the score test's
 #'       approximation at zero, which are typically the strongest variables
-#'       on offer rather than degenerate ones. Those are now refit and tested
-#'       by Wald automatically, counted in `n_wald_fallbacks`; a candidate
-#'       still reaches `uncomputable_reasons` only when that refit itself
-#'       fails, or when the cause is one no refit can rescue, which is
-#'       every cause except `information_indefinite` and
-#'       `coefficient_diverging`, the two a refit exists to rescue. Read
+#'       on offer rather than degenerate ones. Candidates with that cause,
+#'       or with `coefficient_diverging`, are refit and tested by Wald
+#'       automatically, counted in `n_wald_fallbacks`. A candidate still
+#'       reaches `uncomputable_reasons` when that refit fails, or when its
+#'       cause is any other, which no refit can rescue. Read
 #'       `uncomputable_reasons` for which one it was in any given run.  For
 #'       every criterion it also carries
 #'       `refit_failures` (the `"var"` / `"var@phase"` tokens of candidate

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ and extrapolation.
 | Repeating events (epoch decomposition via `Surv(start, stop, event)`) | :white_check_mark: |
 | Time-varying covariates (piecewise windows) | :white_check_mark: |
 | Weighted events across all distributions | :white_check_mark: |
-| Automatic stepwise covariate selection (forward, backward, stepwise; Wald or AIC) | :white_check_mark: |
+| Automatic stepwise covariate selection (forward, backward, stepwise; score (default), Wald or AIC) | :white_check_mark: |
 | Conservation of Events theorem for numerically stable parameter estimation | :white_check_mark: |
 | Covariance and correlation matrix estimation | :white_check_mark: |
 | Delta-method confidence limits on `predict()` (`se.fit = TRUE`) | :white_check_mark: |
@@ -73,8 +73,9 @@ install.packages("TemporalHazard")
 remotes::install_github("ehrlinger/TemporalHazard")
 ```
 
-TemporalHazard requires R >= 4.1.0 and depends on the
-[survival](https://CRAN.R-project.org/package=survival) package.
+TemporalHazard requires R >= 4.1.0 and imports the
+[survival](https://CRAN.R-project.org/package=survival) package. It does not
+attach it, which is why the examples below call `survival::Surv()`.
 Optional packages for visualization and vignettes include ggplot2, numDeriv,
 and quarto.
 
@@ -150,4 +151,3 @@ devtools::check()
 GitHub Actions runs multi-platform `R CMD check` on every push and pull request. Coverage is published to Codecov and the pkgdown site deploys automatically from `main`.
 
 See the development plan in `inst/dev/DEVELOPMENT-PLAN.md` for the full roadmap covering the C/SAS migration, multiphase implementation, CRAN release, and planned feature parity work.
-See `.github/BRANCH_PROTECTION.md` for recommended required-check settings that block merges when CI fails.

--- a/man/avc.Rd
+++ b/man/avc.Rd
@@ -8,7 +8,8 @@
 A data frame with 310 rows and 11 variables:
 \describe{
 \item{study}{Patient identifier}
-\item{status}{NYHA functional class (1--4)}
+\item{status}{NYHA functional class (1--4). A covariate, not a censoring
+status: the event indicator is \code{dead}.}
 \item{inc_surg}{Surgical grade of AV valve incompetence}
 \item{opmos}{Date of operation (months since January 1967)}
 \item{age}{Age at repair (months)}

--- a/man/dot-hzr_phase_n_shape.Rd
+++ b/man/dot-hzr_phase_n_shape.Rd
@@ -10,10 +10,10 @@
 \item{phase}{An \code{hzr_phase} object.}
 }
 \value{
-Integer: 3 or 0.
+Integer: 3, 4 or 0.
 }
 \description{
-Returns 3 (t_half, nu, m) for \code{"cdf"} and \code{"hazard"} phases, 0 for
-\code{"constant"}.
+Returns 3 (t_half, nu, m) for \code{"cdf"} and \code{"hazard"} phases, 4 (tau,
+gamma, alpha, eta) for \code{"g3"}, and 0 for \code{"constant"}.
 }
 \keyword{internal}

--- a/man/dot-hzr_phase_start.Rd
+++ b/man/dot-hzr_phase_start.Rd
@@ -14,10 +14,12 @@
 \item{mu_start}{Numeric scalar; initial scale parameter (default 0.1).}
 }
 \value{
-Named numeric vector of starting values.
+Unnamed numeric vector of starting values.
 }
 \description{
 Returns initial theta sub-vector on the estimation (internal) scale:
-log(mu), log(t_half), nu, m, followed by zeros for covariate coefficients.
+log(mu), then log(t_half), nu, m for \code{"cdf"}/\code{"hazard"} phases or
+log(tau), gamma, alpha, eta for \code{"g3"} (nothing for \code{"constant"}),
+followed by zeros for covariate coefficients.
 }
 \keyword{internal}

--- a/man/dot-hzr_phase_theta_names.Rd
+++ b/man/dot-hzr_phase_theta_names.Rd
@@ -24,6 +24,7 @@ phase in the full theta vector.  The block layout is:
 \details{
 \itemize{
 \item For \code{"cdf"}/\code{"hazard"}: \verb{[log_mu, log_t_half, nu, m, beta_1, ..., beta_p]}
+\item For \code{"g3"}:             \verb{[log_mu, log_tau, gamma, alpha, eta, beta_1, ..., beta_p]}
 \item For \code{"constant"}:       \verb{[log_mu, beta_1, ..., beta_p]}
 }
 }

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -45,9 +45,8 @@ a caller variable wins, and because that silently discards the caller's
 vector (the way a wrapper forwarding its own argument by name does),
 such a name raises a warning naming the symbol and the argument.
 Masked arguments are validated like any other, so an \code{NA} in a
-masked column now errors: an \code{NA} count on the SAS \code{ICENSOR}
-path reaches \code{weights} and stops with \verb{'weights' must be non-negative and finite}, where it was previously accepted
-silently.}
+masked column errors: an \code{NA} count on the SAS \code{ICENSOR}
+path reaches \code{weights} and stops with \verb{'weights' must be non-negative and finite}.}
 
 \item{time}{Numeric follow-up time vector.}
 
@@ -249,7 +248,9 @@ applied;
 
 Read \code{fit$spec$control$conserve_applied}, not
 \code{fit$spec$control$conserve}: the latter says only what you asked for.
-\item \code{nocov}, \code{nocor}: Suppress covariance/correlation output (legacy; no-op in M2)
+\item \code{nocov}, \code{nocor}: Accepted for compatibility with the SAS \verb{PROC HAZARD}
+options of the same names. They change neither the fitted object nor its
+printed summary.
 }
 
 Censoring status coding:

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -228,7 +228,9 @@ with the size of the log-likelihood: about 0.0024 at a log-likelihood of
 -240. On a flat surface a fit can stop that far short of the optimum and
 still report convergence.
 \item \code{abstol}: Absolute gradient norm tolerance (default 1e-6)
-\item \code{method}: Optimization method: "bfgs" or "nm" (default "bfgs").
+\item \code{method}: Recorded but not used. The optimizer is always BFGS (a
+multiphase fit may run a Nelder-Mead warm-up first); the entry is
+accepted so that translated SAS jobs (\code{QUASI}) run unchanged.
 SAS \verb{PROC HAZARD} jobs write \verb{STEEPEST QUASI} together (steepest
 descent first, then quasi-Newton). \code{QUASI}/\code{QUASINEWTON} is \code{"bfgs"};
 \strong{there is no steepest-descent option and no two-stage strategy}. The

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -52,20 +52,25 @@ path reaches \code{weights} and stops with \verb{'weights' must be non-negative 
 
 \item{status}{Numeric or logical event indicator vector.}
 
-\item{time_lower}{Optional numeric vector with two distinct roles, selected
-by \code{status}. Supplying it explicitly is \strong{not} a no-op.
+\item{time_lower}{Optional numeric vector whose role depends on \code{status}.
+Supplying it explicitly is \strong{not} a no-op.
 \itemize{
 \item \code{status == 2} (interval-censored): the lower bound of the censoring
-interval, defaulting to \code{time}.
+interval, defaulting to \code{time}. Every \code{dist} reads it this way.
 \item \code{status \%in\% c(0, 1)} (right-censored or event): the counting-process
 \strong{entry time}, so the row contributes \code{H(time) - H(time_lower)}.
-Left \code{NULL}, the entry time is \strong{\code{0}}, not \code{time}.
+Only \code{dist = "weibull"} and \code{dist = "multiphase"} use this role, and
+\code{"weibull"} only where \code{time_lower < time}. The \code{"exponential"},
+\code{"loglogistic"} and \code{"lognormal"} families ignore \code{time_lower} on these
+rows. Left \code{NULL}, the entry time is \strong{\code{0}}, not \code{time}.
+\item \code{status == -1} (left-censored): not used; the bound is \code{time_upper}.
 }
 
 Passing \code{time_lower = time} therefore states that every subject entered
-the risk set at the instant it left, which contributes nothing and
-removes the row from the likelihood. That is a valid specification and
-the fit will not converge to anything meaningful; it warns.}
+the risk set at the instant it left. \code{hazard()} accepts it with a
+warning. Under \code{"multiphase"} those rows lose their cumulative-hazard
+term and the fit it returns is meaningless; \code{"weibull"} reads them as
+entering at time 0, and the other families ignore the argument there.}
 
 \item{time_upper}{Optional numeric upper bound vector for censoring intervals.
 Used when \code{status \%in\% c(-1, 2)}; defaults to \code{time} if NULL.}

--- a/man/hzr_decompos.Rd
+++ b/man/hzr_decompos.Rd
@@ -32,8 +32,9 @@ phase temporal pattern.}
 \description{
 Computes the cumulative distribution \eqn{G(t)}, density \eqn{g(t)}, and
 hazard \eqn{h(t) = g(t)/(1 - G(t))} for the parametric family defined by
-half-life, time exponent, and shape.  This single function generates all
-temporal phase shapes used in multiphase hazard models.
+half-life, time exponent, and shape.  It supplies the \code{"cdf"} and
+\code{"hazard"} phase shapes of a multiphase hazard model; the \code{"g3"} late phase
+comes from \code{\link[=hzr_decompos_g3]{hzr_decompos_g3()}}, and the \code{"constant"} phase is linear in time.
 }
 \section{Parameter mapping from SAS/C HAZARD}{
 

--- a/man/hzr_decompos.Rd
+++ b/man/hzr_decompos.Rd
@@ -40,8 +40,10 @@ comes from \code{\link[=hzr_decompos_g3]{hzr_decompos_g3()}}, and the \code{"con
 
 
 The original C code used separate parameterizations for early (DELTA,
-RHO/THALF, NU, M) and late (TAU, GAMMA, ALPHA, ETA) phases.  Both
-collapse onto the three parameters here.  See
+RHO/THALF, NU, M) and late (TAU, GAMMA, ALPHA, ETA) phases.  The early
+phase maps onto the three parameters here: DELTA must be 0, and RHO is
+fixed by THALF, NU and M.  The late phase does not: it is a separate
+four-parameter shape computed by \code{\link[=hzr_decompos_g3]{hzr_decompos_g3()}}.  See
 \code{\link[=hzr_argument_mapping]{hzr_argument_mapping()}} for the full translation table.
 }
 

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -24,11 +24,14 @@ A data frame with one row per time point and columns:
 \item{km_surv}{Kaplan-Meier survival estimate.}
 \item{km_cumhaz}{Kaplan-Meier cumulative hazard
 (\eqn{-\log(\text{km\_surv})}).}
-\item{par_surv}{Parametric survival from the fitted model.}
-\item{par_cumhaz}{Parametric cumulative hazard.}
+\item{par_surv}{Parametric survival from the fitted model, at the
+covariate means for a model with covariates.}
+\item{par_cumhaz}{Parametric cumulative hazard, at the covariate
+means for a model with covariates.}
 \item{cum_observed}{Cumulative observed events to this time.}
-\item{cum_expected}{Cumulative expected events (sum of individual
-cumulative hazards for observations exiting the risk set).}
+\item{cum_expected}{Cumulative expected events: \code{par_cumhaz}
+times the number of observations exiting the risk set, summed to
+this time.}
 \item{residual}{Expected minus observed
 (\code{cum_expected - cum_observed}).}
 }
@@ -53,14 +56,30 @@ At each observed event time the function computes:
 \item The parametric survival and cumulative hazard from the fitted
 model (and per-phase components for multiphase models).
 \item Cumulative observed events vs. cumulative expected events
-(sum of individual cumulative hazards for those exiting the risk
-set at each time).
+(the parametric cumulative hazard at each time, times the number
+of observations leaving the risk set then).
 \item The running residual (expected minus observed).
 }
 
-Perfect model fit implies the expected and observed event counts track
-each other (residual near zero).  This is the conservation-of-events
-principle.
+For an intercept-only model every patient shares one curve, so the
+expected count is the sum of each patient's cumulative hazard at their
+own exit time.  At the maximum likelihood estimate that sum equals the
+number of observed events (the conservation-of-events identity): the
+final residual is zero and the printed "Conservation ratio (E/O)" is 1.
+
+A model with covariates is different.  The parametric curve, and so the
+expected count, is evaluated at the covariate means, one "mean patient"
+standing in for everyone.  The mean patient's cumulative hazard is not
+the average of the patients' cumulative hazards, so the printed E/O is
+not the conservation-of-events identity and need not be near 1 at a
+correct fit.  Read it as a mean-patient check: how closely the curve
+for a patient with average covariates follows the whole cohort.
+
+To check conservation of events for a covariate model, sum each
+patient's own cumulative hazard at their follow-up time and compare the
+total with the event count.  Pass the covariate columns plus a \code{time}
+column to \code{\link[=predict.hazard]{predict.hazard()}} with \code{type = "cumulative_hazard"}; the
+Examples show how.
 }
 \examples{
 \donttest{
@@ -75,6 +94,14 @@ fit <- hazard(
 )
 gof <- hzr_gof(fit)
 print(gof)
+
+# With covariates, hzr_gof() uses the covariate means, so its E/O is a
+# mean-patient check.  The conservation-of-events check sums each
+# patient's own cumulative hazard at their follow-up time:
+nd <- avc[, c("age", "mal")]
+nd$time <- avc$int_dead
+c(expected = sum(predict(fit, newdata = nd, type = "cumulative_hazard")),
+  observed = sum(avc$dead))
 
 # Plot observed vs expected events
 if (requireNamespace("ggplot2", quietly = TRUE)) {

--- a/man/hzr_stepwise.Rd
+++ b/man/hzr_stepwise.Rd
@@ -103,12 +103,11 @@ settings actually applied, plus, under \code{criterion = "score"},
 an unscored candidate as a bad one: \code{information_indefinite} marks
 candidates whose effect is too large for the score test's
 approximation at zero, which are typically the strongest variables
-on offer rather than degenerate ones. Those are now refit and tested
-by Wald automatically, counted in \code{n_wald_fallbacks}; a candidate
-still reaches \code{uncomputable_reasons} only when that refit itself
-fails, or when the cause is one no refit can rescue, which is
-every cause except \code{information_indefinite} and
-\code{coefficient_diverging}, the two a refit exists to rescue. Read
+on offer rather than degenerate ones. Candidates with that cause,
+or with \code{coefficient_diverging}, are refit and tested by Wald
+automatically, counted in \code{n_wald_fallbacks}. A candidate still
+reaches \code{uncomputable_reasons} when that refit fails, or when its
+cause is any other, which no refit can rescue. Read
 \code{uncomputable_reasons} for which one it was in any given run.  For
 every criterion it also carries
 \code{refit_failures} (the \code{"var"} / \code{"var@phase"} tokens of candidate

--- a/man/omc.Rd
+++ b/man/omc.Rd
@@ -24,9 +24,8 @@ omc
 }
 \description{
 Data for 339 patients who underwent open mitral commissurotomy at the
-University of Alabama Birmingham. Contains repeated thromboembolic events
-(up to 3 per patient) with left censoring, exercising the interval
-censoring likelihood.
+University of Alabama Birmingham. Records repeated thromboembolic events
+(up to 3 per patient) as indicators; the event dates are not included.
 }
 \seealso{
 Other datasets:

--- a/tests/testthat/test-argument-mapping.R
+++ b/tests/testthat/test-argument-mapping.R
@@ -24,3 +24,17 @@ test_that("mapping table has no duplicate legacy-to-parameter rows", {
   key <- paste(map$legacy_input, map$r_parameter, sep = "::")
   expect_equal(anyDuplicated(key), 0)
 })
+
+test_that("DELTA is listed as planned, so include_planned = FALSE drops it", {
+  # DELTA != 0 is refused or flagged, never fitted (#181), so the row must
+  # not be reported as implemented.
+  full <- hzr_argument_mapping(include_planned = TRUE)
+  impl <- hzr_argument_mapping(include_planned = FALSE)
+  delta <- full[grepl("^DELTA", full$legacy_input), , drop = FALSE]
+  expect_equal(nrow(delta), 1L)
+  expect_equal(delta$implementation_status, "planned")
+  expect_equal(delta$r_parameter, "(not implemented)")
+  expect_false(any(grepl("^DELTA", impl$legacy_input)))
+  expect_equal(nrow(full) - nrow(impl),
+               sum(full$implementation_status == "planned"))
+})

--- a/tests/testthat/test-time-lower-entry.R
+++ b/tests/testthat/test-time-lower-entry.R
@@ -103,6 +103,12 @@ test_that("entry at or after exit warns, and names the NULL default", {
   expect_match(w, paste0(n, " of ", n), all = FALSE)
   # The remedy has to be in the message: NULL is not the same as `time`.
   expect_match(w, "leave 'time_lower' as NULL", all = FALSE)
+  # The warning fires for every `dist`, so its account of the consequence
+  # has to hold for every family: only multiphase honours the entry time on
+  # these rows, and "contribute nothing" was true for multiphase alone.
+  expect_match(w, "dist = \"weibull\" treats them as entering at time 0",
+               fixed = TRUE, all = FALSE)
+  expect_false(any(grepl("contribute nothing", w, fixed = TRUE)))
 })
 
 test_that("genuine left truncation does not warn", {

--- a/vignettes/ar-architecture.qmd
+++ b/vignettes/ar-architecture.qmd
@@ -55,7 +55,7 @@ layout <- data.frame(
     rep("User API", 2),
     rep("Multiphase engine", 3),
     rep("Single-phase likelihoods", 4),
-    rep("Shared infrastructure", 5)
+    rep("Shared infrastructure", 4)
   ),
   File = c(
     "hazard_api.R", "argument_mapping.R",
@@ -63,7 +63,7 @@ layout <- data.frame(
     "likelihood-weibull.R", "likelihood-exponential.R",
     "likelihood-loglogistic.R", "likelihood-lognormal.R",
     "optimizer.R", "math_primitives.R", "formula-helpers.R",
-    "golden_fixtures.R", "parity-helpers.R"
+    "parity-helpers.R"
   ),
   Purpose = c(
     "hazard(), predict.hazard(), print/summary/coef/vcov S3 methods",
@@ -78,11 +78,10 @@ layout <- data.frame(
     "Generic L-BFGS-B/BFGS optimizer with Hessian-based vcov",
     "Numerically stable log1pexp, log1mexp, clamp_prob",
     "Surv() formula parsing for right/left/interval censoring",
-    "Synthetic fixture generators (.rds reference outputs)",
     "Stubs for cross-validating against C HAZARD binary"
   )
 )
-knitr::kable(layout, caption = "R source files by architectural layer")
+knitr::kable(layout, caption = "Selected R source files by architectural layer")
 ```
 
 
@@ -181,8 +180,14 @@ optima that are common in multiphase models.
 
 The optimizer delegates to `.hzr_optim_generic()`, which wraps
 `stats::optim()` with method `"BFGS"` (unconstrained; all scale
-parameters are log-transformed). The Hessian is computed numerically
-at the converged point for variance-covariance estimation.
+parameters are log-transformed). The Hessian at the converged point,
+inverted for the variance-covariance matrix, is analytic when every row
+is an exact event or right-censored (counting-process start times
+included): `.hzr_hessian_multiphase()` for multiphase fits and a
+closed-form Hessian for each single-phase distribution. When any row is
+left- or interval-censored, the analytic Hessian declines and
+`numDeriv::hessian()` computes it numerically. `numDeriv` is a Suggests,
+so without it those fits have no standard errors.
 
 
 # Golden fixture system
@@ -327,7 +332,7 @@ against the C HAZARD binary output for the KUL CABG dataset:
    saturation at the C reference parameter values.
 
 3. **Conservation of events**: checks that the model-implied expected
-   events ($\sum [1 - \exp(-H(t_i))]$) matches the observed event count
+   events ($\sum [1 - \exp(-H(t_i))]$) match the observed event count
    (545), as reported by the C binary (544.9993).
 
 4. **Profile standard errors**: computes a numerical Hessian varying
@@ -404,7 +409,7 @@ covariates for multivariable analysis.
 avc_vars <- data.frame(
   Variable = c("study", "status", "inc_surg", "opmos", "age", "mal",
                "com_iv", "orifice", "dead", "int_dead", "op_age"),
-  Label = c("Study number", "NYHA functional class (I-V)", "Surgical grade of AV valve incompetence",
+  Label = c("Study number", "NYHA functional class (I-IV)", "Surgical grade of AV valve incompetence",
             "Date of operation (months since Jan 1967)", "Age (months) at repair",
             "Important associated cardiac anomaly", "Interventricular communication",
             "Accessory left AV valve orifice", "Death (event indicator)",
@@ -431,9 +436,14 @@ fixed-width file with 6 columns), but only the death endpoint
 
 The OMC dataset contains 339 patients and is unique in the collection
 because it involves **repeated thromboembolic events** (up to 3 per
-patient) with **left censoring**. The SAS analysis transforms the
-dataset into a repeated-events format using STARTTME and CENSORED
-indicators, exercising the interval censoring likelihood.
+patient). The SAS analysis transforms the dataset into a
+repeated-events format in which each interval starts at the previous
+event (STARTTME) and ends at the next event or censoring (CENSORED).
+The SAS job names STARTTME in its `LCENSOR` statement, and the HAZARD
+documentation calls that left censoring, but it records delayed entry
+(left truncation). The analysis therefore exercises the counting-process
+start-time term of the likelihood, not the left- or interval-censoring
+terms.
 
 ### TGA (transposition of great arteries)
 
@@ -474,8 +484,10 @@ These collapse onto the three-parameter decompos family:
 - **DELTA**: time transformation `B(t) = (exp(delta*t) - 1)/delta`.
   When DELTA = 0 (the common case), `B(t) = t` and the transformation
   is absorbed. Non-zero DELTA is not currently supported.
-- **RHO / THALF**: scale parameter. `RHO = NU * THALF * ((2^M - 1)/M)^NU`.
-  Maps directly to `t_half` in `hzr_phase()`.
+- **RHO / THALF**: scale parameter. THALF maps directly to `t_half` in
+  `hzr_phase()`. RHO has no argument of its own in R: it is fixed by NU,
+  THALF and M, and for M > 0 and NU > 0 it is
+  `RHO = NU * THALF * ((2^M - 1)/M)^NU`.
 - **NU**: time exponent. Maps directly.
 - **M**: shape exponent. Maps directly.
 
@@ -494,13 +506,13 @@ $G_3(t) = \left(\left((t/\tau)^\gamma + 1\right)^{1/\alpha} - 1\right)^\eta$
 
 Unlike G1, G3 is unbounded: it can grow without limit, making it
 suitable for late-phase rising hazards. For the KUL benchmark with
-`gamma = 3, alpha = 1, eta = 1`, this simplifies to $G_3(t) = t^3$.
+`tau = 1, gamma = 3, alpha = 1, eta = 1`, this simplifies to $G_3(t) = t^3$.
 
 
 # Version history
 
-The package follows semantic versioning with a prerelease qualifier
-during active development:
+Versions are plain three-part numbers (major.minor.patch). The early
+milestones were:
 
 - **v0.1.0** (single-phase engine): Weibull, exponential, log-logistic,
   log-normal distributions with formula interface, predict, and golden
@@ -508,9 +520,12 @@ during active development:
 - **v0.9.0** (multiphase engine): N-phase additive cumulative hazard,
   `hzr_phase()` specification, decomposition engine, C binary parity
   tests, dataset catalog.
-- **v0.9.1** (current): vignette suite, roxygen multiphase examples,
+- **v0.9.1**: vignette suite, roxygen multiphase examples,
   CI workflow fixes (load_pkgload), SAS missing-value handling
   (`na.strings`), print.hazard phase labels, and README refresh.
+
+Every release since, up to the installed version, is listed in the
+package NEWS: `news(package = "TemporalHazard")`.
 
 
 # References {.unnumbered}

--- a/vignettes/ar-architecture.qmd
+++ b/vignettes/ar-architecture.qmd
@@ -479,11 +479,11 @@ knitr::kable(
 ## Early phase (G1) mapping
 
 The SAS early phase uses four parameters: DELTA, RHO (or THALF), NU, M.
-These collapse onto the three-parameter decompos family:
+With DELTA = 0 they reduce to the three-parameter decompos family:
 
 - **DELTA**: time transformation `B(t) = (exp(delta*t) - 1)/delta`.
   When DELTA = 0 (the common case), `B(t) = t` and the transformation
-  is absorbed. Non-zero DELTA is not currently supported.
+  drops out. Non-zero DELTA is not supported.
 - **RHO / THALF**: scale parameter. THALF maps directly to `t_half` in
   `hzr_phase()`. RHO has no argument of its own in R: it is fixed by NU,
   THALF and M, and for M > 0 and NU > 0 it is

--- a/vignettes/ar-architecture.qmd
+++ b/vignettes/ar-architecture.qmd
@@ -32,8 +32,9 @@ The SAS/C code and this R package are currently developed and maintained at
 The Cleveland Clinic Foundation, and the R code was wholly developed at The
 Cleveland Clinic Foundation. The package provides a
 unified framework for fitting additive hazard models with an arbitrary
-number of temporal phases, each governed by the three-parameter
-`decompos(t; t_half, nu, m)` family. The generalized temporal
+number of temporal phases. The early (`"cdf"`) and `"hazard"` phases use
+the three-parameter `decompos(t; t_half, nu, m)` family, and the late
+(`"g3"`) phase its own four-parameter shape. The generalized temporal
 decomposition extends naturally to longitudinal mixed-effects settings
 (Rajeswaran et al. 2018).
 
@@ -181,9 +182,10 @@ optima that are common in multiphase models.
 The optimizer delegates to `.hzr_optim_generic()`, which wraps
 `stats::optim()` with method `"BFGS"` (unconstrained; all scale
 parameters are log-transformed). The Hessian at the converged point,
-inverted for the variance-covariance matrix, is analytic when every row
-is an exact event or right-censored (counting-process start times
-included): `.hzr_hessian_multiphase()` for multiphase fits and a
+inverted for the variance-covariance matrix, is assembled analytically
+when every row is an exact event or right-censored (counting-process start
+times included): `.hzr_hessian_multiphase()` for multiphase fits, whose
+phase-shape second derivatives inside it are finite differences, and a
 closed-form Hessian for each single-phase distribution. When any row is
 left- or interval-censored, the analytic Hessian declines and
 `numDeriv::hessian()` computes it numerically. `numDeriv` is a Suggests,

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -461,21 +461,27 @@ fit_step$steps[, c("step_num", "action", "variable", "phase",
 ```
 
 The final model is the fit at the top of the object, reachable
-through the usual hazard accessors:
+through the usual hazard accessors.  AIC counts only the estimated
+parameters.  Both models hold the early phase's three shape parameters
+fixed (`fixed = "shapes"`), and `fit$fit$fixed_mask` flags them, so we
+leave them out of the count, as the `Final model` line of `fit_step`
+does:
 
 ```{r}
 #| eval: !expr requireNamespace("TemporalHazard", quietly = TRUE)
 logLik_manual <- fit_mv$fit$objective
 logLik_step   <- fit_step$fit$objective
+n_free <- function(fit) sum(!fit$fit$fixed_mask)
 c(manual = logLik_manual, stepwise = logLik_step,
-  aic_manual = 2 * length(fit_mv$fit$theta) - 2 * logLik_manual,
-  aic_step   = 2 * length(fit_step$fit$theta) - 2 * logLik_step)
+  aic_manual = 2 * n_free(fit_mv) - 2 * logLik_manual,
+  aic_step   = 2 * n_free(fit_step) - 2 * logLik_step)
 ```
 
 The two models need not agree.  Here stepwise enters `status` in both
 phases but `age`, `mal` and `com_iv` in the early phase only, so it
-carries fewer coefficients than the manual fit.  Its log-likelihood is
-lower and its AIC is lower too, because the dropped constant-phase
+carries fewer coefficients than the manual fit (seven free parameters
+against ten).  Its log-likelihood is lower and its AIC is lower too
+(398.2 against 401.1), because the dropped constant-phase
 coefficients cost more in parameters than they bought in fit.  Even on
 an identical covariate set the two log-likelihoods can differ, since
 the fits use different `n_starts` and the multiphase likelihood can
@@ -637,10 +643,18 @@ observed event rates across the risk spectrum.
 
 ### Conservation of events check
 
-The conservation-of-events principle states that a well-fitting model
-should predict the same total number of events as actually observed.
-`hzr_gof()` tracks this cumulatively over time; the residual
-(expected minus observed) should stay near zero.
+The conservation-of-events principle says a model fit by maximum
+likelihood predicts as many events as were observed: add up every
+patient's cumulative hazard at the end of their follow-up and you get
+the event count back.  `hzr_gof()` is the R version of the SAS
+`hazplot` display, a running tally of observed and expected events
+over time.
+
+For a model with covariates you need to know one thing before reading
+its output.  `hzr_gof()` evaluates the parametric curve at the covariate
+means, one "mean patient", and builds the expected count from that
+single curve.  The printed ratio is then a mean-patient check, not the
+conservation-of-events identity, and for `fit_mv` it is well short of 1.
 
 ```{r}
 #| label: gof-summary
@@ -649,9 +663,28 @@ gof <- hzr_gof(fit_mv)
 print(gof)
 ```
 
+The conservation-of-events check itself sums each patient's own
+cumulative hazard, from their own covariates, at their own follow-up
+time:
+
+```{r}
+#| label: coe-per-subject
+#| eval: !expr requireNamespace("TemporalHazard", quietly = TRUE)
+nd_coe <- avc[, c("age", "status", "mal", "com_iv")]
+nd_coe$time <- avc$int_dead
+c(expected = sum(predict(fit_mv, newdata = nd_coe,
+                         type = "cumulative_hazard")),
+  observed = sum(avc$dead))
+```
+
+Expected 68.0 against 68 observed, so the fit conserves events.  The
+gap in the `hzr_gof()` summary belongs to the mean patient, not to the
+fit.  For an intercept-only model every patient shares one curve, the
+two checks give the same answer, and `hzr_gof()` prints an E/O of 1.
+
 ```{r}
 #| label: fig-gof-survival
-#| fig-cap: "Parametric (blue) vs. Kaplan-Meier (orange) survival"
+#| fig-cap: "Parametric survival at the covariate means (blue) vs. Kaplan-Meier (orange)"
 #| eval: !expr requireNamespace("TemporalHazard", quietly = TRUE) && requireNamespace("ggplot2", quietly = TRUE)
 ggplot(gof, aes(x = time)) +
   geom_step(aes(y = km_surv * 100), colour = "#D55E00", linewidth = 0.6) +
@@ -685,9 +718,20 @@ ggplot(gof, aes(x = time, y = residual)) +
   theme_minimal()
 ```
 
-A residual that hovers near zero across the full time range indicates the
-model conserves events well.  Persistent positive residual means the model
-overpredicts risk; persistent negative means it underpredicts.
+Read these three plots as a picture of the mean patient.  The first sets
+that patient's survival curve against the Kaplan-Meier estimate for the
+whole cohort, and it runs above it from the first weeks on.  The other
+two tally the deaths the mean patient's hazard would predict for the
+patients leaving follow-up at each time.  Most of the deaths come in
+the first weeks, and the mean patient's curve accounts for few of them
+(45 observed by two weeks against about 1.4 expected), so the residual
+falls to about -55 by six months and then climbs back slowly, ending
+at -26.8.  That is the mean patient
+understating the cohort's early risk.  It is not the model
+underpredicting, which the per-subject check above rules out.  For an
+intercept-only model the same plots are the conservation-of-events
+picture, and there a residual that stays near zero is what a good fit
+looks like.
 
 ## Why not Cox regression?
 
@@ -699,9 +743,9 @@ several things that Cox proportional hazards does not:
 | Proportional hazards required | Yes | No |
 | Baseline hazard specified | No | Yes (parametric) |
 | Multiple hazard phases | No | Yes (additive) |
-| Patient-specific survival prediction | Approximate | Exact |
+| Patient-specific survival curve | Step function (Breslow baseline) | Smooth, parametric |
 | Smooth extrapolation beyond data | No | Yes |
-| Conservation of events check | No | Yes (`hzr_gof()`) |
+| Conservation of events | Yes (martingale residuals sum to 0) | Yes (per-subject cumulative hazards sum to the event count) |
 | Interval censoring | Not standard | Supported |
 
 Many clinical outcomes show **non-proportional

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -111,11 +111,12 @@ The returned data frame is the life table: one row per event time with
 `n_risk`, `n_event`, `survival`, logit-transformed 95% CLs
 (`cl_lower` / `cl_upper`), and a KM-based cumulative hazard
 (`-log(survival)`; use `hzr_nelson()` if you need the Nelson-Aalen
-estimator instead).  Plotting just requires the survival column:
+estimator instead).  The plot uses the survival column for the step
+curve and the two confidence limits for the band:
 
 ```{r}
 #| label: fig-km-baseline
-#| fig-cap: "Kaplan-Meier survival estimate for AVC patients (n = 310)"
+#| fig-cap: "Kaplan-Meier survival estimate for AVC patients (n = 305)"
 #| eval: !expr requireNamespace("TemporalHazard", quietly = TRUE) && requireNamespace("ggplot2", quietly = TRUE)
 km_df <- data.frame(
   time     = km$time,
@@ -289,9 +290,10 @@ The cheapest screening tool we have is a univariable logistic
 regression of the event indicator on each covariate. It throws away
 the time-to-event structure but it answers a binary question
 quickly: does this covariate have *any* association with mortality
-at all? Covariates whose univariable p-value is huge will not
-suddenly become significant in the multivariable hazard model
-either, so those can be deprioritized. Covariates with small
+at all? Covariates whose univariable p-value is huge can be
+deprioritized, but not discarded outright, because adjusting for
+other covariates can reveal an association the univariable test
+misses. Covariates with small
 univariable p-values deserve closer functional-form inspection
 before they enter the formula.
 
@@ -357,7 +359,7 @@ ggplot(cal_age, aes(mean, link_value)) +
   theme_minimal()
 ```
 
-The blue points are the observed decile logits; the dashed red line is a
+The blue points are the observed decile logits; the dashed orange line is a
 linear reference.  Deviations from linearity flag where a transform is
 warranted.
 
@@ -401,7 +403,7 @@ The manual approach works when screening has already narrowed the
 candidate pool, but with a larger pool it helps to let the model
 choose.  `hzr_stepwise()` runs forward, backward, or two-way
 selection against an existing `hazard` fit, scoring candidates with
-Wald p-values or delta-AIC.  Defaults match SAS `PROC HAZARD`
+the score statistic, Wald p-values or delta-AIC.  Defaults match SAS `PROC HAZARD`
 (`SLENTRY = 0.30`, `SLSTAY = 0.20`).
 
 We start from a baseline with no covariates, offer the same screened
@@ -412,10 +414,11 @@ per `(variable, phase)` pair, letting a covariate enter one phase
 and not another.  Single-distribution models accept either a flat
 one-sided formula or a character vector of names.
 
-`hzr_stepwise()` now defaults to `criterion = "score"`, which reproduces
+`hzr_stepwise()` defaults to `criterion = "score"`, which reproduces
 SAS's `SELECTION` Q statistic by testing each candidate at the current
 estimates without a per-candidate refit.  Here we pass `criterion = "wald"`
-deliberately, so the trace below reports the refit-based Wald statistic.
+deliberately, so the `$steps` table below reports the refit-based Wald
+p-values.
 
 ```{r}
 #| label: stepwise-forward
@@ -469,9 +472,14 @@ c(manual = logLik_manual, stepwise = logLik_step,
   aic_step   = 2 * length(fit_step$fit$theta) - 2 * logLik_step)
 ```
 
-When the screening and stepwise agree on the same covariate set the
-log-likelihoods match exactly; when stepwise selects a leaner model
-AIC drops.  For an AIC-driven run use `criterion = "aic"`; for a
+The two models need not agree.  Here stepwise enters `status` in both
+phases but `age`, `mal` and `com_iv` in the early phase only, so it
+carries fewer coefficients than the manual fit.  Its log-likelihood is
+lower and its AIC is lower too, because the dropped constant-phase
+coefficients cost more in parameters than they bought in fit.  Even on
+an identical covariate set the two log-likelihoods can differ, since
+the fits use different `n_starts` and the multiphase likelihood can
+have more than one optimum.  For an AIC-driven run use `criterion = "aic"`; for a
 forward-only sweep `direction = "forward"`.  See `?hzr_stepwise` for
 the full argument surface including `force_in`, `force_out`, and the
 `max_move` oscillation guard.
@@ -539,7 +547,7 @@ recognizes.
 
 ```{r}
 #| label: fig-sensitivity
-#| fig-cap: "Survival by risk profile: low-risk (blue) vs. high-risk (red)"
+#| fig-cap: "Survival by risk profile: low-risk (blue) vs. high-risk (orange)"
 #| eval: !expr requireNamespace("TemporalHazard", quietly = TRUE) && requireNamespace("ggplot2", quietly = TRUE)
 low_risk <- data.frame(
   time   = t_grid,
@@ -708,7 +716,7 @@ The complete analytical workflow follows a disciplined sequence:
 
 1. **Kaplan-Meier baseline**: establish the empirical survival pattern
 2. **Shape fitting**: match the temporal shape, simple to complex
-3. **Variable screening**: logistic screening, LOESS functional form
+3. **Variable screening**: logistic screening, decile-logit functional form
 4. **Multivariable model**: enter covariates with fixed shapes
 5. **Prediction**: reference curves, sensitivity analysis
 6. **Validation**: decile calibration, conservation-of-events check

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -479,9 +479,11 @@ c(manual = logLik_manual, stepwise = logLik_step,
 
 The two models need not agree.  Here stepwise enters `status` in both
 phases but `age`, `mal` and `com_iv` in the early phase only, so it
-carries fewer coefficients than the manual fit (seven free parameters
-against ten).  Its log-likelihood is lower and its AIC is lower too
-(398.2 against 401.1), because the dropped constant-phase
+carries fewer coefficients than the manual fit (`r n_free(fit_step)`
+free parameters against `r n_free(fit_mv)`).  Its log-likelihood is lower
+and its AIC is lower too
+(`r round(2 * n_free(fit_step) - 2 * logLik_step, 1)` against
+`r round(2 * n_free(fit_mv) - 2 * logLik_manual, 1)`), because the dropped constant-phase
 coefficients cost more in parameters than they bought in fit.  Even on
 an identical covariate set the two log-likelihoods can differ, since
 the fits use different `n_starts` and the multiphase likelihood can

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -727,8 +727,8 @@ the first weeks, and the mean patient's curve accounts for few of them
 (45 observed by two weeks against about 1.4 expected), so the residual
 falls to about -55 by six months and then climbs back slowly, ending
 at -26.8.  That is the mean patient
-understating the cohort's early risk.  It is not the model
-underpredicting, which the per-subject check above rules out.  For an
+understating the cohort's early risk.  The model itself predicts the
+right number of deaths, as the per-subject check above shows.  For an
 intercept-only model the same plots are the conservation-of-events
 picture, and there a residual that stays near zero is what a good fit
 looks like.

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -637,9 +637,11 @@ ggplot(cal, aes(x = group)) +
   theme_minimal()
 ```
 
-A non-significant overall chi-square statistic (p > 0.05) indicates
-adequate calibration, meaning the model's predictions are consistent with
-observed event rates across the risk spectrum.
+A non-significant overall chi-square statistic (p > 0.05) means the test
+found no evidence of poor calibration. It does not prove the model is
+calibrated: with ten groups and few events in each, the test has little
+power. Read the plot as well. Calibration is adequate when the observed and
+expected rates track each other across the deciles.
 
 ### Conservation of events check
 

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -181,7 +181,7 @@ own temporal shape and its own scale:
 $$H(t \mid x) = \sum_{j=1}^{J} \mu_j(x) \cdot \Phi_j(t)$$
 
 Each $\Phi_j(t)$ is a phase-specific unit-scaled curve (early-peaking
-saturating, flat constant, late-rising polynomial) and each $\mu_j(x)$
+saturating, flat constant, late-rising power law) and each $\mu_j(x)$
 is the phase-specific scale, possibly modulated by covariates. The
 phases overlap and add (no switching, no thresholds), so the total
 instantaneous hazard at any $t$ is the sum of the per-phase rates.
@@ -275,8 +275,7 @@ own follow-up time and event indicator.  The same `hazard()` call fits each
 endpoint independently.
 
 Start with the death endpoint. We use age at operation, NYHA class,
-and mechanical-valve indicator as covariates, the clinically
-canonical set for survival after valve replacement.
+and mechanical-valve indicator as covariates.
 
 ```{r}
 #| label: valves-death
@@ -425,20 +424,22 @@ table(status)
 ```
 
 ::: {.callout-note}
-**`time_lower` as a counting-process entry time.**  In the Weibull and
-multiphase likelihoods, `time_lower` doubles as the *entry* (left-truncation)
-time for right-censored and exact-event rows (`status %in% c(0, 1)`): when
-`0 < time_lower < time`, the row contributes H(stop) − H(start), the
-counting-process form used for epoch-decomposed repeated events.  For an
-ordinary right-censored or event row with no entry time, leave `time_lower`
-at `0` or omit it.  Don't set `time_lower = time` to mean "no entry time";
-`hazard()` warns when you do, and the two likelihoods read it differently.
-The Weibull likelihood uses `time_lower` as an entry time only when it is
-strictly less than `time`, so there it changes nothing.  The multiphase
-likelihood takes it at its word: the row enters the risk set at the moment
-it leaves, and it drops out of the likelihood.  The exponential, log-logistic,
-and log-normal likelihoods do not use `time_lower` as an entry time and are
-unaffected.
+**`time_lower` as a counting-process entry time.**  The Weibull and
+multiphase likelihoods also read `time_lower` as the *entry*
+(left-truncation) time on right-censored and exact-event rows
+(`status %in% c(0, 1)`): when `0 < time_lower < time`, the row contributes
+H(stop) − H(start), the counting-process form used for epoch-decomposed
+repeated events.  The exponential, log-logistic, and log-normal likelihoods
+use `time_lower` only as the lower bound of a `status == 2` interval and
+ignore it on every other row.  For an ordinary right-censored or event row
+with no entry time, leave `time_lower` at `0` or omit it.  Don't set
+`time_lower = time` to mean "no entry time".  `hazard()` accepts it with a
+warning, and what it does next depends on the family.  The Weibull
+likelihood uses `time_lower` as an entry time only when it is strictly less
+than `time`, so those rows enter at 0 and nothing changes.  The multiphase
+likelihood takes it at its word.  Each row enters the risk set at the moment
+it leaves, its cumulative-hazard term vanishes, and the fit it returns is
+meaningless.  The other three families ignore it.
 :::
 
 Fit a Weibull model using both censoring types:
@@ -587,7 +588,7 @@ recognizable:
 |---------|--------------|
 | `fit$fit$converged == FALSE` | Optimizer hit `maxit` without satisfying the gradient tolerance |
 | `vcov()` returns `NA` | Hessian is singular; parameters are not jointly identified |
-| A phase scale (`log_mu`) at a boundary value | That phase is contributing essentially zero hazard; it isn't needed |
+| A phase scale (`log_mu`) at a boundary value | Possibly an unneeded phase, but a tiny scale alone does not show it; check the phase's contribution with `predict(..., decompose = TRUE)` |
 | Enormous standard errors on one or more parameters | Flat likelihood in that direction (weak identification) |
 | Two phases with nearly identical shapes | One can be collapsed into the other |
 
@@ -597,7 +598,6 @@ contain over this follow-up window:
 
 ```{r}
 #| label: overparameterized
-set.seed(42)
 fit_3ph <- hazard(
   Surv(int_dead, dead) ~ 1,
   data   = avc,
@@ -612,7 +612,8 @@ fit_3ph <- hazard(
   fit = TRUE, control = list(n_starts = 5, maxit = 1000)
 )
 
-# Scale magnitudes: exp(log_mu) ≈ 0 for any phase the data doesn't support
+# Scale magnitudes. A tiny exp(log_mu) does not by itself mark an unneeded
+# phase; judge each phase by its contribution, from predict(..., decompose = TRUE)
 log_mu_idx <- grep("log_mu", names(coef(fit_3ph)))
 round(exp(coef(fit_3ph)[log_mu_idx]), 6)
 ```
@@ -655,7 +656,6 @@ minima.
 
 ```{r}
 #| label: nstarts
-set.seed(42)
 fit_robust <- hazard(
   Surv(int_dead, dead) ~ 1,
   data   = avc,

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -592,9 +592,9 @@ recognizable:
 | Enormous standard errors on one or more parameters | Flat likelihood in that direction (weak identification) |
 | Two phases with nearly identical shapes | One can be collapsed into the other |
 
-The AVC dataset has a clear two-phase structure (early CDF plus constant).
-Adding a third late-rising phase asks the data for a pattern it doesn't
-contain over this follow-up window:
+Two phases (early CDF plus constant) describe the AVC data well. Adding a
+third, late-rising phase gives the optimizer two ways to describe the risk
+that remains after recovery:
 
 ```{r}
 #| label: overparameterized

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -116,7 +116,9 @@ ggplot() +
 
 A single Weibull captures the broad trend but misses the distinct early
 operative risk and late attrition that the KM curve reveals.  This motivates
-the multiphase approach below.
+the multiphase approach: `vignette("getting-started")` fits a three-phase
+model to this same cohort, and the multiphase section below walks the
+workflow on AVC.
 
 
 ## Multivariable model: AVC repair
@@ -429,9 +431,12 @@ time for right-censored and exact-event rows (`status %in% c(0, 1)`): when
 `0 < time_lower < time`, the row contributes H(stop) − H(start), the
 counting-process form used for epoch-decomposed repeated events.  For an
 ordinary right-censored or event row with no entry time, leave `time_lower`
-at `0` or omit it.  Setting `time_lower = time` is treated as *no entry*:
-`time_lower` acts as an entry time only when strictly less than `time`, so
-it no longer zeroes the row's contribution.  The exponential, log-logistic,
+at `0` or omit it.  Don't set `time_lower = time` to mean "no entry time";
+`hazard()` warns when you do, and the two likelihoods read it differently.
+The Weibull likelihood uses `time_lower` as an entry time only when it is
+strictly less than `time`, so there it changes nothing.  The multiphase
+likelihood takes it at its word: the row enters the risk set at the moment
+it leaves, and it drops out of the likelihood.  The exponential, log-logistic,
 and log-normal likelihoods do not use `time_lower` as an entry time and are
 unaffected.
 :::
@@ -483,8 +488,9 @@ rbind(
 The interval-censored fit recovers both parameters accurately.  The naive
 fit estimates $\mu$ comparably but introduces a substantial positive bias
 in $\nu$; it sees events consistently appearing at visit times (every 6
-months) and infers a sharper, more periodic hazard shape that doesn't
-match the underlying exponential structure.
+months) and infers a hazard that rises with time ($\hat\nu \approx 1.46$
+against a true $\nu = 1$), a shape that doesn't match the underlying
+exponential structure.
 
 
 ## Convergence troubleshooting
@@ -545,7 +551,8 @@ ggplot(data.frame(time = nel$time, cumhaz = nel$cumhaz),
 ```
 
 The early steep rise, the mid-range roughly-linear section, and the late
-upward acceleration map directly onto the three phases in the CABGKUL model.
+upward acceleration map directly onto the three phases of the CABGKUL model
+fitted in `vignette("getting-started")`.
 
 ### When to fix shape parameters
 
@@ -562,10 +569,14 @@ want in two situations:
   is 50 or more events per free shape parameter. Below that threshold the
   shapes are weakly identified and the optimizer wanders.
 
-Estimate shapes freely (`fixed = "none"`, the default) only when you are
-exploring a new dataset for the first time and have no prior on the temporal
-structure. Even then, start with `fixed = "shapes"` and release the
-shapes one at a time if the fixed-shapes fit shows systematic misfit.
+Estimate shapes freely (leave `fixed` at its default, `character(0)`, which
+fixes nothing) only when you are exploring a new dataset for the first time
+and have no prior on the temporal structure. Even then, start with
+`fixed = "shapes"` and release the shapes one at a time if the fixed-shapes
+fit shows systematic misfit. To fix only some shapes, name them: `fixed`
+takes `"t_half"`, `"nu"` and `"m"` for a `"cdf"` phase, `"tau"`, `"gamma"`,
+`"alpha"` and `"eta"` for a `"g3"` phase, or `"shapes"` for all of them.
+There is no `"none"`; `hzr_phase()` rejects it.
 
 ### Signs of overparameterization
 
@@ -606,16 +617,23 @@ log_mu_idx <- grep("log_mu", names(coef(fit_3ph)))
 round(exp(coef(fit_3ph)[log_mu_idx]), 6)
 ```
 
-The constant and late phase scales are both near zero: the optimizer
-found no evidence in the AVC data for either of those temporal shapes over
-this follow-up window. The early phase is absorbing all the identifiable
-structure. Any phase whose fitted scale is $\mu \lesssim 10^{-4}$ is not
-contributing meaningful hazard and is a candidate for removal. The
+The constant phase scale has collapsed to zero
+($\mu \approx 7 \times 10^{-13}$), and `hazard()` warns that the phase is
+not identified. The late phase scale looks just as small
+($\mu \approx 6 \times 10^{-6}$), but $\mu$ multiplies the phase's own
+shape, and $G_3$ with `tau = 5` and `gamma = 3` grows as $(t/5)^3$. By the
+end of follow-up (170.6 months) the late phase carries 0.23 of the 0.48
+total cumulative hazard. With both phases available, the optimizer drops
+the constant phase and hands the slow post-recovery attrition, which the
+two-phase fit gave the constant phase, to the late phase instead. So judge
+a phase by its contribution, from
+`predict(..., type = "cumulative_hazard", decompose = TRUE)`, not by the
+size of its $\mu$. The
 right diagnostic question is not "did the AIC improve?" but "does this
 phase represent real clinical biology?" Late deterioration after AVC
 repair requires long follow-up to observe; this dataset doesn't have it.
 
-When shapes are also free (`fixed = "none"`), a redundant phase can make
+When shapes are also free (no `fixed` argument), a redundant phase can make
 the Hessian rank-deficient and `vcov()` will return `NA` (the Hessian
 inversion failed). Fix by adding `fixed = "shapes"` to each phase to
 reduce the free-parameter count, then release shapes one at a time if the
@@ -626,9 +644,12 @@ fixed-shapes fit shows systematic misfit.
 Three `control` arguments address most remaining convergence problems:
 
 **`n_starts`** (default 5 for multiphase; single-distribution models run
-one optimizer call and ignore this parameter) runs the optimizer from
-`n_starts` randomly jittered copies of the initial `theta`, then keeps the
-best solution. The default of 5 is sufficient for two-phase models; increase
+one optimizer call and ignore this parameter) runs the optimizer from the
+initial `theta` and from `n_starts - 1` perturbed copies of it, then keeps
+the best solution. The perturbations come from a fixed internal seed
+(`control$start_seed`), so the same call returns the same fit whatever
+`set.seed()` you used, and your session's random-number stream is left
+untouched. The default of 5 is sufficient for two-phase models; increase
 to 8–10 for three or more phases where the likelihood surface has more local
 minima.
 
@@ -666,14 +687,15 @@ overparameterized (fix by fixing shapes or dropping a phase). Raising
 
 ## Phase types reference
 
-You've now seen each phase type in use: a `"cdf"` early phase for AVC
-operative mortality, a `"constant"` phase for AVC background rate, and
-the implicit single shape of every Weibull fit. The package supports
-three phase types in total, summarized here for quick reference:
+You've now seen three phase types in use: a `"cdf"` early phase for AVC
+operative mortality, a `"constant"` phase for the AVC background rate, and
+a `"g3"` late phase in the overparameterization example. The package
+supports four phase types in total, summarized here for quick reference:
 
 | Type | Description | Typical use |
 |------|-------------|-------------|
 | `"cdf"` | Sigmoidal CDF shape (parameterized by `t_half`, `nu`, `m`) | Early or late phases with transient risk |
+| `"hazard"` | Unbounded cumulative hazard from the same family, $\Phi(t) = -\log(1 - G(t))$ (parameterized by `t_half`, `nu`, `m`) | Risk that keeps rising as patients age |
 | `"constant"` | Flat hazard (no temporal shape parameters) | Ongoing background risk |
 | `"g3"` | Late-phase G3 parameterization (4 parameters: `tau`, `gamma`, `alpha`, `eta`) | Late-rising risk matching C/SAS G3 output |
 

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -227,13 +227,13 @@ the package; it's a property of this dataset.
 Each phase is specified with `hzr_phase()`. The first argument picks
 the shape function: `"cdf"` for a saturating curve bounded between 0
 and 1 (the SAS "early" / G1 shape), `"constant"` for a flat hazard
-plateau (SAS "G2"), `"g3"` for the polynomial late-rising shape from
+plateau (SAS "G2"), `"g3"` for the power-law late-rising shape from
 the SAS "late" library. Remaining arguments set the shape's free
 parameters, or fix them with `fixed = "shapes"`. The Phase types
 section below has the full menu.
 
 For this fit we use the textbook three-phase decomposition: a
-saturating early peak, a constant background, and a polynomial late
+saturating early peak, a constant background, and a power-law late
 rise. We fix the shapes so we can compare the fitted scales against
 the published reference; in your own work you would usually estimate
 them.
@@ -426,7 +426,7 @@ hzr_phase("g3",       tau = 1, gamma = 3, alpha = 1,   # Late risk (G3 power law
 
 The `"g3"` type uses the four-parameter G3 decomposition from the original
 C/SAS HAZARD program, providing unbounded power-law growth for late-phase
-hazards. See `vignette("mf-mathematical-foundations")` for the full
+hazards (exponential growth in the `alpha = 0` limit). See `vignette("mf-mathematical-foundations")` for the full
 mathematical treatment.
 
 ## Numerical helpers
@@ -441,8 +441,8 @@ $\log(1 + e^x)$ in a numerically stable way. The naive `log(1 + exp(x))`
 overflows once $x$ exceeds about 700 (because `exp(x)` itself
 overflows); the helper switches to the asymptotic $x + \log(1 + e^{-x})$
 for large $x$, which is exact to floating-point precision. The package
-uses it inside every log-likelihood expression that involves a
-log-survival term, so the same evaluation can run on $x = -50$ and
+uses it in `hzr_decompos()`, the shape function behind the `"cdf"` and
+`"hazard"` phase types, so the same evaluation can run on $x = -50$ and
 $x = 5000$ without producing `Inf` or `NaN`.
 
 ```{r}

--- a/vignettes/inference-diagnostics.qmd
+++ b/vignettes/inference-diagnostics.qmd
@@ -403,14 +403,14 @@ uncertainty-quantified, well-calibrated fitted model. The complete sequence:
    reference KM / Nelson cumulative hazard estimators
 3. **Fit hazard model** (`hazard()`): parametric shape + covariates
 4. **Predict & visualize** (`predict()`): survival, hazard, risk profiles
-5. **Goodness-of-fit overlay** (`hzr_gof()`): parametric vs. KM +
-   Conservation-of-Events check
-6. **Bootstrap CIs** (`hzr_bootstrap()`): uncertainty quantification
+5. **Bootstrap CIs** (`hzr_bootstrap()`): uncertainty quantification
    via resampling
-7. **Sensitivity analysis** (`predict()` on covariate profiles):
-   compare scenarios across risk factors
-8. **Decile calibration** (`hzr_deciles()`): chi-square observed
+6. **Goodness-of-fit overlay** (`hzr_gof()`): parametric vs. KM +
+   Conservation-of-Events check
+7. **Decile calibration** (`hzr_deciles()`): chi-square observed
    vs. expected by risk decile
+8. **Sensitivity analysis** (`predict()` on covariate profiles):
+   compare scenarios across risk factors
 
 See `vignette("getting-started")` for the minimal workflow and
 `vignette("fitting-hazard-models")` for the model-fitting details.

--- a/vignettes/inference-diagnostics.qmd
+++ b/vignettes/inference-diagnostics.qmd
@@ -76,7 +76,8 @@ candidates <- c("age", "status", "mal", "com_iv", "inc_surg", "orifice")
 Fit a univariable logistic regression for each candidate against the
 death indicator. The p-values that come out are not the final word on
 whether a covariate matters (they ignore the joint structure of the
-hazard model and they treat the event time as a binary outcome), but
+hazard model, and they model the death indicator as a plain binary
+outcome with no follow-up time), but
 they do tell you which covariates have no chance of mattering, and
 which deserve closer inspection.
 
@@ -394,8 +395,7 @@ statistically meaningful.
 
 The pieces in this vignette chain together into a single analytical
 workflow that goes from raw covariates to a defensible,
-uncertainty-quantified, well-calibrated fitted model. The complete sequence, with the SAS HAZARD
-correspondences each piece descends from:
+uncertainty-quantified, well-calibrated fitted model. The complete sequence:
 
 1. **Exploratory screening** (`glm`, `hzr_calibrate()`): identify
    covariate transformations and functional forms

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -81,9 +81,11 @@ The three parameters control the shape of the distribution:
 The original C code used different parameter names per phase:
 
 - **Early phase (G1):** `DELTA`, `RHO`/`THALF`, `NU`, `M` $\to$ `t_half`, `nu`, `m`
-- **Late phase (G3):** `TAU`, `GAMMA`, `ALPHA`, `ETA` $\to$ `t_half`, `nu`, `m`
+- **Late phase (G3):** `TAU`, `GAMMA`, `ALPHA`, `ETA` $\to$
+  `hzr_phase("g3", tau = , gamma = , alpha = , eta = )`
 
-Both collapse onto the same 3-parameter decomposition family.  The C `DELTA`
+The late phase is not a member of the three-parameter family above. It
+is a separate four-parameter shape, computed by `hzr_decompos_g3()`. The C `DELTA`
 parameter controlled a time transformation $B(t) = (\exp(\delta t) - 1)/\delta$.
 When $\delta = 0$ (the common case), $B(t) = t$ and the transformation drops
 out. Non-zero `DELTA` is not supported.
@@ -240,7 +242,7 @@ The classic three-phase HAZARD model used:
 
 - **G1** (early) $\to$ `hzr_phase("cdf", ...)`
 - **G2** (constant) $\to$ `hzr_phase("constant")`
-- **G3** (late) $\to$ `hzr_phase("hazard", ...)`
+- **G3** (late) $\to$ `hzr_phase("g3", tau = , gamma = , alpha = , eta = )`
 
 TemporalHazard generalizes this to $J$ phases of any type.
 :::

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -61,7 +61,7 @@ parameter names. For the full translation table, see
 
 Every temporal phase in TemporalHazard is built from a single parametric
 family, `decompos(t; t_half, nu, m)`, introduced by Blackstone, Naftel, and
-Turner (1986) that produces three linked quantities from just three parameters:
+Turner (1986), which produces three linked quantities from just three parameters:
 
 - $G(t)$: cumulative distribution function (CDF), bounded $[0, 1]$
 - $g(t) = dG/dt$: probability density function
@@ -84,8 +84,9 @@ The original C code used different parameter names per phase:
 - **Late phase (G3):** `TAU`, `GAMMA`, `ALPHA`, `ETA` $\to$ `t_half`, `nu`, `m`
 
 Both collapse onto the same 3-parameter decomposition family.  The C `DELTA`
-parameter controlled a time transformation $B(t) = (\exp(\delta t) - 1)/\delta$
-that is absorbed into the shape.
+parameter controlled a time transformation $B(t) = (\exp(\delta t) - 1)/\delta$.
+When $\delta = 0$ (the common case), $B(t) = t$ and the transformation drops
+out. Non-zero `DELTA` is not supported.
 :::
 
 In R, `hzr_decompos()` computes all three quantities:
@@ -241,7 +242,7 @@ The classic three-phase HAZARD model used:
 - **G2** (constant) $\to$ `hzr_phase("constant")`
 - **G3** (late) $\to$ `hzr_phase("hazard", ...)`
 
-TemporalHazard generalizes this to $N$ phases of any type.
+TemporalHazard generalizes this to $J$ phases of any type.
 :::
 
 
@@ -461,10 +462,12 @@ scale, wrapped by `.hzr_optim_generic()`.  Key features:
   `control$n_starts`).  The run with the highest log-likelihood is kept.
 - **Feasibility guard**: any parameter vector where $m < 0$ **and**
   $\nu < 0$ for the same phase returns $-\infty$ immediately.
-- **Post-fit Hessian**: the numerical Hessian of the negative
+- **Post-fit Hessian**: the Hessian of the negative
   log-likelihood at the solution is inverted to produce the
   variance-covariance matrix $\hat{V}$, with standard errors
-  $\sqrt{\text{diag}(\hat{V})}$.  The inversion is hardened against the
+  $\sqrt{\text{diag}(\hat{V})}$.  The Hessian is analytic when every row
+  is an exact event or right-censored, and is computed numerically with
+  `numDeriv::hessian()` when any row is left- or interval-censored.  The inversion is hardened against the
   ill-conditioning that arises at high parameter counts: the Hessian is
   symmetrized, its reciprocal condition number is checked, and it is
   inverted via a Cholesky factorization, with a general `solve()` fallback
@@ -597,8 +600,9 @@ likelihood surfaces.  Practical guidelines:
 
 1. **Fix shape parameters when possible.**  If clinical knowledge suggests a
    specific temporal pattern (e.g. early mortality follows a Weibull shape
-   with $m = 0$), fix `m` in the `hzr_phase()` starting values and inspect
-   whether the optimizer moves it.
+   with $m = 0$), hold `m` at that value with
+   `hzr_phase(..., m = 0, fixed = "m")`; the optimizer then estimates only
+   the remaining parameters.
 
 2. **Start from the SAS/C estimates.**  If legacy results are available,
    translate them using `hzr_argument_mapping()` and supply as starting values.
@@ -621,8 +625,11 @@ The decomposition engine applies several guards:
 - Left- and interval-censored contributions use `hzr_log1mexp()` to avoid
   $\log(0)$ when $H(t)$ is very small
 
-Together these keep the gradients finite throughout the optimization, even in
-regions of parameter space far from the optimum.
+These guards remove the common sources of non-finite values, but not all of
+them: an infeasible trial point returns $-\infty$. For those,
+`.hzr_optim_generic()` replaces a non-finite objective with a large finite
+value (`1e10`) and a non-finite gradient component with zero, so the search
+backs away from that region.
 
 
 # Summary of Key Functions {#sec-api}

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -59,8 +59,8 @@ parameter names. For the full translation table, see
 
 ## The parametric family
 
-Every temporal phase in TemporalHazard is built from a single parametric
-family, `decompos(t; t_half, nu, m)`, introduced by Blackstone, Naftel, and
+The early (`"cdf"`) and `"hazard"` phases in TemporalHazard are built from
+a single parametric family, `decompos(t; t_half, nu, m)`, introduced by Blackstone, Naftel, and
 Turner (1986), which produces three linked quantities from just three parameters:
 
 - $G(t)$: cumulative distribution function (CDF), bounded $[0, 1]$
@@ -82,7 +82,7 @@ The original C code used different parameter names per phase:
 
 - **Early phase (G1):** `DELTA`, `RHO`/`THALF`, `NU`, `M` $\to$ `t_half`, `nu`, `m`
 - **Late phase (G3):** `TAU`, `GAMMA`, `ALPHA`, `ETA` $\to$
-  `hzr_phase("g3", tau = , gamma = , alpha = , eta = )`
+  `hzr_phase("g3", tau = 1, gamma = 3, alpha = 1, eta = 1)`
 
 The late phase is not a member of the three-parameter family above. It
 is a separate four-parameter shape, computed by `hzr_decompos_g3()`. The C `DELTA`
@@ -242,7 +242,7 @@ The classic three-phase HAZARD model used:
 
 - **G1** (early) $\to$ `hzr_phase("cdf", ...)`
 - **G2** (constant) $\to$ `hzr_phase("constant")`
-- **G3** (late) $\to$ `hzr_phase("g3", tau = , gamma = , alpha = , eta = )`
+- **G3** (late) $\to$ `hzr_phase("g3", tau = 1, gamma = 3, alpha = 1, eta = 1)`
 
 TemporalHazard generalizes this to $J$ phases of any type.
 :::
@@ -467,9 +467,11 @@ scale, wrapped by `.hzr_optim_generic()`.  Key features:
 - **Post-fit Hessian**: the Hessian of the negative
   log-likelihood at the solution is inverted to produce the
   variance-covariance matrix $\hat{V}$, with standard errors
-  $\sqrt{\text{diag}(\hat{V})}$.  The Hessian is analytic when every row
-  is an exact event or right-censored, and is computed numerically with
-  `numDeriv::hessian()` when any row is left- or interval-censored.  The inversion is hardened against the
+  $\sqrt{\text{diag}(\hat{V})}$.  When every row is an exact event or
+  right-censored the Hessian is assembled analytically, with the
+  multiphase phase-shape second derivatives inside it taken by finite
+  differences; when any row is left- or interval-censored the whole
+  Hessian is computed numerically with `numDeriv::hessian()`.  The inversion is hardened against the
   ill-conditioning that arises at high parameter counts: the Hessian is
   symmetrized, its reciprocal condition number is checked, and it is
   inverted via a Cholesky factorization, with a general `solve()` fallback

--- a/vignettes/prediction-visualization.qmd
+++ b/vignettes/prediction-visualization.qmd
@@ -121,7 +121,7 @@ fit <- hazard(
 ```
 
 Pick a representative patient (here a median-aged, mid-status,
-no-malalignment, no-grade-IV-complication profile) and evaluate the
+no-malalignment, no-interventricular-communication profile) and evaluate the
 prediction types over a fine time grid. The result is a data frame
 with one row per time point, ready for plotting or downstream
 analysis.
@@ -191,7 +191,7 @@ a survival probability of 0.85 with a 0.4–0.97 band around it, even
 though both round to "85%". Delta-method confidence limits let you
 plot the second case honestly instead of pretending it's the first.
 
-As of v0.9.8, `predict.hazard()` accepts `se.fit = TRUE` (default
+`predict.hazard()` accepts `se.fit = TRUE` (default
 `FALSE`) and `level = 0.95` to return delta-method standard errors
 and confidence limits alongside the point estimate. The return value
 changes shape: a plain numeric vector with `se.fit = FALSE`, a data
@@ -347,9 +347,11 @@ constant (blue) phase represents the ongoing background mortality
 that persists once patients are past the operative window. The late
 (pink) phase captures the gradually increasing risk of late
 attrition (graft failure, comorbidity progression, the aging cohort).
-None of these shapes was specified by hand; the optimizer
-landed on them given the data and the phase-type choices we made up
-front. If a phase looked wrong here (a constant phase dominating
+The early and late shapes were set by hand: `fixed = "shapes"` holds
+`t_half`, `nu` and `m` for the early phase and `tau`, `gamma`,
+`alpha` and `eta` for the late phase at the values in the
+`hzr_phase()` calls. The optimizer estimated only the three scales,
+one per phase, which set how much each phase contributes. If a phase looked wrong here (a constant phase dominating
 where we expected an early peak, or a late phase that never rose)
 that would be a signal to revisit either the starting values, the
 shape parameters, or the data itself.
@@ -360,22 +362,26 @@ shape parameters, or the data itself.
 The decomposed-hazard plot above tells us the model has the right
 *shape* per phase. To check that the *total* fit also tracks the
 data, we collapse back to the overall survival curve and overlay it
-on the KM estimate. This is the same diagnostic as the single-Weibull case
-earlier in this vignette, but now against a model that has the
-structural flexibility to follow the cohort's actual mortality
-pattern.
+on the Kaplan-Meier estimate for the same CABGKUL cohort. This is the
+same diagnostic as the single-Weibull case earlier in this vignette,
+but on the CABG data the multiphase model was fit to, and against a
+model that has the structural flexibility to follow the cohort's
+actual mortality pattern.
 
 ```{r}
 #| label: fig-mp-surv
-#| fig-cap: "Multiphase parametric survival vs. Kaplan-Meier"
+#| fig-cap: "Multiphase parametric survival vs. Kaplan-Meier (CABGKUL death)"
 #| fig-width: 7
 #| fig-height: 4.5
-surv_mp <- predict(fit_mp, newdata = nd, type = "survival") * 100
+km_cabg    <- survfit(Surv(int_dead, dead) ~ 1, data = cabgkul)
+km_cabg_df <- data.frame(time = km_cabg$time, survival = km_cabg$surv * 100)
+surv_mp    <- predict(fit_mp, newdata = nd, type = "survival") * 100
 
 ggplot() +
-  geom_step(data = km_df, aes(time, survival, colour = "Kaplan-Meier"),
+  geom_step(data = km_cabg_df,
+            aes(time, survival, colour = "Kaplan-Meier"),
             linewidth = 0.5) +
-  geom_line(data = data.frame(time = t_grid, survival = surv_mp),
+  geom_line(data = data.frame(time = t_mp, survival = surv_mp),
             aes(time, survival, colour = "Multiphase (3-phase)"),
             linewidth = 1) +
   scale_colour_manual(
@@ -383,7 +389,7 @@ ggplot() +
                "Kaplan-Meier"         = "#D55E00")
   ) +
   scale_y_continuous(limits = c(0, 100)) +
-  labs(x = "Months after AVC repair", y = "Freedom from death (%)",
+  labs(x = "Months after CABG", y = "Freedom from death (%)",
        colour = NULL) +
   theme_minimal() +
   theme(legend.position = "bottom")
@@ -400,9 +406,9 @@ Holding the fitted model fixed and varying the covariate profile
 generates patient-specific survival curves you can show side by side.
 Below we score three plausible profiles drawn from the cohort's own
 quantiles: a low-risk patient (young, mild status, no malalignment,
-no grade-IV complications), a median patient, and a high-risk patient
-(older, severe status, with both adverse anatomical and
-post-operative findings).
+no interventricular communication), a median patient, and a high-risk
+patient (older, severe status, with both malalignment and
+interventricular communication).
 
 ```{r}
 #| label: fig-risk-profiles
@@ -454,9 +460,10 @@ When a cohort has multiple clinical endpoints (death, valve
 endocarditis, reoperation), putting them on the same survival axis
 gives an immediate comparative picture of which event the cohort is
 most at risk for, and over what time horizon. The `valves` dataset
-has separate event-time pairs for each endpoint, so we can plot all
-of them as Kaplan-Meier curves on shared axes without needing a
-parametric fit at all. (You'd parametrize them in the next step, one
+has separate event-time pairs for each endpoint, so any of them can
+go on shared axes as a Kaplan-Meier curve without needing a
+parametric fit at all. Below we plot two: death and prosthetic valve
+endocarditis (PVE). (You'd parametrize them in the next step, one
 endpoint per `hazard()` call, as we did in
 `vignette("fitting-hazard-models")`.)
 

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -102,8 +102,9 @@ through `...` as named arguments and stored in `fit$legacy_args`.
 ### `TIME`
 
 Names the follow-up time variable. In SAS HAZARD this is a separate
-statement; in R it's the first argument to `Surv()` inside the
-formula.
+statement; in R it is the `time` argument of the vector interface
+shown here, or the first argument to `Surv()` if you use the formula
+interface.
 
 ```sas
 TIME INT_DEAD;
@@ -128,7 +129,8 @@ fit <- hazard(
 ### `EVENT`
 
 Names the event-indicator variable. Like `TIME`, this is a separate
-statement in SAS HAZARD but enters the R formula through `Surv()`.
+statement in SAS HAZARD; in R it is the `status` argument shown here,
+or the second argument to `Surv()` in the formula interface.
 
 ```sas
 EVENT DEAD;
@@ -460,9 +462,9 @@ fit
 | `$data$time`          | Follow-up time vector                                       |
 | `$data$status`        | Event indicator (numeric)                                   |
 | `$data$x`             | Design matrix                                               |
-| `$fit$theta`          | Coefficient vector (starting values at M1; fitted at M2+)  |
-| `$fit$converged`      | `NA` at M1; `TRUE`/`FALSE` from M2 optimizer               |
-| `$fit$objective`      | Log-likelihood at convergence (M2+)                        |
+| `$fit$theta`          | Coefficient vector: estimates when `fit = TRUE`, the starting values when `fit = FALSE` |
+| `$fit$converged`      | `TRUE`/`FALSE` from the optimizer; `NA` when `fit = FALSE`  |
+| `$fit$objective`      | Log-likelihood at convergence; `NA` when `fit = FALSE`      |
 | `$legacy_args`        | Named pass-through arguments for parity                     |
 
 > **Note:** `$fit$objective` above is a *number*: the log-likelihood the
@@ -653,8 +655,12 @@ makes the document runnable: a later `predict()` chunk from a
 `CONSERVE` becomes `control$conserve = TRUE`, `QUASI` becomes
 `control$method = "bfgs"`, `CONDITION=14` becomes `control$condition
 = 14`, and the `PARMS` early-phase shape (`MUE`/`THALF`/`NU`/`M FIXM`)
-becomes a `hzr_phase("cdf", ...)` with `m` fixed. These are exactly the
-mappings covered statement-by-statement above, applied automatically.
+becomes a `hzr_phase("cdf", ...)` with `m` fixed. Two of these differ
+from the hand translation above, and the translator's forms are the
+ones `hazard()` acts on. `FIXM` holds `m` only through `fixed = "m"` on
+the phase; the fitting path does not read `control$fix`. `QUASI`
+becomes the optimizer choice `control$method = "bfgs"`, which is also
+the default; `control$quasi` is not read either.
 `dist = "multiphase"` is emitted whenever `phases` is, and `theta`
 carries the full interleaved multiphase start vector (early scale,
 then every early-phase shape parameter in phase order, then the
@@ -692,7 +698,7 @@ gaps are common enough in production jobs to know about going in:
 ## Known limitations vs. SAS HAZARD
 
 A SAS HAZARD veteran migrating to `TemporalHazard` should be aware of
-the following scope limits as of v1.2.2.  Detailed status per feature is
+the following scope limits as of v1.2.11.  Detailed status per feature is
 tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md` and
 `inst/dev/DEVELOPMENT-PLAN.md`.
 

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -164,24 +164,31 @@ PARMS MUE=0.3504743 THALF=0.1905077 NU=1.437416 M=1 FIXM
       MUC=4.391673E-07;
 ```
 
-Maps to `theta` (coefficient/parameter vector) and `control` (fix flags):
+Maps to the phases in `phases`, the start vector `theta`, and, for
+`FIXM`, `fixed = "m"` on the early phase:
 
 ```{r}
 #| eval: false
 fit <- hazard(
-  theta   = c(MUE = 0.3504743, THALF = 0.1905077, NU = 1.437416,
-              M = 1,           MUC   = 4.391673e-07),
-  control = list(
-    fix = c("M")   # FIXM → freeze M during optimization
+  ...,
+  dist   = "multiphase",
+  phases = list(
+    early    = hzr_phase("cdf", t_half = 0.1905077, nu = 1.437416, m = 1,
+                         fixed = "m"),       # FIXM: hold M at its start
+    constant = hzr_phase("constant")
   ),
-  ...
+  theta = c(log(0.3504743),                  # MUE
+            log(0.1905077), 1.437416, 1,     # THALF, NU, M
+            log(4.391673e-07))               # MUC
 )
 ```
 
-> **Note:** Full SAS `PARMS` syntax is not mirrored one-for-one in the public API.
-> In the current package, supply the parameter vector directly via `theta` and
-> record fixed-parameter intent in `control$fix`. The legacy parity helpers do
-> generate SAS-style control text when comparing against the historical binaries.
+> **Note:** `theta` takes the `PARMS` values on the scale the optimizer
+> works on, which is not always the scale SAS prints. `MUE`, `MUC` and
+> `THALF` go in as logs; `NU` and `M` go in as written. A fixed parameter is
+> declared on the phase that owns it, so `FIXM` is `fixed = "m"` inside the
+> early `hzr_phase()`. `hazard()` does not read a `control$fix` entry: a fix
+> written there leaves `M` free, and nothing warns you.
 
 ---
 
@@ -199,38 +206,39 @@ EARLY  AGE=-0.03205774, COM_IV=1.336675, MAL=0.6872028,
 CONSTANT INC_SURG=1.375285, ORIFICE=3.11765, STATUS=1.054988;
 ```
 
-In HAZARD, `EARLY` and `CONSTANT` define phase-specific covariate coefficients.
-In `TemporalHazard` these are unified into a single design matrix `x` and
-coefficient vector `theta` during M1. Phase assignment will be formalised in
-M2 when the multi-phase likelihood is implemented.
+In `TemporalHazard` each block becomes the `formula` of the phase it
+names: the `EARLY` list goes on the early `hzr_phase("cdf", ...)`, the
+`CONSTANT` list on `hzr_phase("constant", ...)`. A covariate listed in
+both blocks, `STATUS` here, appears in both formulas and gets a separate
+coefficient in each phase, as it does in SAS. The model formula's right-hand
+side stays `~ 1` because every covariate belongs to a phase.
 
-**Current convention (M1):** combine all covariates into `x` and supply the
-corresponding starting coefficients in `theta`.
+The starting coefficients go into `theta` in phase order: the early
+phase's scale and shapes, then its covariates, then the constant phase's
+scale, then its covariates. In this chunk `avcs` is `data(avc)` with its
+missing `inc_surg` values filled, as in the worked example below.
 
 ```{r}
 #| eval: false
-# Build design matrix from the AVC data set
-X <- data.matrix(avcs[, c("AGE", "COM_IV", "MAL", "OPMOS", "OP_AGE",
-                           "STATUS", "INC_SURG", "ORIFICE")])
-
-# Starting values from SAS EARLY + CONSTANT blocks combined
-theta_start <- c(
-  AGE      = -0.03205774,
-  COM_IV   =  1.336675,
-  MAL      =  0.6872028,
-  OPMOS    = -0.01963377,
-  OP_AGE   =  0.0002086689,
-  STATUS   =  0.5169533,   # EARLY phase coefficient
-  INC_SURG =  1.375285,
-  ORIFICE  =  3.11765
-)
-
 fit <- hazard(
-  time   = avcs$INT_DEAD,
-  status = avcs$DEAD,
-  x      = X,
-  theta  = theta_start,
-  dist   = "weibull"
+  Surv(int_dead, dead) ~ 1,
+  data   = avcs,
+  dist   = "multiphase",
+  phases = list(
+    early    = hzr_phase("cdf", t_half = 0.1905077, nu = 1.437416, m = 1,
+                         formula = ~ age + com_iv + mal + opmos + op_age +
+                           status,
+                         fixed = "m"),
+    constant = hzr_phase("constant", formula = ~ inc_surg + orifice + status)
+  ),
+  theta = c(
+    log(0.3504743), log(0.1905077), 1.437416, 1,  # MUE, THALF, NU, M
+    -0.03205774, 1.336675, 0.6872028,             # EARLY: AGE, COM_IV, MAL,
+    -0.01963377, 0.0002086689, 0.5169533,         #   OPMOS, OP_AGE, STATUS
+    log(4.391673e-07),                            # MUC
+    1.375285, 3.11765, 1.054988                   # CONSTANT: INC_SURG,
+  ),                                              #   ORIFICE, STATUS
+  fit = TRUE
 )
 ```
 
@@ -371,70 +379,73 @@ PROC HAZARD DATA=AVCS P CONSERVE OUTHAZ=OUTEST CONDITION=14 QUASI;
 );
 ```
 
-### R equivalent (current runnable translation pattern)
+### R equivalent
 
-The same model in `TemporalHazard`. Every SAS statement above has a
-corresponding R argument here: `TIME` and `EVENT` collapse into
-`Surv(int_dead, dead)` on the left of the formula; the global
-covariate list goes on the right; the `PARMS` starting values
-become the `theta` vector; phase-specific assignments use the
-`formula` argument inside each `hzr_phase()`; `FIXM` becomes
-`fixed = "shapes"` (or a subset of shape names). The line-by-line
-correspondence is the point. Once you've translated one analysis
-this way, the pattern carries to every other.
+The same model in `TemporalHazard`, with one R argument for each SAS
+statement:
+
+- `TIME INT_DEAD` and `EVENT DEAD` become `Surv(int_dead, dead)` on the
+  left of the formula. In `avc`, `dead` is 0/1, so it is a status as it
+  stands. A job whose `EVENT` variable counts events also needs `weights`;
+  see the translator section below.
+- `PARMS` becomes the phase shapes and the `theta` start vector, and `FIXM`
+  becomes `fixed = "m"` on the early phase.
+- `EARLY` and `CONSTANT` become the `formula` of the matching
+  `hzr_phase()`.
+- `CONDITION=14`, `CONSERVE` and `QUASI` go into `control` as
+  `condition = 14`, `conserve = TRUE` and `method = "bfgs"`. BFGS is the
+  default optimizer, so the last one records the mapping and changes
+  nothing.
+- `PROC STANDARD REPLACE` from the SAS `DATA` steps becomes one line that
+  fills the missing `inc_surg` values with the column mean.
+
+Once you have translated one analysis this way, the pattern carries to
+every other.
 
 ```{r}
 #| label: avc-example
-#| eval: false
-# Assumed: avcs is a data.frame read from the AVC flat file
-# (same variables as the SAS DATA step)
+#| warning: false
+data(avc)   # reload: the diagnostics above dropped the incomplete rows
+avcs <- avc
 
-avcs <- avcs |>
-  transform(
-    LN_AGE   = log(AGE),
-    LN_OPMOS = log(OPMOS),
-    LN_INC   = ifelse(is.na(INC_SURG), NA, log(INC_SURG + 1)),
-    LN_NYHA  = log(STATUS)
-  )
-
-# Replace missing INC_SURG with column mean (mirrors PROC STANDARD REPLACE)
-avcs$INC_SURG[is.na(avcs$INC_SURG)] <- mean(avcs$INC_SURG, na.rm = TRUE)
-
-X <- data.matrix(avcs[, c("AGE", "COM_IV", "MAL", "OPMOS", "OP_AGE",
-                           "STATUS", "INC_SURG", "ORIFICE")])
+# PROC STANDARD REPLACE: fill missing INC_SURG with the column mean
+avcs$inc_surg[is.na(avcs$inc_surg)] <- mean(avcs$inc_surg, na.rm = TRUE)
 
 fit <- hazard(
-  time    = avcs$INT_DEAD,
-  status  = avcs$DEAD,
-  x       = X,
-  theta   = c(
-    # Hazard shape parameters (from PARMS)
-    MUE   = 0.3504743,
-    THALF = 0.1905077,
-    NU    = 1.437416,
-    M     = 1,
-    MUC   = 4.391673e-07,
-    # Covariate coefficients (from EARLY + CONSTANT blocks)
-    AGE      = -0.03205774,
-    COM_IV   =  1.336675,
-    MAL      =  0.6872028,
-    OPMOS    = -0.01963377,
-    OP_AGE   =  0.0002086689,
-    STATUS   =  0.5169533,
-    INC_SURG =  1.375285,
-    ORIFICE  =  3.11765
+  Surv(int_dead, dead) ~ 1,                        # TIME, EVENT
+  data   = avcs,
+  dist   = "multiphase",
+  phases = list(
+    early    = hzr_phase("cdf", t_half = 0.1905077, nu = 1.437416, m = 1,
+                         formula = ~ age + com_iv + mal + opmos + op_age +
+                           status,                 # EARLY
+                         fixed = "m"),             # FIXM
+    constant = hzr_phase("constant",
+                         formula = ~ inc_surg + orifice + status)  # CONSTANT
   ),
-  dist    = "weibull",
-  control = list(
-    condition = 14,
-    quasi     = TRUE,
-    conserve  = TRUE,
-    fix       = c("M")   # FIXM
-  )
+  theta = c(                                       # PARMS, EARLY, CONSTANT
+    log(0.3504743), log(0.1905077), 1.437416, 1,
+    -0.03205774, 1.336675, 0.6872028, -0.01963377, 0.0002086689, 0.5169533,
+    log(4.391673e-07),
+    1.375285, 3.11765, 1.054988
+  ),
+  control = list(condition = 14, conserve = TRUE, method = "bfgs"),
+  fit = TRUE
 )
 
-fit
+summary(fit)
 ```
+
+The `PARMS` and covariate values in this job are the estimates from an
+earlier SAS run of the same model, so both programs start at SAS's
+optimum. R agrees that it is one. The log-likelihood is -160.408, the
+value SAS prints for this model, and the standard errors agree with the
+SAS listing to within 0.31%: `AGE` is 0.009381 here against SAS's 0.009380, and the
+early-phase `log_mu` (SAS's `E0`) is 0.7527 against 0.7550. `summary()`
+notes an ill-conditioned Hessian (`rcond = 4.41e-12`); SAS reports the
+same condition for this fit as a log10 condition code of 11.12. Run
+interactively, the fit also raises `Hessian is ill-conditioned` warnings.
+The chunk hides them because `summary()` reports the same thing.
 
 ---
 
@@ -511,9 +522,16 @@ Everything above is a mapping you apply by hand. `hzr_translate_sas()`
 applies it for you: point it at a `.sas` file and it parses the
 `PROC HAZARD` / `PROC HAZPRED` blocks and emits a `.qmd` document
 whose chunks are the `hazard()` / `predict.hazard()` calls those
-blocks describe. It is the same statement-by-statement mapping this
-vignette documents, run by the parser instead of by you. It is useful
-for a one-off job, and essential for migrating a corpus of hundreds.
+blocks describe. It applies the statement-by-statement mapping this
+vignette documents, with differences of form you will see in its
+output: it writes the vector interface (`data =`, `time =`, `status =`)
+where this vignette writes a `Surv()` formula, it keeps the SAS job's
+upper-case column names, and it turns `EVENT` into a status and
+`weights` pair, covered below. The phases, `fixed = "m"`, `theta` and
+`control` it emits for the AVC model above are the ones the worked
+example uses, and on `avc` its call reaches the same estimates. It is
+useful for a one-off job, and essential for migrating a corpus of
+hundreds.
 
 ::: {.callout-warning}
 ## Experimental: what it will and will not translate
@@ -655,12 +673,11 @@ makes the document runnable: a later `predict()` chunk from a
 `CONSERVE` becomes `control$conserve = TRUE`, `QUASI` becomes
 `control$method = "bfgs"`, `CONDITION=14` becomes `control$condition
 = 14`, and the `PARMS` early-phase shape (`MUE`/`THALF`/`NU`/`M FIXM`)
-becomes a `hzr_phase("cdf", ...)` with `m` fixed. Two of these differ
-from the hand translation above, and the translator's forms are the
-ones `hazard()` acts on. `FIXM` holds `m` only through `fixed = "m"` on
-the phase; the fitting path does not read `control$fix`. `QUASI`
-becomes the optimizer choice `control$method = "bfgs"`, which is also
-the default; `control$quasi` is not read either.
+becomes a `hzr_phase("cdf", ...)` with `m` fixed. These are the forms
+the hand translation above uses. `FIXM` holds `m` only through
+`fixed = "m"` on the phase, and `QUASI` works only as the optimizer
+choice `control$method = "bfgs"`, which is also the default: the fitting
+path reads neither `control$fix` nor `control$quasi`.
 `dist = "multiphase"` is emitted whenever `phases` is, and `theta`
 carries the full interleaved multiphase start vector (early scale,
 then every early-phase shape parameter in phase order, then the
@@ -698,7 +715,7 @@ gaps are common enough in production jobs to know about going in:
 ## Known limitations vs. SAS HAZARD
 
 A SAS HAZARD veteran migrating to `TemporalHazard` should be aware of
-the following scope limits as of v1.2.11.  Detailed status per feature is
+the following scope limits.  Detailed status per feature is
 tracked in `inst/dev/SAS-PARITY-GAP-ANALYSIS.md` and
 `inst/dev/DEVELOPMENT-PLAN.md`.
 

--- a/vignettes/sas-to-r-migration.qmd
+++ b/vignettes/sas-to-r-migration.qmd
@@ -675,9 +675,11 @@ makes the document runnable: a later `predict()` chunk from a
 = 14`, and the `PARMS` early-phase shape (`MUE`/`THALF`/`NU`/`M FIXM`)
 becomes a `hzr_phase("cdf", ...)` with `m` fixed. These are the forms
 the hand translation above uses. `FIXM` holds `m` only through
-`fixed = "m"` on the phase, and `QUASI` works only as the optimizer
-choice `control$method = "bfgs"`, which is also the default: the fitting
-path reads neither `control$fix` nor `control$quasi`.
+`fixed = "m"` on the phase. `QUASI` changes nothing: `hazard()` does not
+read `control$method`, and the fitting path always uses BFGS (a
+multiphase fit may run a Nelder-Mead warm-up first), so the entry only
+records the SAS choice. The fitting path reads none of `control$fix`,
+`control$quasi` or `control$method`.
 `dist = "multiphase"` is emitted whenever `phases` is, and `theta`
 carries the full interleaved multiphase start vector (early scale,
 then every early-phase shape parameter in phase order, then the


### PR DESCRIPTION
This fixes the content flagged in #252. It is stacked on `docs/no-ai-slop` and should retarget to `main` when #252 merges. It is the TemporalHazard counterpart of ggRandomForests#285.

Each of the 70 flags was checked by **running code** against the package and its data, not by reading the source. Five agents took one file group each and ran the vignettes' own chunks, the package's likelihood functions, or the dataset in question.

## Outcome of the 70 flags
| File group | Flags | Real, fixed | Not real | Judgement call |
|---|---|---|---|---|
| fitting, inference, getting-started | 13 | 12 (1 in part) | 0 | 1 |
| clinical walkthrough, prediction-visualization | 14 | 12 | 0 | 2 |
| architecture, mathematical foundations | 13 | 13 | 0 | 0 |
| SAS migration, README, SAS/stepwise roxygen | 15 | 11 | 3 | 1 |
| model roxygen (phase-spec, hazard_api, data, likelihoods, decomposition) | 15 | 12 | 0 | 3 |
| **Total** | **70** | **60** | **3** | **7** |

The three not-real flags: the `score-test.R` sign note is accurate, the fitted objective equals `.hzr_logl_weibull()` at -222.6541, and the real misstatement was in the likelihood files, which are now fixed. The migration vignette's "before 1.2.2" pointer is correct according to NEWS. An 87-character roxygen line is under the repo's 120-column `line_length_linter`. The seven judgement calls went to the maintainer and are recorded below.

## What changed, by weight
**Wrong on its face (fixed, each proved numerically):**
- `?hzr_weibull`-family internals: `likelihood-weibull.R` `@details` subtracted S where it should subtract H. `likelihood-loglogistic.R` added H (the sign was wrong), left `exp(eta)` out of the hazard numerator and the event term, and used `beta` for both the shape and the coefficients. Its score block had the same errors. The corrected formulas reproduce the package's value to about 1e-14, and the score block matches `numDeriv::grad`. Three files called functions "negative log-likelihood" when they return the log-likelihood; they now match `survreg`'s `loglik` exactly.
- `prediction-visualization.qmd`: the multiphase Kaplan-Meier overlay plotted the **CABGKUL** fit against the **AVC** Kaplan-Meier curve on the AVC grid. It is now CABGKUL throughout, and model minus KM stays within 0.7 points up to 118.8 months. The prose said the shapes were estimated, but `fixed = "shapes"` holds them at the start values.
- `fitting-hazard-models.qmd`: `fixed = "none"` is neither the default nor valid (`hzr_phase()` rejects it). The `n_starts` perturbations come from `control$start_seed`, not `set.seed()`. "More periodic" is corrected: the naive interval fit gives nu of 1.46 against a true 1.
- `mf-mathematical-foundations.qmd` / `ar-architecture.qmd`: the post-fit Hessian is **analytic** unless a row is left- or interval-censored, in which case `numDeriv` computes it. This was checked by counting calls on each path. OMC is left **truncation**, not left censoring. Also fixed: NYHA I-IV (not I-V), and a `golden_fixtures.R` table row for a file that is not in `R/`.
- `sas-to-r-migration.qmd`: both hand-translation chunks returned **starting values, not fits**: they left out `fit = TRUE`, whose default is `FALSE`. With it added they errored, because the theta layout was wrong. Their `control$fix` and `control$quasi` entries are not read by `hazard()`: with `control = list(fix = "M")`, `m` moves from 1 to 0.824 and nothing warns. Both are rewritten in the multiphase form, with per-phase formulas and `fixed = "m"`. The worked example is now **evaluated** on `avc` and reproduces the SAS listing: log-likelihood **-160.408**, standard errors within **0.31%**, and the same ill-conditioning (rcond 4.4e-12 against SAS's log10 condition of 11.1). The PARMS chunk uses `fixed = "m"`. The translator paragraphs now describe what `hzr_translate_sas()` actually emits (the vector interface and upper-case names), and on `avc` its call reaches the same estimates.
- README: the stepwise criteria now include `score`, which is the default. A dead link to `.github/BRANCH_PROTECTION.md` is removed.

**Found while verifying, not in the original 70:**
- **#253:** with `time_lower = time` on status 0/1 rows, the five families disagree. Multiphase returns objective **+47915.76 with `converged = TRUE`**. This PR scopes the docs and the warning text to what the code does. The code fix is tracked in #253.
- **#254:** `hzr_gof()` prints a "Conservation ratio (E/O)" computed at the covariate means. On the walkthrough's `fit_mv` it prints 0.606, while the per-subject sum is **68.000 against 68 observed**. This PR documents the behaviour. The fix is tracked in #254.
- The walkthrough's stepwise AIC chunk counted fixed shape parameters (404.21 against the 398.21 that `print()` gives). The `opmos` "won't become significant" advice is disproved by the vignette's own data (p goes from 0.655 univariable to 0.0197 adjusted).

## Judgement calls (your answers, and the defaults applied)
Your four answers:
1. **`time_lower`:** scope the docs to what the code does now, and file an issue. Filed as #253. The `@param`, the warning text and its code comment now say which families honour the entry time. `test-time-lower-entry.R` gains two assertions that **fail against the old text**; the provisional run showed exactly that.
2. **`hzr_gof()`:** document it, and file an issue. Filed as #254. `?hzr_gof` and the walkthrough now say the curve is taken at the covariate means, show the per-subject check, and point to the intercept-only case, where E/O = 1 exactly.
3. **Migration chunks:** rewritten as multiphase (see above).
4. **Smaller calls:** defaults applied, as follows.
   - Cox table: the "Approximate vs Exact" row now reads "Step function (Breslow baseline) vs Smooth, parametric". The Conservation-of-events row claimed Cox has none; Cox martingale residuals sum to -1.9e-14 on this data, so both columns now say "Yes".
   - Walkthrough AIC counts only estimated parameters, via `fit$fit$fixed_mask`: 398.21 stepwise, which matches `print()`, against 401.08 manual.
   - The no-op `set.seed(42)` lines are deleted. The fits are identical with or without them, and `.Random.seed` is untouched by `hazard()`.
   - mf G3 callout: now `hzr_phase("g3", tau, gamma, alpha, eta)`, a separate four-parameter shape. The "collapse onto the same family" line is dropped.
   - `argument_mapping` DELTA row: `r_parameter`, `transform_rule` and `implementation_status` now agree with its notes.
   - "Clinically canonical" is cut. The dead README link stays removed. The migration vignette's version stamp is dropped. The inference workflow list is reordered to match its sections.
   - The architecture source table keeps a "Selected" caption. The version history keeps the early milestones and adds a pointer to `news()`. The `?omc` text is reworded. The ` -- ` inside `@examples` code comments is left alone.

**Left for you, not changed:**
- The DELTA row's status is `"planned"`, the table's only non-implemented value. The notes say a job with non-zero DELTA is refused. A new status value would change what `include_planned` returns.
- The walkthrough's AIC figures are typed into the prose by hand.
- The migration example starts from SAS's converged estimates. From a perturbed start it stops 0.0035 short, which is the known reltol behaviour. It also emits about 10 intermediate Hessian warnings before the final rcond, hidden with `warning: false`.
- The TIME and EVENT statement chunks in the migration vignette still use the vector interface next to the new formula chunks.

## Verification
- `devtools::document()` regenerated the affected `man/` pages. `lintr::lint_package()` gives **0 lints**. `spelling::spell_check_package()` gives **0** (one coined word was reworded in `8a3914a`).
- `NOT_CRAN=true devtools::test()` on the final tree: **0 failures, 0 errors, 4174 passes, 10 skips**. That is two more passes than #252, from the new warning-text assertions. All 10 skips are environment availability: the bh.dead fixture, maze datasets not mounted, the weighted-AVC fixture, and the legacy binary exiting 126. A provisional run over a half-edited tree failed exactly those two new assertions against the old message, so they can fail.
- `R CMD check --as-cran` **with the manual**, from a `git archive` export of `9776775`: **Status: OK** (0/0/0). The PDF manual, the examples (including `--run-donttest` and the new `?hzr_gof` per-subject example) and the vignette rebuild all pass. Tests took 122 s and vignettes 57 s. `8a3914a` afterwards changes one prose word and passed spelling.
- **No behaviour change.** Every non-roxygen line changed in `R/` is either the #136 warning's string literal and its code comment in `hazard_api.R`, or the three DELTA fields in the `argument_mapping.R` table. A filter that drops comment, string and `warning(` lines leaves nothing in `hazard_api.R`. `test-argument-mapping.R` (5) and `test-sas-grammar.R` (20) are unchanged.
- Every edited vignette was purled and run top to bottom under `load_all()`.
- The tarball is 3,137,634 bytes, 11.9 KB more than #252, because the migration example is now evaluated.

- **CI on this PR is partial until it is retargeted.** It targets `docs/no-ai-slop`, and only `spelling.yaml` fires for PRs into any branch. `R-CMD-check` (the five-platform matrix), `lint`, `pkgdown` and `test-coverage` fire only for PRs into `main`. A near-empty checks list here is not a pass: the matrix runs when this PR is retargeted to `main` after #252 merges. Until then, the local gates above are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
