### PR TITLE
feat(optimizer): SAS/C relative-gradient acceptance test, with an nlm() polish

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,9 +101,10 @@
   improves. The default `reltol` is unchanged: tightening it instead cost
   30% to 60% more time on the test suite and broke eight or nine tests.
 
-  Every fit records the test in `fit$fit$rel_gradient` and
-  `fit$fit$polish_code` (`nlm()`'s termination code), and `print()` and
-  `summary()` show it. Only SAS/C's two hard failures warn: code 4, the
+  Every fit records the test in `fit$fit$rel_gradient` (`NA` where the
+  gradient cannot be evaluated at the estimates) and, when the continuation
+  improved the fit, `nlm()`'s termination code in `fit$fit$polish_code`, and
+  `print()` and `summary()` show it. Only SAS/C's two hard failures warn: code 4, the
   iteration limit, and code 5, where the likelihood kept rising along some
   direction and may have no maximum. Codes 2 and 3, where SAS/C prints a
   caution and retries, are recorded without a warning. The test is relative

--- a/NEWS.md
+++ b/NEWS.md
@@ -101,10 +101,14 @@
   improves. The default `reltol` is unchanged: tightening it instead cost
   30% to 60% more time on the test suite and broke eight or nine tests.
 
-  Every fit records the test in `fit$fit$rel_gradient` (`NA` where the
-  gradient cannot be evaluated at the estimates) and, when the continuation
-  improved the fit, `nlm()`'s termination code in `fit$fit$polish_code`, and
-  `print()` and `summary()` show it. Only SAS/C's two hard failures warn: code 4, the
+  Every fit records the test in `fit$fit$rel_gradient` (`NA` when the test
+  was not applied, because the optimizer did not report convergence, or the
+  gradient cannot be evaluated) and, when the continuation improved the fit,
+  `nlm()`'s termination code in `fit$fit$polish_code`, and `print()` and
+  `summary()` show it. Under Conservation of Events the analytic score omits
+  how the conserved scale moves with the other parameters, so there the test
+  and the continuation use finite differences of the log-likelihood, as
+  SAS/C does. Only SAS/C's two hard failures warn: code 4, the
   iteration limit, and code 5, where the likelihood kept rising along some
   direction and may have no maximum. Codes 2 and 3, where SAS/C prints a
   caution and retries, are recorded without a warning. The test is relative
@@ -112,11 +116,13 @@
   tolerance of the maximum rather than exactly at it.
 
   Estimates of fits that used to stop short now change. One test depended
-  on that: it showed `gamma` and `eta` non-identified at `alpha = 1` by a
-  large standard error at the point BFGS happened to stop. Followed further
-  along the ridge the Hessian is singular and there is no standard error, so
-  the test now also checks that both fits reach the same log-likelihood and
-  the same `gamma * eta`.
+  on a detail of where BFGS stopped: it showed `gamma` and `eta`
+  non-identified at `alpha = 1` by a large standard error. On that exactly
+  flat ridge the Hessian is singular in theory, so whether a finite standard
+  error comes out at all is numerical noise, and at the polished point it
+  does not. The test now accepts either a missing or a 100-fold larger
+  standard error, and also checks that both fits reach the same
+  log-likelihood and the same `gamma * eta`.
 
 * **A Weibull fit with one masked variance reported the others on the wrong
   scale.** When the Hessian inverse has a non-positive variance, its row and

--- a/NEWS.md
+++ b/NEWS.md
@@ -107,8 +107,9 @@
   `nlm()`'s termination code in `fit$fit$polish_code`, and `print()` and
   `summary()` show it. Under Conservation of Events the analytic score omits
   how the conserved scale moves with the other parameters, so there the test
-  and the continuation use finite differences of the log-likelihood, as
-  SAS/C does. Only SAS/C's two hard failures warn: code 4, the
+  is computed from finite differences of the log-likelihood, as SAS/C does.
+  The continuation keeps the analytic score, so a CoE fit can honestly end
+  with the test not met. Only SAS/C's two hard failures warn: code 4, the
   iteration limit, and code 5, where the likelihood kept rising along some
   direction and may have no maximum. Codes 2 and 3, where SAS/C prints a
   caution and retries, are recorded without a warning. The test is relative

--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,37 @@
   point: it estimates `log|M|` with the sign fixed by the starting value, so
   `M` cannot reach or cross 0. `hazard()` estimates `m` directly and can.
 
+* **A fit that reports convergence now meets SAS/C HAZARD's own test for
+  it.** `hazard()`'s BFGS optimizer stops on the relative change in the
+  log-likelihood (`control$reltol`, default 1e-5), which lets a flat ridge
+  end short of the maximum with `converged = TRUE`: a 13-parameter
+  early-CDF plus late-G3 model stopped 0.013 below the SAS listing's
+  log-likelihood, and synthetic fits of the same shape up to 5 units below.
+  SAS/C accepts an optimum only when the relative gradient,
+  `max |g_i| * max(|x_i|, 1) / max(|f|, 1)`, is at most `eps^(1/3)`, about
+  6e-6. When BFGS reports convergence and that test fails, every
+  distribution's fit is now continued with `stats::nlm()`, the
+  Dennis-Schnabel algorithm SAS/C's optimizer was ported from, at SAS's
+  tolerances, and the continued point is kept only if the log-likelihood
+  improves. The default `reltol` is unchanged: tightening it instead cost
+  30% to 60% more time on the test suite and broke eight or nine tests.
+
+  Every fit records the test in `fit$fit$rel_gradient` and
+  `fit$fit$polish_code` (`nlm()`'s termination code), and `print()` and
+  `summary()` show it. Only SAS/C's two hard failures warn: code 4, the
+  iteration limit, and code 5, where the likelihood kept rising along some
+  direction and may have no maximum. Codes 2 and 3, where SAS/C prints a
+  caution and retries, are recorded without a warning. The test is relative
+  to the size of the log-likelihood, so a fit that meets it is within SAS's
+  tolerance of the maximum rather than exactly at it.
+
+  Estimates of fits that used to stop short now change. One test depended
+  on that: it showed `gamma` and `eta` non-identified at `alpha = 1` by a
+  large standard error at the point BFGS happened to stop. Followed further
+  along the ridge the Hessian is singular and there is no standard error, so
+  the test now also checks that both fits reach the same log-likelihood and
+  the same `gamma * eta`.
+
 * **A Weibull fit with one masked variance reported the others on the wrong
   scale.** When the Hessian inverse has a non-positive variance, its row and
   column are set to `NA`. The delta-method transform from the internal

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -67,6 +67,27 @@ NULL
 #' and transformed back for reporting; see
 #' `vignette("mf-mathematical-foundations")`.
 #'
+#' @section Convergence:
+#'
+#' The optimizer stops when an iteration improves the log-likelihood by less
+#' than `control$reltol` relative to its size, and on a flat ridge that can
+#' happen well short of the maximum. SAS/C HAZARD accepts an optimum only on a
+#' different test, the relative gradient
+#' \eqn{\max_i |g_i| \max(|x_i|, 1) / \max(|\ell|, 1) \le \epsilon^{1/3}}{max_i
+#' |g_i| max(|x_i|, 1) / max(|l|, 1) <= eps^(1/3)}, about 6e-6, and `hazard()`
+#' applies it too: when the optimizer reports convergence and the test fails,
+#' the fit is continued with [stats::nlm()] at SAS's tolerances, and the
+#' continued point is kept if it improves the log-likelihood.
+#'
+#' Every fit records the result in `fit$fit$rel_gradient` and, when the
+#' continuation ran, its termination code in `fit$fit$polish_code`. `print()`
+#' and `summary()` show both. A warning is raised only for code 4, the
+#' iteration limit (raise `control$maxit`), and code 5, where the
+#' log-likelihood kept rising along some direction and the model may have no
+#' maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without
+#' one. The test is relative to the size of the log-likelihood, so a fit that
+#' meets it is within SAS's tolerance of the maximum, not exactly at it.
+#'
 #' @section Baseline distributions:
 #'
 #' The `dist` argument selects the parametric form of the baseline hazard.  The
@@ -244,9 +265,13 @@ NULL
 #'   log-likelihood (default 1e-5). BFGS stops when an iteration reduces it by
 #'   less than `reltol * (|objective| + reltol)`, so the stopping gap grows
 #'   with the size of the log-likelihood: about 0.0024 at a log-likelihood of
-#'   -240. On a flat surface a fit can stop that far short of the optimum and
-#'   still report convergence.
-#' - `abstol`: Absolute gradient norm tolerance (default 1e-6)
+#'   -240. On a flat surface plain BFGS can stop that far short of the optimum
+#'   and still report convergence, so `hazard()` then applies SAS/C HAZARD's
+#'   relative-gradient test and, when the stop fails it, continues with
+#'   [stats::nlm()]; see the "Convergence" section.
+#' - `abstol`: Projected-gradient tolerance, used only by the bounded
+#'   (L-BFGS-B) optimizer (default 1e-6). The fits `hazard()` runs use BFGS
+#'   and ignore it.
 #' - `method`: Optimization method: "bfgs" or "nm" (default "bfgs").
 #'   SAS `PROC HAZARD` jobs write `STEEPEST QUASI` together -- steepest
 #'   descent first, then quasi-Newton. `QUASI`/`QUASINEWTON` is `"bfgs"`;
@@ -428,7 +453,9 @@ NULL
 #'   \code{data} (input data: \code{time}, \code{status}, \code{x},
 #'   \code{weights}, etc.),
 #'   \code{fit} (optimisation results: \code{theta}, \code{objective},
-#'   \code{converged}, \code{se}, \code{vcov}, \code{counts}, \code{message};
+#'   \code{converged}, \code{se}, \code{vcov}, \code{counts}, \code{message},
+#'   and \code{rel_gradient} and \code{polish_code}, the SAS/C acceptance
+#'   test described under "Convergence";
 #'   all \code{NULL} when \code{fit = FALSE}; multiphase fits add
 #'   \code{starts}, one row per optimisation start with its \code{status}
 #'   (\code{"ok"}, \code{"nonconverged"}, \code{"infeasible"},
@@ -875,6 +902,38 @@ hazard <- function(formula = NULL,
     fit_state$message <- optim_result$message
     fit_ran <- TRUE
     degraded_reasons$se <- optim_result$se_unavailable_reason
+  }
+
+  # SAS/C's acceptance test, applied by .hzr_optim_generic() and polished
+  # towards when BFGS stopped short of it. Both results are recorded on
+  # every fit and shown by print() and summary(). Only the polish's two hard
+  # failures warn -- the ones SAS/C reports as "reached no convergence"
+  # (nlm code 4) and "unbounded ... or has a finite asymptote" (code 5). A
+  # code 2 or 3 stop (step too small, or no lower point found) is where SAS
+  # prints a caution and retries; on the test suite about a third of stops
+  # end there, mostly on deliberately awkward fixtures, and warning on each
+  # would bury the two that matter.
+  if (fit_ran) {
+    fit_state$rel_gradient <- optim_result$rel_gradient
+    fit_state$polish_code  <- optim_result$polish_code
+    if (isTRUE(fit_state$converged) &&
+        isTRUE(fit_state$polish_code %in% c(4L, 5L))) {
+      warning(
+        "The optimizer reported convergence, but the relative gradient at ",
+        "the estimates is ", signif(fit_state$rel_gradient, 3), ", above ",
+        "the ", signif(.Machine$double.eps^(1 / 3), 3), " that SAS/C ",
+        "HAZARD requires. ",
+        if (identical(fit_state$polish_code, 5L)) {
+          paste0("The likelihood kept rising along a direction in which no ",
+                 "maximum was found; the model may not have one.")
+        } else {
+          paste0("Further optimization stopped at its iteration limit; ",
+                 "the estimates may not be at the maximum. Raise ",
+                 "control$maxit to continue.")
+        },
+        call. = FALSE
+      )
+    }
   }
 
   # An ill-conditioned Hessian already warns that standard errors are
@@ -1527,6 +1586,23 @@ predict.hazard <- function(object, newdata = NULL,
 }
 
 
+# The SAS/C acceptance test's result, for print() and summary(). NULL when the
+# test was not evaluated: an unfitted or imported model, a bounded
+# (L-BFGS-B) fit, or a BFGS run that did not converge.
+.hzr_format_gradient_test <- function(rel_gradient, polish_code) {
+  if (length(rel_gradient) != 1L || is.na(rel_gradient)) return(NULL)
+  gradtl <- .Machine$double.eps^(1 / 3)
+  verdict <- if (rel_gradient <= gradtl) {
+    "met"
+  } else if (length(polish_code) == 1L && !is.na(polish_code)) {
+    paste0("not met, nlm code ", polish_code)
+  } else {
+    "not met"
+  }
+  paste0("  gradient:     relative ", signif(rel_gradient, 3),
+         " (SAS/C requires <= ", signif(gradtl, 3), "; ", verdict, ")")
+}
+
 #' Print method for fitted hazard models
 #'
 #' Compact one-block summary of a fitted `hazard` object: sample size,
@@ -1558,6 +1634,8 @@ print.hazard <- function(x, ...) {
   if (!anyNA(x$fit$objective)) {
     cat("  log-lik:     ", format(x$fit$objective, digits = 6), "\n")
     cat("  converged:   ", x$fit$converged, "\n")
+    cat(.hzr_format_gradient_test(x$fit$rel_gradient, x$fit$polish_code),
+        sep = "\n")
   }
   # Always printed, "none" included (#242).
   cat(.hzr_format_not_done(x$degraded, x$degraded_causes), sep = "\n")
@@ -1653,6 +1731,8 @@ summary.hazard <- function(object, ...) {
     dist = object$spec$dist,
     engine = object$engine,
     converged = object$fit$converged,
+    rel_gradient = object$fit$rel_gradient,
+    polish_code = object$fit$polish_code,
     log_lik = object$fit$objective,
     counts = object$fit$counts,
     message = object$fit$message,
@@ -1714,6 +1794,7 @@ print.summary.hazard <- function(x, ...) {
 
   if (!is.null(x$converged) && !is.na(x$converged)) {
     cat("  converged:   ", x$converged, "\n")
+    cat(.hzr_format_gradient_test(x$rel_gradient, x$polish_code), sep = "\n")
   }
   if (!is.null(x$log_lik) && !is.na(x$log_lik)) {
     cat("  log-lik:     ", format(x$log_lik, digits = 6), "\n")

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -79,10 +79,15 @@ NULL
 #' the fit is continued with [stats::nlm()] at SAS's tolerances, and the
 #' continued point is kept if it improves the log-likelihood.
 #'
-#' Every fit records the result in `fit$fit$rel_gradient` (`NA` where the
-#' gradient cannot be evaluated at the estimates, which is never reported as
-#' a pass) and, when the continuation improved the fit, its termination code
-#' in `fit$fit$polish_code`. `print()` and `summary()` show both. A warning is raised only for code 4, the
+#' Every fit records the result in `fit$fit$rel_gradient` and, when the
+#' continuation improved the fit, its termination code in
+#' `fit$fit$polish_code`. `print()` and `summary()` show both.
+#' `rel_gradient` is `NA` when the test was not applied (the optimizer did
+#' not report convergence) or the gradient cannot be evaluated at the
+#' estimates; `NA` is never reported as a pass. Under Conservation of Events
+#' the test and the continuation use finite differences of the
+#' log-likelihood with the conserved scale re-solved, as SAS/C does, because
+#' the analytic score there omits how that scale moves. A warning is raised only for code 4, the
 #' iteration limit (raise `control$maxit`), and code 5, where the
 #' log-likelihood kept rising along some direction and the model may have no
 #' maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without
@@ -920,10 +925,15 @@ hazard <- function(formula = NULL,
     if (isTRUE(fit_state$converged) &&
         isTRUE(fit_state$polish_code %in% c(4L, 5L))) {
       warning(
-        "The optimizer reported convergence, but the relative gradient at ",
-        "the estimates is ", signif(fit_state$rel_gradient, 3), ", above ",
-        "the ", signif(.Machine$double.eps^(1 / 3), 3), " that SAS/C ",
-        "HAZARD requires. ",
+        "The optimizer reported convergence, but the estimates fail the ",
+        "relative-gradient test SAS/C HAZARD requires (at most ",
+        signif(.Machine$double.eps^(1 / 3), 3), "; ",
+        if (is.finite(fit_state$rel_gradient)) {
+          paste0("here ", signif(fit_state$rel_gradient, 3))
+        } else {
+          "here the gradient could not be evaluated"
+        },
+        "). ",
         if (identical(fit_state$polish_code, 5L)) {
           paste0("The likelihood kept rising along a direction in which no ",
                  "maximum was found; the model may not have one.")

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -79,9 +79,10 @@ NULL
 #' the fit is continued with [stats::nlm()] at SAS's tolerances, and the
 #' continued point is kept if it improves the log-likelihood.
 #'
-#' Every fit records the result in `fit$fit$rel_gradient` and, when the
-#' continuation ran, its termination code in `fit$fit$polish_code`. `print()`
-#' and `summary()` show both. A warning is raised only for code 4, the
+#' Every fit records the result in `fit$fit$rel_gradient` (`NA` where the
+#' gradient cannot be evaluated at the estimates, which is never reported as
+#' a pass) and, when the continuation improved the fit, its termination code
+#' in `fit$fit$polish_code`. `print()` and `summary()` show both. A warning is raised only for code 4, the
 #' iteration limit (raise `control$maxit`), and code 5, where the
 #' log-likelihood kept rising along some direction and the model may have no
 #' maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -923,8 +923,11 @@ hazard <- function(formula = NULL,
   if (fit_ran) {
     fit_state$rel_gradient <- optim_result$rel_gradient
     fit_state$polish_code  <- optim_result$polish_code
+    # Codes 4 and 5 imply a failed test when nlm() and the statistic use the
+    # same gradient; under CoE they need not, so the statistic is checked too.
     if (isTRUE(fit_state$converged) &&
-        isTRUE(fit_state$polish_code %in% c(4L, 5L))) {
+        isTRUE(fit_state$polish_code %in% c(4L, 5L)) &&
+        !isTRUE(fit_state$rel_gradient <= .Machine$double.eps^(1 / 3))) {
       warning(
         "The optimizer reported convergence, but the estimates fail the ",
         "relative-gradient test SAS/C HAZARD requires (at most ",
@@ -1599,20 +1602,24 @@ predict.hazard <- function(object, newdata = NULL,
 
 
 # The SAS/C acceptance test's result, for print() and summary(). NULL when the
-# test was not evaluated: an unfitted or imported model, a bounded
-# (L-BFGS-B) fit, or a BFGS run that did not converge.
-.hzr_format_gradient_test <- function(rel_gradient, polish_code) {
-  if (length(rel_gradient) != 1L || is.na(rel_gradient)) return(NULL)
-  gradtl <- .Machine$double.eps^(1 / 3)
-  verdict <- if (rel_gradient <= gradtl) {
-    "met"
-  } else if (length(polish_code) == 1L && !is.na(polish_code)) {
-    paste0("not met, nlm code ", polish_code)
-  } else {
-    "not met"
+# test was not applied: a fit that did not report convergence, or an object
+# with no record of it (imported from SAS, or saved by an earlier version).
+# A converged fit whose gradient could not be evaluated says so, because
+# printing nothing would read as a test that never ran; the nlm() code is
+# shown whenever there is one.
+.hzr_format_gradient_test <- function(rel_gradient, polish_code,
+                                      converged = TRUE) {
+  if (!isTRUE(converged) || length(rel_gradient) != 1L) return(NULL)
+  has_code <- length(polish_code) == 1L && !is.na(polish_code)
+  if (is.na(rel_gradient)) {
+    return(paste0("  gradient:     not evaluated at the estimates",
+                  if (has_code) paste0(" (nlm code ", polish_code, ")")))
   }
+  gradtl <- .Machine$double.eps^(1 / 3)
+  verdict <- if (rel_gradient <= gradtl) "met" else "not met"
   paste0("  gradient:     relative ", signif(rel_gradient, 3),
-         " (SAS/C requires <= ", signif(gradtl, 3), "; ", verdict, ")")
+         " (SAS/C requires <= ", signif(gradtl, 3), "; ", verdict,
+         if (has_code) paste0(", nlm code ", polish_code), ")")
 }
 
 #' Print method for fitted hazard models
@@ -1646,7 +1653,8 @@ print.hazard <- function(x, ...) {
   if (!anyNA(x$fit$objective)) {
     cat("  log-lik:     ", format(x$fit$objective, digits = 6), "\n")
     cat("  converged:   ", x$fit$converged, "\n")
-    cat(.hzr_format_gradient_test(x$fit$rel_gradient, x$fit$polish_code),
+    cat(.hzr_format_gradient_test(x$fit$rel_gradient, x$fit$polish_code,
+                                  converged = x$fit$converged),
         sep = "\n")
   }
   # Always printed, "none" included (#242).
@@ -1806,7 +1814,8 @@ print.summary.hazard <- function(x, ...) {
 
   if (!is.null(x$converged) && !is.na(x$converged)) {
     cat("  converged:   ", x$converged, "\n")
-    cat(.hzr_format_gradient_test(x$rel_gradient, x$polish_code), sep = "\n")
+    cat(.hzr_format_gradient_test(x$rel_gradient, x$polish_code,
+                                  converged = x$converged), sep = "\n")
   }
   if (!is.null(x$log_lik) && !is.na(x$log_lik)) {
     cat("  log-lik:     ", format(x$log_lik, digits = 6), "\n")

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -85,9 +85,10 @@ NULL
 #' `rel_gradient` is `NA` when the test was not applied (the optimizer did
 #' not report convergence) or the gradient cannot be evaluated at the
 #' estimates; `NA` is never reported as a pass. Under Conservation of Events
-#' the test and the continuation use finite differences of the
-#' log-likelihood with the conserved scale re-solved, as SAS/C does, because
-#' the analytic score there omits how that scale moves. A warning is raised only for code 4, the
+#' the analytic score omits how the conserved scale moves, so the test is
+#' computed from finite differences of the log-likelihood with that scale
+#' re-solved, as SAS/C does; the continuation still uses the analytic score,
+#' so a CoE fit can honestly end with the test not met. A warning is raised only for code 4, the
 #' iteration limit (raise `control$maxit`), and code 5, where the
 #' log-likelihood kept rising along some direction and the model may have no
 #' maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -2003,7 +2003,10 @@
         weights     = weights,
         control     = control,
         use_bounds  = FALSE,
-        hessian_fn  = hessian_fn_mp
+        hessian_fn  = hessian_fn_mp,
+        # Under CoE gradient_fn is the partial score at the conserved theta,
+        # not the gradient of the objective being maximised.
+        gradient_exact = !(use_conserve && !is.null(fixmu_pos))
       ),
       error = function(e) e
     )

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -142,6 +142,50 @@ NULL
     )
   }
 
+  # SAS/C's acceptance test (src/optim/umstop.c): the optimum is accepted
+  # only when the relative gradient max_i |g_i| * max(|x_i|, 1) / max(|f|, 1)
+  # is at most gradtl = eps^(1/3).  optim()'s BFGS stops on the relative
+  # change in the objective instead, and at the default reltol = 1e-5 that
+  # accepts a flat ridge well short of the optimum while reporting
+  # convergence 0: on the test suite, 70% of converged BFGS stops failed
+  # SAS's test.  When BFGS reports convergence and the test fails, polish
+  # with stats::nlm() -- R's Dennis-Schnabel UNCMIN, the algorithm SAS/C's
+  # optimizer was ported from -- at SAS's tolerances; its typsize = 1 and
+  # fscale = 1 defaults are SAS's typx and typf.  The polished point is kept
+  # only when it improves the objective.  L-BFGS-B stops on a projected
+  # gradient already, so the bounded path is left alone.
+  gradtl <- .Machine$double.eps^(1 / 3)
+  rel_gradient <- function(theta, value) {
+    max(abs(gradient(theta)) * pmax(abs(theta), 1)) / max(abs(value), 1)
+  }
+  rel_grad <- NA_real_
+  polish_code <- NA_integer_
+  if (!use_bounds && result$convergence == 0L) {
+    rel_grad <- rel_gradient(result$par, result$value)
+    if (is.finite(rel_grad) && rel_grad > gradtl) {
+      f_nlm <- function(theta) {
+        v <- objective(theta)
+        attr(v, "gradient") <- gradient(theta)
+        v
+      }
+      polish <- tryCatch(
+        suppressWarnings(stats::nlm(
+          f_nlm, result$par, gradtol = gradtl,
+          steptol = .Machine$double.eps^(2 / 3), iterlim = control$maxit,
+          check.analyticals = FALSE
+        )),
+        error = function(e) NULL
+      )
+      if (!is.null(polish) && is.finite(polish$minimum) &&
+          polish$minimum <= result$value) {
+        result$par   <- polish$estimate
+        result$value <- polish$minimum
+        polish_code  <- as.integer(polish$code)
+        rel_grad     <- rel_gradient(result$par, result$value)
+      }
+    }
+  }
+
   # Post-fit Hessian for standard errors.  Prefer the caller's analytic Hessian
   # (on the objective / negative-log-likelihood scale) when supplied; otherwise,
   # or when it declines by returning NULL, fall back to a numerical Hessian.
@@ -230,6 +274,11 @@ NULL
     vcov = inv$vcov,
     rcond = inv$rcond,
     pd = inv$pd,
-    se_unavailable_reason = if (is.matrix(inv$vcov)) NA_character_ else inv$reason
+    se_unavailable_reason = if (is.matrix(inv$vcov)) NA_character_ else inv$reason,
+    # SAS/C's relative gradient at the returned point, after any polish; NA
+    # when not evaluated (the bounded path, or BFGS did not converge).
+    rel_gradient = rel_grad,
+    # stats::nlm()'s termination code when the polish ran and was kept.
+    polish_code = polish_code
   )
 }

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -54,9 +54,11 @@ NULL
 #'   the gradient of the objective being maximised. Conservation of Events
 #'   passes `FALSE`: its `gradient_fn` is the partial score at the conserved
 #'   theta, which leaves out how the conserved `log_mu` moves with the free
-#'   parameters. SAS/C's acceptance test and the `nlm()` continuation then use
-#'   finite differences of the objective itself, as SAS/C does
-#'   (`setobj.c` re-solves the scale at every numerical-derivative step).
+#'   parameters. SAS/C's acceptance test is then computed from finite
+#'   differences of the objective itself, with the scale re-solved at every
+#'   step as SAS/C does (`setobj.c`). The `nlm()` continuation keeps the
+#'   analytic score: with finite differences it walks onto the CoE solve's
+#'   discontinuity where no events are left to conserve.
 #'
 #' @return List with par, value (log-likelihood), convergence, counts, message,
 #'   hessian, vcov. Includes \code{se_unavailable_reason}.
@@ -168,12 +170,18 @@ NULL
   # there would read as a pass; so this calls gradient_fn itself and refuses
   # the 1e10 sentinel, a non-finite point, and any non-finite component.
   # Central differences of the objective, for when gradient_fn is not its
-  # gradient (gradient_exact = FALSE).
+  # gradient (gradient_exact = FALSE). A side that lands on the 1e10 clamp
+  # would turn the difference into 1e10 / (2h) -- a number that looks like a
+  # measured gradient and is not -- so such a component is NA, and
+  # rel_gradient() then reports NA rather than a fabricated value.
   fd_gradient <- function(theta) {
     h <- .Machine$double.eps^(1 / 3) * pmax(abs(theta), 1)
     vapply(seq_along(theta), function(i) {
       e <- replace(numeric(length(theta)), i, h[i])
-      (objective(theta + e) - objective(theta - e)) / (2 * h[i])
+      up <- objective(theta + e)
+      down <- objective(theta - e)
+      if (up >= 1e10 || down >= 1e10) return(NA_real_)
+      (up - down) / (2 * h[i])
     }, numeric(1))
   }
   rel_gradient <- function(theta, value) {
@@ -204,7 +212,7 @@ NULL
     if (is.finite(rel_grad) && rel_grad > gradtl) {
       f_nlm <- function(theta) {
         v <- objective(theta)
-        if (gradient_exact) attr(v, "gradient") <- gradient(theta)
+        attr(v, "gradient") <- gradient(theta)
         v
       }
       polish <- tryCatch(

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -155,8 +155,26 @@ NULL
   # only when it improves the objective.  L-BFGS-B stops on a projected
   # gradient already, so the bounded path is left alone.
   gradtl <- .Machine$double.eps^(1 / 3)
+  # NA, never 0, wherever the gradient cannot be trusted. The wrapped
+  # gradient() above returns zeros at a clamped or failing point, and a zero
+  # there would read as a pass; so this calls gradient_fn itself and refuses
+  # the 1e10 sentinel, a non-finite point, and any non-finite component.
   rel_gradient <- function(theta, value) {
-    max(abs(gradient(theta)) * pmax(abs(theta), 1)) / max(abs(value), 1)
+    if (!all(is.finite(theta)) || !is.finite(value) || value >= 1e10) {
+      return(NA_real_)
+    }
+    g <- tryCatch(
+      gradient_fn(
+        theta = theta, time = time, status = status,
+        time_lower = time_lower, time_upper = time_upper,
+        x = x, weights = weights
+      ),
+      error = function(e) NULL
+    )
+    if (is.null(g) || length(g) != length(theta) || !all(is.finite(g))) {
+      return(NA_real_)
+    }
+    max(abs(g) * pmax(abs(theta), 1)) / max(abs(value), 1)
   }
   rel_grad <- NA_real_
   polish_code <- NA_integer_
@@ -178,10 +196,18 @@ NULL
       )
       if (!is.null(polish) && is.finite(polish$minimum) &&
           polish$minimum <= result$value) {
-        result$par   <- polish$estimate
+        # nlm() drops names; optim() keeps them, and the single-distribution
+        # fits hand par straight back to hazard().
+        result$par   <- stats::setNames(polish$estimate, names(result$par))
         result$value <- polish$minimum
         polish_code  <- as.integer(polish$code)
         rel_grad     <- rel_gradient(result$par, result$value)
+        # counts still describe the BFGS run alone, so say the fit went on.
+        result$message <- paste0(
+          if (length(result$message)) paste0(result$message, "; ") else "",
+          "continued with nlm() for ", polish$iterations,
+          " iterations (code ", polish$code, ")"
+        )
       }
     }
   }

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -167,8 +167,9 @@ NULL
   gradtl <- .Machine$double.eps^(1 / 3)
   # NA, never 0, wherever the gradient cannot be trusted. The wrapped
   # gradient() above returns zeros at a clamped or failing point, and a zero
-  # there would read as a pass; so this calls gradient_fn itself and refuses
-  # the 1e10 sentinel, a non-finite point, and any non-finite component.
+  # there would read as a pass; so this calls gradient_fn itself (or, when
+  # gradient_exact is FALSE, differences the objective) and refuses the 1e10
+  # sentinel, a non-finite point, and any non-finite component.
   # Central differences of the objective, for when gradient_fn is not its
   # gradient (gradient_exact = FALSE). A side that lands on the 1e10 clamp
   # would turn the difference into 1e10 / (2h) -- a number that looks like a

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -50,6 +50,13 @@ NULL
 #'   \code{NULL} (e.g. a censoring branch it does not cover analytically), or
 #'   when it errors.  A non-NULL, non-conformant return raises a warning and
 #'   also falls back to the numerical Hessian.
+#' @param gradient_exact Logical; `TRUE` (the default) when `gradient_fn` is
+#'   the gradient of the objective being maximised. Conservation of Events
+#'   passes `FALSE`: its `gradient_fn` is the partial score at the conserved
+#'   theta, which leaves out how the conserved `log_mu` moves with the free
+#'   parameters. SAS/C's acceptance test and the `nlm()` continuation then use
+#'   finite differences of the objective itself, as SAS/C does
+#'   (`setobj.c` re-solves the scale at every numerical-derivative step).
 #'
 #' @return List with par, value (log-likelihood), convergence, counts, message,
 #'   hessian, vcov. Includes \code{se_unavailable_reason}.
@@ -67,7 +74,8 @@ NULL
     control = list(),
     use_bounds = FALSE,
     lower_bounds = NULL,
-    hessian_fn = NULL) {
+    hessian_fn = NULL,
+    gradient_exact = TRUE) {
 
   control <- utils::modifyList(
     list(maxit = 1000, reltol = 1e-5, abstol = 1e-6),
@@ -159,18 +167,31 @@ NULL
   # gradient() above returns zeros at a clamped or failing point, and a zero
   # there would read as a pass; so this calls gradient_fn itself and refuses
   # the 1e10 sentinel, a non-finite point, and any non-finite component.
+  # Central differences of the objective, for when gradient_fn is not its
+  # gradient (gradient_exact = FALSE).
+  fd_gradient <- function(theta) {
+    h <- .Machine$double.eps^(1 / 3) * pmax(abs(theta), 1)
+    vapply(seq_along(theta), function(i) {
+      e <- replace(numeric(length(theta)), i, h[i])
+      (objective(theta + e) - objective(theta - e)) / (2 * h[i])
+    }, numeric(1))
+  }
   rel_gradient <- function(theta, value) {
     if (!all(is.finite(theta)) || !is.finite(value) || value >= 1e10) {
       return(NA_real_)
     }
-    g <- tryCatch(
-      gradient_fn(
-        theta = theta, time = time, status = status,
-        time_lower = time_lower, time_upper = time_upper,
-        x = x, weights = weights
-      ),
-      error = function(e) NULL
-    )
+    g <- if (gradient_exact) {
+      tryCatch(
+        gradient_fn(
+          theta = theta, time = time, status = status,
+          time_lower = time_lower, time_upper = time_upper,
+          x = x, weights = weights
+        ),
+        error = function(e) NULL
+      )
+    } else {
+      fd_gradient(theta)
+    }
     if (is.null(g) || length(g) != length(theta) || !all(is.finite(g))) {
       return(NA_real_)
     }
@@ -183,7 +204,7 @@ NULL
     if (is.finite(rel_grad) && rel_grad > gradtl) {
       f_nlm <- function(theta) {
         v <- objective(theta)
-        attr(v, "gradient") <- gradient(theta)
+        if (gradient_exact) attr(v, "gradient") <- gradient(theta)
         v
       }
       polish <- tryCatch(
@@ -195,7 +216,7 @@ NULL
         error = function(e) NULL
       )
       if (!is.null(polish) && is.finite(polish$minimum) &&
-          polish$minimum <= result$value) {
+          polish$minimum < result$value) {
         # nlm() drops names; optim() keeps them, and the single-distribution
         # fits hand par straight back to hazard().
         result$par   <- stats::setNames(polish$estimate, names(result$par))

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -323,9 +323,10 @@ applies it too: when the optimizer reports convergence and the test fails,
 the fit is continued with \code{\link[stats:nlm]{stats::nlm()}} at SAS's tolerances, and the
 continued point is kept if it improves the log-likelihood.
 
-Every fit records the result in \code{fit$fit$rel_gradient} and, when the
-continuation ran, its termination code in \code{fit$fit$polish_code}. \code{print()}
-and \code{summary()} show both. A warning is raised only for code 4, the
+Every fit records the result in \code{fit$fit$rel_gradient} (\code{NA} where the
+gradient cannot be evaluated at the estimates, which is never reported as
+a pass) and, when the continuation improved the fit, its termination code
+in \code{fit$fit$polish_code}. \code{print()} and \code{summary()} show both. A warning is raised only for code 4, the
 iteration limit (raise \code{control$maxit}), and code 5, where the
 log-likelihood kept rising along some direction and the model may have no
 maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -329,9 +329,10 @@ continuation improved the fit, its termination code in
 \code{rel_gradient} is \code{NA} when the test was not applied (the optimizer did
 not report convergence) or the gradient cannot be evaluated at the
 estimates; \code{NA} is never reported as a pass. Under Conservation of Events
-the test and the continuation use finite differences of the
-log-likelihood with the conserved scale re-solved, as SAS/C does, because
-the analytic score there omits how that scale moves. A warning is raised only for code 4, the
+the analytic score omits how the conserved scale moves, so the test is
+computed from finite differences of the log-likelihood with that scale
+re-solved, as SAS/C does; the continuation still uses the analytic score,
+so a CoE fit can honestly end with the test not met. A warning is raised only for code 4, the
 iteration limit (raise \code{control$maxit}), and code 5, where the
 log-likelihood kept rising along some direction and the model may have no
 maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -323,10 +323,15 @@ applies it too: when the optimizer reports convergence and the test fails,
 the fit is continued with \code{\link[stats:nlm]{stats::nlm()}} at SAS's tolerances, and the
 continued point is kept if it improves the log-likelihood.
 
-Every fit records the result in \code{fit$fit$rel_gradient} (\code{NA} where the
-gradient cannot be evaluated at the estimates, which is never reported as
-a pass) and, when the continuation improved the fit, its termination code
-in \code{fit$fit$polish_code}. \code{print()} and \code{summary()} show both. A warning is raised only for code 4, the
+Every fit records the result in \code{fit$fit$rel_gradient} and, when the
+continuation improved the fit, its termination code in
+\code{fit$fit$polish_code}. \code{print()} and \code{summary()} show both.
+\code{rel_gradient} is \code{NA} when the test was not applied (the optimizer did
+not report convergence) or the gradient cannot be evaluated at the
+estimates; \code{NA} is never reported as a pass. Under Conservation of Events
+the test and the continuation use finite differences of the
+log-likelihood with the conserved scale re-solved, as SAS/C does, because
+the analytic score there omits how that scale moves. A warning is raised only for code 4, the
 iteration limit (raise \code{control$maxit}), and code 5, where the
 log-likelihood kept rising along some direction and the model may have no
 maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -135,7 +135,9 @@ An object of class \code{hazard}, a named list with components:
 \code{data} (input data: \code{time}, \code{status}, \code{x},
 \code{weights}, etc.),
 \code{fit} (optimisation results: \code{theta}, \code{objective},
-\code{converged}, \code{se}, \code{vcov}, \code{counts}, \code{message};
+\code{converged}, \code{se}, \code{vcov}, \code{counts}, \code{message},
+and \code{rel_gradient} and \code{polish_code}, the SAS/C acceptance
+test described under "Convergence";
 all \code{NULL} when \code{fit = FALSE}; multiphase fits add
 \code{starts}, one row per optimisation start with its \code{status}
 (\code{"ok"}, \code{"nonconverged"}, \code{"infeasible"},
@@ -221,9 +223,13 @@ phases, set it to 0 to silence the check.
 log-likelihood (default 1e-5). BFGS stops when an iteration reduces it by
 less than \verb{reltol * (|objective| + reltol)}, so the stopping gap grows
 with the size of the log-likelihood: about 0.0024 at a log-likelihood of
--240. On a flat surface a fit can stop that far short of the optimum and
-still report convergence.
-\item \code{abstol}: Absolute gradient norm tolerance (default 1e-6)
+-240. On a flat surface plain BFGS can stop that far short of the optimum
+and still report convergence, so \code{hazard()} then applies SAS/C HAZARD's
+relative-gradient test and, when the stop fails it, continues with
+\code{\link[stats:nlm]{stats::nlm()}}; see the "Convergence" section.
+\item \code{abstol}: Projected-gradient tolerance, used only by the bounded
+(L-BFGS-B) optimizer (default 1e-6). The fits \code{hazard()} runs use BFGS
+and ignore it.
 \item \code{method}: Optimization method: "bfgs" or "nm" (default "bfgs").
 SAS \verb{PROC HAZARD} jobs write \verb{STEEPEST QUASI} together -- steepest
 descent first, then quasi-Newton. \code{QUASI}/\code{QUASINEWTON} is \code{"bfgs"};
@@ -302,6 +308,29 @@ of this additive form.  Parameters are estimated
 on an unconstrained internal scale (e.g. \eqn{\log\mu}, \eqn{\log t_{1/2}})
 and transformed back for reporting; see
 \code{vignette("mf-mathematical-foundations")}.
+}
+
+\section{Convergence}{
+
+
+The optimizer stops when an iteration improves the log-likelihood by less
+than \code{control$reltol} relative to its size, and on a flat ridge that can
+happen well short of the maximum. SAS/C HAZARD accepts an optimum only on a
+different test, the relative gradient
+\eqn{\max_i |g_i| \max(|x_i|, 1) / \max(|\ell|, 1) \le \epsilon^{1/3}}{max_i
+|g_i| max(|x_i|, 1) / max(|l|, 1) <= eps^(1/3)}, about 6e-6, and \code{hazard()}
+applies it too: when the optimizer reports convergence and the test fails,
+the fit is continued with \code{\link[stats:nlm]{stats::nlm()}} at SAS's tolerances, and the
+continued point is kept if it improves the log-likelihood.
+
+Every fit records the result in \code{fit$fit$rel_gradient} and, when the
+continuation ran, its termination code in \code{fit$fit$polish_code}. \code{print()}
+and \code{summary()} show both. A warning is raised only for code 4, the
+iteration limit (raise \code{control$maxit}), and code 5, where the
+log-likelihood kept rising along some direction and the model may have no
+maximum. Codes 2 and 3, where SAS/C prints a caution, are recorded without
+one. The test is relative to the size of the log-likelihood, so a fit that
+meets it is within SAS's tolerance of the maximum, not exactly at it.
 }
 
 \section{Baseline distributions}{

--- a/tests/testthat/test-repeated-events-parity.R
+++ b/tests/testthat/test-repeated-events-parity.R
@@ -244,11 +244,13 @@ test_that("hz.ce_cardioversion_repeated.ehb: the stratified model reproduces the
   events <- cardioversion_events(dir)
   expect_false(anyNA(events[c("maze_prc", "iso_pvi")]))
 
-  # reltol is tightened on purpose. Under the default (1e-5) BFGS stops at LL
-  # -242.2675 and reports convergence; R's log likelihood at the listing's own
-  # estimates is -242.2541, so the likelihoods agree and the default optimizer
-  # tolerance stopped 0.013 short on a flat ridge in the late shapes.
-  ctl <- list(n_starts = 1L, reltol = 1e-12, maxit = 5000L)
+  # Default optimizer tolerance on purpose: this is the fit that showed the
+  # defect. Plain BFGS at reltol = 1e-5 stops at LL -242.2675 and reports
+  # convergence, 0.013 short of R's own log likelihood at the listing's
+  # estimates (-242.2541). hazard() now applies SAS/C's relative-gradient
+  # test and continues with nlm() when a stop fails it, so the default must
+  # reach the listing.
+  ctl <- list(n_starts = 1L)
   expect_no_warning(fit <- fit_translated(job, events, "fit_2", "status_2", ctl))
   expect_listing_rows(fit)
   # NOCONSERVE: "Conservation of events: Not invoked".

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -1,0 +1,112 @@
+# test-sas-gradient-check.R -- SAS/C's acceptance test in .hzr_optim_generic()
+#
+# SAS/C HAZARD accepts an optimum only when the relative gradient
+#   max_i |g_i| * max(|x_i|, 1) / max(|f|, 1)
+# is at most gradtl = eps^(1/3) (src/optim/umstop.c). optim()'s BFGS stops on
+# the relative change in the objective instead, which reports convergence
+# short of the optimum on a flat valley. .hzr_optim_generic() now polishes
+# such a stop with stats::nlm() at SAS's tolerances.
+#
+# The objective is a Rosenbrock valley shifted by 1e4. The offset makes
+# optim's relative criterion, reltol * |f|, about 0.1, so BFGS stops well
+# down the valley and still reports convergence 0 -- the shape of the defect
+# on real fits, in two parameters with a known optimum at (1, 1).
+
+gradtl <- .Machine$double.eps^(1 / 3)
+
+rosen_logl <- function(theta, ...) {
+  -(1e4 + 100 * (theta[2] - theta[1]^2)^2 + (1 - theta[1])^2)
+}
+rosen_score <- function(theta, ...) {
+  c(400 * theta[1] * (theta[2] - theta[1]^2) + 2 * (1 - theta[1]),
+    -200 * (theta[2] - theta[1]^2))
+}
+# Hessian of the negative log-likelihood, so no numDeriv is needed.
+rosen_hessian <- function(theta) {
+  matrix(c(1200 * theta[1]^2 - 400 * theta[2] + 2, -400 * theta[1],
+           -400 * theta[1], 200), 2, 2)
+}
+rel_gradient <- function(theta) {
+  max(abs(rosen_score(theta)) * pmax(abs(theta), 1)) /
+    max(abs(rosen_logl(theta)), 1)
+}
+start <- c(-1.2, 1)
+plain_bfgs <- function() {
+  stats::optim(start, function(th) -rosen_logl(th),
+               function(th) -rosen_score(th), method = "BFGS",
+               control = list(maxit = 1000, reltol = 1e-5))
+}
+# Log-likelihood below the optimum, whose value is exactly -1e4.
+ll_gap <- function(theta) -1e4 - rosen_logl(theta)
+
+test_that("plain BFGS at the default reltol stops short of SAS's test here", {
+  # The premise of the next test. If this ever passes gradtl, the fixture no
+  # longer exercises the polish and must be made harder.
+  bfgs <- plain_bfgs()
+  expect_equal(bfgs$convergence, 0L)
+  expect_gt(rel_gradient(bfgs$par), 10 * gradtl)
+})
+
+test_that("a converged BFGS stop that fails SAS's test is polished to pass it", {
+  fit <- .hzr_optim_generic(
+    logl_fn = rosen_logl, gradient_fn = rosen_score,
+    time = 1, status = 1, theta_start = start, hessian_fn = rosen_hessian
+  )
+  expect_equal(fit$convergence, 0L)
+  expect_lte(fit$rel_gradient, gradtl)
+  expect_equal(fit$polish_code, 1L)
+  # SAS's test is relative to |f|: at |f| = 1e4 it accepts |g_i * x_i| up to
+  # about 0.06, so a passing point is within SAS's tolerance of the optimum,
+  # not at it. What it buys is the log-likelihood, so assert on that: the
+  # polished point is within 1e-4 of the maximum and at least 100 times
+  # closer than plain BFGS stopped.
+  expect_lt(ll_gap(fit$par), 1e-4)
+  expect_lt(ll_gap(fit$par), ll_gap(plain_bfgs()$par) / 100)
+  expect_true(all(abs(fit$par - c(1, 1)) < 1e-2),
+              label = paste("par =", paste(signif(fit$par, 8), collapse = ", ")))
+  # The recorded statistic is the one at the returned point.
+  expect_equal(fit$rel_gradient, rel_gradient(fit$par), tolerance = 1e-8)
+})
+
+test_that("hazard() warns only on the polish's hard failures, and records every result", {
+  # The optimizer's return is the real one with the two fields overridden, so
+  # everything else hazard() reads from it is genuine.
+  set.seed(7)
+  df <- data.frame(time = stats::rexp(80, 0.4), status = rep(c(1, 1, 0), length.out = 80),
+                   z = stats::rnorm(80))
+  real <- .hzr_optim_exponential
+  fit_with <- function(code, rel = 1e-2) {
+    testthat::local_mocked_bindings(.hzr_optim_exponential = function(...) {
+      r <- real(...)
+      r$polish_code <- code
+      r$rel_gradient <- rel
+      r
+    })
+    hazard(survival::Surv(time, status) ~ z, data = df, dist = "exponential",
+           theta = c(log_rate = 0, z = 0), fit = TRUE)
+  }
+  # nlm code 5, SAS/C's "unbounded": warns.
+  expect_warning(f5 <- fit_with(5L), "kept rising")
+  expect_identical(f5$fit$polish_code, 5L)
+  # nlm code 4, SAS/C's "reached no convergence": warns and says how to go on.
+  expect_warning(fit_with(4L), "iteration limit.*control\\$maxit")
+  # nlm code 3, where SAS/C prints a caution and retries: recorded, not warned.
+  expect_no_warning(f3 <- fit_with(3L), message = "relative gradient")
+  expect_identical(f3$fit$polish_code, 3L)
+  expect_equal(f3$fit$rel_gradient, 1e-2)
+  expect_output(print(f3), "relative 0.01 .*not met, nlm code 3")
+  expect_output(print(summary(f3)), "relative 0.01 .*not met, nlm code 3")
+  # A passing fit says so.
+  f_ok <- fit_with(NA_integer_, rel = 1e-9)
+  expect_output(print(f_ok), "relative 1e-09 .*; met\\)")
+})
+
+test_that("the bounded (L-BFGS-B) path is not polished", {
+  fit <- .hzr_optim_generic(
+    logl_fn = rosen_logl, gradient_fn = rosen_score,
+    time = 1, status = 1, theta_start = start, hessian_fn = rosen_hessian,
+    use_bounds = TRUE, lower_bounds = c(-Inf, -Inf)
+  )
+  expect_true(is.na(fit$rel_gradient))
+  expect_true(is.na(fit$polish_code))
+})

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -93,16 +93,20 @@ test_that("hazard() warns only on the polish's hard failures, and records every 
   expect_warning(fit_with(4L), "iteration limit.*control\\$maxit")
   # A fit that did not converge is not "converged over a failing point": no
   # gradient warning even with a hard-failure code attached.
-  expect_no_warning(fit_with(4L, conv = 1L), message = "relative gradient")
+  expect_no_warning(fit_with(4L, conv = 1L), message = "relative-gradient test")
   # nlm code 3, where SAS/C prints a caution and retries: recorded, not warned.
-  expect_no_warning(f3 <- fit_with(3L), message = "relative gradient")
+  expect_no_warning(f3 <- fit_with(3L), message = "relative-gradient test")
   expect_identical(f3$fit$polish_code, 3L)
   expect_equal(f3$fit$rel_gradient, 1e-2)
   expect_output(print(f3), "relative 0.01 .*not met, nlm code 3")
   expect_output(print(summary(f3)), "relative 0.01 .*not met, nlm code 3")
-  # A passing fit says so.
+  # A passing fit says so, and shows the nlm() code when there is one.
   f_ok <- fit_with(NA_integer_, rel = 1e-9)
   expect_output(print(f_ok), "relative 1e-09 .*; met\\)")
+  expect_output(print(fit_with(1L, rel = 1e-9)), "; met, nlm code 1\\)")
+  # Code 4 whose statistic nonetheless meets the test -- possible when
+  # nlm() stops on a partial score, as under CoE -- does not warn.
+  expect_no_warning(fit_with(4L, rel = 1e-9), message = "relative-gradient test")
 })
 
 test_that("a polished fit keeps the caller's parameter names and says it went on", {
@@ -136,8 +140,14 @@ test_that("rel_gradient is NA, never a pass, where the gradient cannot be truste
     time = 1, status = 1, theta_start = start, hessian_fn = rosen_hessian
   ))
   expect_true(is.na(nan_score$rel_gradient))
-  expect_null(.hzr_format_gradient_test(nan_score$rel_gradient,
-                                        nan_score$polish_code))
+  # Converged with no usable gradient: said, not left blank.
+  expect_match(.hzr_format_gradient_test(nan_score$rel_gradient,
+                                         nan_score$polish_code),
+               "not evaluated")
+  # Not converged, or no record at all: no line.
+  expect_null(.hzr_format_gradient_test(NA_real_, NA_integer_,
+                                        converged = FALSE))
+  expect_null(.hzr_format_gradient_test(NULL, NULL))
 })
 
 test_that("with an inexact score the recorded test uses the objective's own gradient", {
@@ -198,6 +208,27 @@ test_that("multiphase passes gradient_exact = FALSE exactly when CoE is applied"
   expect_false(off$applied)
   expect_true(length(on$seen) > 0 && !any(on$seen))
   expect_true(length(off$seen) > 0 && all(off$seen))
+})
+
+test_that("a finite difference that lands on the clamp is NA, not a fabricated gradient", {
+  # The maximum sits on the edge of the region where the likelihood is
+  # defined: beyond theta[1] = 1 it is -Inf, so the objective is clamped to
+  # 1e10 there, and a central difference taken at the edge has one side on
+  # the clamp. Without the guard that side makes a "gradient" of 1e10 / (2h).
+  edge_logl <- function(theta, ...) {
+    if (theta[1] > 1) -Inf else -(1e4 + (theta[1] - 2)^2 + theta[2]^2)
+  }
+  edge_score <- function(theta, ...) c(-2 * (theta[1] - 2), -2 * theta[2])
+  fit <- suppressWarnings(.hzr_optim_generic(
+    logl_fn = edge_logl, gradient_fn = edge_score, time = 1, status = 1,
+    theta_start = c(0, 0.5), hessian_fn = function(theta) diag(2),
+    gradient_exact = FALSE
+  ))
+  expect_equal(fit$convergence, 0L)
+  # Premise: the fit stopped within one difference step of the edge.
+  expect_true(fit$par[1] <= 1 &&
+                fit$par[1] > 1 - .Machine$double.eps^(1 / 3))
+  expect_true(is.na(fit$rel_gradient))
 })
 
 test_that("the bounded (L-BFGS-B) path is not polished", {

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -140,6 +140,35 @@ test_that("rel_gradient is NA, never a pass, where the gradient cannot be truste
                                         nan_score$polish_code))
 })
 
+test_that("with an inexact score the test and the polish use the objective's own gradient", {
+  # Conservation of Events hands .hzr_optim_generic() the partial score at the
+  # conserved theta, which omits how the conserved scale moves: a gradient
+  # that is not the objective's. Model that with a score that is wrong in a
+  # known way: a hundredth of the truth in its first component, which is the
+  # one that sets SAS's maximum near this optimum, and right in its second.
+  # Judged by that score, a point can pass SAS's test while the objective's
+  # true gradient fails it.
+  biased <- function(theta, ...) rosen_score(theta) * c(0.01, 1)
+  rel_biased <- function(theta) {
+    max(abs(biased(theta)) * pmax(abs(theta), 1)) /
+      max(abs(rosen_logl(theta)), 1)
+  }
+  fit <- .hzr_optim_generic(
+    logl_fn = rosen_logl, gradient_fn = biased, time = 1, status = 1,
+    theta_start = start, hessian_fn = rosen_hessian, gradient_exact = FALSE
+  )
+  expect_equal(fit$convergence, 0L)
+  # Premise: at the returned point the two statistics differ, so the next
+  # assertion can tell them apart. If this fails the fixture no longer
+  # discriminates and must change.
+  expect_gt(abs(rel_biased(fit$par) / rel_gradient(fit$par) - 1), 0.1)
+  # The returned point passes SAS's test under the true gradient...
+  expect_lte(rel_gradient(fit$par), gradtl)
+  # ...and the recorded statistic is that true one, to finite-difference
+  # accuracy, not the biased score's.
+  expect_lt(abs(fit$rel_gradient / rel_gradient(fit$par) - 1), 1e-3)
+})
+
 test_that("the bounded (L-BFGS-B) path is not polished", {
   fit <- .hzr_optim_generic(
     logl_fn = rosen_logl, gradient_fn = rosen_score,

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -75,11 +75,12 @@ test_that("hazard() warns only on the polish's hard failures, and records every 
   df <- data.frame(time = stats::rexp(80, 0.4), status = rep(c(1, 1, 0), length.out = 80),
                    z = stats::rnorm(80))
   real <- .hzr_optim_exponential
-  fit_with <- function(code, rel = 1e-2) {
+  fit_with <- function(code, rel = 1e-2, conv = 0L) {
     testthat::local_mocked_bindings(.hzr_optim_exponential = function(...) {
       r <- real(...)
       r$polish_code <- code
       r$rel_gradient <- rel
+      r$convergence <- conv
       r
     })
     hazard(survival::Surv(time, status) ~ z, data = df, dist = "exponential",
@@ -90,6 +91,9 @@ test_that("hazard() warns only on the polish's hard failures, and records every 
   expect_identical(f5$fit$polish_code, 5L)
   # nlm code 4, SAS/C's "reached no convergence": warns and says how to go on.
   expect_warning(fit_with(4L), "iteration limit.*control\\$maxit")
+  # A fit that did not converge is not "converged over a failing point": no
+  # gradient warning even with a hard-failure code attached.
+  expect_no_warning(fit_with(4L, conv = 1L), message = "relative gradient")
   # nlm code 3, where SAS/C prints a caution and retries: recorded, not warned.
   expect_no_warning(f3 <- fit_with(3L), message = "relative gradient")
   expect_identical(f3$fit$polish_code, 3L)
@@ -99,6 +103,41 @@ test_that("hazard() warns only on the polish's hard failures, and records every 
   # A passing fit says so.
   f_ok <- fit_with(NA_integer_, rel = 1e-9)
   expect_output(print(f_ok), "relative 1e-09 .*; met\\)")
+})
+
+test_that("a polished fit keeps the caller's parameter names and says it went on", {
+  # nlm() returns an unnamed estimate; optim() keeps names, and the
+  # single-distribution fits return par as is, so a lost name surfaced as an
+  # unnamed coef() only on fits that happened to be polished.
+  fit <- .hzr_optim_generic(
+    logl_fn = rosen_logl, gradient_fn = rosen_score, time = 1, status = 1,
+    theta_start = c(a = -1.2, b = 1), hessian_fn = rosen_hessian
+  )
+  expect_equal(fit$polish_code, 1L)
+  expect_named(fit$par, c("a", "b"))
+  expect_match(fit$message, "continued with nlm\\(\\)")
+})
+
+test_that("rel_gradient is NA, never a pass, where the gradient cannot be trusted", {
+  # A likelihood that is -Inf everywhere: the objective is clamped to 1e10 and
+  # the wrapped gradient returns zeros, which read as a relative gradient of 0.
+  flat <- .hzr_optim_generic(
+    logl_fn = function(theta, ...) -Inf, gradient_fn = rosen_score,
+    time = 1, status = 1, theta_start = start,
+    hessian_fn = function(theta) diag(2)
+  )
+  expect_true(is.na(flat$rel_gradient))
+  # A score with a NaN component: the wrapper zeroes it, and BFGS stops far
+  # from the optimum with an apparently tiny gradient.
+  nan_score <- suppressWarnings(.hzr_optim_generic(
+    logl_fn = rosen_logl, gradient_fn = function(theta, ...) {
+      c(NaN, rosen_score(theta)[2])
+    },
+    time = 1, status = 1, theta_start = start, hessian_fn = rosen_hessian
+  ))
+  expect_true(is.na(nan_score$rel_gradient))
+  expect_null(.hzr_format_gradient_test(nan_score$rel_gradient,
+                                        nan_score$polish_code))
 })
 
 test_that("the bounded (L-BFGS-B) path is not polished", {

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -140,14 +140,13 @@ test_that("rel_gradient is NA, never a pass, where the gradient cannot be truste
                                         nan_score$polish_code))
 })
 
-test_that("with an inexact score the test and the polish use the objective's own gradient", {
+test_that("with an inexact score the recorded test uses the objective's own gradient", {
   # Conservation of Events hands .hzr_optim_generic() the partial score at the
   # conserved theta, which omits how the conserved scale moves: a gradient
   # that is not the objective's. Model that with a score that is wrong in a
   # known way: a hundredth of the truth in its first component, which is the
   # one that sets SAS's maximum near this optimum, and right in its second.
-  # Judged by that score, a point can pass SAS's test while the objective's
-  # true gradient fails it.
+  # The continuation still follows that score; the recorded test must not.
   biased <- function(theta, ...) rosen_score(theta) * c(0.01, 1)
   rel_biased <- function(theta) {
     max(abs(biased(theta)) * pmax(abs(theta), 1)) /
@@ -162,11 +161,43 @@ test_that("with an inexact score the test and the polish use the objective's own
   # assertion can tell them apart. If this fails the fixture no longer
   # discriminates and must change.
   expect_gt(abs(rel_biased(fit$par) / rel_gradient(fit$par) - 1), 0.1)
-  # The returned point passes SAS's test under the true gradient...
-  expect_lte(rel_gradient(fit$par), gradtl)
-  # ...and the recorded statistic is that true one, to finite-difference
+  # The recorded statistic is the objective's own, to finite-difference
   # accuracy, not the biased score's.
   expect_lt(abs(fit$rel_gradient / rel_gradient(fit$par) - 1), 1e-3)
+})
+
+test_that("multiphase passes gradient_exact = FALSE exactly when CoE is applied", {
+  # The flag is set at .hzr_optim_multiphase()'s call; spy on it there, so
+  # reverting that one line fails this test.
+  set.seed(3)
+  n <- 300
+  tt <- c(stats::rexp(n / 2, 3), stats::rexp(n / 2, 0.15))
+  cens <- stats::runif(n, 1, 15)
+  d <- data.frame(time = pmin(tt, cens), status = as.integer(tt <= cens))
+  real <- .hzr_optim_generic
+  seen <- logical(0)
+  testthat::local_mocked_bindings(
+    .hzr_optim_generic = function(..., gradient_exact = TRUE) {
+      seen <<- c(seen, gradient_exact)
+      real(..., gradient_exact = gradient_exact)
+    }
+  )
+  fit_with <- function(conserve) {
+    seen <<- logical(0)
+    f <- suppressWarnings(hazard(
+      survival::Surv(time, status) ~ 1, data = d, dist = "multiphase",
+      phases = list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0),
+                    constant = hzr_phase("constant")),
+      fit = TRUE, control = list(n_starts = 1, conserve = conserve)
+    ))
+    list(applied = isTRUE(f$spec$control$conserve_applied), seen = seen)
+  }
+  on <- fit_with(TRUE)
+  off <- fit_with(FALSE)
+  expect_true(on$applied)
+  expect_false(off$applied)
+  expect_true(length(on$seen) > 0 && !any(on$seen))
+  expect_true(length(off$seen) > 0 && all(off$seen))
 })
 
 test_that("the bounded (L-BFGS-B) path is not polished", {

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -265,9 +265,9 @@ test_that("fixing ETA at alpha = 1 is what makes GAMMA estimable", {
   # alpha = 1, tau = 1 only gamma * eta is identified, so the free fit must
   # reach the same log-likelihood and the same product, and its gamma must
   # be undetermined: a standard error at least 100 times the fixed fit's
-  # (about 0.02), or none at all. It was 7.5 when BFGS stopped partway along
-  # the ridge; an optimizer that follows the ridge further, as the SAS/C
-  # acceptance test makes it do, reaches a singular Hessian and reports none.
+  # (about 0.02), or none at all. On an exactly flat ridge the Hessian is
+  # singular in theory, so which of the two comes out is numerical noise:
+  # 7.5 where plain BFGS stopped, none 4e-6 away after the polish.
   skip_on_cran()
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=2",
                             "ETA=3", "FIXALPHA"))

--- a/tests/testthat/test-sas-parse-parms.R
+++ b/tests/testthat/test-sas-parse-parms.R
@@ -261,9 +261,13 @@ test_that("alpha = 1 fixed with GAMMA and ETA both free fixes ETA, as SAS does",
 
 test_that("fixing ETA at alpha = 1 is what makes GAMMA estimable", {
   # Two-sided, because "the standard error is finite" alone could come from
-  # anything: fit the SAME phase with ETA left free and show the ridge. The
-  # emitted (fixed) form gives gamma an SE around 0.02; leaving ETA free gives
-  # 7.5 on gamma and 13.7 on eta -- the flat direction, not a tighter fit.
+  # anything: fit the SAME phase with ETA left free and show the ridge. At
+  # alpha = 1, tau = 1 only gamma * eta is identified, so the free fit must
+  # reach the same log-likelihood and the same product, and its gamma must
+  # be undetermined: a standard error at least 100 times the fixed fit's
+  # (about 0.02), or none at all. It was 7.5 when BFGS stopped partway along
+  # the ridge; an optimizer that follows the ridge further, as the SAS/C
+  # acceptance test makes it do, reaches a singular Hessian and reports none.
   skip_on_cran()
   got <- .hzr_parse_parms(c("MUL=0.01", "TAU=1", "ALPHA=1", "GAMMA=2",
                             "ETA=3", "FIXALPHA"))
@@ -271,17 +275,26 @@ test_that("fixing ETA at alpha = 1 is what makes GAMMA estimable", {
   n <- 400
   d <- data.frame(t = stats::rexp(n, 0.3), s = rep(c(1, 0), length.out = n))
   fit_one <- function(phases) {
-    f <- suppressWarnings(hazard(
+    suppressWarnings(hazard(
       time = d$t, status = d$s, dist = "multiphase",
       phases = phases, theta = eval(got$theta), fit = TRUE
     ))
-    sqrt(diag(stats::vcov(f)))[["phase_1.gamma"]]
   }
-  se_fixed <- fit_one(eval(got$phases))
-  se_free <- fit_one(list(hzr_phase("g3", tau = 1, gamma = 2, alpha = 1,
-                                    eta = 3, fixed = c("tau", "alpha"))))
-  expect_true(is.finite(se_fixed))
-  expect_lt(se_fixed, se_free / 100)
+  se_gamma <- function(f) {
+    v <- stats::vcov(f)
+    if (is.matrix(v)) sqrt(diag(v))[["phase_1.gamma"]] else NA_real_
+  }
+  product <- function(f) {
+    f$fit$theta[["phase_1.gamma"]] * f$fit$theta[["phase_1.eta"]]
+  }
+  fixed <- fit_one(eval(got$phases))
+  free <- fit_one(list(hzr_phase("g3", tau = 1, gamma = 2, alpha = 1,
+                                 eta = 3, fixed = c("tau", "alpha"))))
+  expect_true(is.finite(se_gamma(fixed)))
+  expect_true(!is.finite(se_gamma(free)) ||
+                se_gamma(free) > 100 * se_gamma(fixed))
+  expect_lt(abs(free$fit$objective - fixed$fit$objective), 1e-4)
+  expect_lt(abs(product(free) / product(fixed) - 1), 1e-3)
 })
 
 test_that("alpha = 1 fixed with GAMMA fixed is not recorded", {

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -574,7 +574,7 @@ recognizable:
 
 | Symptom | What it means |
 |---------|--------------|
-| `fit$fit$converged == FALSE` | Optimizer hit `maxit` without satisfying the gradient tolerance |
+| `fit$fit$converged == FALSE` | Optimizer hit `maxit` before its stopping criterion was met |
 | `vcov()` returns `NA` | Hessian is singular — parameters are not jointly identified |
 | A phase scale (`log_mu`) at a boundary value | That phase is contributing essentially zero hazard; it isn't needed |
 | Enormous standard errors on one or more parameters | Flat likelihood in that direction — weak identification |
@@ -657,7 +657,16 @@ basin, then BFGS polishes the solution. This warm-up is transparent —
 it happens automatically when the conditions are met and there is no
 user-facing control to switch it on or off.
 
-**`maxit`** (default 1000) sets the BFGS iteration cap. Hitting `maxit`
+**Acceptance test (automatic).** BFGS stops when an iteration improves the
+log-likelihood by less than `reltol` relative to its size, which on a flat
+ridge can be short of the maximum. `hazard()` then applies SAS/C HAZARD's
+own test, a relative gradient of at most about 6e-6, and when a stop fails
+it continues with `stats::nlm()`. The result is kept in
+`fit$fit$rel_gradient` and `fit$fit$polish_code`, and `print()` shows it;
+see the "Convergence" section of `?hazard`.
+
+**`maxit`** (default 1000) sets the iteration cap for BFGS and for the
+`nlm()` continuation. Hitting `maxit`
 without converging usually means either the starting values are far from
 the optimum (fix with better starts or `n_starts`) or the model is
 overparameterized (fix by fixing shapes or dropping a phase). Raising

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -456,11 +456,13 @@ concatenation of all phase sub-vectors.
 The optimizer uses `stats::optim()` with BFGS on the unconstrained internal
 scale, wrapped by `.hzr_optim_generic()`.  Key features:
 
-- **Acceptance test**: a BFGS stop is accepted only when SAS/C HAZARD's
-  relative gradient, $\max_i |g_i| \max(|x_i|, 1) / \max(|\ell|, 1)$, is at
-  most $\epsilon^{1/3}$ (about $6 \times 10^{-6}$); otherwise the fit
-  continues with `stats::nlm()`, the Dennis-Schnabel algorithm SAS/C's
-  optimizer was ported from.
+- **Acceptance test**: a BFGS stop is checked against SAS/C HAZARD's
+  relative gradient, $\max_i |g_i| \max(|x_i|, 1) / \max(|\ell|, 1)$, which
+  SAS/C requires to be at most $\epsilon^{1/3}$ (about $6 \times 10^{-6}$).
+  A stop that fails it is continued with `stats::nlm()`, the Dennis-Schnabel
+  algorithm SAS/C's optimizer was ported from, and the continuation is kept
+  when it improves the log-likelihood. The result is recorded either way: a
+  fit can still end, and report convergence, without meeting the test.
 - **Multi-start**: the optimizer runs from $k$ random perturbations around
   the user-supplied starting values (default $k = 5$, controlled by
   `control$n_starts`).  The run with the highest log-likelihood is kept.

--- a/vignettes/mf-mathematical-foundations.qmd
+++ b/vignettes/mf-mathematical-foundations.qmd
@@ -456,6 +456,11 @@ concatenation of all phase sub-vectors.
 The optimizer uses `stats::optim()` with BFGS on the unconstrained internal
 scale, wrapped by `.hzr_optim_generic()`.  Key features:
 
+- **Acceptance test**: a BFGS stop is accepted only when SAS/C HAZARD's
+  relative gradient, $\max_i |g_i| \max(|x_i|, 1) / \max(|\ell|, 1)$, is at
+  most $\epsilon^{1/3}$ (about $6 \times 10^{-6}$); otherwise the fit
+  continues with `stats::nlm()`, the Dennis-Schnabel algorithm SAS/C's
+  optimizer was ported from.
 - **Multi-start**: the optimizer runs from $k$ random perturbations around
   the user-supplied starting values (default $k = 5$, controlled by
   `control$n_starts`).  The run with the highest log-likelihood is kept.


### PR DESCRIPTION
Follows #251 (the m = 0 derivative fix), which it needs: `nlm()`'s stops are only as good as the gradient, and before #251 the `m` derivative was wrong near `m = 0`. Rebased onto `main` at `254dd6f`, then merged `main` at `228c9c3`, which brings in #257 (the house-style recompose, so `.claude/house-style.md` matches `main`) and #258 (the #248 follow-up); that merge was clean. The one rebase conflict was `control$reltol`'s documentation, which #247 (`3795ebe`) had already corrected. #247's paragraph is kept whole. "A fit can stop that far short … and still report convergence" now reads "plain BFGS can…", because after this PR `hazard()` goes on from such a stop. The polish sentence is appended. `abstol`, which `main` still called a gradient-norm tolerance, is corrected: under BFGS it is unused.

## The finding

Reproducing SAS job `hz.ce_cardioversion_repeated.ehb` (second, stratified model: early CDF + late G3, `maze_prc` and `iso_pvi` in both phases, `noconserve`, 13 free parameters), the translated `hazard()` call with default control returned `converged = TRUE` at log-likelihood -242.2675 against SAS's -242.254. R's own likelihood at SAS's estimates is -242.2541227, so the likelihoods agree; the optimizer stopped short. `control = list(n_starts = 1, reltol = 1e-12, maxit = 5000)` reaches -242.2541227.

Cause: `.hzr_optim_generic()` runs `stats::optim(method = "BFGS")` with `reltol = 1e-5`, which stops when an iteration improves the objective by less than `reltol * (|f| + reltol)` -- about 0.0024 at |LL| 242 -- and never looks at the gradient. That is the package's signature defect shape: `converged = TRUE` over a point that is not the optimum. The data are PHI; everything below uses synthetic data or the test suite.

## What SAS/C does

SAS/C HAZARD's optimizer (Dennis-Schnabel UNCMIN) stops on the relative gradient `max_i |g_i| * max(|x_i|, typx) / max(|f|, typf) <= gradtl`, `gradtl = eps^(1/3)` ~ 6.06e-6, `typx = typf = 1` (`src/optim/umstop.c:176-186`, defaults `uminck.c:229-233`). Only that test prints "Normal exit: Convergence attained" (`setopt.c:507-511`, `hazrd3.c`). trmcod 2 (step) and 3 (no lower point) print a caution and retry once; 4 is the iteration limit ("reached no convergence"); 5 is five maximum-length steps ("unbounded below or has a finite asymptote"). `stats::nlm()` is the same UNCMIN family with the same scaled-gradient stop, and its `code` 1-5 are SAS's trmcod 1-5.

## Measurements behind the design

Three options were on the table: tighten the default `reltol`, a post-fit gradient check, or document.

- **Synthetic reproduction** (early CDF + late G3, two binary covariates in both phases, 13 free parameters, `conserve = FALSE`, n = 800 and 3000): default control stopped 0.8-5 LL units short on every seed, `converged = TRUE`.
- **Tightening `reltol`:** 1e-8 still left a median 0.39 LL on those seeds; only 1e-12 closed all of them, at about 7x the per-fit time. On the suite, default reltol 1e-8 / 1e-10 took +29% / +58% time (indicative: the runs overlapped other work) and broke 8 / 9 tests.
- **Census of every `.hzr_optim_generic()` stop in the suite:** 70% of 2390 converged BFGS stops fail SAS's `gradtl` (median relative gradient 1.35e-4). A warn-only check would fire on most fits.
- **With the `nlm()` polish:** failing stops fall from 1681 to 841 (the rest end with nlm code 2: 283, 3: 529, 4: 3; none 5); median 2 extra iterations. The remaining failures sit far from the threshold (median 5e-3), so they are not a gradient-accuracy floor.

The maintainer chose the polish, and to warn only on SAS/C's hard failures (codes 4 and 5) while recording every result.

## The change

- `.hzr_optim_generic()`: when BFGS reports convergence and SAS's test fails, continue with `stats::nlm(gradtol = eps^(1/3), steptol = eps^(2/3), iterlim = maxit)` using the analytic gradient, and keep the polished point only if it improves the objective. Returns `rel_gradient` (at the returned point) and `polish_code`. The bounded L-BFGS-B path, which no caller in `R/` uses, is untouched. `reltol`'s default is unchanged.
- `hazard()`: records `fit$fit$rel_gradient` and `fit$fit$polish_code` for every fit; warns only on nlm code 4 (iteration limit, with "raise control$maxit") or 5 (the likelihood kept rising; the model may have no maximum). `print()` and `summary()` show a "gradient:" line.
- Docs: `control$reltol` / `abstol` were described as a parameter-change and a gradient-norm tolerance; under BFGS they are an objective-change tolerance and unused. Corrected, plus a "Convergence" section.

SAS's test is relative to |LL|, so a fit that meets it is within SAS's tolerance of the maximum rather than exactly at it (on the Rosenbrock test fixture the polished point is 8.5e-6 below the maximum, 2.6e-3 from the argmax).

## Tests

- `test-sas-gradient-check.R` (new): a Rosenbrock valley shifted by 1e4 so plain BFGS stops with a relative gradient 45x `gradtl` while reporting convergence; the polished fit passes with code 1 and is within 1e-4 LL of the maximum and 100x closer than BFGS; the bounded path is not polished; `hazard()` warns on codes 4 and 5, not on 3, and `print()` / `print(summary())` show the line. Mutation-checked: disabling the polish fails 5 of 11 mechanism assertions; leaving `rel_gradient` at its pre-polish value fails 2.
- `test-sas-parse-parms.R`, "fixing ETA at alpha = 1 is what makes GAMMA estimable": its ETA-free side got a finite SE(gamma) of 7.5 only because BFGS stopped partway along an exactly flat ridge (gamma * eta identified, alpha = tau = 1). At an exactly flat ridge the Hessian is singular in theory, so whether a finite SE comes out at all is numerical noise. The polish moved gamma by only 4e-6, and at that point there is none. The test now asserts the free SE is either non-finite or more than 100x the fixed one, and that both fits reach the same LL and the same gamma * eta.

## Second review round (after the rebase)

`r-reviewer` ran again over the rebased diff. I verified each finding before acting on it.

- **Conservation of Events used the wrong gradient.** Under CoE, `gradient_fn` is the partial score at the conserved theta. It leaves out how the conserved `log_mu` moves with the free parameters. SAS's test and `nlm()`'s own stop were both judged on it, so a CoE fit could print "met" while failing the test. The reviewer saw 5.3e-6 recorded against 1.03e-5 true; synthetic CoE data here gave 4.12e-6 against 5.76e-6. Without CoE the two agree to every digit. CoE is on by default for multiphase fits.
  - **Fix:** a new `gradient_exact` argument, which multiphase passes as `FALSE` under CoE. SAS's test is then computed from central differences of the objective itself, with the scale re-solved at every step, as SAS/C does (`setobj.c:229-236`).
  - **The continuation still uses the analytic score under CoE. This is the maintainer's choice.** A third review pass found that letting `nlm()` use its own finite differences there walks onto a discontinuity in the CoE solve. `.hzr_conserve_events()` returns theta unchanged when `jevent <= 0`, so the objective jumps. On `avc` early + constant + late this drove `constant.log_mu` from -10.7 to -27.7, and it broke 5 assertions in `test-score-fallback-no-variance.R`. With the analytic score, CoE fits are identical to the version that passed the suite, and only the recorded statistic changes. It never claims "met" on the wrong vector, so a CoE fit can honestly end with the test not met. The discontinuity is filed as #261, with its reproduction and SAS/C's behaviour at that point (it refuses, with `SETCOE1200`). It is likelihood-level, and so out of scope here.
  - **Clamp guard:** a central difference whose side lands on the 1e10 clamp now gives `NA`, not a fabricated value. Before this guard it recorded 1.19e12 on a synthetic CoE fit.
  - **Call-site test:** a spy on `.hzr_optim_generic()` asserts that multiphase passes `gradient_exact = FALSE` exactly when CoE is applied, and `TRUE` with `conserve = FALSE`. Reverting that one line fails it. The unit test also fails if the statistic ignores the flag.
- **The polish is kept only on strict improvement.** Previously a continuation that could not move still recorded a code and a message.
- **The warning is `NA`-safe.**
- **Documentation fixes.** The docs now say `rel_gradient` is also `NA` when the test was not applied. The vignettes described stopping, and `maxit`, as BFGS-only; they now mention the continuation.
- **The ridge-test explanation was wrong.** The polish moved gamma by 4e-6, not along the ridge. At an exactly flat ridge the Hessian is singular in theory, so whether a finite SE comes out at all is numerical noise. NEWS and the test comment now say that.
- **The cardioversion parity test now runs at default control.** It had forced `reltol = 1e-12`; now the fit that showed the defect guards the fix. Locally, with the volume mounted: 61 passed, 0 failed, 0 skipped.
- **API change (additive only).** `summary.hazard` gains `rel_gradient` and `polish_code`, placed between `converged` and `log_lik`, and `fit$fit` gains the same two elements. Nothing is removed and `NAMESPACE` is unchanged. Only code that indexes the summary list by position is affected.

New test: the score is biased in its dominant component and `gradient_exact = FALSE`. The returned point must pass SAS's test under the true gradient, and the recorded statistic must be the true one. A premise assertion checks that the biased and true statistics differ at that point, so the test cannot go hollow. Making the statistic ignore the flag fails it, and so does making `nlm()` ignore it. The strict-improvement change has no test that can fail, because nothing moves a fit to exactly the same value.

## Final review round (over `git diff origin/main...HEAD`, after merging `228c9c3`)

- **Two no-warning assertions could not fail.** Their `message =` filter said "relative gradient". Since the wording change, the warning says "relative-gradient test", so the filter never matched and a real warning would have slipped past as a non-failure. Both now filter on the actual wording.
- **The code-4/5 warning now also requires the recorded statistic to fail the test.** With the same gradient in both places, codes 4 and 5 already imply a failure. Under CoE, though, `nlm()` stops on the partial score, so the warning could have said "fails" while `print()` said "met".
- **A converged fit with no evaluable gradient now prints "gradient: not evaluated at the estimates".** It used to print nothing, which reads like a fit that was never tested. The `nlm()` code is now shown whenever there is one, including after "met". An object with no record of the test, such as one imported from SAS or saved by an earlier version, still prints no line.
- **The clamp guard now has a test.** The fixture's maximum sits on the edge of where the likelihood is defined. The test asserts that the fit stopped at the edge and that `rel_gradient` is `NA`.

Mutation-checked against an unmutated control (41 passed): warning on code 3 too, dropping the `converged` guard, dropping the new statistic guard, and removing the clamp guard each fail one test.

## Gates

- `devtools::document()`: no changes after the rebase (the `man/hazard.Rd` conflict was resolved by regenerating it). `lintr::lint_package()`: 0.
- `devtools::test()` (`NOT_CRAN=true`) on the final head `1347780`, with the maze study volume mounted so the volume-gated parity tests run: **4358 passed, 0 failed, 6 skipped, 0 errors**. All six skips are local fixture or binary guards: `bhdead` (3), the C-binary integration test (1) and the weighted AVC fixture (2). The cardioversion stratified-model parity test runs and passes at default control.
- `spelling::spell_check_package()`: clean.
- `R CMD check --as-cran` with the manual, from `git archive`: **Status: OK** (0/0/0) on both halves of a paired run. I checked `main` and this branch (`8dfe342`) at the same time, so both saw the same machine load. `main` was `afab795` by then: `254dd6f` plus #257, which changes only `.claude/house-style.md` and so no R code or tarball content:

  | | overall | tests (CPU / elapsed) | vignettes |
  |---|---|---|---|
  | `main` `afab795` | 247 s | 99 s / 106 s | 48 s / 51 s |
  | branch `8dfe342` | 265 s | 118 s / 125 s | 51 s / 53 s |

  This pair ran on `8dfe342`. The commit after it, `1347780`, changes only print and warning logic, two guards and tests, so it should not move check time; CI checks the final head on all five platforms.

  The polish adds about 19 s of test CPU and 18 s overall (+7%). That agrees with earlier pairs at `88cbec8` (+28 s) and `6e4bb61` (+24 s, when CoE used the finite-difference continuation). The branch sits well inside CRAN's roughly 10-minute ceiling, against AGENTS.md's clean baseline of about 211-221 s. Tarballs are about 3.14 MB and contain no `CLAUDE` or `AGENTS` files.
- `r-reviewer`: three passes. I verified every finding before acting on it, and each fix is mutation-checked.
  - **First pass (pre-rebase):** nlm dropped the parameter names; a hollow "met" came from the zero-returning wrapped gradient; `counts` and `message` ignored the polish; the docs overstated when `polish_code` is set; the non-converged warn case was missing.
  - **Second pass (after rebasing onto `254dd6f`):** the CoE partial-score statistic; keeping a polish that did not improve; `NA` in the warning text; the doc and vignette wording; the ridge explanation; no default-control test of the headline case.
  - **Third pass (the CoE commit):** the finite-difference continuation walked onto the `jevent <= 0` discontinuity, and the maintainer chose the analytic score for the continuation; the clamp crossing; a missing call-site test; a vignette overstatement.
  - Every pass confirmed the implementation of the maintainer's two choices, the `nlm()` polish and the warn-on-4/5 rule. None relitigated them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
