### PR TITLE
docs/test: #248 Copilot follow-up: 'seldom saved' wording and all-column bdrein comparison

### DIFF
--- a/R/repeated-events.R
+++ b/R/repeated-events.R
@@ -4,8 +4,8 @@
 # -------
 # Repeated-events HAZARD jobs build their fit input with the SAS macro
 # %repeat (~/Documents/macro.library/repeat.sas, 161 lines, 2003-10-17).
-# That input was never saved, so those jobs cannot be reproduced without
-# rebuilding it.  This file rebuilds it in R.
+# That input was seldom saved, so most of those jobs cannot be reproduced
+# without rebuilding it.  This file rebuilds it in R.
 #
 # The macro is long-in, long-out: its input is already one row per
 # candidate event per subject.  The transform is gap-filling and
@@ -393,7 +393,7 @@
 #' Converts a long data set of candidate event times into one row per
 #' inter-event segment, ready to fit as a repeated-events model. This is a
 #' native R implementation of the SAS macro `%repeat` used by the
-#' repeated-events HAZARD jobs, whose fit input was never saved.
+#' repeated-events HAZARD jobs, whose fit input was seldom saved.
 #'
 #' @details
 #' The input holds one row per candidate event per subject, with an indicator

--- a/inst/dev/REPEATED-EVENTS-DESIGN.md
+++ b/inst/dev/REPEATED-EVENTS-DESIGN.md
@@ -10,7 +10,8 @@
 ## Purpose
 
 Repeated-events HAZARD jobs in the corpus build their fit input with the SAS macro
-`%repeat`. That input was never saved, so those jobs cannot be reproduced today. This
+`%repeat`. That input was seldom saved (the few jobs that keep it are counted under
+Acceptance), so most of those jobs cannot be reproduced today. This
 adds a native R implementation so they can be, which is TemporalHazard's remit: SAS
 reproduction.
 

--- a/inst/dev/REPEATED-EVENTS-PLAN.md
+++ b/inst/dev/REPEATED-EVENTS-PLAN.md
@@ -150,8 +150,8 @@ Create `R/repeated-events.R`:
 # -------
 # Repeated-events HAZARD jobs build their fit input with the SAS macro
 # %repeat (~/Documents/macro.library/repeat.sas, 161 lines, 2003-10-17).
-# That input was never saved, so those jobs cannot be reproduced without
-# rebuilding it.  This file rebuilds it in R.
+# That input was seldom saved, so most of those jobs cannot be reproduced
+# without rebuilding it.  This file rebuilds it in R.
 #
 # The macro is long-in, long-out: its input is already one row per
 # candidate event per subject.  The transform is gap-filling and
@@ -844,7 +844,7 @@ Append to `R/repeated-events.R`:
 #' Converts a long data set of candidate event times into one row per
 #' inter-event segment, ready to fit as a repeated-events model. This is a
 #' native R implementation of the SAS macro `%repeat` used by the
-#' repeated-events HAZARD jobs, whose fit input was never saved.
+#' repeated-events HAZARD jobs, whose fit input was seldom saved.
 #'
 #' @details
 #' The input holds one row per candidate event per subject, with an indicator

--- a/man/hzr_repeated_events.Rd
+++ b/man/hzr_repeated_events.Rd
@@ -46,7 +46,7 @@ subject can have two rows with \code{last == 1} together, or two with
 Converts a long data set of candidate event times into one row per
 inter-event segment, ready to fit as a repeated-events model. This is a
 native R implementation of the SAS macro \verb{\%repeat} used by the
