### PR TITLE
hzr_translate_sas(): translate %repeat into hzr_repeated_events()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,9 +56,11 @@
 * **`hzr_translate_sas()` translates a `%repeat` call** into
   `hzr_repeated_events()` (#241), renaming its outputs to the names the job
   gives them so the job's fit reads them. The macro's input is still the
-  reader's to supply. A DATA step that changes the macro's output before the
-  fit now stops the document with the step quoted; the translation no longer
-  fits data that SAS did not fit.
+  reader's to supply. Any step between the macro and the fit that names the
+  macro's output, other than a plain `PROC SORT`, stops the document with the
+  step quoted, rather than fitting data the job changed. A step that changes
+  the output without naming it, such as a macro that writes it internally, is
+  not detected.
 
 # TemporalHazard 1.2.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,13 @@
   `NA` exactly when `"weak_direction_check"` is listed. An object saved by an
   earlier version prints "not recorded" rather than "none".
 
+* **`hzr_translate_sas()` translates a `%repeat` call** into
+  `hzr_repeated_events()` (#241), renaming its outputs to the names the job
+  gives them so the job's fit reads them. The macro's input is still the
+  reader's to supply. A DATA step that changes the macro's output before the
+  fit now stops the document with the step quoted; the translation no longer
+  fits data that SAS did not fit.
+
 # TemporalHazard 1.2.10
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -57,10 +57,11 @@
   `hzr_repeated_events()` (#241), renaming its outputs to the names the job
   gives them so the job's fit reads them. The macro's input is still the
   reader's to supply. Any step between the macro and the fit that names the
-  macro's output, other than a plain `PROC SORT`, stops the document with the
-  step quoted, rather than fitting data the job changed. A step that changes
-  the output without naming it, such as a macro that writes it internally, is
-  not detected.
+  macro's output, or uses a macro variable that might, stops the document
+  with the step quoted, rather than fitting data the job changed; a plain
+  `PROC SORT` is the one step let through. A step that changes the output
+  without naming it, such as a macro that writes it internally, is not
+  detected.
 
 ## Bug fixes
 

--- a/R/sas-lex.R
+++ b/R/sas-lex.R
@@ -163,7 +163,22 @@
   trimws(.hzr_sas_strip_inline_comments(s))
 }
 
-#' Extract PROC HAZARD / PROC HAZPRED blocks from normalised source.
+#' Offset of the `)` that balances the `(` at `open_at`, or NA if none does.
+#' @noRd
+.hzr_sas_close_paren <- function(txt, open_at) {
+  depth <- 0L
+  for (i in seq(open_at, nchar(txt))) {
+    ch <- substr(txt, i, i)
+    if (ch == "(") depth <- depth + 1L
+    if (ch == ")") {
+      depth <- depth - 1L
+      if (depth == 0L) return(i)
+    }
+  }
+  NA_integer_
+}
+
+#' Extract PROC HAZARD / PROC HAZPRED blocks and %repeat calls from normalised source.
 #'
 #' Blocks are delimited by parentheses, not by the macro call's name: HAZARD's
 #' own lexer treats `)` as whitespace, so a parenthesised group -- not the
@@ -182,15 +197,35 @@
 #' function only ever runs on output from `.hzr_sas_normalise()`, which has
 #' already stripped all comments, so there is no trailing comment prose left
 #' to sweep in.
+#'
+#' A `%REPEAT(` call is returned as a third kind, `proc = "REPEAT"`, whose text
+#' is its argument list. It is an ordinary macro call, so its group is the one
+#' that opens right after the name and no backwards search is needed. Every
+#' block also carries `start` and `end`, offsets into `txt`, so the caller can
+#' read the source text between two blocks.
 #' @noRd
 .hzr_sas_blocks <- function(txt) {
   out <- list()
-  procs <- gregexpr("PROC HAZ(ARD|PRED) ", txt)[[1L]]
+  procs <- gregexpr("PROC HAZ(ARD|PRED) |%REPEAT *[(]", txt)[[1L]]
   if (procs[1L] == -1L) return(out)
   proc_lens <- attr(procs, "match.length")
 
   for (k in seq_along(procs)) {
     proc_at <- procs[k]
+
+    if (identical(substring(txt, proc_at, proc_at + 6L), "%REPEAT")) {
+      open_at <- proc_at + proc_lens[k] - 1L
+      close_at <- .hzr_sas_close_paren(txt, open_at)
+      end_at <- if (is.na(close_at)) nchar(txt) else close_at
+      body_end <- if (is.na(close_at)) end_at else close_at - 1L
+      out[[length(out) + 1L]] <- list(
+        proc = "REPEAT", text = trimws(substring(txt, open_at + 1L, body_end)),
+        terminator = if (is.na(close_at)) "none" else "paren",
+        start = proc_at, end = end_at
+      )
+      next
+    }
+
     proc <- if (identical(substring(txt, proc_at, proc_at + 10L), "PROC HAZARD")) {
       "HAZARD"
     } else {
@@ -227,33 +262,22 @@
       search_from <- proc_at + proc_lens[k]
       rest <- substring(txt, search_from)
       b <- regexpr("PROC |DATA |RUN;", rest)
-      body <- if (b == -1L) {
-        substring(txt, proc_at)
-      } else {
-        substring(txt, proc_at, search_from + b - 2L)
-      }
+      end_at <- if (b == -1L) nchar(txt) else search_from + b - 2L
+      body <- substring(txt, proc_at, end_at)
       term <- "none"
+      start_at <- proc_at
     } else {
-      depth <- 0L
-      close_at <- NA_integer_
-      for (i in seq(open_at, nchar(txt))) {
-        ch <- substr(txt, i, i)
-        if (ch == "(") depth <- depth + 1L
-        if (ch == ")") {
-          depth <- depth - 1L
-          if (depth == 0L) {
-            close_at <- i
-            break
-          }
-        }
-      }
+      close_at <- .hzr_sas_close_paren(txt, open_at)
       term <- if (is.na(close_at)) "none" else "paren"
       body <- substring(txt, open_at + 1L,
                         if (is.na(close_at)) nchar(txt) else close_at - 1L)
+      start_at <- open_at
+      end_at <- if (is.na(close_at)) nchar(txt) else close_at
     }
 
     out[[length(out) + 1L]] <- list(proc = proc, text = trimws(body),
-                                    terminator = term)
+                                    terminator = term,
+                                    start = start_at, end = end_at)
   }
   out
 }

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -1314,8 +1314,9 @@
     args[[key]] <- val
   }
 
-  # A WORK. libref names the same dataset as the bare name, which is how the
-  # job's own PROC HAZARD DATA= and the rewrite scan refer to it.
+  # A WORK. libref names the same dataset as the bare name, and the rewrite
+  # scan compares bare names. A fit written DATA=WORK.X keeps its libref, so it
+  # is not matched to this OUT= and gets the ordinary "Assign" guard instead.
   args[c("IN", "OUT")] <- sub("^WORK[.]", "", args[c("IN", "OUT")])
 
   inputs <- unname(args[c("ID", "EVENTYPE", "IV_EVENT", "IV_END")])
@@ -1389,13 +1390,17 @@
 #' the same dataset as the bare name. Each hit is returned quoted: the step's
 #' statements up to the next `DATA`, `PROC`, `%HAZ`, `%REPEAT`, `RUN` or `QUIT`.
 #' A step that changes `out` without naming it (a macro that writes it
-#' internally) cannot be seen from here.
+#' internally) cannot be seen from here. Any statement starting with `%` (a
+#' macro call) is a step of its own, so it cannot hide inside an exempt one.
+#' A sort counts as plain only when every statement after its PROC line is a
+#' `BY`: a `WHERE` statement subsets the data. A step that uses a macro
+#' variable (`&name`) is a hit, because the variable could name `out`.
 #' @noRd
 .hzr_repeat_rewrites <- function(segment, out) {
   out <- sub("^WORK[.]", "", out)
   stmts <- trimws(strsplit(segment, ";", fixed = TRUE)[[1L]])
   stmts <- stmts[nzchar(stmts)]
-  boundary <- "^(DATA |PROC |%HAZ|%REPEAT|RUN$|QUIT$)"
+  boundary <- "^(DATA |PROC |%|RUN$|QUIT$)"
   names_in <- function(s) sub("^WORK[.]", "", strsplit(s, "[^A-Z0-9_.]+")[[1L]])
   plain_sort <- paste0("PROC SORT DATA=", c(out, paste0("WORK.", out)))
   hits <- character(0)
@@ -1410,13 +1415,41 @@
     writes <- if (startsWith(s, "DATA ")) {
       targets <- strsplit(trimws(gsub("[(][^)]*[)]", " ", substring(s, 6L))), " +")[[1L]]
       out %in% sub("^WORK[.]", "", targets)
-    } else if (s %in% plain_sort) {
+    } else if (s %in% plain_sort && all(grepl("^BY ", step[-1L]))) {
       FALSE
     } else {
       any(vapply(step, function(x) out %in% names_in(x), logical(1L)))
     }
+    # A macro variable (&DSN) could name OUT; its value is not known here, so
+    # a step that uses one is treated as naming it -- the same call
+    # .hzr_parse_repeat() makes when it refuses IN=&DSN.
+    writes <- writes || any(grepl("&[A-Z_]", step))
     if (writes) hits <- c(hits, paste0(paste(step, collapse = "; "), ";"))
     i <- last + 1L
   }
   hits
