### PR TITLE
ci(check-manual): drop the release trigger

### DIFF
--- a/.github/workflows/check-manual.yaml
+++ b/.github/workflows/check-manual.yaml
@@ -14,8 +14,10 @@ on:
     paths-ignore:
       - '.claude/**'
     branches: [main]
-  release:
-    types: [published]
+  # No `release:` trigger, deliberately. A release tags a commit already on
+  # main, and every push to main that can change the package has already run
+  # this check, so a release-triggered run only repeats it on the same code.
+  # The release gate is check-release.yaml, which builds the manual as well.
   workflow_dispatch:
 
 name: Check manual
@@ -25,7 +27,7 @@ concurrency:
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
   # 2026-08-17 behind work that had already been replaced. Protected branches
-  # are exempt, so a release run is never cancelled mid-flight.
+  # are exempt, so a run on main is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !github.ref_protected }}
 

--- a/.github/workflows/check-manual.yaml
+++ b/.github/workflows/check-manual.yaml
@@ -27,7 +27,7 @@ concurrency:
   # fresh run while the superseded one keeps holding a runner, and the queue
   # grows faster than it drains -- one run sat queued for 410 minutes on
   # 2026-08-17 behind work that had already been replaced. Protected branches
-  # are exempt, so a run on main is never cancelled mid-flight.
+  # are exempt, main among them, so a run there is never cancelled mid-flight.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !github.ref_protected }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,9 +103,9 @@ The rest run and report but do not block.
 | `lint.yaml` → `house-style` | PR, push | **yes** | fails when `.claude/house-style.md` has drifted from its vault sources |
 | `lint.yaml` → `docs-current` | PR, push | no | `git diff --exit-code man/ NAMESPACE DESCRIPTION` after `document()` |
 | `spelling.yaml` | PR, push | **yes** | `spelling::spell_check_package(use_wordlist = TRUE)` |
-| `R-CMD-check.yaml` | PR, push, release | **yes**, all five | ubuntu devel/release/oldrel-1, macOS, Windows |
-| `test-coverage.yaml` | PR, push, release | no | coverage upload |
-| `pkgdown.yaml` → `build-and-deploy` | PR, push, release | no | docs site |
+| `R-CMD-check.yaml` | PR, push | **yes**, all five | ubuntu devel/release/oldrel-1, macOS, Windows |
+| `test-coverage.yaml` | PR, push | no | coverage upload |
+| `pkgdown.yaml` → `build-and-deploy` | PR, push | no | docs site |
 | `check-manual.yaml` | push to `main` | **cannot** | the PDF manual — the only thing that catches raw Unicode in `Rd` |
 | `check-release.yaml` | release published | no | `R CMD check --as-cran` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ The rest run and report but do not block.
 | `R-CMD-check.yaml` | PR, push, release | **yes**, all five | ubuntu devel/release/oldrel-1, macOS, Windows |
 | `test-coverage.yaml` | PR, push, release | no | coverage upload |
 | `pkgdown.yaml` → `build-and-deploy` | PR, push, release | no | docs site |
-| `check-manual.yaml` | push to `main`, release | **cannot** | the PDF manual — the only thing that catches raw Unicode in `Rd` |
+| `check-manual.yaml` | push to `main` | **cannot** | the PDF manual — the only thing that catches raw Unicode in `Rd` |
 | `check-release.yaml` | release published | no | `R CMD check --as-cran` |
 
 `check-manual` says *cannot* rather than *no*: it deliberately does not run on pull requests,


### PR DESCRIPTION
Removes the `release: types: [published]` trigger from `check-manual.yaml`, the follow-up to the pkgdown change.

Unlike pkgdown, this workflow deploys nothing, so a release run could never roll anything back. It was only a repeat. A release tags a commit already on `main`, and every push to `main` that can change the package has already run this check on that code. A comment above `workflow_dispatch:` records why the trigger is absent.

**What does not change**
- `push` to `main` and `workflow_dispatch` are untouched. There is still no `pull_request` trigger, as before, so this is not a PR check and no required check is affected.
- No ruleset change.
- No NEWS entry or version bump: a CI-only change, following ehrlinger/hvtiR#65.
- The release gate here is `check-release.yaml`, which runs the full `--as-cran` check, manual included, on a published release. The comment says so.
- The concurrency comment said protected branches are exempt "so a release run is never cancelled"; it now says a run on `main`.
- `AGENTS.md`: the gates table listed `release` for `check-manual`, `R-CMD-check`, `test-coverage` and `pkgdown`. Only `check-manual` ever had the trigger. The other three have never had one in any commit on `main`, including 0ee475f9, which wrote the table. The likely source is the R-version matrix leg named `release` (`ubuntu devel/release/oldrel-1`), which is not a release event. All four rows now match the workflows, and `check-release.yaml` remains the one workflow that runs on a published release.

The `.claude/house-style.md` workflow table still lists `release` for this workflow and for pkgdown. That row is composed from the house-style standard, so it gets fixed there and arrives here with the next recompose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