-repeated-events HAZARD jobs, whose fit input was never saved.
+repeated-events HAZARD jobs, whose fit input was seldom saved.
 }
 \details{
 The input holds one row per candidate event per subject, with an indicator

--- a/tests/testthat/test-repeated-events-renewal-parity.R
+++ b/tests/testthat/test-repeated-events-renewal-parity.R
@@ -92,6 +92,41 @@ test_that("ac.reintervention: %repeat reproduces the SAS log, the .lst and libra
     expect_equal(sum(bad, na.rm = TRUE), 0L, label = paste(v, "value mismatches"))
   }
 
+  # Every other column too: those the job carried through the macro unchanged.
+  # Coverage first, so a comparison over no columns cannot pass. Only four
+  # names are on one side: R's `event` and `rcensor` are the job's ev_rein and
+  # cn_rein (compared above), and SAS keeps lag_iv and number, the macro's
+  # loop counters, which R does not return by design.
+  expect_equal(sort(setdiff(names(events), names(sas))), c("event", "rcensor"))
+  expect_equal(sort(setdiff(names(sas), names(events))), c("cn_rein", "lag_iv", "number"))
+
+  # ev_rein is on both sides but is not the same column. The job's event=
+  # alias made SAS overwrite its indicator with the 0/1 event flag, while R's
+  # keeps the input value, missing for a non-event. Its values were compared
+  # above as `event`; here, only that both sides mark the same rows as events.
+  expect_equal(sum(xor(!is.na(events$ev_rein) & events$ev_rein == 1, sas$ev_rein == 1)), 0L)
+
+  shared <- setdiff(intersect(names(events), names(sas)), c(names(pairs), "ev_rein"))
+  expect_equal(length(shared), 216L)
+  same_class <- vapply(shared, function(v) identical(class(events[[v]]), class(sas[[v]])), logical(1))
+  expect_equal(shared[!same_class], character(0))
+
+  # Dates, times and durations as numbers; character columns exactly. The
+  # failure output is column names only, never values.
+  as_value <- function(x) if (inherits(x, c("Date", "POSIXt", "difftime"))) as.numeric(x) else x
+  mismatches <- vapply(shared, function(v) {
+    got <- as_value(events[[v]])
+    want <- as_value(sas[[v]])
+    both <- !is.na(got) & !is.na(want)
+    differ <- if (is.numeric(want)) {
+      abs(got[both] - want[both]) > 1e-9 * abs(want[both])
+    } else {
+      got[both] != want[both]
+    }
+    sum(is.na(got) != is.na(want)) + sum(differ)
+  }, numeric(1))
+  expect_equal(shared[mismatches > 0], character(0))
+
   # bdrein's first and last are the stage-4 flags, carried stale into the
   # renewal step. On 75 rows they are not the subject's first or last row of
   # the output, and R matches SAS on every one of them above: SAS evidence that

--- a/tests/testthat/test-repeated-events-renewal-parity.R
+++ b/tests/testthat/test-repeated-events-renewal-parity.R
@@ -106,6 +106,13 @@ test_that("ac.reintervention: %repeat reproduces the SAS log, the .lst and libra
   # above as `event`; here, only that both sides mark the same rows as events.
   expect_equal(sum(xor(!is.na(events$ev_rein) & events$ev_rein == 1, sas$ev_rein == 1)), 0L)
 
+  # The ten paired columns are excluded from `shared` below, so their classes
+  # are checked here: an integer against a double passes the value comparison
+  # above without complaint. All ten are double on both sides.
+  pair_class <- vapply(names(pairs), function(v) identical(class(events[[v]]), class(sas[[pairs[[v]]]])),
+                       logical(1))
+  expect_equal(names(pairs)[!pair_class], character(0))
+
   shared <- setdiff(intersect(names(events), names(sas)), c(names(pairs), "ev_rein"))
   expect_equal(length(shared), 216L)
   same_class <- vapply(shared, function(v) identical(class(events[[v]]), class(sas[[v]])), logical(1))


### PR DESCRIPTION
## Why this exists

#248 merged at its original head, `c1199ad`, before the fixes for its [Copilot review](https://github.com/ehrlinger/TemporalHazard/pull/248#pullrequestreview-5173706764) were pushed. Those fixes were `fb04a62` on the now-deleted #248 branch. This PR cherry-picks that commit onto `main` (`254dd6f`). It applied cleanly.

## What it changes

Docs and tests only. There are no code changes, so there is no NEWS entry: the user-facing "seldom saved" wording is already on `main` from #248.

**1. "never saved" → "seldom saved"** (Copilot items 1 and 2). NEWS already said "seldom", but these three places still said "never":
- `R/repeated-events.R` (the header comment and the roxygen description);
- `man/hzr_repeated_events.Rd`, regenerated by `document()`;
- the Purpose section of the design doc.

The corpus scan found several jobs that do keep `%repeat`'s output, so "never" was wrong. No "never saved" remains.

**2. The renewal parity test compares every shared column** (Copilot item 3). It used to compare only the ten derived columns against SAS's `library.bdrein`. It now compares all **216** columns the two share: 11 character, 20 `Date`, 2 `hms` and 183 numeric.

Coverage is asserted before any value, so a comparison over no columns cannot pass. Exactly four columns are allowed on one side only:
- R's `event` and `rcensor`, which are the job's `ev_rein` and `cn_rein` and are compared through the existing pairs;
- SAS's `lag_iv` and `number`, the macro's loop counters, which R does not return by design.

No other column is excluded.

`ev_rein` exists on both sides but means different things. The job passed `event=ev_rein`, so SAS overwrote the indicator with the 0/1 event flag, while R keeps the input value, which is missing for a non-event. So `ev_rein` is checked as "both sides mark the same rows as events". A plain value comparison would differ on 381 rows.

Classes must agree column by column. Dates, times and durations are compared as numbers, with a relative tolerance of 1e-9 (a zero must be exactly zero). Character columns are compared exactly, and missingness is checked separately.

A failure prints column names only, never values. The data are PHI.

**Mutation check.** I altered one value in one passthrough character column in a scratch copy. The test failed exactly one assertion, and it printed only that column's name.

Copilot's fourth item, the inline comment that `pmax()` should handle `-Inf`, was declined on #248. `pmax(na.rm = TRUE)` already returns `NA` when every argument is `NA`, which is what SAS `max()` does.

## Gates on `f252531`

- Volume: both study directories present; `HEAD` `f252531`, tree clean.
- `devtools::document()`: no diff.
- `lintr::lint_package()`: 0 lints.
- `spelling::spell_check_package()`: clean.
- `devtools::test()` with `NOT_CRAN=true` and the volume mounted: 0 failed, 6 skipped, 4314 passed, 0 errors. The 6 skips are the usual local fixture and compiled-binary skips (`test-bhdead-sas-parity.R` x3, `test-parity-c-binary.R`, `test-weights-sas-parity.R` x2); none is a repeated-events test.
- `test-repeated-events-renewal-parity.R` on its own: 59 passed, 0 skipped, 0 failed, so it ran. `test-repeated-events-parity.R` also ran: 61 passed across its 4 tests.
- `R CMD check --as-cran` with the manual, from a `git archive` of `f252531`: Status: OK (0 errors, 0 warnings, 0 notes). No `CLAUDE`/`AGENTS` files in the tarball.

- Then merged `origin/main` (`afab795`, after #257) as `9845bb5`. Only `.claude/house-style.md` came in, a generated file that is excluded from the tarball, so the suite and the check above still hold. Lint (0 lints) and spelling (clean) were re-run on `9845bb5`.

The renewal parity test skips when the study volume is not mounted, which is every CI runner. A green CI run is therefore not evidence of parity; the local run above is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