+}
+
+#' The stop() chunks and $untranslated rows for steps that may change `out`.
+#'
+#' One chunk per step `.hzr_repeat_rewrites()` finds in `segment`, each quoting
+#' the step and telling the reader to replace it with R code, or delete it if
+#' the step leaves `out` unchanged.
+#' @noRd
+.hzr_rewrite_stops <- function(segment, out) {
+  steps <- .hzr_repeat_rewrites(segment, out)
+  stops <- lapply(steps, function(step) {
+    bquote(stop(.(paste0(
+      "This job may change ", out, " after %repeat, in a SAS step that ",
+      "hzr_translate_sas() does not translate: ", step, " Replace this chunk ",
+      "with R code that makes the same change to ", out, ", or delete it if ",
+      "the step leaves ", out, " unchanged."
+    ))))
+  })
+  list(
+    calls = stops,
+    untranslated = .hzr_untranslated_frame(
+      rep(NA_integer_, length(steps)), rep(paste0(out, " changed after %repeat"), length(steps)), steps
+    )
+  )
 }

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -424,7 +424,10 @@
     }
     mapped <- mapped + 1L
     switch(token,
-      DATA        = data_name <- val,
+      # A WORK. libref names the same dataset as the bare name. Dropping it
+      # here makes the emitted data =, the status chunk and the guard use the
+      # bare name, which is also how a %repeat OUT= is recorded.
+      DATA        = data_name <- sub("^WORK[.]", "", val),
       OUTHAZ      = outhaz <- val,
       MAXITER     = {
         val_num <- suppressWarnings(as.numeric(val))
@@ -1273,11 +1276,11 @@
 #' keyword, a positional argument, a value that is not a plain SAS name (a
 #' `&macro` reference, say), an input column that is also an output
 #' (`EVENTYPE=RCENSOR`: SAS zeroes that indicator before reading it, so the job's
-#' own answer is not the model it describes), and two outputs with one name. So
-#' are a keyword given twice, which SAS rejects, and an output named `LAG_IV` or
-#' `NUMBER`, the macro's own loop counters. The body is split on every comma; a
-#' value holding parentheses, where a comma could be nested, is refused as not a
-#' plain name either way.
+#' own answer is not the model it describes), and two outputs with one name. A
+#' keyword given twice, which SAS rejects, is refused too, and so is an output
+#' named `LAG_IV` or `NUMBER`, the macro's own loop counters. The body is split
+#' on every comma; a value holding parentheses, where a comma could be nested, is
+#' refused as not a plain name either way.
 #' @noRd
 .hzr_parse_repeat <- function(block) {
   parts <- if (nzchar(block$text)) trimws(strsplit(block$text, ",", fixed = TRUE)[[1L]]) else character(0)

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -1357,3 +1357,35 @@
        tokens_seen = length(parts), tokens_mapped = length(parts),
        in_name = in_name, out_name = out_name)
 }
+
+#' Steps between a `%repeat` call and a fit that rewrite the macro's `OUT=`.
+#'
+#' `segment` is the normalised source between the two. A hit is a `DATA`
+#' statement naming `out` among its output datasets (options in parentheses
+#' ignored) or a `PROC SQL` `CREATE TABLE out`. Each is returned quoted, from
+#' that statement up to the next `DATA`, `PROC`, `%HAZ`, `%REPEAT` or `RUN`.
+#' `PROC SORT` is not a rewrite: reordering rows does not change the
+#' likelihood.
+#' @noRd
+.hzr_repeat_rewrites <- function(segment, out) {
+  stmts <- trimws(strsplit(segment, ";", fixed = TRUE)[[1L]])
+  stmts <- stmts[nzchar(stmts)]
+  boundary <- "^(DATA |PROC |%HAZ|%REPEAT|RUN$)"
+  hits <- character(0)
+  for (i in seq_along(stmts)) {
+    s <- stmts[i]
+    tok <- strsplit(s, " ", fixed = TRUE)[[1L]]
+    writes <- if (startsWith(s, "DATA ")) {
+      out %in% strsplit(trimws(gsub("[(][^)]*[)]", " ", substring(s, 6L))), " +")[[1L]]
+    } else {
+      j <- which(tok == "CREATE")
+      any(tok[j + 1L] %in% "TABLE" & tok[j + 2L] %in% out)
+    }
+    if (writes) {
+      last <- i
+      while (last < length(stmts) && !grepl(boundary, stmts[last + 1L])) last <- last + 1L
+      hits <- c(hits, paste0(paste(stmts[i:last], collapse = "; "), ";"))
+    }
+  }
+  hits
+}

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -1273,14 +1273,17 @@
 #' keyword, a positional argument, a value that is not a plain SAS name (a
 #' `&macro` reference, say), an input column that is also an output
 #' (`EVENTYPE=RCENSOR`: SAS zeroes that indicator before reading it, so the job's
-#' own answer is not the model it describes), and two outputs with one name. The
-#' body is split on every comma; a value holding parentheses, where a comma could
-#' be nested, is refused as not a plain name either way.
+#' own answer is not the model it describes), and two outputs with one name. So
+#' are a keyword given twice, which SAS rejects, and an output named `LAG_IV` or
+#' `NUMBER`, the macro's own loop counters. The body is split on every comma; a
+#' value holding parentheses, where a comma could be nested, is refused as not a
+#' plain name either way.
 #' @noRd
 .hzr_parse_repeat <- function(block) {
   parts <- if (nzchar(block$text)) trimws(strsplit(block$text, ",", fixed = TRUE)[[1L]]) else character(0)
   args <- .hzr_repeat_defaults
   problems <- character(0)
+  seen_keys <- character(0)
 
   for (p in parts) {
     kv <- regmatches(p, regexec("^([A-Z_][A-Z0-9_]*) ?= ?(.*)$", p))[[1L]]
@@ -1294,6 +1297,11 @@
       problems <- c(problems, sprintf("`%s=` is not a %%repeat parameter", key))
       next
     }
+    if (key %in% seen_keys) {
+      problems <- c(problems, sprintf("`%s=` is given more than once", key))
+      next
+    }
+    seen_keys <- c(seen_keys, key)
     name_re <- if (key %in% c("IN", "OUT")) {
       "^[A-Z_][A-Z0-9_]*([.][A-Z_][A-Z0-9_]*)?$"
     } else {
@@ -1306,6 +1314,10 @@
     args[[key]] <- val
   }
 
+  # A WORK. libref names the same dataset as the bare name, which is how the
+  # job's own PROC HAZARD DATA= and the rewrite scan refer to it.
+  args[c("IN", "OUT")] <- sub("^WORK[.]", "", args[c("IN", "OUT")])
+
   inputs <- unname(args[c("ID", "EVENTYPE", "IV_EVENT", "IV_END")])
   targets <- c(unname(args[.hzr_repeat_outputs]), "FIRST", "LAST")
   for (hit in intersect(inputs, targets)) {
@@ -1317,6 +1329,12 @@
   dup <- unique(targets[duplicated(targets)])
   if (length(dup)) {
     problems <- c(problems, sprintf("two outputs are both named %s", paste(dup, collapse = ", ")))
+  }
+  for (hit in intersect(targets, c("LAG_IV", "NUMBER"))) {
+    problems <- c(problems, sprintf(paste(
+      "output %s has the name of a %%repeat loop counter; SAS's RETAIN reads it,",
+      "so the job's own result is not the model it describes"
+    ), hit))
   }
 
   if (length(problems)) {
@@ -1358,34 +1376,47 @@
        in_name = in_name, out_name = out_name)
 }
 
-#' Steps between a `%repeat` call and a fit that rewrite the macro's `OUT=`.
+#' Steps between a `%repeat` call and a fit that may change the macro's `OUT=`.
 #'
-#' `segment` is the normalised source between the two. A hit is a `DATA`
-#' statement naming `out` among its output datasets (options in parentheses
-#' ignored) or a `PROC SQL` `CREATE TABLE out`. Each is returned quoted, from
-#' that statement up to the next `DATA`, `PROC`, `%HAZ`, `%REPEAT` or `RUN`.
-#' `PROC SORT` is not a rewrite: reordering rows does not change the
-#' likelihood.
+#' `segment` is the normalised source between the two, and the scan fails
+#' closed. A `DATA` step is a hit when its output list names `out`; a step that
+#' only reads it (`SET out`) is not. Any other step or statement that names
+#' `out` is a hit as well -- `PROC SQL`, `PROC APPEND`, `PROC DATASETS`, a sort
+#' with `NODUPKEY`, `OUT=` or `WHERE=`, a macro call -- because a false stop
+#' costs the reader one deleted chunk and a missed rewrite fits data SAS did
+#' not fit. The one exception is the plain `PROC SORT DATA=out`, which only
+#' reorders rows and so cannot change the likelihood. A `WORK.` prefix names
+#' the same dataset as the bare name. Each hit is returned quoted: the step's
+#' statements up to the next `DATA`, `PROC`, `%HAZ`, `%REPEAT`, `RUN` or `QUIT`.
+#' A step that changes `out` without naming it (a macro that writes it
+#' internally) cannot be seen from here.
 #' @noRd
 .hzr_repeat_rewrites <- function(segment, out) {
+  out <- sub("^WORK[.]", "", out)
   stmts <- trimws(strsplit(segment, ";", fixed = TRUE)[[1L]])
   stmts <- stmts[nzchar(stmts)]
-  boundary <- "^(DATA |PROC |%HAZ|%REPEAT|RUN$)"
+  boundary <- "^(DATA |PROC |%HAZ|%REPEAT|RUN$|QUIT$)"
+  names_in <- function(s) sub("^WORK[.]", "", strsplit(s, "[^A-Z0-9_.]+")[[1L]])
+  plain_sort <- paste0("PROC SORT DATA=", c(out, paste0("WORK.", out)))
   hits <- character(0)
-  for (i in seq_along(stmts)) {
-    s <- stmts[i]
-    tok <- strsplit(s, " ", fixed = TRUE)[[1L]]
-    writes <- if (startsWith(s, "DATA ")) {
-      out %in% strsplit(trimws(gsub("[(][^)]*[)]", " ", substring(s, 6L))), " +")[[1L]]
-    } else {
-      j <- which(tok == "CREATE")
-      any(tok[j + 1L] %in% "TABLE" & tok[j + 2L] %in% out)
-    }
-    if (writes) {
-      last <- i
+  i <- 1L
+  while (i <= length(stmts)) {
+    last <- i
+    if (grepl("^(DATA |PROC )", stmts[i])) {
       while (last < length(stmts) && !grepl(boundary, stmts[last + 1L])) last <- last + 1L
-      hits <- c(hits, paste0(paste(stmts[i:last], collapse = "; "), ";"))
     }
+    step <- stmts[i:last]
+    s <- stmts[i]
+    writes <- if (startsWith(s, "DATA ")) {
+      targets <- strsplit(trimws(gsub("[(][^)]*[)]", " ", substring(s, 6L))), " +")[[1L]]
+      out %in% sub("^WORK[.]", "", targets)
+    } else if (s %in% plain_sort) {
+      FALSE
+    } else {
+      any(vapply(step, function(x) out %in% names_in(x), logical(1L)))
+    }
+    if (writes) hits <- c(hits, paste0(paste(step, collapse = "; "), ";"))
+    i <- last + 1L
   }
   hits
 }

--- a/R/sas-parse-job.R
+++ b/R/sas-parse-job.R
@@ -1236,3 +1236,124 @@
     tokens_seen = seen, tokens_mapped = mapped
   )
 }
+
+# ---------------------------------------------------------------------------
+# %repeat -> hzr_repeated_events()
+# ---------------------------------------------------------------------------
+
+# %repeat's keyword parameters and defaults, as the macro declares them
+# (~/Documents/macro.library/repeat.sas), upper-cased as
+# .hzr_sas_normalise() leaves every name.
+.hzr_repeat_defaults <- c(
+  IN = "BUILT", OUT = "EVENTS", EVENTYPE = "EVENTYPE", IV_EVENT = "IV_EVENT",
+  IV_END = "IV_END", ID = "ID", EVENT = "EVENT", EVENT_NO = "EVENT_NO",
+  RCENSOR = "RCENSOR", IV_START = "IV_START", IV_SEG = "IV_SEG", RENEWAL = "RENEWAL"
+)
+
+# hzr_repeated_events()'s fixed output names, each mapped to the macro
+# parameter that renames it. first and last have no parameter: the macro
+# always writes them under those names.
+.hzr_repeat_outputs <- c(
+  event = "EVENT", event_no = "EVENT_NO", rcensor = "RCENSOR",
+  iv_start = "IV_START", iv_seg = "IV_SEG", renewal = "RENEWAL"
+)
+
+#' Translate one `%repeat(...)` call into an `hzr_repeated_events()` chunk.
+#'
+#' The emitted chunk renames the function's lower-case outputs to the names the
+#' job uses, upper-cased like every name this translator emits; without that the
+#' fit reads a column that does not exist. Before the call it drops any input
+#' column named like one of those outputs. SAS overwrites such a column, and the
+#' macro assigns each output on every row before reading it, so dropping is
+#' exactly what SAS does. Left in place, the rename would produce two columns of
+#' one name, and `$` would return the stale one.
+#'
+#' A call this cannot express is refused rather than guessed at: the chunk is a
+#' `stop()`, and each problem is an `$untranslated` row. That covers an unknown
+#' keyword, a positional argument, a value that is not a plain SAS name (a
+#' `&macro` reference, say), an input column that is also an output
+#' (`EVENTYPE=RCENSOR`: SAS zeroes that indicator before reading it, so the job's
+#' own answer is not the model it describes), and two outputs with one name. The
+#' body is split on every comma; a value holding parentheses, where a comma could
+#' be nested, is refused as not a plain name either way.
+#' @noRd
+.hzr_parse_repeat <- function(block) {
+  parts <- if (nzchar(block$text)) trimws(strsplit(block$text, ",", fixed = TRUE)[[1L]]) else character(0)
+  args <- .hzr_repeat_defaults
+  problems <- character(0)
+
+  for (p in parts) {
+    kv <- regmatches(p, regexec("^([A-Z_][A-Z0-9_]*) ?= ?(.*)$", p))[[1L]]
+    if (!length(kv)) {
+      problems <- c(problems, sprintf("`%s` is not a KEY=VALUE argument", p))
+      next
+    }
+    key <- kv[2L]
+    val <- trimws(kv[3L])
+    if (!key %in% names(args)) {
+      problems <- c(problems, sprintf("`%s=` is not a %%repeat parameter", key))
+      next
+    }
+    name_re <- if (key %in% c("IN", "OUT")) {
+      "^[A-Z_][A-Z0-9_]*([.][A-Z_][A-Z0-9_]*)?$"
+    } else {
+      "^[A-Z_][A-Z0-9_]*$"
+    }
+    if (!grepl(name_re, val)) {
+      problems <- c(problems, sprintf("`%s=%s` is not a plain SAS name", key, val))
+      next
+    }
+    args[[key]] <- val
+  }
+
+  inputs <- unname(args[c("ID", "EVENTYPE", "IV_EVENT", "IV_END")])
+  targets <- c(unname(args[.hzr_repeat_outputs]), "FIRST", "LAST")
+  for (hit in intersect(inputs, targets)) {
+    problems <- c(problems, sprintf(paste(
+      "input column %s is also an output %%repeat writes; SAS overwrites it before reading it,",
+      "so the job's own result is not the model it describes"
+    ), hit))
+  }
+  dup <- unique(targets[duplicated(targets)])
+  if (length(dup)) {
+    problems <- c(problems, sprintf("two outputs are both named %s", paste(dup, collapse = ", ")))
+  }
+
+  if (length(problems)) {
+    msg <- paste0("hzr_translate_sas() did not translate this job's %repeat call: ",
+                  paste(problems, collapse = "; "), ".")
+    return(list(
+      call = bquote(stop(.(msg))),
+      untranslated = .hzr_untranslated_frame(rep(NA_integer_, length(problems)),
+                                             rep("%repeat", length(problems)), problems),
+      tokens_seen = length(parts), tokens_mapped = 0L, in_name = NULL, out_name = NULL
+    ))
+  }
+
+  in_name <- args[["IN"]]
+  out_name <- args[["OUT"]]
+  from <- c(names(.hzr_repeat_outputs), "first", "last")
+  overwrite_msg <- paste0(" in ", in_name, ": %repeat writes columns of these names, so they were dropped ",
+                          "before the call, as SAS overwrites them.")
+  loop_msg <- paste0(" in ", in_name, ": SAS's %repeat reads a LAG_IV or NUMBER column in place of its ",
+                     "own loop counters, so for this job the SAS listing's segment starts and event ",
+                     "counts are not comparable with these.")
+  call <- bquote(.(as.name(out_name)) <- local({
+    d <- .(as.name(in_name))
+    drop <- intersect(names(d), .(targets))
+    if (length(drop)) {
+      warning(paste(drop, collapse = ", "), .(overwrite_msg), call. = FALSE)
+      d <- d[setdiff(names(d), drop)]
+    }
+    loop <- intersect(names(d), c("LAG_IV", "NUMBER"))
+    if (length(loop)) warning(paste(loop, collapse = ", "), .(loop_msg), call. = FALSE)
+    out <- hzr_repeated_events(d, id = .(args[["ID"]]), time = .(args[["IV_EVENT"]]),
+                               followup = .(args[["IV_END"]]), indicator = .(args[["EVENTYPE"]]))
+    names(out)[match(.(from), names(out))] <- .(targets)
+    out
+  }))
+
+  list(call = call, untranslated = .hzr_untranslated_frame(),
+       tokens_seen = length(parts), tokens_mapped = length(parts),
+       in_name = in_name, out_name = out_name)
+}

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -113,13 +113,15 @@
 #' every name the translator emits, so the fit reads them. An input column named
 #' like one of those outputs is dropped first, with a warning, because the macro
 #' overwrites it. The macro's input is built by the job's own DATA steps, which
-#' are not translated, so the document stops until that input is assigned. Any
-#' step between the macro and the fit that names the macro's output is not
-#' translated either, apart from a plain `PROC SORT`, which only reorders rows.
-#' Its chunk stops and quotes the step, for the reader to replace with R code or
-#' to delete if the step leaves the output unchanged. A step that changes the
-#' output without naming it, such as a macro that writes it internally, is not
-#' detected.
+#' are not translated, so the document stops until that input is assigned.
+#' Any step between the macro and the fit that names the macro's output, or
+#' uses a macro variable that might, is not translated either; a plain
+#' `PROC SORT` that only reorders rows is the one step let through. Its chunk
+#' stops and quotes the step, for the reader to replace with R code or to delete
+#' if the step leaves the output unchanged. The same holds between two
+#' `%repeat` calls when the second reads the first's output. A step that changes
+#' the output without naming it, such as a macro that writes it internally, is
+#' not detected.
 #'
 #' @section Comparing a translated fit against a SAS listing:
 #' The emitted `hzr_phase("g3", ...)` call carries the `TAU`, `GAMMA`,

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -193,6 +193,16 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
   for (b in blocks) {
     if (identical(b$proc, "REPEAT")) {
       r <- .hzr_parse_repeat(b)
+      # A %repeat whose IN= is an earlier %repeat's OUT= reads that dataset as
+      # the job left it, so a step between the two that changes it is the same
+      # untranslated rewrite a fit would read; stop on it here, ahead of the
+      # second macro's chunk.
+      if (!is.null(r$in_name) && !is.null(repeat_scan[[r$in_name]])) {
+        rs <- .hzr_rewrite_stops(substring(txt, repeat_scan[[r$in_name]] + 1L, b$start - 1L), r$in_name)
+        for (cl in rs$calls) calls[[.hzr_next_call_name(calls, "rewrite")]] <- cl
+        untr <- rbind(untr, rs$untranslated)
+        repeat_scan[[r$in_name]] <- b$end
+      }
       # The macro's input is built by the job's own DATA steps, which this
       # translator does not translate: the same loud guard a PROC HAZARD
       # DATA= gets, once per name.
@@ -226,18 +236,9 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
       # last one ended, so one rewrite stops once however many fits follow.
       dname <- if (is.null(r$call[["data"]])) NULL else as.character(r$call[["data"]])
       if (!is.null(dname) && !is.null(repeat_scan[[dname]])) {
-        seg <- substring(txt, repeat_scan[[dname]] + 1L, b$start - 1L)
-        for (step in .hzr_repeat_rewrites(seg, dname)) {
-          calls[[.hzr_next_call_name(calls, "rewrite")]] <- bquote(stop(.(paste0(
-            "This job may change ", dname, " after %repeat, in a SAS step that ",
-            "hzr_translate_sas() does not translate: ", step, " Replace this chunk ",
-            "with R code that makes the same change to ", dname, ", or delete it if ",
-            "the step leaves ", dname, " unchanged."
-          ))))
-          untr <- rbind(untr, .hzr_untranslated_frame(
-            NA_integer_, paste0(dname, " changed after %repeat"), step
-          ))
-        }
+        rs <- .hzr_rewrite_stops(substring(txt, repeat_scan[[dname]] + 1L, b$start - 1L), dname)
+        for (cl in rs$calls) calls[[.hzr_next_call_name(calls, "rewrite")]] <- cl
+        untr <- rbind(untr, rs$untranslated)
         repeat_scan[[dname]] <- b$end
       }
 

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -106,6 +106,17 @@
 #' confidence limits unless the SAS job says `NOCL`, so such a job stops at
 #' its `predict()` chunks.
 #'
+#' @section Repeated events:
+#' A job that builds its fit input with the SAS macro `%repeat` has that call
+#' translated to [hzr_repeated_events()]. The emitted chunk renames the
+#' function's output columns to the names the job gives them, upper-cased like
+#' every name the translator emits, so the fit reads them. An input column named
+#' like one of those outputs is dropped first, with a warning, because the macro
+#' overwrites it. The macro's input is built by the job's own DATA steps, which
+#' are not translated, so the document stops until that input is assigned. A DATA
+#' step that changes the macro's output before the fit is not translated either.
+#' Its chunk stops and quotes the step, for the reader to replace with R code.
+#'
 #' @section Comparing a translated fit against a SAS listing:
 #' The emitted `hzr_phase("g3", ...)` call carries the `TAU`, `GAMMA`,
 #' `ALPHA` and `ETA` that `PARMS` specified. `PROC HAZARD` does not always

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -156,7 +156,9 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
 
   txt <- .hzr_sas_normalise(readLines(path, warn = FALSE))
   blocks <- .hzr_sas_blocks(txt)
-  if (!length(blocks)) {
+  # A %repeat call alone is a dataset-building job (the tp.bd.* templates),
+  # not a HAZARD job, and there is nothing to fit.
+  if (!any(vapply(blocks, function(b) b$proc != "REPEAT", logical(1L)))) {
     stop("no HAZARD or HAZPRED block found in ", path, call. = FALSE)
   }
 
@@ -173,6 +175,7 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
   n_unresolved_inhaz <- 0L
 
   for (b in blocks) {
+    if (identical(b$proc, "REPEAT")) next # translated in Task 3
     if (identical(b$proc, "HAZARD")) {
       r <- tryCatch(.hzr_parse_hazard(b), error = function(e) {
         stop("failed to parse PROC HAZARD block in ", basename(path), ": ",

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -173,14 +173,57 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
   loaded_ext <- list()       # raw INHAZ string -> loaded chunk's slot name
   first_unresolved_inhaz <- NULL
   n_unresolved_inhaz <- 0L
+  repeat_scan <- list()      # %repeat OUT= -> offset its rewrite scan resumes from
 
   for (b in blocks) {
-    if (identical(b$proc, "REPEAT")) next # translated in Task 3
-    if (identical(b$proc, "HAZARD")) {
+    if (identical(b$proc, "REPEAT")) {
+      r <- .hzr_parse_repeat(b)
+      # The macro's input is built by the job's own DATA steps, which this
+      # translator does not translate: the same loud guard a PROC HAZARD
+      # DATA= gets, once per name.
+      if (!is.null(r$in_name) && !(r$in_name %in% guarded_data)) {
+        calls[[.hzr_next_call_name(calls, "data")]] <- bquote(
+          if (!exists(.(r$in_name))) {
+            stop("This job built ", .(r$in_name), " in SAS DATA steps, which ",
+                 "hzr_translate_sas() does not translate. Assign ", .(r$in_name),
+                 " as it stood at the job's %repeat call, with its columns named ",
+                 "as the job spells them, in upper case, before rendering.")
+          }
+        )
+        guarded_data <- c(guarded_data, r$in_name)
+      }
+      calls[[.hzr_next_call_name(calls, "repeated")]] <- r$call
+      # OUT= is now built by a chunk, so a fit reading it needs no guard.
+      if (!is.null(r$out_name)) {
+        guarded_data <- c(guarded_data, r$out_name)
+        repeat_scan[[r$out_name]] <- b$end
+      }
+    } else if (identical(b$proc, "HAZARD")) {
       r <- tryCatch(.hzr_parse_hazard(b), error = function(e) {
         stop("failed to parse PROC HAZARD block in ", basename(path), ": ",
              conditionMessage(e), call. = FALSE)
       })
+
+      # A DATA step between %repeat and this fit that rewrites the macro's
+      # OUT= is job code this translator does not fold in. Fitting without it
+      # fits data SAS did not fit, so stop here -- ahead of the status chunk,
+      # which writes into the same data frame. The scan resumes where the
+      # last one ended, so one rewrite stops once however many fits follow.
+      dname <- if (is.null(r$call[["data"]])) NULL else as.character(r$call[["data"]])
+      if (!is.null(dname) && !is.null(repeat_scan[[dname]])) {
+        seg <- substring(txt, repeat_scan[[dname]] + 1L, b$start - 1L)
+        for (step in .hzr_repeat_rewrites(seg, dname)) {
+          calls[[.hzr_next_call_name(calls, "rewrite")]] <- bquote(stop(.(paste0(
+            "This job changes ", dname, " after %repeat, in a SAS DATA step that ",
+            "hzr_translate_sas() does not translate: ", step, " Replace this chunk ",
+            "with R code that makes the same change to ", dname, "."
+          ))))
+          untr <- rbind(untr, .hzr_untranslated_frame(
+            NA_integer_, paste0("DATA ", dname, " after %repeat"), step
+          ))
+        }
+        repeat_scan[[dname]] <- b$end
+      }
 
       # A hazard() call that reads a SAS DATA= dataset by name cannot
       # actually run: the DATA step that built it is out of scope for this

--- a/R/translate-sas.R
+++ b/R/translate-sas.R
@@ -113,9 +113,13 @@
 #' every name the translator emits, so the fit reads them. An input column named
 #' like one of those outputs is dropped first, with a warning, because the macro
 #' overwrites it. The macro's input is built by the job's own DATA steps, which
-#' are not translated, so the document stops until that input is assigned. A DATA
-#' step that changes the macro's output before the fit is not translated either.
-#' Its chunk stops and quotes the step, for the reader to replace with R code.
+#' are not translated, so the document stops until that input is assigned. Any
+#' step between the macro and the fit that names the macro's output is not
+#' translated either, apart from a plain `PROC SORT`, which only reorders rows.
+#' Its chunk stops and quotes the step, for the reader to replace with R code or
+#' to delete if the step leaves the output unchanged. A step that changes the
+#' output without naming it, such as a macro that writes it internally, is not
+#' detected.
 #'
 #' @section Comparing a translated fit against a SAS listing:
 #' The emitted `hzr_phase("g3", ...)` call carries the `TAU`, `GAMMA`,
@@ -215,7 +219,7 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
              conditionMessage(e), call. = FALSE)
       })
 
-      # A DATA step between %repeat and this fit that rewrites the macro's
+      # A step between %repeat and this fit that may change the macro's
       # OUT= is job code this translator does not fold in. Fitting without it
       # fits data SAS did not fit, so stop here -- ahead of the status chunk,
       # which writes into the same data frame. The scan resumes where the
@@ -225,12 +229,13 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
         seg <- substring(txt, repeat_scan[[dname]] + 1L, b$start - 1L)
         for (step in .hzr_repeat_rewrites(seg, dname)) {
           calls[[.hzr_next_call_name(calls, "rewrite")]] <- bquote(stop(.(paste0(
-            "This job changes ", dname, " after %repeat, in a SAS DATA step that ",
+            "This job may change ", dname, " after %repeat, in a SAS step that ",
             "hzr_translate_sas() does not translate: ", step, " Replace this chunk ",
-            "with R code that makes the same change to ", dname, "."
+            "with R code that makes the same change to ", dname, ", or delete it if ",
+            "the step leaves ", dname, " unchanged."
           ))))
           untr <- rbind(untr, .hzr_untranslated_frame(
-            NA_integer_, paste0("DATA ", dname, " after %repeat"), step
+            NA_integer_, paste0(dname, " changed after %repeat"), step
           ))
         }
         repeat_scan[[dname]] <- b$end
@@ -242,8 +247,7 @@ hzr_translate_sas <- function(path, out_dir = NULL, librefs = NULL) {
       # "object 'AVCS' not found", insert a chunk that fails loudly and
       # explains what the reader still has to supply, right before this
       # fit -- once per distinct dataset name, however many fits reference it.
-      if (!is.null(r$call[["data"]])) {
-        dname <- as.character(r$call[["data"]])
+      if (!is.null(dname)) {
         if (!(dname %in% guarded_data)) {
           guard_slot <- .hzr_next_call_name(calls, "data")
           calls[[guard_slot]] <- bquote(

--- a/inst/dev/REPEAT-TRANSLATOR-PLAN.md
+++ b/inst/dev/REPEAT-TRANSLATOR-PLAN.md
@@ -1,0 +1,1042 @@
+# `%repeat` → `hzr_repeated_events()` in `hzr_translate_sas()`: implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A SAS job that calls `%repeat(...)` is translated into an emitted chunk that calls
+`hzr_repeated_events()` and renames the function's outputs to the job's names, so that the
+job's `PROC HAZARD` fit reads the right columns.
+
+**Architecture:** `.hzr_sas_blocks()` gains a third block kind, `REPEAT`, and records every
+block's `start`/`end` offset. That keeps blocks in file order. `.hzr_parse_repeat()` turns a
+`REPEAT` block into one emitted call, or into a `stop()` when the call cannot be translated.
+`hzr_translate_sas()` dispatches the new kind: it guards `IN=`, marks `OUT=` as built, and
+before each fit that reads `OUT=` it scans the text since the macro for DATA steps that
+rewrite `OUT=`, emitting a quoted `stop()` for each.
+
+**Tech Stack:** base R only; testthat 3e; withr (already used in tests); haven (Suggests,
+gated test only).
+
+**Spec:** `inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md` §5.5. Branch `feat/translate-repeat`.
+
+## Global Constraints
+
+- No new dependency. `Imports:` stays `survival`; `haven` and `withr` are already Suggests.
+- `stats::`-prefix any stats generic in `R/`. No `browser()`, bare `print()`, `cat()` or
+  `library()` in `R/`.
+- Version stays **1.2.11**. No bump. The NEWS bullet goes under the existing
+  `# TemporalHazard 1.2.11` heading (several PRs share one patch version; that is deliberate).
+- `man/` and `NAMESPACE` are generated. Run `devtools::document()`; never hand-edit them.
+- Every emitted name is upper case (the translator runs `.hzr_sas_normalise()`, which calls
+  `toupper()`).
+- The chunk that calls the function is labelled **`repeated`**, never `repeat`: `repeat` is an
+  R reserved word, so `job$calls$repeat` is a syntax error (verified 2026-09-10).
+- Tests must be able to fail. Execute the emitted calls with `eval()`. Compare against
+  vectors derived by hand from the macro, never from the function. Assert the shape before
+  the values. For small numbers compare a ratio to 1, not a difference (waldo goes absolute
+  when `expected < tolerance`).
+- Anything that fits a model gets `skip_on_cran()`.
+- PHI: nothing from `/Volumes/qhsstudies` enters the repository. The gated test reads the
+  volume at run time and asserts only aggregates.
+- Gates, in this order: `devtools::document()`, `lintr::lint_package()` (0 lints),
+  `devtools::test()` (0 failures), `spelling::spell_check_package(use_wordlist = TRUE)`, then
+  once per PR `R CMD check --as-cran` **with** the manual, built from a `git archive` of a
+  **committed** tree under the session scratchpad.
+- Never push to `main`. Branch, PR, stop; the maintainer merges.
+
+## The synthetic fixture (used by Tasks 2–3)
+
+Four columns, three subjects. The expected output below was derived **by hand** from
+`repeat.sas`, stage by stage, and then confirmed to match `hzr_repeated_events()` on
+2026-09-10:
+
+- Subject A has events at 1 and 3 and a non-event row at 2, which stage 2 drops. Its
+  follow-up ends at 5, so stage 4 appends a censored row at 5.
+- Subject B has no event and a missing time. Stage 3 pads the row to `IV_END` = 4 with
+  `rcensor` 1.
+- Subject C has events at 1 and 6, with 6 equal to `IV_END`. Stage 4 appends a row at 6.
+  Stage 6 sets `rcensor` to 1 on the event row at 6, so it is both an event and censored.
+  Stage 7 drops the appended row, because it has zero length.
+
+| CCFID | IV_EVENT | IV_END | CE_CARD | CN_CARD | FIRST | LAST | EV_CARD | IV_START | EVENT_NO | IV_SEG | RENEWAL |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| A | 1 | 5 | 1 | 0 | 1 | 0 | 1 | 0 | 1 | 1 | 1 |
+| A | 3 | 5 | 1 | 0 | 0 | 1 | 1 | 1 | 2 | 2 | 2 |
+| A | 5 | 5 | 0 | 1 | 0 | 1 | 0 | 3 | 2 | 2 | 3 |
+| B | 4 | 4 | 0 | 1 | 1 | 1 | 0 | 0 | 0 | 4 | 1 |
+| C | 1 | 6 | 1 | 0 | 1 | 0 | 1 | 0 | 1 | 1 | 1 |
+| C | 6 | 6 | 1 | 1 | 0 | 1 | 1 | 1 | 2 | 5 | 2 |
+
+A constant-hazard fit of this frame with `LCENSOR IV_START` has a closed-form MLE:
+4 events over 15 units of exposure (the sum of `IV_SEG`), so `mu = 4/15`. The prototype gave
+`exp(log_mu) = 0.266666555`. If `time_lower` were ignored, the exposure would be the sum of
+`IV_EVENT`, 20, giving 4/20. That is why the end-to-end test fails if the rename is broken.
+
+---
+
+### Task 1: `.hzr_sas_blocks()` recognises `%REPEAT(` and records offsets
+
+**Files:**
+- Modify: `R/sas-lex.R` (roxygen for `.hzr_sas_blocks()` and the function itself, lines 166–259)
+- Modify: `R/translate-sas.R:157-161` (refuse a job with only `REPEAT` blocks) and the top of the `for (b in blocks)` loop at line 175 (skip `REPEAT` for now; Task 3 replaces this)
+- Modify: `tests/testthat/test-sas-lex.R` (append)
+- Create: `tests/testthat/test-sas-translate-repeat.R`
+
+**Interfaces:**
+- Produces: `.hzr_sas_blocks(txt)` returns a list of `list(proc, text, terminator, start, end)`.
+  `proc` is one of `"HAZARD"`, `"HAZPRED"` or `"REPEAT"`. For `REPEAT`, `text` is the
+  argument list inside the parentheses, `start` is the offset of `%`, and `end` is the offset
+  of the closing `)`. For `HAZARD`/`HAZPRED`, `start` is the opening `(`, or the `P` of `PROC`
+  when there is no enclosing paren, and `end` is the closing `)`, or the last character of
+  the bounded body.
+- Produces: `.hzr_sas_close_paren(txt, open_at)` returns the integer offset of the `)` that
+  balances the `(` at `open_at`, or `NA_integer_`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/testthat/test-sas-lex.R`:
+
+```r
+test_that("%REPEAT calls are blocks too, in file order, with offsets", {
+  txt <- .hzr_sas_normalise(c(
+    "%repeat(in=bd, out=events, id=ccfid);",
+    "%hazard( proc hazard data=events; time t; event e; parms muc=0.1; );",
+    "%hazpred( proc hazpred data=g inhaz=outest; time t; );"
+  ))
+  b <- .hzr_sas_blocks(txt)
+  expect_equal(vapply(b, `[[`, "", "proc"), c("REPEAT", "HAZARD", "HAZPRED"))
+  expect_equal(b[[1]]$text, "IN=BD, OUT=EVENTS, ID=CCFID")
+  expect_equal(b[[1]]$terminator, "paren")
+  expect_equal(substring(txt, b[[1]]$start, b[[1]]$end), "%REPEAT(IN=BD, OUT=EVENTS, ID=CCFID)")
+  # A paren-bounded PROC block starts at its own opening paren.
+  expect_equal(substr(txt, b[[2]]$start, b[[2]]$start), "(")
+  expect_equal(substr(txt, b[[2]]$end, b[[2]]$end), ")")
+  expect_lt(b[[1]]$end, b[[2]]$start)
+  expect_lt(b[[2]]$end, b[[3]]$start)
+})
+
+test_that("a macro definition or a longer macro name is not a %repeat call", {
+  txt <- .hzr_sas_normalise(c(
+    "%macro repeat(in=built, out=events);",
+    "%repeated(in=x);",
+    "%hazard( proc hazard data=a; time t; event e; );"
+  ))
+  expect_equal(vapply(.hzr_sas_blocks(txt), `[[`, "", "proc"), "HAZARD")
+})
+
+test_that("an unenclosed PROC records where its bounded body ends", {
+  txt <- .hzr_sas_normalise("PROC HAZARD DATA=A; EVENT D; DATA NEXT;")
+  b <- .hzr_sas_blocks(txt)
+  expect_equal(b[[1]]$start, 1L)
+  expect_equal(substring(txt, b[[1]]$start, b[[1]]$end), "PROC HAZARD DATA=A; EVENT D; ")
+})
+```
+
+Create `tests/testthat/test-sas-translate-repeat.R`:
+
+```r
+# test-sas-translate-repeat.R -- hzr_translate_sas() on jobs that call the
+# SAS macro %repeat. Every test evaluates the emitted chunks; expected values
+# are derived by hand from ~/Documents/macro.library/repeat.sas (see
+# inst/dev/REPEAT-TRANSLATOR-PLAN.md, "The synthetic fixture"), never from
+# hzr_repeated_events() itself.
+
+translate_lines <- function(lines) {
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(lines, f)
+  suppressWarnings(hzr_translate_sas(f))
+}
+
+test_that("a job with %repeat but no PROC HAZARD or HAZPRED is still refused", {
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines("%repeat(in=bd, out=events);", f)
+  expect_error(hzr_translate_sas(f), "no HAZARD or HAZPRED block found")
+})
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `Rscript -e 'devtools::test(filter = "sas-lex|sas-translate-repeat")'`
+Expected: FAIL. The first new lex test gets `c("HAZARD", "HAZPRED")` where it expects three
+kinds; the offset tests fail on `NULL` `start`; the refusal test fails because translation
+proceeds past the check.
+
+- [ ] **Step 3: Implement**
+
+In `R/sas-lex.R`, add the helper directly above `.hzr_sas_blocks()`'s roxygen block:
+
+```r
+#' Offset of the `)` that balances the `(` at `open_at`, or NA if none does.
+#' @noRd
+.hzr_sas_close_paren <- function(txt, open_at) {
+  depth <- 0L
+  for (i in seq(open_at, nchar(txt))) {
+    ch <- substr(txt, i, i)
+    if (ch == "(") depth <- depth + 1L
+    if (ch == ")") {
+      depth <- depth - 1L
+      if (depth == 0L) return(i)
+    }
+  }
+  NA_integer_
+}
+```
+
+Change the first line of `.hzr_sas_blocks()`'s roxygen title and add a paragraph before
+`#' @noRd`:
+
+```r
+#' Extract PROC HAZARD / PROC HAZPRED blocks and %repeat calls from normalised source.
+```
+
+```r
+#'
+#' A `%REPEAT(` call is returned as a third kind, `proc = "REPEAT"`, whose text
+#' is its argument list. It is an ordinary macro call, so its group is the one
+#' that opens right after the name and no backwards search is needed. Every
+#' block also carries `start` and `end`, offsets into `txt`, so the caller can
+#' read the source text between two blocks.
+```
+
+Replace the body of `.hzr_sas_blocks()` with:
+
+```r
+.hzr_sas_blocks <- function(txt) {
+  out <- list()
+  procs <- gregexpr("PROC HAZ(ARD|PRED) |%REPEAT *[(]", txt)[[1L]]
+  if (procs[1L] == -1L) return(out)
+  proc_lens <- attr(procs, "match.length")
+
+  for (k in seq_along(procs)) {
+    proc_at <- procs[k]
+
+    if (identical(substring(txt, proc_at, proc_at + 6L), "%REPEAT")) {
+      open_at <- proc_at + proc_lens[k] - 1L
+      close_at <- .hzr_sas_close_paren(txt, open_at)
+      end_at <- if (is.na(close_at)) nchar(txt) else close_at
+      body_end <- if (is.na(close_at)) end_at else close_at - 1L
+      out[[length(out) + 1L]] <- list(
+        proc = "REPEAT", text = trimws(substring(txt, open_at + 1L, body_end)),
+        terminator = if (is.na(close_at)) "none" else "paren",
+        start = proc_at, end = end_at
+      )
+      next
+    }
+
+    proc <- if (identical(substring(txt, proc_at, proc_at + 10L), "PROC HAZARD")) {
+      "HAZARD"
+    } else {
+      "HAZPRED"
+    }
+
+    # Scan backwards from the PROC keyword for the nearest unmatched `(` --
+    # the paren that opens the group containing this PROC statement.
+    open_at <- NA_integer_
+    balance <- 0L
+    if (proc_at > 1L) {
+      for (i in seq(proc_at - 1L, 1L)) {
+        ch <- substr(txt, i, i)
+        if (ch == ")") {
+          balance <- balance + 1L
+        } else if (ch == "(") {
+          if (balance == 0L) {
+            open_at <- i
+            break
+          }
+          balance <- balance - 1L
+        }
+      }
+    }
+
+    if (is.na(open_at)) {
+      # No enclosing paren anywhere before this PROC. Bound the text at the
+      # next PROC / DATA / RUN; boundary, never dropping the block. If none
+      # of those follow either, the block genuinely extends to the end of
+      # txt -- that is safe here because .hzr_sas_blocks() only ever sees
+      # output from .hzr_sas_normalise(), which has already stripped all
+      # comments, so the end-of-file-prose hazard this bounding rule exists
+      # to prevent cannot arise at this point.
+      search_from <- proc_at + proc_lens[k]
+      rest <- substring(txt, search_from)
+      b <- regexpr("PROC |DATA |RUN;", rest)
+      end_at <- if (b == -1L) nchar(txt) else search_from + b - 2L
+      body <- substring(txt, proc_at, end_at)
+      term <- "none"
+      start_at <- proc_at
+    } else {
+      close_at <- .hzr_sas_close_paren(txt, open_at)
+      term <- if (is.na(close_at)) "none" else "paren"
+      body <- substring(txt, open_at + 1L,
+                        if (is.na(close_at)) nchar(txt) else close_at - 1L)
+      start_at <- open_at
+      end_at <- if (is.na(close_at)) nchar(txt) else close_at
+    }
+
+    out[[length(out) + 1L]] <- list(proc = proc, text = trimws(body),
+                                    terminator = term,
+                                    start = start_at, end = end_at)
+  }
+  out
+}
+```
+
+In `R/translate-sas.R`, replace
+
+```r
+  blocks <- .hzr_sas_blocks(txt)
+  if (!length(blocks)) {
+    stop("no HAZARD or HAZPRED block found in ", path, call. = FALSE)
+  }
+```
+
+with
+
+```r
+  blocks <- .hzr_sas_blocks(txt)
+  # A %repeat call alone is a dataset-building job (the tp.bd.* templates),
+  # not a HAZARD job, and there is nothing to fit.
+  if (!any(vapply(blocks, function(b) b$proc != "REPEAT", logical(1L)))) {
+    stop("no HAZARD or HAZPRED block found in ", path, call. = FALSE)
+  }
+```
+
+and make the first statement inside `for (b in blocks) {`:
+
+```r
+    if (identical(b$proc, "REPEAT")) next # translated in Task 3
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `Rscript -e 'devtools::test(filter = "sas-lex|sas-translate-repeat|translate-sas|sas-parse")'`
+Expected: 0 failures. The existing lex, parse and translate tests still pass: the new fields
+are additive and their fixtures contain no `%REPEAT`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/sas-lex.R R/translate-sas.R tests/testthat/test-sas-lex.R tests/testthat/test-sas-translate-repeat.R
+git commit -m "feat: recognise %repeat calls as SAS job blocks, with source offsets
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `.hzr_parse_repeat()` builds the call, or refuses
+
+**Files:**
+- Modify: `R/sas-parse-job.R` (append at the end of the file)
+- Modify: `tests/testthat/test-sas-translate-repeat.R` (append)
+
+**Interfaces:**
+- Consumes: the `REPEAT` block from Task 1, `list(proc = "REPEAT", text = <chr>, ...)`.
+- Produces: `.hzr_parse_repeat(block)` returns `list(call, untranslated, tokens_seen,
+  tokens_mapped, in_name, out_name)`.
+  - `call` is `<OUT> <- local({...})`, or `stop("<msg>")` when refused.
+  - `untranslated` is a `.hzr_untranslated_frame()` with construct `"%repeat"`, one row per
+    problem, and no rows when accepted.
+  - `in_name` and `out_name` are `character(1)` (upper case, possibly `LIB.MEMBER`) when
+    accepted, and `NULL` when refused.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/testthat/test-sas-translate-repeat.R`:
+
+```r
+# Subject A: events at 1 and 3, a non-event at 2; B: no event, missing time;
+# C: events at 1 and 6, where 6 is also end of follow-up.
+bd_card <- function() {
+  data.frame(
+    CCFID = c("A", "A", "A", "B", "C", "C"),
+    IV_EVENT = c(1, 2, 3, NA, 1, 6),
+    IV_END = c(5, 5, 5, 4, 6, 6),
+    CE_CARD = c(1, 0, 1, 0, 1, 1),
+    stringsAsFactors = FALSE
+  )
+}
+
+# Derived by hand from repeat.sas; see the plan's fixture table.
+expected_events <- function() {
+  data.frame(
+    CCFID = c("A", "A", "A", "B", "C", "C"),
+    IV_EVENT = c(1, 3, 5, 4, 1, 6),
+    IV_END = c(5, 5, 5, 4, 6, 6),
+    CE_CARD = c(1, 1, 0, 0, 1, 1),
+    CN_CARD = c(0, 0, 1, 1, 0, 1),
+    FIRST = c(1, 0, 0, 1, 1, 0),
+    LAST = c(0, 1, 1, 1, 0, 1),
+    EV_CARD = c(1, 1, 0, 0, 1, 1),
+    IV_START = c(0, 1, 3, 0, 0, 1),
+    EVENT_NO = c(1, 2, 2, 0, 1, 2),
+    IV_SEG = c(1, 2, 2, 4, 1, 5),
+    RENEWAL = c(1, 2, 3, 1, 1, 2),
+    stringsAsFactors = FALSE
+  )
+}
+
+parse_repeat <- function(args) {
+  txt <- .hzr_sas_normalise(paste0("%repeat(", args, ");"))
+  .hzr_parse_repeat(.hzr_sas_blocks(txt)[[1L]])
+}
+
+cardio_args <- "in=bd_card, out=events, id=ccfid, eventype=ce_card, iv_end=iv_end, rcensor=cn_card, event=ev_card"
+
+test_that("the emitted %repeat call builds the macro's output under the job's names", {
+  r <- parse_repeat(cardio_args)
+  expect_equal(r$in_name, "BD_CARD")
+  expect_equal(r$out_name, "EVENTS")
+  expect_equal(nrow(r$untranslated), 0L)
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  expect_no_warning(eval(r$call, env))
+  expect_equal(dim(env$EVENTS), c(6L, 12L))
+  expect_equal(env$EVENTS, expected_events())
+})
+
+test_that("an input column the macro would overwrite is dropped, with a warning", {
+  r <- parse_repeat(cardio_args)
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- transform(bd_card(), EV_CARD = 99)
+  expect_warning(eval(r$call, env), "EV_CARD")
+  # Without the drop, names<- would leave two EV_CARD columns and $EV_CARD
+  # would return the stale 99s.
+  expect_equal(sum(names(env$EVENTS) == "EV_CARD"), 1L)
+  expect_equal(env$EVENTS$EV_CARD, c(1, 1, 0, 0, 1, 1))
+})
+
+test_that("a NUMBER column in the input warns that SAS's event counts are not comparable", {
+  r <- parse_repeat(cardio_args)
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- transform(bd_card(), NUMBER = 7)
+  expect_warning(eval(r$call, env), "NUMBER")
+  # R's result is the macro's intent: the column is neither dropped nor read.
+  expect_equal(env$EVENTS$EVENT_NO, c(1, 2, 2, 0, 1, 2))
+  expect_equal(env$EVENTS$NUMBER, rep(7, 6))
+})
+
+test_that("defaults are the macro's own, upper-cased", {
+  r <- parse_repeat("")
+  expect_equal(r$in_name, "BUILT")
+  expect_equal(r$out_name, "EVENTS")
+  env <- new.env(parent = globalenv())
+  d <- bd_card()
+  names(d) <- c("ID", "IV_EVENT", "IV_END", "EVENTYPE")
+  env$BUILT <- d
+  eval(r$call, env)
+  expect_equal(
+    names(env$EVENTS),
+    c("ID", "IV_EVENT", "IV_END", "EVENTYPE", "RCENSOR", "FIRST", "LAST",
+      "EVENT", "IV_START", "EVENT_NO", "IV_SEG", "RENEWAL")
+  )
+  expect_equal(env$EVENTS$IV_START, c(0, 1, 3, 0, 0, 1))
+})
+
+test_that("uncallable %repeat arguments are refused, each with its reason", {
+  cases <- list(
+    list("in=bd_card, eventype=rcensor", "RCENSOR is also an output"),
+    list("in=bd_card, foo=bar", "`FOO=` is not a %repeat parameter"),
+    list("in=&dsn", "`IN=&DSN` is not a plain SAS name"),
+    list("event=x, rcensor=x", "two outputs are both named X"),
+    list("bd_card", "`BD_CARD` is not a KEY=VALUE argument")
+  )
+  for (cs in cases) {
+    r <- parse_repeat(cs[[1]])
+    expect_null(r$in_name)
+    expect_null(r$out_name)
+    expect_identical(r$call[[1L]], as.name("stop"))
+    expect_error(eval(r$call, new.env()), cs[[2]], fixed = TRUE)
+    expect_equal(r$untranslated$construct, "%repeat")
+    expect_length(r$untranslated$reason, 1L)
+    expect_true(grepl(cs[[2]], r$untranslated$reason, fixed = TRUE))
+    expect_equal(r$tokens_mapped, 0L)
+  }
+})
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `Rscript -e 'devtools::test(filter = "sas-translate-repeat")'`
+Expected: FAIL with `could not find function ".hzr_parse_repeat"`.
+
+- [ ] **Step 3: Implement**
+
+Append to `R/sas-parse-job.R`:
+
+```r
+# ---------------------------------------------------------------------------
+# %repeat -> hzr_repeated_events()
+# ---------------------------------------------------------------------------
+
+# %repeat's keyword parameters and defaults, as the macro declares them
+# (~/Documents/macro.library/repeat.sas), upper-cased as
+# .hzr_sas_normalise() leaves every name.
+.hzr_repeat_defaults <- c(
+  IN = "BUILT", OUT = "EVENTS", EVENTYPE = "EVENTYPE", IV_EVENT = "IV_EVENT",
+  IV_END = "IV_END", ID = "ID", EVENT = "EVENT", EVENT_NO = "EVENT_NO",
+  RCENSOR = "RCENSOR", IV_START = "IV_START", IV_SEG = "IV_SEG", RENEWAL = "RENEWAL"
+)
+
+# hzr_repeated_events()'s fixed output names, each mapped to the macro
+# parameter that renames it. first and last have no parameter: the macro
+# always writes them under those names.
+.hzr_repeat_outputs <- c(
+  event = "EVENT", event_no = "EVENT_NO", rcensor = "RCENSOR",
+  iv_start = "IV_START", iv_seg = "IV_SEG", renewal = "RENEWAL"
+)
+
+#' Translate one `%repeat(...)` call into an `hzr_repeated_events()` chunk.
+#'
+#' The emitted chunk renames the function's lower-case outputs to the names the
+#' job uses, upper-cased like every name this translator emits; without that the
+#' fit reads a column that does not exist. Before the call it drops any input
+#' column named like one of those outputs. SAS overwrites such a column, and the
+#' macro assigns each output on every row before reading it, so dropping is
+#' exactly what SAS does. Left in place, the rename would produce two columns of
+#' one name, and `$` would return the stale one.
+#'
+#' A call this cannot express is refused rather than guessed at: the chunk is a
+#' `stop()`, and each problem is an `$untranslated` row. That covers an unknown
+#' keyword, a positional argument, a value that is not a plain SAS name (a
+#' `&macro` reference, say), an input column that is also an output
+#' (`EVENTYPE=RCENSOR`: SAS zeroes that indicator before reading it, so the job's
+#' own answer is not the model it describes), and two outputs with one name. The
+#' body is split on every comma; a value holding parentheses, where a comma could
+#' be nested, is refused as not a plain name either way.
+#' @noRd
+.hzr_parse_repeat <- function(block) {
+  parts <- if (nzchar(block$text)) trimws(strsplit(block$text, ",", fixed = TRUE)[[1L]]) else character(0)
+  args <- .hzr_repeat_defaults
+  problems <- character(0)
+
+  for (p in parts) {
+    kv <- regmatches(p, regexec("^([A-Z_][A-Z0-9_]*) ?= ?(.*)$", p))[[1L]]
+    if (!length(kv)) {
+      problems <- c(problems, sprintf("`%s` is not a KEY=VALUE argument", p))
+      next
+    }
+    key <- kv[2L]
+    val <- trimws(kv[3L])
+    if (!key %in% names(args)) {
+      problems <- c(problems, sprintf("`%s=` is not a %%repeat parameter", key))
+      next
+    }
+    name_re <- if (key %in% c("IN", "OUT")) {
+      "^[A-Z_][A-Z0-9_]*([.][A-Z_][A-Z0-9_]*)?$"
+    } else {
+      "^[A-Z_][A-Z0-9_]*$"
+    }
+    if (!grepl(name_re, val)) {
+      problems <- c(problems, sprintf("`%s=%s` is not a plain SAS name", key, val))
+      next
+    }
+    args[[key]] <- val
+  }
+
+  inputs <- unname(args[c("ID", "EVENTYPE", "IV_EVENT", "IV_END")])
+  targets <- c(unname(args[.hzr_repeat_outputs]), "FIRST", "LAST")
+  for (hit in intersect(inputs, targets)) {
+    problems <- c(problems, sprintf(paste(
+      "input column %s is also an output %%repeat writes; SAS overwrites it before reading it,",
+      "so the job's own result is not the model it describes"
+    ), hit))
+  }
+  dup <- unique(targets[duplicated(targets)])
+  if (length(dup)) {
+    problems <- c(problems, sprintf("two outputs are both named %s", paste(dup, collapse = ", ")))
+  }
+
+  if (length(problems)) {
+    msg <- paste0("hzr_translate_sas() did not translate this job's %repeat call: ",
+                  paste(problems, collapse = "; "), ".")
+    return(list(
+      call = bquote(stop(.(msg))),
+      untranslated = .hzr_untranslated_frame(rep(NA_integer_, length(problems)),
+                                             rep("%repeat", length(problems)), problems),
+      tokens_seen = length(parts), tokens_mapped = 0L, in_name = NULL, out_name = NULL
+    ))
+  }
+
+  in_name <- args[["IN"]]
+  out_name <- args[["OUT"]]
+  from <- c(names(.hzr_repeat_outputs), "first", "last")
+  overwrite_msg <- paste0(" in ", in_name, ": %repeat writes columns of these names, so they were dropped ",
+                          "before the call, as SAS overwrites them.")
+  loop_msg <- paste0(" in ", in_name, ": SAS's %repeat reads a LAG_IV or NUMBER column in place of its ",
+                     "own loop counters, so for this job the SAS listing's segment starts and event ",
+                     "counts are not comparable with these.")
+  call <- bquote(.(as.name(out_name)) <- local({
+    d <- .(as.name(in_name))
+    drop <- intersect(names(d), .(targets))
+    if (length(drop)) {
+      warning(paste(drop, collapse = ", "), .(overwrite_msg), call. = FALSE)
+      d <- d[setdiff(names(d), drop)]
+    }
+    loop <- intersect(names(d), c("LAG_IV", "NUMBER"))
+    if (length(loop)) warning(paste(loop, collapse = ", "), .(loop_msg), call. = FALSE)
+    out <- hzr_repeated_events(d, id = .(args[["ID"]]), time = .(args[["IV_EVENT"]]),
+                               followup = .(args[["IV_END"]]), indicator = .(args[["EVENTYPE"]]))
+    names(out)[match(.(from), names(out))] <- .(targets)
+    out
+  }))
+
+  list(call = call, untranslated = .hzr_untranslated_frame(),
+       tokens_seen = length(parts), tokens_mapped = length(parts),
+       in_name = in_name, out_name = out_name)
+}
+```
+
+`targets` is in the same order as `from`: the six outputs in `.hzr_repeat_outputs` order,
+then `FIRST` and `LAST`. That is what makes the `names<-` rename correct, and the
+`expected_events()` test fails if the two orders ever diverge.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `Rscript -e 'devtools::test(filter = "sas-translate-repeat")'`
+Expected: 0 failures.
+
+Then **mutate the implementation once to prove the tests can fail**, and revert each change:
+- Delete the `d <- d[setdiff(names(d), drop)]` line. The clash test should now fail on
+  `sum(names(...) == "EV_CARD")`.
+- Swap `"FIRST", "LAST"` to `"LAST", "FIRST"` in `targets`. `expected_events()` should now
+  fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/sas-parse-job.R tests/testthat/test-sas-translate-repeat.R
+git commit -m "feat: translate a %repeat call into an hzr_repeated_events() chunk
+
+Renames outputs to the job's upper-case names, drops input columns SAS would
+overwrite (with a warning), warns on LAG_IV/NUMBER, and refuses calls it
+cannot express.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: wire `REPEAT` blocks into `hzr_translate_sas()` and stop on post-macro rewrites
+
+**Files:**
+- Modify: `R/sas-parse-job.R` (append `.hzr_repeat_rewrites()`)
+- Modify: `R/translate-sas.R` (loop body at line 175 onward: replace Task 1's `next` and add the rewrite check inside the `HAZARD` branch)
+- Modify: `tests/testthat/test-sas-translate-repeat.R` (append)
+
+**Interfaces:**
+- Consumes: `.hzr_sas_blocks()` `start`/`end` (Task 1); `.hzr_parse_repeat()` (Task 2).
+- Produces: `.hzr_repeat_rewrites(segment, out)` returns a `character` vector, one element
+  per step that writes `out`, each the step's normalised statements joined by `"; "` and
+  ending in `;`.
+- Produces: new chunk kinds in `job$calls`: `data` (the `IN=` guard, via
+  `.hzr_next_call_name(calls, "data")`), `repeated`, and `rewrite`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/testthat/test-sas-translate-repeat.R`:
+
+```r
+repeat_call <- paste0("%repeat(", cardio_args, ");")
+hz_block <- c("%hazard( proc hazard data=events condition=14;",
+              "lcensor iv_start; event ce_card; time iv_event; parms muc=0.5; );")
+
+eval_upto <- function(job, env, last) {
+  for (nm in names(job$calls)[seq_len(match(last, names(job$calls)))]) {
+    eval(job$calls[[nm]], env)
+  }
+  env
+}
+
+test_that("a %repeat job emits guard, macro, status and fit, in that order", {
+  job <- translate_lines(c(repeat_call, hz_block))
+  expect_equal(names(job$calls), c("data", "repeated", "status", "fit"))
+  # The guard is on the macro's input; EVENTS is built by a chunk, so it gets none.
+  expect_error(eval(job$calls$data, new.env(parent = globalenv())), "Assign BD_CARD")
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "repeated")
+  expect_equal(env$EVENTS, expected_events())
+})
+
+test_that("the translated fit reads the renamed IV_START: mu is 4 events over 15 units", {
+  skip_on_cran()
+  job <- translate_lines(c(repeat_call, hz_block))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "fit")
+  expect_true(env$fit$fit$converged)
+  # 4/15 needs time_lower = IV_START; without it the exposure is sum(IV_EVENT) = 20.
+  expect_equal(unname(exp(coef(env$fit))) / (4 / 15), 1, tolerance = 1e-4)
+})
+
+test_that("a non-default output name is what the job's fit reads", {
+  job <- translate_lines(c(
+    "%repeat(in=bd_card, id=ccfid, eventype=ce_card, event=ev_x);",
+    "%hazard( proc hazard data=events; event ev_x; time iv_event; parms muc=0.5; );"
+  ))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "repeated")
+  expect_false("event" %in% names(env$EVENTS))
+  expect_equal(env$EVENTS$EV_X, c(1, 1, 0, 0, 1, 1))
+})
+
+test_that("a DATA step rewriting OUT= stops the document before the fit, quoted", {
+  job <- translate_lines(c(
+    repeat_call,
+    "data events; set events; if iv_start ge iv_event then iv_event=iv_event+0.0001;",
+    hz_block
+  ))
+  expect_equal(names(job$calls), c("data", "repeated", "rewrite", "status", "fit"))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "repeated")
+  expect_error(
+    eval(job$calls$rewrite, env),
+    "DATA EVENTS; SET EVENTS; IF IV_START GE IV_EVENT THEN IV_EVENT=IV_EVENT+0.0001;",
+    fixed = TRUE
+  )
+  expect_true("DATA EVENTS after %repeat" %in% job$untranslated$construct)
+})
+
+test_that("steps that do not rewrite OUT= emit no rewrite stop", {
+  job <- translate_lines(c(
+    repeat_call,
+    "data other; set events; x=1;",
+    "proc sort data=events; by ccfid;",
+    hz_block
+  ))
+  expect_equal(names(job$calls), c("data", "repeated", "status", "fit"))
+})
+
+test_that("CREATE TABLE OUT is a rewrite too", {
+  job <- translate_lines(c(
+    # `select ccfid`, not `select *`: a `*` risks the normaliser's comment stripping.
+    repeat_call, "proc sql; create table events as select ccfid from events; quit;", hz_block
+  ))
+  expect_equal(names(job$calls), c("data", "repeated", "rewrite", "status", "fit"))
+})
+
+test_that("one rewrite stops once, however many fits read OUT= after it", {
+  job <- translate_lines(c(
+    repeat_call, "data events; set events; x=1;", hz_block, hz_block
+  ))
+  expect_equal(sum(grepl("^rewrite", names(job$calls))), 1L)
+  expect_equal(which(names(job$calls) == "rewrite"), 3L)
+})
+
+test_that("a refused %repeat still leaves a guard on the fit's DATA=", {
+  job <- translate_lines(c("%repeat(in=bd_card, eventype=rcensor);", hz_block))
+  expect_equal(names(job$calls), c("repeated", "data", "status", "fit"))
+  expect_error(eval(job$calls[["repeated"]], new.env()), "RCENSOR is also an output", fixed = TRUE)
+})
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `Rscript -e 'devtools::test(filter = "sas-translate-repeat")'`
+Expected: FAIL. Chunk names come out as `c("data", "status", "fit")`, because Task 1's `next`
+skips the macro and the guard is on `EVENTS`. The call to `.hzr_repeat_rewrites` errors as
+not found once it is referenced.
+
+- [ ] **Step 3: Implement**
+
+Append to `R/sas-parse-job.R`:
+
+```r
+#' Steps between a `%repeat` call and a fit that rewrite the macro's `OUT=`.
+#'
+#' `segment` is the normalised source between the two. A hit is a `DATA`
+#' statement naming `out` among its output datasets (options in parentheses
+#' ignored) or a `PROC SQL` `CREATE TABLE out`. Each is returned quoted, from
+#' that statement up to the next `DATA`, `PROC`, `%HAZ`, `%REPEAT` or `RUN`.
+#' `PROC SORT` is not a rewrite: reordering rows does not change the
+#' likelihood.
+#' @noRd
+.hzr_repeat_rewrites <- function(segment, out) {
+  stmts <- trimws(strsplit(segment, ";", fixed = TRUE)[[1L]])
+  stmts <- stmts[nzchar(stmts)]
+  boundary <- "^(DATA |PROC |%HAZ|%REPEAT|RUN$)"
+  hits <- character(0)
+  for (i in seq_along(stmts)) {
+    s <- stmts[i]
+    tok <- strsplit(s, " ", fixed = TRUE)[[1L]]
+    writes <- if (startsWith(s, "DATA ")) {
+      out %in% strsplit(trimws(gsub("[(][^)]*[)]", " ", substring(s, 6L))), " +")[[1L]]
+    } else {
+      j <- which(tok == "CREATE")
+      any(tok[j + 1L] %in% "TABLE" & tok[j + 2L] %in% out)
+    }
+    if (writes) {
+      last <- i
+      while (last < length(stmts) && !grepl(boundary, stmts[last + 1L])) last <- last + 1L
+      hits <- c(hits, paste0(paste(stmts[i:last], collapse = "; "), ";"))
+    }
+  }
+  hits
+}
+```
+
+In `R/translate-sas.R`, after `first_unresolved_inhaz <- NULL` / `n_unresolved_inhaz <- 0L`,
+add:
+
+```r
+  repeat_scan <- list()      # %repeat OUT= -> offset its rewrite scan resumes from
+```
+
+Replace Task 1's `if (identical(b$proc, "REPEAT")) next # translated in Task 3` with:
+
+```r
+    if (identical(b$proc, "REPEAT")) {
+      r <- .hzr_parse_repeat(b)
+      # The macro's input is built by the job's own DATA steps, which this
+      # translator does not translate: the same loud guard a PROC HAZARD
+      # DATA= gets, once per name.
+      if (!is.null(r$in_name) && !(r$in_name %in% guarded_data)) {
+        calls[[.hzr_next_call_name(calls, "data")]] <- bquote(
+          if (!exists(.(r$in_name))) {
+            stop("This job built ", .(r$in_name), " in SAS DATA steps, which ",
+                 "hzr_translate_sas() does not translate. Assign ", .(r$in_name),
+                 " as it stood at the job's %repeat call, with its columns named ",
+                 "as the job spells them, in upper case, before rendering.")
+          }
+        )
+        guarded_data <- c(guarded_data, r$in_name)
+      }
+      calls[[.hzr_next_call_name(calls, "repeated")]] <- r$call
+      # OUT= is now built by a chunk, so a fit reading it needs no guard.
+      if (!is.null(r$out_name)) {
+        guarded_data <- c(guarded_data, r$out_name)
+        repeat_scan[[r$out_name]] <- b$end
+      }
+    } else if (identical(b$proc, "HAZARD")) {
+```
+
+and remove the original `if (identical(b$proc, "HAZARD")) {` line that this now replaces.
+The `} else {` HAZPRED branch and the trailing `untr <- rbind(untr, r$untranslated)` /
+`seen` / `mapped` lines are unchanged. They already accumulate the `REPEAT` branch's
+fields.
+
+Inside the `HAZARD` branch, immediately after the `tryCatch(.hzr_parse_hazard(b), ...)`
+assignment and **before** the existing `if (!is.null(r$call[["data"]]))` guard block, add:
+
+```r
+      # A DATA step between %repeat and this fit that rewrites the macro's
+      # OUT= is job code this translator does not fold in. Fitting without it
+      # fits data SAS did not fit, so stop here -- ahead of the status chunk,
+      # which writes into the same data frame. The scan resumes where the
+      # last one ended, so one rewrite stops once however many fits follow.
+      dname <- if (is.null(r$call[["data"]])) NULL else as.character(r$call[["data"]])
+      if (!is.null(dname) && !is.null(repeat_scan[[dname]])) {
+        seg <- substring(txt, repeat_scan[[dname]] + 1L, b$start - 1L)
+        for (step in .hzr_repeat_rewrites(seg, dname)) {
+          calls[[.hzr_next_call_name(calls, "rewrite")]] <- bquote(stop(.(paste0(
+            "This job changes ", dname, " after %repeat, in a SAS DATA step that ",
+            "hzr_translate_sas() does not translate: ", step, " Replace this chunk ",
+            "with R code that makes the same change to ", dname, "."
+          ))))
+          untr <- rbind(untr, .hzr_untranslated_frame(
+            NA_integer_, paste0("DATA ", dname, " after %repeat"), step
+          ))
+        }
+        repeat_scan[[dname]] <- b$end
+      }
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `Rscript -e 'devtools::test(filter = "sas-translate-repeat|translate-sas|sas-translate")'`
+Expected: 0 failures, and the fit test reports no skip. `devtools::test()` sets `NOT_CRAN`,
+so check the `[ FAIL 0 | WARN 0 | SKIP n | PASS m ]` line and confirm the 4/15 test is not
+among the skips.
+
+Mutate once, then revert. Change `.hzr_repeat_rewrites(seg, dname)` to
+`.hzr_repeat_rewrites("", dname)`, so the scan sees nothing. The rewrite test should now fail
+on the chunk names. If it passes, it cannot detect a missed rewrite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/sas-parse-job.R R/translate-sas.R tests/testthat/test-sas-translate-repeat.R
+git commit -m "feat: hzr_translate_sas() translates %repeat and stops on post-macro rewrites
+
+Guards the macro's IN=, drops the guard on its OUT=, and emits a quoted stop()
+before any fit that reads an OUT= a DATA step rewrote after the macro.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: volume-gated parity on the real cardioversion job
+
+**Files:**
+- Modify: `tests/testthat/test-repeated-events-parity.R` (append)
+
+**Interfaces:**
+- Consumes: `skip_if_no_maze_datasets()` (defined at the top of this file);
+  `.hzr_derive_bd_card(dir)` and `.hzr_maze_datasets_dir()` (`inst/sas-parity/helper-sas-parity.R`,
+  sourced by `tests/testthat/helper-sas-parity.R`); the chunk names from Task 3.
+
+- [ ] **Step 1: Write the test**
+
+```r
+test_that("hzr_translate_sas() on the cardioversion job builds EVENTS, then stops at line 65", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("haven")
+  dir <- skip_if_no_maze_datasets()
+  sas <- file.path(dirname(dir), "distributions", "hz.ce_cardioversion_repeated.ehb.sas")
+  testthat::skip_if_not(file.exists(sas), "hz.ce_cardioversion_repeated.ehb.sas not on the volume")
+
+  job <- suppressWarnings(hzr_translate_sas(sas))
+  expect_equal(names(job$calls)[1:5], c("data", "repeated", "rewrite", "status", "fit"))
+
+  bd_card <- .hzr_derive_bd_card(dir)
+  names(bd_card) <- toupper(names(bd_card))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card
+  eval(job$calls$data, env)
+  expect_no_warning(eval(job$calls[["repeated"]], env))
+  # Shape first, then values: the .log's 962 rows, and 357 input columns plus
+  # the function's eight.
+  expect_equal(dim(env$EVENTS), c(962L, 365L))
+  expect_equal(sum(env$EVENTS$CE_CARD == 1), 388L)
+  # The job's line 65 is job code, not macro code; the document stops on it.
+  expect_error(eval(job$calls$rewrite, env), "IV_EVENT=IV_EVENT+0.0001141553", fixed = TRUE)
+})
+```
+
+- [ ] **Step 2: Run it with the volume mounted**
+
+Run: `Rscript -e 'devtools::test(filter = "repeated-events-parity")'`
+Expected: PASS, and **not** SKIP. If it skips, the volume is not mounted and the test is not
+evidence. Say so in the PR rather than counting it green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/testthat/test-repeated-events-parity.R
+git commit -m "test: translated cardioversion job builds EVENTS and stops at its line 65
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: documentation, NEWS, spec pointers
+
+**Files:**
+- Modify: `R/translate-sas.R` (roxygen: add a section after `@section Experimental:`)
+- Modify: `NEWS.md` (bullet under `# TemporalHazard 1.2.11` → `## New features`)
+- Modify: `inst/dev/REPEATED-EVENTS-DESIGN.md` ("Out of scope", the `hzr_translate_sas()` bullet)
+- Modify: `inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md` §5.5 "Evidence" (final census count)
+- Modify: `inst/WORDLIST` (only the words spelling flags)
+- Regenerate: `man/hzr_translate_sas.Rd`
+
+- [ ] **Step 1: Roxygen.** In `R/translate-sas.R`, insert before `#' @section Comparing a translated fit against a SAS listing:`:
+
+```r
+#' @section Repeated events:
+#' A job that builds its fit input with the SAS macro `%repeat` has that call
+#' translated to [hzr_repeated_events()]. The emitted chunk renames the
+#' function's output columns to the names the job gives them, upper-cased like
+#' every name the translator emits, so the fit reads them. An input column named
+#' like one of those outputs is dropped first, with a warning, because the macro
+#' overwrites it. The macro's input is built by the job's own DATA steps, which
+#' are not translated, so the document stops until that input is assigned. A DATA
+#' step that changes the macro's output before the fit is not translated either.
+#' Its chunk stops and quotes the step, for the reader to replace with R code.
+#'
+```
+
+- [ ] **Step 2: Regenerate and check the Rd escaping**
+
+Run: `Rscript -e 'devtools::document()'` and then `grep -n 'repeat' man/hzr_translate_sas.Rd`
+Expected: the section is present, and each backticked `%repeat` appears as
+`\verb{\%repeat}`. Roxygen escapes it inside a code span, as `man/hzr_repeated_events.Rd`
+line 5 already shows (checked 2026-09-10). An unescaped `%` in Rd starts a comment and
+silently truncates the line, so keep every `%repeat` in the roxygen text inside backticks.
+
+- [ ] **Step 3: NEWS.** In `NEWS.md`, insert immediately before the line `# TemporalHazard 1.2.10` (keep one blank line on each side):
+
+```markdown
+* **`hzr_translate_sas()` translates a `%repeat` call** into
+  `hzr_repeated_events()` (#241), renaming its outputs to the names the job
+  gives them so the job's fit reads them. The macro's input is still the
+  reader's to supply. A DATA step that changes the macro's output before the
+  fit now stops the document with the step quoted; the translation no longer
+  fits data that SAS did not fit.
+```
+
+- [ ] **Step 4: Spec pointers.** In `inst/dev/REPEATED-EVENTS-DESIGN.md`, replace the "Out of scope" bullet that begins `- Wiring \`hzr_repeated_events()\` into \`hzr_translate_sas()\`.` with:
+
+```markdown
+- Wiring `hzr_repeated_events()` into `hzr_translate_sas()`. Done separately; see
+  `SAS-JOB-TRANSLATOR-DESIGN.md` §5.5.
+```
+
+In `SAS-JOB-TRANSLATOR-DESIGN.md` §5.5 "Evidence", replace "found **at least 526**" and "138
+of them" with the census's final counts. Read them from the scratchpad
+`repeat-census.txt` once its background scan has printed `exit=`. If it has not finished, keep
+"at least" and give the latest count and the time it was read.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/translate-sas.R man/hzr_translate_sas.Rd NEWS.md inst/dev/REPEATED-EVENTS-DESIGN.md inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+git commit -m "docs: document %repeat translation in hzr_translate_sas() and NEWS
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: gates, review, PR
+
+**Files:** `inst/WORDLIST` only if spelling flags words.
+
+- [ ] **Step 1: The definition of done, in order.** Each must pass before the next:
+
+```bash
+Rscript -e 'devtools::document()'
+Rscript -e 'lintr::lint_package()'
+Rscript -e 'devtools::test()'
+Rscript -e 'spelling::spell_check_package(use_wordlist = TRUE)'
+```
+
+Expected: `document()` leaves `git status` clean (commit it if not). Lint prints no lints.
+Tests: `FAIL 0`. Record the `SKIP`/`PASS` counts for the PR. Spelling: no words, or add
+each flagged SAS identifier to `inst/WORDLIST` (sorted) and commit.
+
+- [ ] **Step 2: `R CMD check --as-cran` from a committed tree, under the scratchpad**
+
+Run the full suite in the **foreground** with a 600000 ms timeout; never background it and
+return early.
+
+```bash
+SCRATCH=/private/tmp/claude-504/-Users-ehrlinj-Documents-GitHub-TemporalHazard--claude-worktrees-charming-mirzakhani-331055/831a925a-4e5d-4c94-a0fd-c82969ba4fef/scratchpad
+rm -rf "$SCRATCH/tree" "$SCRATCH/check" && mkdir -p "$SCRATCH/tree" "$SCRATCH/check"
+git archive HEAD | tar -x -C "$SCRATCH/tree"
+cd "$SCRATCH/check" && R CMD build "$SCRATCH/tree" && R CMD check --as-cran TemporalHazard_1.2.11.tar.gz
+tar tzf TemporalHazard_1.2.11.tar.gz | grep -iE 'CLAUDE|AGENTS|REPEAT-TRANSLATOR-PLAN' || echo "no dev files in tarball"
+```
+
+Expected: `Status: OK`, or only the NOTEs already present on `main`; no WARNING or ERROR.
+Record the overall time against the 3m 41s (221s) baseline in `AGENTS.md`.
+
+- [ ] **Step 3: Advisory review.** Dispatch the `r-reviewer` agent over `git diff origin/main...HEAD`. Verify each finding against the code before acting on it; a clean report does not replace Steps 1–2.
+
+- [ ] **Step 4: Push the branch and open the PR.** Never push `main`.
+
+```bash
+git push -u origin feat/translate-repeat
+gh pr create --base main --title "hzr_translate_sas(): translate %repeat into hzr_repeated_events()" --body-file <body>
+```
+
+The body states:
+- what is translated;
+- the three decisions (clash drop, rewrite stop, `IN=` guard) and the `LAG_IV`/`NUMBER` warning;
+- the gate results with counts, and whether the volume-gated test **ran or skipped**;
+- that fitting the cardioversion job to LL −267.885 is still the next piece of work.
+
+End the body with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`. Then
+stop: the maintainer merges.

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -322,8 +322,7 @@ manual from a clean `git archive` export of a **committed** tree.
 ## Out of scope
 
 - Any change to the likelihood, the optimizer, or the existing `hzr_*` surface.
-- Wiring `hzr_repeated_events()` into `hzr_translate_sas()`. The translator will need to
-  recognise a `%repeat` call and emit this function, but that is a separate change with
-  its own parity evidence.
+- Wiring `hzr_repeated_events()` into `hzr_translate_sas()`. Done separately; see
+  `SAS-JOB-TRANSLATOR-DESIGN.md` §5.5.
 - Running the cardioversion fit itself and reproducing LL -267.885. That is the payoff,
   and it is the *next* piece of work; this spec covers building the input it needs.

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -346,7 +346,8 @@ as not a plain name either way. It then fills the macro's twelve defaults, upper
 `WORK.` libref on `IN=` or `OUT=` is stripped, because it names the same dataset as the bare
 name. It returns the same
 shape as `.hzr_parse_hazard()` (`call`, `untranslated`, `tokens_seen`, `tokens_mapped`)
-plus `in` and `out`. Each argument counts as one token seen and, if accepted, one mapped.
+plus `in_name` and `out_name` (`in` is reserved in R). Each argument counts as one token seen
+and, if accepted, one mapped.
 
 These are refused at translate time. Each becomes a `stop()` chunk in place of the call,
 plus an `$untranslated` row:
@@ -422,7 +423,16 @@ cannot change the likelihood. A `WORK.` prefix names the same dataset as the bar
 `QUIT` joins `DATA`, `PROC`, `%HAZ`, `%REPEAT` and `RUN` as a statement boundary. The
 r-reviewer found the earlier enumerated detector (a `DATA` statement naming `OUT`, or `CREATE
 TABLE OUT`) missed `WORK.EVENTS`, `NODUPKEY`, SQL `DELETE`/`UPDATE`/`INSERT`, `PROC APPEND`
-and `PROC DATASETS`; the maintainer chose to fail closed on 2026-09-11. Each hit emits one
+and `PROC DATASETS`; the maintainer chose to fail closed on 2026-09-11. The final whole-branch
+review, 2026-09-11, found three more gaps and the maintainer closed them the same way: any
+statement starting with `%` (a macro call) is now a boundary of its own, so it cannot hide
+inside an exempt sort or a read-only `DATA` step; a sort counts as plain only when every
+statement after its `PROC SORT` line is a `BY` clause, because a `WHERE` statement subsets the
+data; and a step that uses a macro variable (`&name`) is a hit, since the variable's value is
+not known here and could name `OUT`. The scan also now runs between two chained `%repeat`
+calls, when the second's `IN=` is the first's `OUT=`: a step in between that changes the first
+macro's output is the same untranslated rewrite a fit would read, so it stops there too, ahead
+of the second macro's chunk. Each hit emits one
 `stop()` chunk, directly before the first such fit that follows it; a later fit reading the
 same `OUT=` gets no second copy, since the first stop already halts the render. The chunk
 quotes the step: the normalised text, cut at the next `DATA`, `PROC`, `%HAZ`, `%REPEAT`,
@@ -440,6 +450,10 @@ A wrapper macro that encloses both the `%repeat` call and `PROC HAZARD` needs no
 own. The fit's parse reads the PROC options from the block's first statement, which is then
 the macro call, so `DATA=` is lost and the document stops at its status chunk before any fit
 exists (the r-reviewer's Low 4, found unreachable on 2026-09-11 and pinned by a test).
+
+**Known limit (M2).** A step that changes `OUT=` after the fit but before a `PROC HAZPRED`
+reading it is not scanned. §5.5 covers fits only, and a prediction grid is rarely the macro's
+output.
 
 #### The input dataset
 
@@ -492,12 +506,17 @@ vectors derived by hand from the macro, never from the function:
 8. `BD_CARD` carrying a `NUMBER` column: expect a warning naming it, and `EVENT_NO` exactly
    equal to the hand-derived vector. A negative control with no such column expects no
    such warning.
-9. The rewrite scan fails closed: 9 stop forms (`WORK.EVENTS`, `NODUPKEY`, a sort's `OUT=`
-   or `WHERE=`, SQL `DELETE`/`CREATE TABLE`, `PROC APPEND`, `PROC DATASETS`, a macro call)
-   and 5 pass forms (`DATA OTHER`, `DATA _NULL_`, a plain `PROC SORT` bare or `WORK.`-
+9. The rewrite scan fails closed: 14 stop forms (`WORK.EVENTS`, `NODUPKEY`, a sort's `OUT=`
+   or `WHERE=`, SQL `DELETE`/`CREATE TABLE`, `PROC APPEND`, `PROC DATASETS`, a macro call, a
+   sort with a trailing `WHERE` statement, a plain sort followed by a macro call, a `DATA`
+   step followed by a macro call, and a `&name` macro variable on both a `DATA` step and a
+   sort) and 5 pass forms (`DATA OTHER`, `DATA _NULL_`, a plain `PROC SORT` bare or `WORK.`-
    prefixed, a sort on an unrelated dataset).
 10. A wrapper-enclosed job cannot render a fit: the fit's parsed `data =` argument is absent,
     and evaluating the job's calls in order errors before a `fit` object is ever assigned.
+11. A step between two chained `%repeat` calls that changes the first `OUT=` stops before the
+    second macro's chunk, quoting the step and naming the first `OUT=` in `$untranslated`; the
+    same two calls with no step in between emit no stop.
 
 A volume-gated case in `test-repeated-events-parity.R` translates the real cardioversion
 `.sas` file. It binds `BD_CARD` from `.hzr_derive_bd_card()`, with names upper-cased, and

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -339,8 +339,10 @@ Those fields are additive, so existing callers are unaffected. A job with `%repe
 `HAZARD`/`HAZPRED` block still errors ("no HAZARD or HAZPRED block found"); the `tp.bd.*`
 dataset builders are out of scope.
 
-`.hzr_parse_repeat()` (in `R/sas-parse-job.R`) splits the body on depth-0 commas into
-`KEY=VALUE` pairs and fills the macro's twelve defaults, upper-cased. It returns the same
+`.hzr_parse_repeat()` (in `R/sas-parse-job.R`) splits the body on every comma into
+`KEY=VALUE` pairs. That is equivalent to splitting on depth-0 commas for every call it
+accepts, because a value containing parentheses, where a comma could be nested, is refused
+as not a plain name either way. It then fills the macro's twelve defaults, upper-cased. It returns the same
 shape as `.hzr_parse_hazard()` (`call`, `untranslated`, `tokens_seen`, `tokens_mapped`)
 plus `in` and `out`. Each argument counts as one token seen and, if accepted, one mapped.
 
@@ -363,7 +365,7 @@ iv_end=iv_end, rcensor=cn_card, event=ev_card)`:
 # label: data -- the existing guard, once per distinct IN=
 if (!exists("BD_CARD")) stop("This job read BD_CARD from a SAS DATA step, ...")
 
-# label: repeat
+# label: repeated -- not `repeat`, a reserved word: job$calls$repeat does not parse
 EVENTS <- local({
   d <- BD_CARD
   drop <- intersect(names(d), c("EV_CARD", "EVENT_NO", "CN_CARD", "IV_START",

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -316,9 +316,9 @@ Designed 2026-09-10, branch `feat/translate-repeat`. `hzr_repeated_events()` (#2
 reimplements the macro; see `inst/dev/REPEATED-EVENTS-DESIGN.md`. This section covers only
 how a job's `%repeat(...)` call reaches it.
 
-**Evidence.** A scan of `/Volumes/qhsstudies` on 2026-09-10 found **at least 526** `.sas`
-files calling `%repeat(`, 138 of them `hz.*` or `tp.hz.*` HAZARD jobs. The scan was still
-running when this was written, so the count is a floor. The public corpus has none. Three
+**Evidence.** A scan of `/Volumes/qhsstudies` on 2026-09-10 found **at least 1684** `.sas`
+files calling `%repeat(`, 384 of them `hz.*` or `tp.hz.*` HAZARD jobs. The scan was still
+running when these counts were read (2026-09-10 22:20), so they are floors. The public corpus has none. Three
 consulting templates recur, eight copies each; among the copies checked, seven of each are
 identical and one differs:
 

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -310,6 +310,171 @@ until then unresolved grids emit `UNTRANSLATED` and the document says so.
 
 `derived_set` grids emit `UNTRANSLATED` by design.
 
+### 5.5 `%repeat` translates to `hzr_repeated_events()`
+
+Designed 2026-09-10, branch `feat/translate-repeat`. `hzr_repeated_events()` (#241)
+reimplements the macro; see `inst/dev/REPEATED-EVENTS-DESIGN.md`. This section covers only
+how a job's `%repeat(...)` call reaches it.
+
+**Evidence.** A scan of `/Volumes/qhsstudies` on 2026-09-10 found **at least 526** `.sas`
+files calling `%repeat(`, 138 of them `hz.*` or `tp.hz.*` HAZARD jobs. The scan was still
+running when this was written, so the count is a floor. The public corpus has none. Three
+consulting templates recur, eight copies each; among the copies checked, seven of each are
+identical and one differs:
+
+| job | rewrites `OUT=` after the macro | reads a renamed output |
+|---|---|---|
+| `tp.hz.repeated_events` | no | `LCENSOR IV_START` |
+| `tp.hz.repeated_events.modulated_renewal` | no | `EVENT EV_INFD` |
+| `tp.hz.repeated.event.weighted` | yes: `KEEP` plus an `IV_EVENT` nudge | `CN_RADMT`, `EV_RADMT` |
+| `hz.ce_cardioversion_repeated.ehb` | yes: the line 65 nudge | `LCENSOR IV_START` |
+
+#### Extraction and parsing
+
+`.hzr_sas_blocks()` gains a third block kind, `REPEAT`, matched on `%REPEAT *\(` and bounded
+by its own balanced parentheses. Blocks therefore come out in file order, which is the one
+property this feature cannot get wrong: the `%repeat` chunk must precede the fit that reads
+its `OUT=`. Each block also records `start` and `end` offsets into the normalised text.
+Those fields are additive, so existing callers are unaffected. A job with `%repeat` and no
+`HAZARD`/`HAZPRED` block still errors ("no HAZARD or HAZPRED block found"); the `tp.bd.*`
+dataset builders are out of scope.
+
+`.hzr_parse_repeat()` (in `R/sas-parse-job.R`) splits the body on depth-0 commas into
+`KEY=VALUE` pairs and fills the macro's twelve defaults, upper-cased. It returns the same
+shape as `.hzr_parse_hazard()` (`call`, `untranslated`, `tokens_seen`, `tokens_mapped`)
+plus `in` and `out`. Each argument counts as one token seen and, if accepted, one mapped.
+
+These are refused at translate time. Each becomes a `stop()` chunk in place of the call,
+plus an `$untranslated` row:
+
+- an unknown keyword, or a positional argument (SAS itself errors on both);
+- a value that is not a plain SAS name, such as `&VAR` or an empty value;
+- an argument column (`ID`, `EVENTYPE`, `IV_EVENT`, `IV_END`) equal to one of the
+  eight output names, for example `EVENTYPE=RCENSOR`. SAS zeroes that indicator at its
+  first DATA step, so the job's own answer is garbage, and the call text alone shows it;
+- two output names that are equal to each other.
+
+#### Emitted code
+
+For the cardioversion call, `%repeat(in=bd_card, out=events, id=ccfid, eventype=ce_card,
+iv_end=iv_end, rcensor=cn_card, event=ev_card)`:
+
+```r
+# label: data -- the existing guard, once per distinct IN=
+if (!exists("BD_CARD")) stop("This job read BD_CARD from a SAS DATA step, ...")
+
+# label: repeat
+EVENTS <- local({
+  d <- BD_CARD
+  drop <- intersect(names(d), c("EV_CARD", "EVENT_NO", "CN_CARD", "IV_START",
+                                "IV_SEG", "RENEWAL", "FIRST", "LAST"))
+  if (length(drop)) {
+    warning(...)  # names the dropped columns
+    d <- d[setdiff(names(d), drop)]
+  }
+  out <- hzr_repeated_events(d, id = "CCFID", time = "IV_EVENT",
+                             followup = "IV_END", indicator = "CE_CARD")
+  names(out)[match(c("event", "event_no", "rcensor", "iv_start", "iv_seg",
+                     "renewal", "first", "last"), names(out))] <-
+    c("EV_CARD", "EVENT_NO", "CN_CARD", "IV_START", "IV_SEG", "RENEWAL",
+      "FIRST", "LAST")
+  out
+})
+```
+
+`OUT=` joins the set of datasets that an emitted chunk builds, so the fit's `DATA=EVENTS`
+gets no "Assign EVENTS" guard. An `IN=` that is itself an earlier `%repeat`'s `OUT=` gets
+none either.
+
+**The rename is always emitted, not only for non-default names.** The translator
+upper-cases the whole job, so the fit references `IV_START`, while the function returns
+`iv_start`. R is case-sensitive, so without the rename the fit reads a column that does
+not exist.
+
+**The drop is what makes the rename safe.** Suppose `IN=` already carries a column named as
+a rename target, say `EV_CARD`. Without the drop, `names<-` would produce two columns named
+`EV_CARD`, and `$EV_CARD` returns the first one, which is the stale input. That would be a
+wrong answer with no error. Dropping reproduces SAS exactly, because the macro assigns each
+of its eight outputs unconditionally on every row before any statement reads it: `rcensor`
+at the first DATA step, `first` and `last` at the fourth, `event` at the fifth, and
+`event_no`, `iv_start`, `iv_seg` and `renewal` at the sixth. An argument column can never be
+dropped, since that case was refused at translate time. A lower-case `rcensor` in a
+mixed-case frame is not dropped either; it reaches `hzr_repeated_events()`'s own refusal,
+which is loud.
+
+#### Rewrites of `OUT=` after the macro
+
+The maintainer decided on 2026-09-10 that a job's post-macro statements are not folded into
+the function. Before each `PROC HAZARD` whose `DATA=` is an earlier `%repeat`'s `OUT=`, the
+text between that macro's `end` and the fit's `start` is scanned for a `DATA` statement that
+names `OUT`, or for `CREATE TABLE OUT`. Each hit emits one `stop()` chunk, directly before
+the first such fit that follows it; a later fit reading the same `OUT=` gets no second copy,
+since the first stop already halts the render. The chunk quotes the step: the normalised text, cut at the next `DATA`, `PROC`, `%HAZ`,
+`%REPEAT` or `RUN;`. It tells the reader to replace the chunk with R code that makes the same
+change. The hit is also recorded in `$untranslated`, which the translate-time warning
+reports.
+
+A silently skipped rewrite would be the house failure mode: a fit that converges over data
+SAS never fitted. In the cardioversion job that means 15 zero-length segments left
+un-nudged. Placing the stop at the fit, rather than right after the macro, still catches a
+rewrite that follows an intervening block. `PROC SORT` is not treated as a rewrite, because
+reordering rows does not change the likelihood. The quote carries no line number: every
+`$untranslated` row today has `line = NA`, since the parser sees only normalised text.
+
+#### The input dataset
+
+`IN=` is usually built by DATA steps this translator does not translate. It gets the same
+`if (!exists(...)) stop()` guard that a `PROC HAZARD` `DATA=` gets. The message asks the
+reader to assign the dataset as it stood at the `%repeat` call, with the columns named as
+the job spells them, in upper case. That is the existing convention for `DATA=`, kept
+deliberately; the emitted code does not upper-case names for the reader. A data frame read
+by `haven` keeps the stored case (`ccfid`), and `hzr_repeated_events()`'s own error for a
+missing column names the one it wanted.
+
+#### ⚠️ Open: a `LAG_IV` or `NUMBER` column in `IN=`
+
+This was found while writing this section and is not part of the approved design. The
+macro's sixth DATA step keeps two loop variables with `RETAIN lag_iv 0 number 0`. A
+variable that also arrives through `SET` is re-read from the input on every iteration,
+which overwrites the value retained from the previous row. So if `IN=` has a `LAG_IV` or
+`NUMBER` column, SAS computes `iv_start` and `event_no` from that column rather than from its
+own lag. `hzr_repeated_events()` has no such coupling, so the translated document would
+disagree with the SAS listing without saying so. Here SAS is the one that is wrong: this is
+a finding to document, not behaviour to reproduce. The cardioversion input has neither
+column; SAS's jump from 361 to 367 columns at that step is exactly the six variables the
+step adds. **Proposed:** the `repeat` chunk warns at render, naming the column and saying
+that SAS's `iv_start`/`event_no` for this job are not comparable.
+
+#### Tests
+
+A new file, `tests/testthat/test-sas-translate-repeat.R`, evaluates the emitted chunks with
+`eval()` into an environment that holds a small synthetic `BD_CARD`. It compares against
+vectors derived by hand from the macro, never from the function:
+
+1. End to end: the chunk names are exactly `c("data", "repeat", ..., "fit")`; `EV_CARD`,
+   `CN_CARD`, `IV_START` and `IV_EVENT` equal hand-derived vectors; and a fit that uses
+   `LCENSOR IV_START` runs (`skip_on_cran()`). This test fails if the rename is removed.
+2. A non-default output name read by `EVENT EV_X`: the lower-case `event` is absent, and
+   `EV_X` holds the exact vector.
+3. The clash drop: `BD_CARD` carries a stale `EV_CARD` of wrong values. The test expects a
+   warning naming it, exactly one `EV_CARD` column, and the macro's values. It fails if the
+   drop is removed.
+4. Each translate-time refusal: a `stop()` chunk whose `eval()` errors with the expected
+   message, and an exact `$untranslated$construct`.
+5. A post-macro rewrite: evaluation halts at the stop chunk before the fit. Negative
+   controls, so the detector cannot pass by always firing: `DATA OTHER; ...` and
+   `PROC SORT DATA=EVENTS` produce no stop.
+6. Defaults: `%REPEAT()` guards `BUILT` and calls with `ID`, `EVENTYPE`, `IV_EVENT` and
+   `IV_END`.
+7. Extraction: a mixed fixture yields block kinds exactly `c("REPEAT", "HAZARD",
+   "HAZPRED")`.
+
+A volume-gated case in `test-repeated-events-parity.R` translates the real cardioversion
+`.sas` file. It binds `BD_CARD` from `.hzr_derive_bd_card()`, with names upper-cased, and
+asserts that evaluation halts at the line 65 stop chunk. It then checks that `EVENTS` is 962
+by 365 and holds 388 `CE_CARD` events, checking the shape before comparing any value. It
+does not fit the model; reproducing LL -267.885 is the next piece of work.
+
 ## 6. Testing
 
 - `test-sas-grammar.R` — table populated, statuses valid, keyword unique per

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -316,9 +316,9 @@ Designed 2026-09-10, branch `feat/translate-repeat`. `hzr_repeated_events()` (#2
 reimplements the macro; see `inst/dev/REPEATED-EVENTS-DESIGN.md`. This section covers only
 how a job's `%repeat(...)` call reaches it.
 
-**Evidence.** A scan of `/Volumes/qhsstudies` on 2026-09-10 found **at least 1684** `.sas`
-files calling `%repeat(`, 384 of them `hz.*` or `tp.hz.*` HAZARD jobs. The scan was still
-running when these counts were read (2026-09-10 22:20), so they are floors. The public corpus has none. Three
+**Evidence.** A scan of `/Volumes/qhsstudies` on 2026-09-10 found **1733** `.sas`
+files calling `%repeat(`, 403 of them `hz.*` or `tp.hz.*` HAZARD jobs. The scan finished on
+2026-09-11. The public corpus has none. Three
 consulting templates recur, eight copies each; among the copies checked, seven of each are
 identical and one differs:
 
@@ -342,7 +342,9 @@ dataset builders are out of scope.
 `.hzr_parse_repeat()` (in `R/sas-parse-job.R`) splits the body on every comma into
 `KEY=VALUE` pairs. That is equivalent to splitting on depth-0 commas for every call it
 accepts, because a value containing parentheses, where a comma could be nested, is refused
-as not a plain name either way. It then fills the macro's twelve defaults, upper-cased. It returns the same
+as not a plain name either way. It then fills the macro's twelve defaults, upper-cased. A
+`WORK.` libref on `IN=` or `OUT=` is stripped, because it names the same dataset as the bare
+name. It returns the same
 shape as `.hzr_parse_hazard()` (`call`, `untranslated`, `tokens_seen`, `tokens_mapped`)
 plus `in` and `out`. Each argument counts as one token seen and, if accepted, one mapped.
 
@@ -354,7 +356,9 @@ plus an `$untranslated` row:
 - an argument column (`ID`, `EVENTYPE`, `IV_EVENT`, `IV_END`) equal to one of the
   eight output names, for example `EVENTYPE=RCENSOR`. SAS zeroes that indicator at its
   first DATA step, so the job's own answer is garbage, and the call text alone shows it;
-- two output names that are equal to each other.
+- two output names that are equal to each other;
+- a keyword given twice, which SAS rejects;
+- an output named `LAG_IV` or `NUMBER`, the names of the macro's own `RETAIN` loop counters.
 
 #### Emitted code
 
@@ -363,7 +367,7 @@ iv_end=iv_end, rcensor=cn_card, event=ev_card)`:
 
 ```r
 # label: data -- the existing guard, once per distinct IN=
-if (!exists("BD_CARD")) stop("This job read BD_CARD from a SAS DATA step, ...")
+if (!exists("BD_CARD")) stop("This job built BD_CARD in SAS DATA steps, ...")
 
 # label: repeated -- not `repeat`, a reserved word: job$calls$repeat does not parse
 EVENTS <- local({
@@ -408,20 +412,34 @@ which is loud.
 
 The maintainer decided on 2026-09-10 that a job's post-macro statements are not folded into
 the function. Before each `PROC HAZARD` whose `DATA=` is an earlier `%repeat`'s `OUT=`, the
-text between that macro's `end` and the fit's `start` is scanned for a `DATA` statement that
-names `OUT`, or for `CREATE TABLE OUT`. Each hit emits one `stop()` chunk, directly before
-the first such fit that follows it; a later fit reading the same `OUT=` gets no second copy,
-since the first stop already halts the render. The chunk quotes the step: the normalised text, cut at the next `DATA`, `PROC`, `%HAZ`,
-`%REPEAT` or `RUN;`. It tells the reader to replace the chunk with R code that makes the same
-change. The hit is also recorded in `$untranslated`, which the translate-time warning
-reports.
+text between that macro's `end` and the fit's `start` is scanned with a fail-closed rule: a
+`DATA` step is a hit when its output list names `OUT`; a step that only reads it (`SET OUT`)
+is not. Any other step or statement that names `OUT` is a hit as well -- `PROC SQL`, `PROC
+APPEND`, `PROC DATASETS`, a sort with `NODUPKEY`, `OUT=` or `WHERE=`, a macro call -- because
+a false stop costs the reader one deleted chunk and a missed rewrite fits data SAS did not
+fit. The one exception is the plain `PROC SORT DATA=OUT`, which only reorders rows and so
+cannot change the likelihood. A `WORK.` prefix names the same dataset as the bare name, and
+`QUIT` joins `DATA`, `PROC`, `%HAZ`, `%REPEAT` and `RUN` as a statement boundary. The
+r-reviewer found the earlier enumerated detector (a `DATA` statement naming `OUT`, or `CREATE
+TABLE OUT`) missed `WORK.EVENTS`, `NODUPKEY`, SQL `DELETE`/`UPDATE`/`INSERT`, `PROC APPEND`
+and `PROC DATASETS`; the maintainer chose to fail closed on 2026-09-11. Each hit emits one
+`stop()` chunk, directly before the first such fit that follows it; a later fit reading the
+same `OUT=` gets no second copy, since the first stop already halts the render. The chunk
+quotes the step: the normalised text, cut at the next `DATA`, `PROC`, `%HAZ`, `%REPEAT`,
+`RUN` or `QUIT`. It tells the reader to replace the chunk with R code that makes the same
+change, or delete it if the step leaves the output unchanged. The hit is also recorded in
+`$untranslated`, which the translate-time warning reports.
 
 A silently skipped rewrite would be the house failure mode: a fit that converges over data
 SAS never fitted. In the cardioversion job that means 15 zero-length segments left
 un-nudged. Placing the stop at the fit, rather than right after the macro, still catches a
-rewrite that follows an intervening block. `PROC SORT` is not treated as a rewrite, because
-reordering rows does not change the likelihood. The quote carries no line number: every
+rewrite that follows an intervening block. The quote carries no line number: every
 `$untranslated` row today has `line = NA`, since the parser sees only normalised text.
+
+A wrapper macro that encloses both the `%repeat` call and `PROC HAZARD` needs no guard of its
+own. The fit's parse reads the PROC options from the block's first statement, which is then
+the macro call, so `DATA=` is lost and the document stops at its status chunk before any fit
+exists (the r-reviewer's Low 4, found unreachable on 2026-09-11 and pinned by a test).
 
 #### The input dataset
 
@@ -444,7 +462,7 @@ own lag. `hzr_repeated_events()` has no such coupling, so the translated documen
 disagree with the SAS listing without saying so. Here SAS is the one that is wrong: this is
 a finding to document, not behaviour to reproduce. The cardioversion input has neither
 column; SAS's jump from 361 to 367 columns at that step is exactly the six variables the
-step adds. **Decided:** the `repeat` chunk warns at render, naming the column and saying
+step adds. **Decided:** the `repeated` chunk warns at render, naming the column and saying
 that SAS's `iv_start`/`event_no` for this job are not comparable. R's result, which is the
 macro's intent, stands; the column is neither dropped nor used.
 
@@ -454,7 +472,7 @@ A new file, `tests/testthat/test-sas-translate-repeat.R`, evaluates the emitted 
 `eval()` into an environment that holds a small synthetic `BD_CARD`. It compares against
 vectors derived by hand from the macro, never from the function:
 
-1. End to end: the chunk names are exactly `c("data", "repeat", ..., "fit")`; `EV_CARD`,
+1. End to end: the chunk names are exactly `c("data", "repeated", ..., "fit")`; `EV_CARD`,
    `CN_CARD`, `IV_START` and `IV_EVENT` equal hand-derived vectors; and a fit that uses
    `LCENSOR IV_START` runs (`skip_on_cran()`). This test fails if the rename is removed.
 2. A non-default output name read by `EVENT EV_X`: the lower-case `event` is absent, and
@@ -474,6 +492,12 @@ vectors derived by hand from the macro, never from the function:
 8. `BD_CARD` carrying a `NUMBER` column: expect a warning naming it, and `EVENT_NO` exactly
    equal to the hand-derived vector. A negative control with no such column expects no
    such warning.
+9. The rewrite scan fails closed: 9 stop forms (`WORK.EVENTS`, `NODUPKEY`, a sort's `OUT=`
+   or `WHERE=`, SQL `DELETE`/`CREATE TABLE`, `PROC APPEND`, `PROC DATASETS`, a macro call)
+   and 5 pass forms (`DATA OTHER`, `DATA _NULL_`, a plain `PROC SORT` bare or `WORK.`-
+   prefixed, a sort on an unrelated dataset).
+10. A wrapper-enclosed job cannot render a fit: the fit's parsed `data =` argument is absent,
+    and evaluating the job's calls in order errors before a `fit` object is ever assigned.
 
 A volume-gated case in `test-repeated-events-parity.R` translates the real cardioversion
 `.sas` file. It binds `BD_CARD` from `.hzr_derive_bd_card()`, with names upper-cased, and

--- a/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
+++ b/inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md
@@ -431,9 +431,9 @@ deliberately; the emitted code does not upper-case names for the reader. A data 
 by `haven` keeps the stored case (`ccfid`), and `hzr_repeated_events()`'s own error for a
 missing column names the one it wanted.
 
-#### ⚠️ Open: a `LAG_IV` or `NUMBER` column in `IN=`
+#### A `LAG_IV` or `NUMBER` column in `IN=`: warn, do not reproduce
 
-This was found while writing this section and is not part of the approved design. The
+This was found while writing this section, and the maintainer decided it on 2026-09-10. The
 macro's sixth DATA step keeps two loop variables with `RETAIN lag_iv 0 number 0`. A
 variable that also arrives through `SET` is re-read from the input on every iteration,
 which overwrites the value retained from the previous row. So if `IN=` has a `LAG_IV` or
@@ -442,8 +442,9 @@ own lag. `hzr_repeated_events()` has no such coupling, so the translated documen
 disagree with the SAS listing without saying so. Here SAS is the one that is wrong: this is
 a finding to document, not behaviour to reproduce. The cardioversion input has neither
 column; SAS's jump from 361 to 367 columns at that step is exactly the six variables the
-step adds. **Proposed:** the `repeat` chunk warns at render, naming the column and saying
-that SAS's `iv_start`/`event_no` for this job are not comparable.
+step adds. **Decided:** the `repeat` chunk warns at render, naming the column and saying
+that SAS's `iv_start`/`event_no` for this job are not comparable. R's result, which is the
+macro's intent, stands; the column is neither dropped nor used.
 
 #### Tests
 
@@ -468,6 +469,9 @@ vectors derived by hand from the macro, never from the function:
    `IV_END`.
 7. Extraction: a mixed fixture yields block kinds exactly `c("REPEAT", "HAZARD",
    "HAZPRED")`.
+8. `BD_CARD` carrying a `NUMBER` column: expect a warning naming it, and `EVENT_NO` exactly
+   equal to the hand-derived vector. A negative control with no such column expects no
+   such warning.
 
 A volume-gated case in `test-repeated-events-parity.R` translates the real cardioversion
 `.sas` file. It binds `BD_CARD` from `.hzr_derive_bd_card()`, with names upper-cased, and

--- a/man/hzr_translate_sas.Rd
+++ b/man/hzr_translate_sas.Rd
@@ -79,6 +79,19 @@ confidence limits unless the SAS job says \code{NOCL}, so such a job stops at
 its \code{predict()} chunks.
 }
 
+\section{Repeated events}{
+
+A job that builds its fit input with the SAS macro \verb{\%repeat} has that call
+translated to \code{\link[=hzr_repeated_events]{hzr_repeated_events()}}. The emitted chunk renames the
+function's output columns to the names the job gives them, upper-cased like
+every name the translator emits, so the fit reads them. An input column named
+like one of those outputs is dropped first, with a warning, because the macro
+overwrites it. The macro's input is built by the job's own DATA steps, which
+are not translated, so the document stops until that input is assigned. A DATA
+step that changes the macro's output before the fit is not translated either.
+Its chunk stops and quotes the step, for the reader to replace with R code.
+}
+
 \section{Comparing a translated fit against a SAS listing}{
 
 The emitted \code{hzr_phase("g3", ...)} call carries the \code{TAU}, \code{GAMMA},

--- a/man/hzr_translate_sas.Rd
+++ b/man/hzr_translate_sas.Rd
@@ -87,13 +87,15 @@ function's output columns to the names the job gives them, upper-cased like
 every name the translator emits, so the fit reads them. An input column named
 like one of those outputs is dropped first, with a warning, because the macro
 overwrites it. The macro's input is built by the job's own DATA steps, which
-are not translated, so the document stops until that input is assigned. Any
-step between the macro and the fit that names the macro's output is not
-translated either, apart from a plain \verb{PROC SORT}, which only reorders rows.
-Its chunk stops and quotes the step, for the reader to replace with R code or
-to delete if the step leaves the output unchanged. A step that changes the
-output without naming it, such as a macro that writes it internally, is not
-detected.
+are not translated, so the document stops until that input is assigned.
+Any step between the macro and the fit that names the macro's output, or
+uses a macro variable that might, is not translated either; a plain
+\verb{PROC SORT} that only reorders rows is the one step let through. Its chunk
+stops and quotes the step, for the reader to replace with R code or to delete
+if the step leaves the output unchanged. The same holds between two
+\verb{\%repeat} calls when the second reads the first's output. A step that changes
+the output without naming it, such as a macro that writes it internally, is
+not detected.
 }
 
 \section{Comparing a translated fit against a SAS listing}{

--- a/man/hzr_translate_sas.Rd
+++ b/man/hzr_translate_sas.Rd
@@ -87,9 +87,13 @@ function's output columns to the names the job gives them, upper-cased like
 every name the translator emits, so the fit reads them. An input column named
 like one of those outputs is dropped first, with a warning, because the macro
 overwrites it. The macro's input is built by the job's own DATA steps, which
-are not translated, so the document stops until that input is assigned. A DATA
-step that changes the macro's output before the fit is not translated either.
-Its chunk stops and quotes the step, for the reader to replace with R code.
+are not translated, so the document stops until that input is assigned. Any
+step between the macro and the fit that names the macro's output is not
+translated either, apart from a plain \verb{PROC SORT}, which only reorders rows.
+Its chunk stops and quotes the step, for the reader to replace with R code or
+to delete if the step leaves the output unchanged. A step that changes the
+output without naming it, such as a macro that writes it internally, is not
+detected.
 }
 
 \section{Comparing a translated fit against a SAS listing}{

--- a/tests/testthat/test-repeated-events-parity.R
+++ b/tests/testthat/test-repeated-events-parity.R
@@ -118,10 +118,20 @@ test_that("hz.ce_cardioversion_repeated.ehb: the result does not depend on input
 cardioversion_job <- function(dir) {
   path <- file.path(dirname(dir), "distributions", "hz.ce_cardioversion_repeated.ehb.sas")
   testthat::skip_if_not(file.exists(path), "cardioversion job not found beside the datasets")
-  # STEEPEST, in both blocks, is the one construct the translator leaves out:
-  # SAS's steepest-descent warm-up (issue #145). Nothing else may go missing.
+  # STEEPEST, in both blocks, is SAS's steepest-descent warm-up (issue #145),
+  # which the translator leaves out. The other two rows come from its
+  # fail-closed scan of steps that may change the %repeat output EVENTS
+  # before a fit reads it. The first is the job's line 65 nudge, a genuine
+  # rewrite, which this file applies itself in cardioversion_events(). The
+  # second is %HAZPLOT(IN=EVENTS, ...) before the stratified fit. It only
+  # reads EVENTS, but a macro call naming the output stops by design, since
+  # a false stop costs a deleted chunk and a miss fits the wrong data.
+  # Nothing else may go missing.
   expect_warning(job <- hzr_translate_sas(path), "STEEPEST")
-  expect_equal(job$untranslated$construct, c("STEEPEST", "STEEPEST"))
+  expect_equal(
+    job$untranslated$construct,
+    c("EVENTS changed after %repeat", "STEEPEST", "EVENTS changed after %repeat", "STEEPEST")
+  )
   job
 }
 

--- a/tests/testthat/test-repeated-events-parity.R
+++ b/tests/testthat/test-repeated-events-parity.R
@@ -101,3 +101,27 @@ test_that("hz.ce_cardioversion_repeated.ehb: the result does not depend on input
     expect_equal(canon(run(shuffled)), base, label = paste("shuffle", k))
   }
 })
+
+test_that("hzr_translate_sas() on the cardioversion job builds EVENTS, then stops at line 65", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("haven")
+  dir <- skip_if_no_maze_datasets()
+  sas <- file.path(dirname(dir), "distributions", "hz.ce_cardioversion_repeated.ehb.sas")
+  testthat::skip_if_not(file.exists(sas), "hz.ce_cardioversion_repeated.ehb.sas not on the volume")
+
+  job <- suppressWarnings(hzr_translate_sas(sas))
+  expect_equal(names(job$calls)[1:5], c("data", "repeated", "rewrite", "status", "fit"))
+
+  bd_card <- .hzr_derive_bd_card(dir)
+  names(bd_card) <- toupper(names(bd_card))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card
+  eval(job$calls$data, env)
+  expect_no_warning(eval(job$calls[["repeated"]], env))
+  # Shape first, then values: the .log's 962 rows, and 357 input columns plus
+  # the function's eight.
+  expect_equal(dim(env$EVENTS), c(962L, 365L))
+  expect_equal(sum(env$EVENTS$CE_CARD == 1), 388L)
+  # The job's line 65 is job code, not macro code; the document stops on it.
+  expect_error(eval(job$calls$rewrite, env), "IV_EVENT=IV_EVENT+0.0001141553", fixed = TRUE)
+})

--- a/tests/testthat/test-sas-lex.R
+++ b/tests/testthat/test-sas-lex.R
@@ -92,3 +92,37 @@ test_that("an unenclosed PROC with nothing following extends to end of text", {
   expect_equal(b[[1]]$terminator, "none")
   expect_true(grepl("EVENT D;", b[[1]]$text, fixed = TRUE))
 })
+
+test_that("%REPEAT calls are blocks too, in file order, with offsets", {
+  txt <- .hzr_sas_normalise(c(
+    "%repeat(in=bd, out=events, id=ccfid);",
+    "%hazard( proc hazard data=events; time t; event e; parms muc=0.1; );",
+    "%hazpred( proc hazpred data=g inhaz=outest; time t; );"
+  ))
+  b <- .hzr_sas_blocks(txt)
+  expect_equal(vapply(b, `[[`, "", "proc"), c("REPEAT", "HAZARD", "HAZPRED"))
+  expect_equal(b[[1]]$text, "IN=BD, OUT=EVENTS, ID=CCFID")
+  expect_equal(b[[1]]$terminator, "paren")
+  expect_equal(substring(txt, b[[1]]$start, b[[1]]$end), "%REPEAT(IN=BD, OUT=EVENTS, ID=CCFID)")
+  # A paren-bounded PROC block starts at its own opening paren.
+  expect_equal(substr(txt, b[[2]]$start, b[[2]]$start), "(")
+  expect_equal(substr(txt, b[[2]]$end, b[[2]]$end), ")")
+  expect_lt(b[[1]]$end, b[[2]]$start)
+  expect_lt(b[[2]]$end, b[[3]]$start)
+})
+
+test_that("a macro definition or a longer macro name is not a %repeat call", {
+  txt <- .hzr_sas_normalise(c(
+    "%macro repeat(in=built, out=events);",
+    "%repeated(in=x);",
+    "%hazard( proc hazard data=a; time t; event e; );"
+  ))
+  expect_equal(vapply(.hzr_sas_blocks(txt), `[[`, "", "proc"), "HAZARD")
+})
+
+test_that("an unenclosed PROC records where its bounded body ends", {
+  txt <- .hzr_sas_normalise("PROC HAZARD DATA=A; EVENT D; DATA NEXT;")
+  b <- .hzr_sas_blocks(txt)
+  expect_equal(b[[1]]$start, 1L)
+  expect_equal(substring(txt, b[[1]]$start, b[[1]]$end), "PROC HAZARD DATA=A; EVENT D; ")
+})

--- a/tests/testthat/test-sas-translate-repeat.R
+++ b/tests/testthat/test-sas-translate-repeat.R
@@ -110,7 +110,9 @@ test_that("uncallable %repeat arguments are refused, each with its reason", {
     list("in=bd_card, foo=bar", "`FOO=` is not a %repeat parameter"),
     list("in=&dsn", "`IN=&DSN` is not a plain SAS name"),
     list("event=x, rcensor=x", "two outputs are both named X"),
-    list("bd_card", "`BD_CARD` is not a KEY=VALUE argument")
+    list("bd_card", "`BD_CARD` is not a KEY=VALUE argument"),
+    list("in=bd_card, event_no=number", "output NUMBER has the name of a %repeat loop counter"),
+    list("in=bd_card, id=a, id=b", "`ID=` is given more than once")
   )
   for (cs in cases) {
     r <- parse_repeat(cs[[1]])
@@ -185,7 +187,7 @@ test_that("a DATA step rewriting OUT= stops the document before the fit, quoted"
     "DATA EVENTS; SET EVENTS; IF IV_START GE IV_EVENT THEN IV_EVENT=IV_EVENT+0.0001;",
     fixed = TRUE
   )
-  expect_true("DATA EVENTS after %repeat" %in% job$untranslated$construct)
+  expect_true("EVENTS changed after %repeat" %in% job$untranslated$construct)
 })
 
 test_that("steps that do not rewrite OUT= emit no rewrite stop", {
@@ -218,4 +220,64 @@ test_that("a refused %repeat still leaves a guard on the fit's DATA=", {
   job <- translate_lines(c("%repeat(in=bd_card, eventype=rcensor);", hz_block))
   expect_equal(names(job$calls), c("repeated", "data", "status", "fit"))
   expect_error(eval(job$calls[["repeated"]], new.env()), "RCENSOR is also an output", fixed = TRUE)
+})
+
+test_that("the rewrite scan fails closed: any step naming OUT= stops, bar a plain sort or a read", {
+  stops <- c(
+    "data work.events; set events; x=1; run;",
+    "proc sort data=events nodupkey; by ccfid; run;",
+    "proc sort data=bd_card out=events; by ccfid;",
+    "proc sort data=events(where=(iv_seg>0)); by ccfid;",
+    "proc sql; delete from events where iv_seg=0; quit;",
+    "proc sql; create table work.events(drop=x) as select ccfid from events; quit;",
+    "proc append base=events data=extra; run;",
+    "proc datasets; modify events; rename a=b; quit;",
+    "%vars(in=bd, out=events);"
+  )
+  for (s in stops) {
+    job <- translate_lines(c(repeat_call, s, hz_block))
+    expect_equal(names(job$calls), c("data", "repeated", "rewrite", "status", "fit"), info = s)
+  }
+  passes <- c(
+    "data other; set events; x=1;",
+    "data _null_; set events; put ccfid;",
+    "proc sort data=events; by ccfid; run;",
+    "proc sort data=work.events; by ccfid;",
+    "proc sort data=bd_card; by ccfid; data x; set bd_card;"
+  )
+  for (s in passes) {
+    job <- translate_lines(c(repeat_call, s, hz_block))
+    expect_equal(names(job$calls), c("data", "repeated", "status", "fit"), info = s)
+  }
+})
+
+test_that("a fit whose block encloses the %repeat call cannot render a fit", {
+  # The fit's parse reads PROC HAZARD options from the block's first
+  # statement, which here is the %repeat call, so DATA= is lost and the
+  # rewrite scan never runs. That is loud, not silent: evaluation stops before
+  # a fit exists. If a parser change ever keeps DATA= here, the first
+  # assertion fails, and the rewrite scan must then handle an enclosing block.
+  job <- translate_lines(c(
+    "%run( %repeat(in=bd_card, id=ccfid, eventype=ce_card);",
+    "data events; set events; x=1;",
+    "proc hazard data=events; event ce_card; time iv_event; parms muc=0.5; );"
+  ))
+  expect_null(job$calls$fit[[3L]][["data"]])
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  expect_error(for (nm in names(job$calls)) eval(job$calls[[nm]], env), "CE_CARD")
+  expect_false(exists("fit", envir = env, inherits = FALSE))
+})
+
+test_that("a WORK. libref on IN= and OUT= names the same dataset as the bare name", {
+  job <- translate_lines(c(
+    paste("%repeat(in=work.bd_card, out=work.events, id=ccfid, eventype=ce_card,",
+          "iv_end=iv_end, rcensor=cn_card, event=ev_card);"),
+    hz_block
+  ))
+  expect_equal(names(job$calls), c("data", "repeated", "status", "fit"))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "repeated")
+  expect_equal(env$EVENTS, expected_events())
 })

--- a/tests/testthat/test-sas-translate-repeat.R
+++ b/tests/testthat/test-sas-translate-repeat.R
@@ -112,7 +112,8 @@ test_that("uncallable %repeat arguments are refused, each with its reason", {
     list("event=x, rcensor=x", "two outputs are both named X"),
     list("bd_card", "`BD_CARD` is not a KEY=VALUE argument"),
     list("in=bd_card, event_no=number", "output NUMBER has the name of a %repeat loop counter"),
-    list("in=bd_card, id=a, id=b", "`ID=` is given more than once")
+    list("in=bd_card, id=a, id=b", "`ID=` is given more than once"),
+    list("in=bd_card, iv_start=lag_iv", "output LAG_IV has the name of a %repeat loop counter")
   )
   for (cs in cases) {
     r <- parse_repeat(cs[[1]])
@@ -232,7 +233,12 @@ test_that("the rewrite scan fails closed: any step naming OUT= stops, bar a plai
     "proc sql; create table work.events(drop=x) as select ccfid from events; quit;",
     "proc append base=events data=extra; run;",
     "proc datasets; modify events; rename a=b; quit;",
-    "%vars(in=bd, out=events);"
+    "%vars(in=bd, out=events);",
+    "proc sort data=events; by ccfid; where iv_seg > 0;",
+    "proc sort data=events; by ccfid; %fix(data=events);",
+    "data other; set events; x=1; %fix(data=events);",
+    "data &dsn; set &dsn; x=1;",
+    "proc sort data=&dsn nodupkey; by ccfid;"
   )
   for (s in stops) {
     job <- translate_lines(c(repeat_call, s, hz_block))
@@ -267,6 +273,17 @@ test_that("a fit whose block encloses the %repeat call cannot render a fit", {
   env$BD_CARD <- bd_card()
   expect_error(for (nm in names(job$calls)) eval(job$calls[[nm]], env), "CE_CARD")
   expect_false(exists("fit", envir = env, inherits = FALSE))
+})
+
+test_that("a step between chained %repeat calls that changes the first OUT= stops", {
+  first <- "%repeat(in=bd_card, out=ev1, id=ccfid, eventype=ce_card);"
+  second <- "%repeat(in=ev1, out=events, id=ccfid, eventype=ce_card);"
+  job <- translate_lines(c(first, "data ev1; set ev1; iv_event=iv_event+1;", second, hz_block))
+  expect_equal(names(job$calls), c("data", "repeated", "rewrite", "repeated_2", "status", "fit"))
+  expect_true("EV1 changed after %repeat" %in% job$untranslated$construct)
+  # Without a step between them, the chain emits no stop.
+  job <- translate_lines(c(first, second, hz_block))
+  expect_equal(names(job$calls), c("data", "repeated", "repeated_2", "status", "fit"))
 })
 
 test_that("a WORK. libref on IN= and OUT= names the same dataset as the bare name", {

--- a/tests/testthat/test-sas-translate-repeat.R
+++ b/tests/testthat/test-sas-translate-repeat.R
@@ -1,0 +1,17 @@
+# test-sas-translate-repeat.R -- hzr_translate_sas() on jobs that call the
+# SAS macro %repeat. Every test evaluates the emitted chunks; expected values
+# are derived by hand from ~/Documents/macro.library/repeat.sas (see
+# inst/dev/REPEAT-TRANSLATOR-PLAN.md, "The synthetic fixture"), never from
+# hzr_repeated_events() itself.
+
+translate_lines <- function(lines) {
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines(lines, f)
+  suppressWarnings(hzr_translate_sas(f))
+}
+
+test_that("a job with %repeat but no PROC HAZARD or HAZPRED is still refused", {
+  f <- withr::local_tempfile(fileext = ".sas")
+  writeLines("%repeat(in=bd, out=events);", f)
+  expect_error(hzr_translate_sas(f), "no HAZARD or HAZPRED block found")
+})

--- a/tests/testthat/test-sas-translate-repeat.R
+++ b/tests/testthat/test-sas-translate-repeat.R
@@ -124,3 +124,98 @@ test_that("uncallable %repeat arguments are refused, each with its reason", {
     expect_equal(r$tokens_mapped, 0L)
   }
 })
+
+repeat_call <- paste0("%repeat(", cardio_args, ");")
+hz_block <- c("%hazard( proc hazard data=events condition=14;",
+              "lcensor iv_start; event ce_card; time iv_event; parms muc=0.5; );")
+
+eval_upto <- function(job, env, last) {
+  for (nm in names(job$calls)[seq_len(match(last, names(job$calls)))]) {
+    eval(job$calls[[nm]], env)
+  }
+  env
+}
+
+test_that("a %repeat job emits guard, macro, status and fit, in that order", {
+  job <- translate_lines(c(repeat_call, hz_block))
+  expect_equal(names(job$calls), c("data", "repeated", "status", "fit"))
+  # The guard is on the macro's input; EVENTS is built by a chunk, so it gets none.
+  expect_error(eval(job$calls$data, new.env(parent = globalenv())), "Assign BD_CARD")
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "repeated")
+  expect_equal(env$EVENTS, expected_events())
+})
+
+test_that("the translated fit reads the renamed IV_START: mu is 4 events over 15 units", {
+  skip_on_cran()
+  job <- translate_lines(c(repeat_call, hz_block))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "fit")
+  expect_true(env$fit$fit$converged)
+  # 4/15 needs time_lower = IV_START; without it the exposure is sum(IV_EVENT) = 20.
+  expect_equal(unname(exp(coef(env$fit))) / (4 / 15), 1, tolerance = 1e-4)
+})
+
+test_that("a non-default output name is what the job's fit reads", {
+  job <- translate_lines(c(
+    "%repeat(in=bd_card, id=ccfid, eventype=ce_card, event=ev_x);",
+    "%hazard( proc hazard data=events; event ev_x; time iv_event; parms muc=0.5; );"
+  ))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "repeated")
+  expect_false("event" %in% names(env$EVENTS))
+  expect_equal(env$EVENTS$EV_X, c(1, 1, 0, 0, 1, 1))
+})
+
+test_that("a DATA step rewriting OUT= stops the document before the fit, quoted", {
+  job <- translate_lines(c(
+    repeat_call,
+    "data events; set events; if iv_start ge iv_event then iv_event=iv_event+0.0001;",
+    hz_block
+  ))
+  expect_equal(names(job$calls), c("data", "repeated", "rewrite", "status", "fit"))
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  eval_upto(job, env, "repeated")
+  expect_error(
+    eval(job$calls$rewrite, env),
+    "DATA EVENTS; SET EVENTS; IF IV_START GE IV_EVENT THEN IV_EVENT=IV_EVENT+0.0001;",
+    fixed = TRUE
+  )
+  expect_true("DATA EVENTS after %repeat" %in% job$untranslated$construct)
+})
+
+test_that("steps that do not rewrite OUT= emit no rewrite stop", {
+  job <- translate_lines(c(
+    repeat_call,
+    "data other; set events; x=1;",
+    "proc sort data=events; by ccfid;",
+    hz_block
+  ))
+  expect_equal(names(job$calls), c("data", "repeated", "status", "fit"))
+})
+
+test_that("CREATE TABLE OUT is a rewrite too", {
+  job <- translate_lines(c(
+    # `select ccfid`, not `select *`: a `*` risks the normaliser's comment stripping.
+    repeat_call, "proc sql; create table events as select ccfid from events; quit;", hz_block
+  ))
+  expect_equal(names(job$calls), c("data", "repeated", "rewrite", "status", "fit"))
+})
+
+test_that("one rewrite stops once, however many fits read OUT= after it", {
+  job <- translate_lines(c(
+    repeat_call, "data events; set events; x=1;", hz_block, hz_block
+  ))
+  expect_equal(sum(grepl("^rewrite", names(job$calls))), 1L)
+  expect_equal(which(names(job$calls) == "rewrite"), 3L)
+})
+
+test_that("a refused %repeat still leaves a guard on the fit's DATA=", {
+  job <- translate_lines(c("%repeat(in=bd_card, eventype=rcensor);", hz_block))
+  expect_equal(names(job$calls), c("repeated", "data", "status", "fit"))
+  expect_error(eval(job$calls[["repeated"]], new.env()), "RCENSOR is also an output", fixed = TRUE)
+})

--- a/tests/testthat/test-sas-translate-repeat.R
+++ b/tests/testthat/test-sas-translate-repeat.R
@@ -15,3 +15,112 @@ test_that("a job with %repeat but no PROC HAZARD or HAZPRED is still refused", {
   writeLines("%repeat(in=bd, out=events);", f)
   expect_error(hzr_translate_sas(f), "no HAZARD or HAZPRED block found")
 })
+
+# Subject A: events at 1 and 3, a non-event at 2; B: no event, missing time;
+# C: events at 1 and 6, where 6 is also end of follow-up.
+bd_card <- function() {
+  data.frame(
+    CCFID = c("A", "A", "A", "B", "C", "C"),
+    IV_EVENT = c(1, 2, 3, NA, 1, 6),
+    IV_END = c(5, 5, 5, 4, 6, 6),
+    CE_CARD = c(1, 0, 1, 0, 1, 1),
+    stringsAsFactors = FALSE
+  )
+}
+
+# Derived by hand from repeat.sas; see the plan's fixture table.
+expected_events <- function() {
+  data.frame(
+    CCFID = c("A", "A", "A", "B", "C", "C"),
+    IV_EVENT = c(1, 3, 5, 4, 1, 6),
+    IV_END = c(5, 5, 5, 4, 6, 6),
+    CE_CARD = c(1, 1, 0, 0, 1, 1),
+    CN_CARD = c(0, 0, 1, 1, 0, 1),
+    FIRST = c(1, 0, 0, 1, 1, 0),
+    LAST = c(0, 1, 1, 1, 0, 1),
+    EV_CARD = c(1, 1, 0, 0, 1, 1),
+    IV_START = c(0, 1, 3, 0, 0, 1),
+    EVENT_NO = c(1, 2, 2, 0, 1, 2),
+    IV_SEG = c(1, 2, 2, 4, 1, 5),
+    RENEWAL = c(1, 2, 3, 1, 1, 2),
+    stringsAsFactors = FALSE
+  )
+}
+
+parse_repeat <- function(args) {
+  txt <- .hzr_sas_normalise(paste0("%repeat(", args, ");"))
+  .hzr_parse_repeat(.hzr_sas_blocks(txt)[[1L]])
+}
+
+cardio_args <- "in=bd_card, out=events, id=ccfid, eventype=ce_card, iv_end=iv_end, rcensor=cn_card, event=ev_card"
+
+test_that("the emitted %repeat call builds the macro's output under the job's names", {
+  r <- parse_repeat(cardio_args)
+  expect_equal(r$in_name, "BD_CARD")
+  expect_equal(r$out_name, "EVENTS")
+  expect_equal(nrow(r$untranslated), 0L)
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- bd_card()
+  expect_no_warning(eval(r$call, env))
+  expect_equal(dim(env$EVENTS), c(6L, 12L))
+  expect_equal(env$EVENTS, expected_events())
+})
+
+test_that("an input column the macro would overwrite is dropped, with a warning", {
+  r <- parse_repeat(cardio_args)
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- transform(bd_card(), EV_CARD = 99)
+  expect_warning(eval(r$call, env), "EV_CARD")
+  # Without the drop, names<- would leave two EV_CARD columns and $EV_CARD
+  # would return the stale 99s.
+  expect_equal(sum(names(env$EVENTS) == "EV_CARD"), 1L)
+  expect_equal(env$EVENTS$EV_CARD, c(1, 1, 0, 0, 1, 1))
+})
+
+test_that("a NUMBER column in the input warns that SAS's event counts are not comparable", {
+  r <- parse_repeat(cardio_args)
+  env <- new.env(parent = globalenv())
+  env$BD_CARD <- transform(bd_card(), NUMBER = 7)
+  expect_warning(eval(r$call, env), "NUMBER")
+  # R's result is the macro's intent: the column is neither dropped nor read.
+  expect_equal(env$EVENTS$EVENT_NO, c(1, 2, 2, 0, 1, 2))
+  expect_equal(env$EVENTS$NUMBER, rep(7, 6))
+})
+
+test_that("defaults are the macro's own, upper-cased", {
+  r <- parse_repeat("")
+  expect_equal(r$in_name, "BUILT")
+  expect_equal(r$out_name, "EVENTS")
+  env <- new.env(parent = globalenv())
+  d <- bd_card()
+  names(d) <- c("ID", "IV_EVENT", "IV_END", "EVENTYPE")
+  env$BUILT <- d
+  eval(r$call, env)
+  expect_equal(
+    names(env$EVENTS),
+    c("ID", "IV_EVENT", "IV_END", "EVENTYPE", "RCENSOR", "FIRST", "LAST",
+      "EVENT", "IV_START", "EVENT_NO", "IV_SEG", "RENEWAL")
+  )
+  expect_equal(env$EVENTS$IV_START, c(0, 1, 3, 0, 0, 1))
+})
+
+test_that("uncallable %repeat arguments are refused, each with its reason", {
+  cases <- list(
+    list("in=bd_card, eventype=rcensor", "RCENSOR is also an output"),
+    list("in=bd_card, foo=bar", "`FOO=` is not a %repeat parameter"),
+    list("in=&dsn", "`IN=&DSN` is not a plain SAS name"),
+    list("event=x, rcensor=x", "two outputs are both named X"),
+    list("bd_card", "`BD_CARD` is not a KEY=VALUE argument")
+  )
+  for (cs in cases) {
+    r <- parse_repeat(cs[[1]])
+    expect_null(r$in_name)
+    expect_null(r$out_name)
+    expect_identical(r$call[[1L]], as.name("stop"))
+    expect_error(eval(r$call, new.env()), cs[[2]], fixed = TRUE)
+    expect_equal(r$untranslated$construct, "%repeat")
+    expect_length(r$untranslated$reason, 1L)
+    expect_true(grepl(cs[[2]], r$untranslated$reason, fixed = TRUE))
+    expect_equal(r$tokens_mapped, 0L)
+  }
+})

--- a/tests/testthat/test-sas-translate-repeat.R
+++ b/tests/testthat/test-sas-translate-repeat.R
@@ -298,3 +298,18 @@ test_that("a WORK. libref on IN= and OUT= names the same dataset as the bare nam
   eval_upto(job, env, "repeated")
   expect_equal(env$EVENTS, expected_events())
 })
+
+test_that("a WORK. libref on the fit's DATA= reads the %repeat OUT= (Copilot, #256)", {
+  hz_work <- c(sub("data=events", "data=work.events", hz_block[1L], fixed = TRUE), hz_block[2L])
+  job <- translate_lines(c(
+    paste("%repeat(in=work.bd_card, out=work.events, id=ccfid, eventype=ce_card,",
+          "iv_end=iv_end, rcensor=cn_card, event=ev_card);"),
+    hz_work
+  ))
+  # No "Assign WORK.EVENTS" guard: the fit reads the EVENTS the macro chunk built.
+  expect_equal(names(job$calls), c("data", "repeated", "status", "fit"))
+  expect_identical(job$calls$fit[[3L]][["data"]], as.name("EVENTS"))
+  # The rewrite scan matches it too, so a step changing WORK.EVENTS still stops.
+  job <- translate_lines(c(repeat_call, "data work.events; set events; x=1;", hz_work))
+  expect_equal(names(job$calls), c("data", "repeated", "rewrite", "status", "fit"))
+})


### PR DESCRIPTION
> **The volume-gated parity tests ran against the real data and pass.** At `dc19ced`, with `/Volumes/qhsstudies` mounted, the full `NOT_CRAN=true` suite ran all three repeated-events files and none skipped. `test-repeated-events-parity.R` had 66 passes (the translator test plus #247's two cardioversion fits, now at #260's default control), `test-repeated-events-renewal-parity.R` 60 (#248) and `test-repeated-events.R` 87.
>
> **One test outside this branch's own files had to change** (`781db93`). #247's `cardioversion_job()` pinned the translator's untranslated constructs to `c("STEEPEST", "STEEPEST")`. This branch's fail-closed rewrite scan adds one row for each step that may change `EVENTS` before a fit.
> - The first is the job's line-65 nudge. That is a genuine rewrite, and the test file applies it itself.
> - The second is `%HAZPLOT(IN=EVENTS, ...)` before the stratified fit. It only reads `EVENTS`, but a macro call naming the output stops by design. That makes it the first real-corpus false stop, recorded here as a candidate for a later refinement.
>
> The assertion now pins the exact 4-row vector and explains it in a comment. On `main` those tests pass unchanged. On this branch they failed on that assertion alone.

## What this does

`hzr_translate_sas()` now translates a SAS job's `%repeat(...)` call into an emitted `repeated` chunk that calls `hzr_repeated_events()` (#241). The design is `inst/dev/SAS-JOB-TRANSLATOR-DESIGN.md` §5.5.

The chunk does six things:

- **Renames the outputs.** The function's lower-case outputs always become the job's upper-case names (`EV_CARD`, `CN_CARD`, `IV_START`, ...). The translator upper-cases every name it emits, so without the rename the fit would read columns that do not exist.
- **Drops clashing input columns, with a warning.** An input column named like an output is dropped first, which matches SAS: the macro assigns all eight outputs on every row before it reads any of them. Without the drop, the rename would produce two columns with the same name, and `$` would return the stale one.
- **Warns on `LAG_IV` or `NUMBER` input columns.** The macro's `RETAIN` re-reads such a column, so SAS's own listing is not comparable for that job. R's result is what the macro intended.
- **Refuses what it cannot express.** A call is refused at translate time, and becomes a `stop()` chunk plus a `$untranslated` row, if it has:
  - an unknown or positional argument;
  - a value that is not a plain name (`&dsn`);
  - an argument column that is also an output;
  - two outputs with one name;
  - a keyword given twice;
  - an output named `LAG_IV` or `NUMBER`.
- **Guards `IN=` and strips `WORK.`.** The macro's `IN=` gets the same "Assign X before rendering" guard as `DATA=`. `OUT=` gets none, because a chunk builds it. A `WORK.` libref is stripped from both.
- **Stops on anything that might change `OUT=` (fails closed).** Some steps sit between the macro and a fit that reads `OUT=`, or between two chained `%repeat` calls. Any such step that names `OUT=`, or uses a `&macvar`, gets a quoted `stop()` chunk. Only two kinds of step are exempt: a plain `PROC SORT DATA=OUT; BY ...;` and a DATA step that only reads `OUT`. A false stop costs one deleted chunk; a miss fits data SAS did not fit.

Jobs without `%repeat` are unaffected. The final reviewer checked all 115 non-PHI `.sas` files, and the job object, its warnings and the rendered `.qmd` were byte-identical at base and head.

Why this is worth doing: a scan of `/Volumes/qhsstudies` found **1733** `.sas` files that call `%repeat`. **403** of them are HAZARD jobs, mostly copies of three consulting templates.

## How it got here

| Step | Outcome |
|---|---|
| Brainstorm, spec, plan | Three decisions: clash handling, post-macro rewrites, the input guard |
| Tasks 1–5 | Each passed spec and quality review |
| `r-reviewer` (advisory) | High: the rewrite detector enumerated forms and missed `WORK.EVENTS`, `NODUPKEY`, SQL `DELETE`, `PROC APPEND` and others. The maintainer decided to **fail closed** (fix wave 1) |
| Final whole-branch review | Critical: only a step's first statement was judged, so a sort `WHERE` statement or an absorbed macro call slipped through. Chained `%repeat` calls and `&macvars` were also missed. Fixed in fix wave 2, which passed re-review |
| Low 4 ("empty scan segment") | Found **unreachable**: a wrapper around `%repeat` and `PROC HAZARD` loses `DATA=`, and the document already stops before any fit. The guard was dropped and a test pins this behaviour |

Every fix was mutation-tested: each test was shown to fail when its fix was removed.

## Copilot review (on `dc19ced`), addressed in `52630d1`

- **The two inline threads (valid, fixed):** `PROC HAZARD DATA=WORK.EVENTS` kept its libref, while `%repeat(OUT=WORK.EVENTS)` was recorded as `EVENTS`, so the fit got an "Assign WORK.EVENTS" guard and stopped. `WORK.` is now stripped where `DATA=` is parsed. A new test covers it, and it fails with the fix removed.
- **Suppressed, 1280 (wording, valid):** reworded.
- **Suppressed, 1418 (`DATA _NULL_; MODIFY EVENTS`): declined.** SAS's MODIFY reference requires the modified data set to "also appear in the DATA statement", so every legal in-place update is already caught by the scan's DATA-statement check. The evidence is in the PR comment.

## Gates at `52630d1`

- `devtools::document()` produced no diff.
- `lintr::lint_package()` reported 0 lints, and `spelling::spell_check_package()` reported 0 words.
- The full `NOT_CRAN=true devtools::test()` suite, run with the PHI volume mounted, gave `FAIL 0 | SKIP 6 | PASS 4501 | WARN 610` in 1079 s. All three repeated-events files ran with no skips (66, 60 and 87 passes). The 6 skips are only the existing fixture-dependent files (`bhdead`, `parity-c-binary`, `weights`).
- `R CMD check --as-cran` with the manual, built from a clean `git archive`, returned **Status OK** at `d13172b`: 246 s, tarball 3,135,063 bytes, no dev files. The merges since then brought in only `main`'s own reviewed changes, and CI runs the full check matrix on this push.

## Branch state

`main` was merged in three times. Each time the push waited for the PRs ahead of it in the merge queue, so CI runs only once:

- `d71dca8` merged `a442dfd` (#245–#247, #250), resolving conflicts in NEWS, the repeated-events design doc and the parity test.
- `84e5b49` merged `254dd6f` (#248, #249, #251), with no conflicts.
- `dc19ced` merged `938ca31` (#257 house-style recompose, #258 renewal-parity follow-up, #260 SAS gradient check), with no conflicts.

## Known limits (shipped deliberately)

- A step that changes `OUT=` without naming it, such as a macro that writes it internally, cannot be seen.
- A step that changes `OUT=` after the fit but before a `PROC HAZPRED` that reads `OUT=` is not scanned. §5.5 covers fits only, and a prediction grid is rarely the macro's output.
- A `&macvar` in any step between the macro and the fit stops the document, even when it is harmless. So does a macro call that only reads `OUT=` (the `%HAZPLOT` case above). Both are the price of failing closed.
- Two test gaps remain, both minor: an unterminated `%REPEAT(` is refused loudly but untested, and so is a refusal with several problems at once.

## Not in scope

Fitting the cardioversion job to LL −267.885 is covered on `main` (#247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
