### PR TITLE
fix(optimizer): #260 Copilot follow-up: test the unsanitised score, keep the FD check off m = 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,8 +86,9 @@
   point: it estimates `log|M|` with the sign fixed by the starting value, so
   `M` cannot reach or cross 0. `hazard()` estimates `m` directly and can.
 
-* **A fit that reports convergence now meets SAS/C HAZARD's own test for
-  it.** `hazard()`'s BFGS optimizer stops on the relative change in the
+* **A fit that reports convergence is now checked against SAS/C HAZARD's
+  own test for it, and continued with `stats::nlm()` when it fails the
+  test.** `hazard()`'s BFGS optimizer stops on the relative change in the
   log-likelihood (`control$reltol`, default 1e-5), which lets a flat ridge
   end short of the maximum with `converged = TRUE`: a 13-parameter
   early-CDF plus late-G3 model stopped 0.013 below the SAS listing's

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1780,15 +1780,19 @@
       }
 
       gradient_fn_pre_coe <- gradient_fn
+      # Same formals as the base gradient_fn, sanitize included: R CMD check
+      # flags local redefinitions whose formal arguments differ.
       gradient_fn <- function(theta, time, status, time_lower,
-                              time_upper, x, weights = NULL, ...) {
+                              time_upper, x, weights = NULL,
+                              sanitize = TRUE, ...) {
         theta <- .hzr_conserve_events(
           theta, fixmu_phase, fixmu_pos,
           time, status, phases, covariate_counts, x_list, total_events,
           weights = weights, time_lower = time_lower
         )
         gradient_fn_pre_coe(theta, time, status, time_lower,
-                            time_upper, x, weights = weights, ...)
+                            time_upper, x, weights = weights,
+                            sanitize = sanitize, ...)
       }
     } else {
       use_conserve <- FALSE
@@ -1831,11 +1835,13 @@
     }
 
     gradient_fn_full <- gradient_fn
+    # Same formals as the base gradient_fn; see the CoE wrapper above.
     gradient_fn <- function(theta, time, status, time_lower, time_upper, x,
-                            weights = NULL, ...) {
+                            weights = NULL, sanitize = TRUE, ...) {
       grad_full <- gradient_fn_full(expand_theta(theta), time, status,
                                      time_lower, time_upper, x,
-                                     weights = weights, ...)
+                                     weights = weights, sanitize = sanitize,
+                                     ...)
       grad_full[free_idx]
     }
 

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1212,8 +1212,9 @@
     }
   }
 
-  # Safety: zero out non-finite entries (for the optimizer only)
-  if (sanitize) grad[!is.finite(grad)] <- 0
+  # Non-finite entries: 0 for the optimizer; NA for the acceptance test, which
+  # must report a component it could not evaluate, not a NaN or an Inf.
+  grad[!is.finite(grad)] <- if (sanitize) 0 else NA_real_
 
   grad
 }

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -779,15 +779,25 @@
 #'
 #' @inheritParams .hzr_logl_multiphase
 #' @return Numeric vector of length `length(theta)` -- the gradient.
-#'   Returns a zero vector if any component is non-finite (guards optimizer).
+#'   With `sanitize = TRUE` (the default) a component that cannot be evaluated
+#'   is 0, and so is the whole vector at an infeasible point (guards the
+#'   optimizer); with `sanitize = FALSE` those are `NA`.
+#' @param sanitize Logical; `FALSE` returns `NA` where the default returns 0.
+#'   Used by SAS/C's acceptance test, which must not read a zero it could not
+#'   compute as a small gradient.
 #' @keywords internal
 .hzr_gradient_multiphase <- function(theta, time, status,
                                       time_lower = NULL, time_upper = NULL,
                                       x = NULL, weights = NULL,
                                       phases, covariate_counts, x_list,
                                       objective = c("likelihood", "sas"),
+                                      sanitize = TRUE,
                                       ...) {
   objective <- match.arg(objective)
+  # A gradient that cannot be evaluated is zeros for the optimizer, which
+  # needs a finite vector to keep moving, and NA for anything that must not
+  # read it as a measurement (the SAS acceptance test asks with sanitize =
+  # FALSE).
   .hzr_check_sas_status(status, objective)
   n <- length(time)
   p <- length(theta)
@@ -799,10 +809,12 @@
   for (nm in names(phases)) {
     pars <- .hzr_unpack_phase_theta(theta_split[[nm]], phases[[nm]])
     if (phases[[nm]]$type %in% c("cdf", "hazard")) {
-      if (pars$m < 0 && pars$nu < 0) return(grad)
+      if (pars$m < 0 && pars$nu < 0) return(if (sanitize) grad else grad * NA)
     }
     if (phases[[nm]]$type == "g3") {
-      if (pars$gamma <= 0 || pars$eta <= 0 || pars$alpha < 0) return(grad)
+      if (pars$gamma <= 0 || pars$eta <= 0 || pars$alpha < 0) {
+        return(if (sanitize) grad else grad * NA)
+      }
     }
   }
 
@@ -928,7 +940,9 @@
   }
 
   # Guard: if total hazard or cumhaz is non-finite, return zero gradient
-  if (any(!is.finite(H_t)) || any(!is.finite(h_t))) return(grad)
+  if (any(!is.finite(H_t)) || any(!is.finite(h_t))) {
+    return(if (sanitize) grad else grad * NA)
+  }
 
   # -- Per-observation weight vectors ----------------------------------------
   # dLogl/dH(t_i) depends on observation type:
@@ -1198,8 +1212,8 @@
     }
   }
 
-  # Safety: zero out non-finite entries
-  grad[!is.finite(grad)] <- 0
+  # Safety: zero out non-finite entries (for the optimizer only)
+  if (sanitize) grad[!is.finite(grad)] <- 0
 
   grad
 }
@@ -1647,18 +1661,19 @@
   logl_fn_unwrapped <- logl_fn
 
   gradient_fn <- function(theta, time, status, time_lower, time_upper, x,
-                          weights = NULL, ...) {
+                          weights = NULL, sanitize = TRUE, ...) {
     grad <- .hzr_gradient_multiphase(
       theta = theta, time = time, status = status,
       time_lower = time_lower, time_upper = time_upper, x = x,
       weights = weights,
       phases = phases, covariate_counts = covariate_counts, x_list = x_list,
-      objective = objective
+      objective = objective, sanitize = sanitize
     )
 
     # Fallback: if gradient is all zero (e.g. at infeasible point), try
-    # numerical gradient of the *weighted* LL to keep optimizer moving.
-    if (all(grad == 0)) {
+    # numerical gradient of the *weighted* LL to keep optimizer moving. Not
+    # when the raw score was asked for: its NAs are the answer.
+    if (sanitize && isTRUE(all(grad == 0))) {
       eps_rel <- sqrt(.Machine$double.eps)
       p <- length(theta)
       ll0 <- logl_fn_unwrapped(theta, time, status, time_lower,
@@ -1829,6 +1844,17 @@
     free_idx_eff <- seq_along(theta_start)
     theta_start_optim <- theta_start
   }
+
+  # Positions, in the optimizer's vector, of each free shape m. The
+  # finite-difference acceptance check (gradient_exact = FALSE) must not
+  # straddle m = 0, where the cdf and hazard families meet in a cusp (#251).
+  # Taken from the layout -- log_mu, log_t_half, nu, m, then covariates --
+  # not from names, which a covariate called m would collide with.
+  mu_pos <- .hzr_log_mu_positions(phases, covariate_counts)
+  m_full <- unlist(lapply(names(phases), function(nm) {
+    if (phases[[nm]]$type %in% c("cdf", "hazard")) mu_pos[[nm]] + 3L
+  }), use.names = FALSE)
+  m_free_idx <- if (any_fixed) which(free_idx %in% m_full) else m_full
 
   # --- Multi-start optimization -----------------------------------------------
   n_starts <- if (!is.null(control$n_starts)) control$n_starts else 5L
@@ -2006,7 +2032,8 @@
         hessian_fn  = hessian_fn_mp,
         # Under CoE gradient_fn is the partial score at the conserved theta,
         # not the gradient of the objective being maximised.
-        gradient_exact = !(use_conserve && !is.null(fixmu_pos))
+        gradient_exact = !(use_conserve && !is.null(fixmu_pos)),
+        sign_bounded = m_free_idx
       ),
       error = function(e) e
     )

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -21,8 +21,10 @@ NULL
 # `sign_bounded` -- the multiphase shape m -- never straddle 0, where the cdf
 # and hazard families meet in a cusp (#251), and follow the rule of
 # .hzr_phase_derivatives(): one-sided second order forward from m >= 0; from
-# m < 0 a step capped at 1% of |m| (floored at 1e-10), one-sided backward if
-# it would still reach 0.
+# m < 0 a step capped at 1% of |m|, one-sided backward if it would still reach
+# 0. The floor on that step is 1e-8, not the decomposition's 1e-10: these
+# differences are of the whole log-likelihood, whose rounding error relative
+# to |f| is about eps / h, and at 1e-10 that is already near SAS's gradtl.
 .hzr_fd_gradient <- function(objective, theta, sign_bounded = integer(0)) {
   f0 <- NULL
   vapply(seq_along(theta), function(i) {
@@ -30,7 +32,7 @@ NULL
     h <- .Machine$double.eps^(1 / 3) * max(abs(x), 1)
     side <- 0
     if (i %in% sign_bounded) {
-      if (x < 0) h <- min(h, max(0.01 * abs(x), 1e-10))
+      if (x < 0) h <- min(h, max(0.01 * abs(x), 1e-8))
       side <- if (x >= 0 && x - h < 0) {
         1
       } else if (x < 0 && x + h >= 0) {

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -15,6 +15,49 @@ NULL
   requireNamespace("numDeriv", quietly = TRUE)
 }
 
+# Central differences of an objective, for when the analytic gradient is not
+# the objective's own (Conservation of Events). A point on the 1e10 clamp makes
+# that component NA rather than a number that looks measured. Components in
+# `sign_bounded` -- the multiphase shape m -- never straddle 0, where the cdf
+# and hazard families meet in a cusp (#251), and follow the rule of
+# .hzr_phase_derivatives(): one-sided second order forward from m >= 0; from
+# m < 0 a step capped at 1% of |m| (floored at 1e-10), one-sided backward if
+# it would still reach 0.
+.hzr_fd_gradient <- function(objective, theta, sign_bounded = integer(0)) {
+  f0 <- NULL
+  vapply(seq_along(theta), function(i) {
+    x <- theta[i]
+    h <- .Machine$double.eps^(1 / 3) * max(abs(x), 1)
+    side <- 0
+    if (i %in% sign_bounded) {
+      if (x < 0) h <- min(h, max(0.01 * abs(x), 1e-10))
+      side <- if (x >= 0 && x - h < 0) {
+        1
+      } else if (x < 0 && x + h >= 0) {
+        -1
+      } else {
+        0
+      }
+    }
+    at <- function(step) {
+      z <- theta
+      z[i] <- x + step
+      objective(z)
+    }
+    if (side == 0) {
+      up <- at(h)
+      down <- at(-h)
+      if (up >= 1e10 || down >= 1e10) return(NA_real_)
+      return((up - down) / (2 * h))
+    }
+    if (is.null(f0)) f0 <<- objective(theta)
+    near <- at(side * h)
+    far <- at(2 * side * h)
+    if (f0 >= 1e10 || near >= 1e10 || far >= 1e10) return(NA_real_)
+    side * (-3 * f0 + 4 * near - far) / (2 * h)
+  }, numeric(1))
+}
+
 #' Generic optimizer for parametric hazard likelihoods
 #'
 #' Maximises a log-likelihood by minimising its negation via \code{stats::optim}.
@@ -59,6 +102,10 @@ NULL
 #'   step as SAS/C does (`setobj.c`). The `nlm()` continuation keeps the
 #'   analytic score: with finite differences it walks onto the CoE solve's
 #'   discontinuity where no events are left to conserve.
+#' @param sign_bounded Integer positions in `theta_start` whose
+#'   finite-difference stencil must not cross 0 (the multiphase shape `m`,
+#'   where the phase families meet in a cusp). Used only when
+#'   `gradient_exact = FALSE`.
 #'
 #' @return List with par, value (log-likelihood), convergence, counts, message,
 #'   hessian, vcov. Includes \code{se_unavailable_reason}.
@@ -77,7 +124,8 @@ NULL
     use_bounds = FALSE,
     lower_bounds = NULL,
     hessian_fn = NULL,
-    gradient_exact = TRUE) {
+    gradient_exact = TRUE,
+    sign_bounded = integer(0)) {
 
   control <- utils::modifyList(
     list(maxit = 1000, reltol = 1e-5, abstol = 1e-6),
@@ -170,20 +218,16 @@ NULL
   # there would read as a pass; so this calls gradient_fn itself (or, when
   # gradient_exact is FALSE, differences the objective) and refuses the 1e10
   # sentinel, a non-finite point, and any non-finite component.
-  # Central differences of the objective, for when gradient_fn is not its
-  # gradient (gradient_exact = FALSE). A side that lands on the 1e10 clamp
-  # would turn the difference into 1e10 / (2h) -- a number that looks like a
-  # measured gradient and is not -- so such a component is NA, and
-  # rel_gradient() then reports NA rather than a fabricated value.
-  fd_gradient <- function(theta) {
-    h <- .Machine$double.eps^(1 / 3) * pmax(abs(theta), 1)
-    vapply(seq_along(theta), function(i) {
-      e <- replace(numeric(length(theta)), i, h[i])
-      up <- objective(theta + e)
-      down <- objective(theta - e)
-      if (up >= 1e10 || down >= 1e10) return(NA_real_)
-      (up - down) / (2 * h[i])
-    }, numeric(1))
+  # The acceptance test needs the unsanitised score. The multiphase gradient
+  # zeroes components it cannot evaluate, which the optimizer needs and this
+  # test must not see: a zero there reads as a pass over a point that was not
+  # scored. Asked only of a gradient_fn that can take the request (it names
+  # `sanitize` or `...`); the single-distribution gradients take neither and
+  # do not sanitise.
+  raw_score_arg <- if (any(c("sanitize", "...") %in% names(formals(gradient_fn)))) {
+    list(sanitize = FALSE)
+  } else {
+    list()
   }
   rel_gradient <- function(theta, value) {
     if (!all(is.finite(theta)) || !is.finite(value) || value >= 1e10) {
@@ -191,15 +235,16 @@ NULL
     }
     g <- if (gradient_exact) {
       tryCatch(
-        gradient_fn(
-          theta = theta, time = time, status = status,
-          time_lower = time_lower, time_upper = time_upper,
-          x = x, weights = weights
-        ),
+        do.call(gradient_fn, c(
+          list(theta = theta, time = time, status = status,
+               time_lower = time_lower, time_upper = time_upper,
+               x = x, weights = weights),
+          raw_score_arg
+        )),
         error = function(e) NULL
       )
     } else {
-      fd_gradient(theta)
+      .hzr_fd_gradient(objective, theta, sign_bounded)
     }
     if (is.null(g) || length(g) != length(theta) || !all(is.finite(g))) {
       return(NA_real_)

--- a/R/optimizer.R
+++ b/R/optimizer.R
@@ -26,37 +26,38 @@ NULL
 # differences are of the whole log-likelihood, whose rounding error relative
 # to |f| is about eps / h, and at 1e-10 that is already near SAS's gradtl.
 .hzr_fd_gradient <- function(objective, theta, sign_bounded = integer(0)) {
-  f0 <- NULL
-  vapply(seq_along(theta), function(i) {
+  n <- length(theta)
+  h <- .Machine$double.eps^(1 / 3) * pmax(abs(theta), 1)
+  side <- numeric(n)
+  for (i in intersect(sign_bounded, seq_len(n))) {
     x <- theta[i]
-    h <- .Machine$double.eps^(1 / 3) * max(abs(x), 1)
-    side <- 0
-    if (i %in% sign_bounded) {
-      if (x < 0) h <- min(h, max(0.01 * abs(x), 1e-8))
-      side <- if (x >= 0 && x - h < 0) {
-        1
-      } else if (x < 0 && x + h >= 0) {
-        -1
-      } else {
-        0
-      }
+    if (x < 0) h[i] <- min(h[i], max(0.01 * abs(x), 1e-8))
+    side[i] <- if (x >= 0 && x - h[i] < 0) {
+      1
+    } else if (x < 0 && x + h[i] >= 0) {
+      -1
+    } else {
+      0
     }
-    at <- function(step) {
-      z <- theta
-      z[i] <- x + step
-      objective(z)
-    }
-    if (side == 0) {
-      up <- at(h)
-      down <- at(-h)
+  }
+  # The centre point is needed only by a one-sided stencil; evaluate it once.
+  f0 <- if (any(side != 0)) objective(theta) else NA_real_
+  at <- function(i, step) {
+    z <- theta
+    z[i] <- theta[i] + step
+    objective(z)
+  }
+  vapply(seq_len(n), function(i) {
+    if (side[i] == 0) {
+      up <- at(i, h[i])
+      down <- at(i, -h[i])
       if (up >= 1e10 || down >= 1e10) return(NA_real_)
-      return((up - down) / (2 * h))
+      return((up - down) / (2 * h[i]))
     }
-    if (is.null(f0)) f0 <<- objective(theta)
-    near <- at(side * h)
-    far <- at(2 * side * h)
+    near <- at(i, side[i] * h[i])
+    far <- at(i, 2 * side[i] * h[i])
     if (f0 >= 1e10 || near >= 1e10 || far >= 1e10) return(NA_real_)
-    side * (-3 * f0 + 4 * near - far) / (2 * h)
+    side[i] * (-3 * f0 + 4 * near - far) / (2 * h[i])
   }, numeric(1))
 }
 

--- a/man/dot-hzr_gradient_multiphase.Rd
+++ b/man/dot-hzr_gradient_multiphase.Rd
@@ -16,6 +16,7 @@
   covariate_counts,
   x_list,
   objective = c("likelihood", "sas"),
+  sanitize = TRUE,
   ...
 )
 }
@@ -43,11 +44,17 @@
 see \code{.hzr_logl_interval()}. Exact-event, right-censored and left-censored
 rows are unaffected.}
 
+\item{sanitize}{Logical; \code{FALSE} returns \code{NA} where the default returns 0.
+Used by SAS/C's acceptance test, which must not read a zero it could not
+compute as a small gradient.}
+
 \item{...}{Ignored.}
 }
 \value{
 Numeric vector of length \code{length(theta)} -- the gradient.
-Returns a zero vector if any component is non-finite (guards optimizer).
+With \code{sanitize = TRUE} (the default) a component that cannot be evaluated
+is 0, and so is the whole vector at an infeasible point (guards the
+optimizer); with \code{sanitize = FALSE} those are \code{NA}.
 }
 \description{
 Computes the score vector \eqn{d\ell / d\theta} using analytic chain-rule

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -260,11 +260,43 @@ test_that(".hzr_gradient_multiphase returns NA, not zeros, when asked for the ra
   expect_true(all(do.call(.hzr_gradient_multiphase, args) == 0))
   expect_true(all(is.na(do.call(.hzr_gradient_multiphase,
                                 c(args, sanitize = FALSE)))))
+
+  # A g3 phase with gamma <= 0 is infeasible too (the g3 early exit).
+  g3_args <- list(c(log(0.1), log(1), -1, 1, 1),
+                  tt, rep(1, 50), phases = list(late = hzr_phase("g3")),
+                  covariate_counts = c(late = 0L), x_list = list(late = NULL))
+  expect_true(all(do.call(.hzr_gradient_multiphase, g3_args) == 0))
+  expect_true(all(is.na(do.call(.hzr_gradient_multiphase,
+                                c(g3_args, sanitize = FALSE)))))
+
+  # A cumulative hazard that overflows (the non-finite H/h guard).
+  big <- args
+  big[[1]] <- c(log(0.5), log(1), 1, 0, 800)
+  expect_true(all(do.call(.hzr_gradient_multiphase, big) == 0))
+  expect_true(all(is.na(do.call(.hzr_gradient_multiphase,
+                                c(big, sanitize = FALSE)))))
+
+  # One non-finite component at a feasible point (the final zeroing, the
+  # site that matters most): a shape derivative that comes back NaN.
+  ok <- args
+  ok[[1]] <- c(log(0.5), log(1), 1, 0.5, log(0.1))
+  real_pd <- .hzr_phase_derivatives
+  testthat::local_mocked_bindings(.hzr_phase_derivatives = function(...) {
+    pd <- real_pd(...)
+    pd$dPhi_dm[1] <- NaN
+    pd
+  })
+  g_sane <- do.call(.hzr_gradient_multiphase, ok)
+  g_raw <- do.call(.hzr_gradient_multiphase, c(ok, sanitize = FALSE))
+  expect_true(all(is.finite(g_sane)))
+  expect_true(any(!is.finite(g_raw)))
+  expect_true(all(is.finite(g_raw[-4])))
 })
 
 test_that("a multiphase fit's acceptance test reaches the gradient unsanitised", {
-  # Through the base closure and the fixed-mask wrapper: the test asks for the
-  # raw score at least once, and the optimizer still gets the sanitised one.
+  # Through the base closure and the fixed-mask wrapper (m is fixed, so the
+  # wrapper is on the path): the test asks for the raw score at least once,
+  # and the optimizer still gets the sanitised one.
   set.seed(3)
   n <- 300
   tt <- c(stats::rexp(n / 2, 3), stats::rexp(n / 2, 0.15))
@@ -280,7 +312,8 @@ test_that("a multiphase fit's acceptance test reaches the gradient unsanitised",
   )
   suppressWarnings(hazard(
     survival::Surv(time, status) ~ 1, data = d, dist = "multiphase",
-    phases = list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0),
+    phases = list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0,
+                                    fixed = "m"),
                   constant = hzr_phase("constant")),
     fit = TRUE, control = list(n_starts = 1, conserve = FALSE)
   ))
@@ -302,6 +335,15 @@ test_that("the finite-difference check does not straddle m = 0", {
   }
   # Without the bound the central stencil mixes the two slopes (2.33 here).
   expect_gt(abs(.hzr_fd_gradient(kinked, c(0.5, h / 3))[[2]] - 5), 1)
+
+  # The 1% cap below 0: a left branch that varies on the scale of |m|, as the
+  # cusp does. A step of eps^(1/3) would dwarf |m| and miss the slope.
+  cusp <- function(theta) {
+    (theta[1] - 1)^2 + ifelse(theta[2] >= 0, 5 * theta[2], sqrt(-theta[2]))
+  }
+  m <- -h / 3
+  expect_equal(.hzr_fd_gradient(cusp, c(0.5, m), sign_bounded = 2L)[[2]],
+               -1 / (2 * sqrt(-m)), tolerance = 1e-3)
 })
 
 test_that("multiphase marks every free shape m, and only m, as sign-bounded", {
@@ -315,19 +357,42 @@ test_that("multiphase marks every free shape m, and only m, as sign-bounded", {
   got <- list()
   testthat::local_mocked_bindings(
     .hzr_optim_generic = function(..., theta_start, sign_bounded = integer(0)) {
-      got[[length(got) + 1L]] <<- names(theta_start)[sign_bounded]
+      got[[length(got) + 1L]] <<- list(free = names(theta_start),
+                                       bounded = names(theta_start)[sign_bounded])
       real(..., theta_start = theta_start, sign_bounded = sign_bounded)
     }
   )
-  suppressWarnings(hazard(
-    survival::Surv(time, status) ~ 1, data = d, dist = "multiphase",
-    phases = list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0,
-                                    formula = ~ z),
-                  constant = hzr_phase("constant")),
-    fit = TRUE, control = list(n_starts = 1)
-  ))
-  expect_true(length(got) > 0)
-  for (nm in got) expect_identical(nm, "early.m")
+  fit_phases <- function(phases) {
+    got <<- list()
+    suppressWarnings(hazard(
+      survival::Surv(time, status) ~ 1, data = d, dist = "multiphase",
+      phases = phases, fit = TRUE, control = list(n_starts = 1)
+    ))
+    got
+  }
+  # A: a parameter ahead of a free m leaves the optimizer's vector (e1's nu is
+  # fixed), so e1.m's reduced position (3) differs from its full one (4).
+  runs <- fit_phases(list(e1 = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0,
+                                         formula = ~ z, fixed = "nu"),
+                          constant = hzr_phase("constant")))
+  expect_true(length(runs) > 0)
+  # Premise: without a dropped parameter before e1.m this could not tell full
+  # positions from reduced ones.
+  expect_false("e1.nu" %in% runs[[1]]$free)
+  for (r in runs) expect_identical(r$bounded, "e1.m")
+  # B: a fixed m is not in the optimizer's vector and must not be marked.
+  runs <- fit_phases(list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0),
+                          mid = hzr_phase("hazard", t_half = 5, nu = 1, m = 0,
+                                          fixed = "m"),
+                          constant = hzr_phase("constant")))
+  expect_true(length(runs) > 0)
+  for (r in runs) expect_identical(r$bounded, "early.m")
+  # C: both families that carry m are marked, cdf and hazard.
+  runs <- fit_phases(list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0),
+                          mid = hzr_phase("hazard", t_half = 5, nu = 1, m = 0),
+                          constant = hzr_phase("constant")))
+  expect_true(length(runs) > 0)
+  for (r in runs) expect_setequal(r$bounded, c("early.m", "mid.m"))
 })
 
 test_that("the bounded (L-BFGS-B) path is not polished", {

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -289,7 +289,8 @@ test_that(".hzr_gradient_multiphase returns NA, not zeros, when asked for the ra
   g_sane <- do.call(.hzr_gradient_multiphase, ok)
   g_raw <- do.call(.hzr_gradient_multiphase, c(ok, sanitize = FALSE))
   expect_true(all(is.finite(g_sane)))
-  expect_true(any(!is.finite(g_raw)))
+  # NA exactly, as documented: a NaN passes is.na() but is not NA_real_.
+  expect_identical(g_raw[4], NA_real_)
   expect_true(all(is.finite(g_raw[-4])))
 })
 

--- a/tests/testthat/test-sas-gradient-check.R
+++ b/tests/testthat/test-sas-gradient-check.R
@@ -231,6 +231,105 @@ test_that("a finite difference that lands on the clamp is NA, not a fabricated g
   expect_true(is.na(fit$rel_gradient))
 })
 
+test_that("the acceptance test asks for the unsanitised score", {
+  # A gradient that, like .hzr_gradient_multiphase(), zeroes a component it
+  # cannot evaluate unless asked not to. The optimizer needs the zero; the
+  # test must see the NaN and report NA, never a small gradient.
+  guarded <- function(theta, ..., sanitize = TRUE) {
+    g <- c(NaN, rosen_score(theta)[2])
+    if (sanitize) g[!is.finite(g)] <- 0
+    g
+  }
+  fit <- suppressWarnings(.hzr_optim_generic(
+    logl_fn = rosen_logl, gradient_fn = guarded, time = 1, status = 1,
+    theta_start = start, hessian_fn = rosen_hessian
+  ))
+  expect_equal(fit$convergence, 0L)
+  expect_true(is.na(fit$rel_gradient))
+})
+
+test_that(".hzr_gradient_multiphase returns NA, not zeros, when asked for the raw score", {
+  phases <- list(early = hzr_phase("cdf", t_half = 1, nu = 1, m = 0),
+                 const = hzr_phase("constant"))
+  set.seed(1)
+  tt <- stats::rexp(50) + 0.01
+  # m < 0 with nu < 0 is undefined: the gradient cannot be evaluated there.
+  args <- list(c(log(0.5), log(1), -1, -0.5, log(0.1)), tt, rep(1, 50),
+               phases = phases, covariate_counts = c(early = 0L, const = 0L),
+               x_list = list(early = NULL, const = NULL))
+  expect_true(all(do.call(.hzr_gradient_multiphase, args) == 0))
+  expect_true(all(is.na(do.call(.hzr_gradient_multiphase,
+                                c(args, sanitize = FALSE)))))
+})
+
+test_that("a multiphase fit's acceptance test reaches the gradient unsanitised", {
+  # Through the base closure and the fixed-mask wrapper: the test asks for the
+  # raw score at least once, and the optimizer still gets the sanitised one.
+  set.seed(3)
+  n <- 300
+  tt <- c(stats::rexp(n / 2, 3), stats::rexp(n / 2, 0.15))
+  cens <- stats::runif(n, 1, 15)
+  d <- data.frame(time = pmin(tt, cens), status = as.integer(tt <= cens))
+  real <- .hzr_gradient_multiphase
+  seen <- logical(0)
+  testthat::local_mocked_bindings(
+    .hzr_gradient_multiphase = function(..., sanitize = TRUE) {
+      seen <<- c(seen, sanitize)
+      real(..., sanitize = sanitize)
+    }
+  )
+  suppressWarnings(hazard(
+    survival::Surv(time, status) ~ 1, data = d, dist = "multiphase",
+    phases = list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0),
+                  constant = hzr_phase("constant")),
+    fit = TRUE, control = list(n_starts = 1, conserve = FALSE)
+  ))
+  expect_true(any(!seen))
+  expect_true(any(seen))
+})
+
+test_that("the finite-difference check does not straddle m = 0", {
+  # A kink at theta[2] = 0 -- slope +5 above, -3 below -- standing in for the
+  # cusp where the cdf and hazard families meet.
+  kinked <- function(theta) {
+    (theta[1] - 1)^2 + ifelse(theta[2] >= 0, 5 * theta[2], -3 * theta[2])
+  }
+  h <- .Machine$double.eps^(1 / 3)
+  for (m in c(h / 3, 0, -h / 3)) {
+    g <- .hzr_fd_gradient(kinked, c(0.5, m), sign_bounded = 2L)
+    expect_equal(g[[2]], if (m >= 0) 5 else -3, tolerance = 1e-6,
+                 label = sprintf("slope at m = %g", m))
+  }
+  # Without the bound the central stencil mixes the two slopes (2.33 here).
+  expect_gt(abs(.hzr_fd_gradient(kinked, c(0.5, h / 3))[[2]] - 5), 1)
+})
+
+test_that("multiphase marks every free shape m, and only m, as sign-bounded", {
+  set.seed(3)
+  n <- 300
+  tt <- c(stats::rexp(n / 2, 3), stats::rexp(n / 2, 0.15))
+  cens <- stats::runif(n, 1, 15)
+  d <- data.frame(time = pmin(tt, cens), status = as.integer(tt <= cens),
+                  z = stats::rnorm(n))
+  real <- .hzr_optim_generic
+  got <- list()
+  testthat::local_mocked_bindings(
+    .hzr_optim_generic = function(..., theta_start, sign_bounded = integer(0)) {
+      got[[length(got) + 1L]] <<- names(theta_start)[sign_bounded]
+      real(..., theta_start = theta_start, sign_bounded = sign_bounded)
+    }
+  )
+  suppressWarnings(hazard(
+    survival::Surv(time, status) ~ 1, data = d, dist = "multiphase",
+    phases = list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0,
+                                    formula = ~ z),
+                  constant = hzr_phase("constant")),
+    fit = TRUE, control = list(n_starts = 1)
+  ))
+  expect_true(length(got) > 0)
+  for (nm in got) expect_identical(nm, "early.m")
+})
+
 test_that("the bounded (L-BFGS-B) path is not polished", {
   fit <- .hzr_optim_generic(
     logl_fn = rosen_logl, gradient_fn = rosen_score,


### PR DESCRIPTION
#260 merged at `1347780` before the commit fixing its three accepted Copilot items was pushed. This PR carries those fixes to `main`. Copilot's review of #260 is linked from the three threads on that PR; each gets a reply pointing here.

## The three Copilot items (all verified, all fixed)
- **The acceptance test read a sanitised score** (thread on `R/optimizer.R` ~204). `.hzr_gradient_multiphase()` sets non-finite components to 0, and returns an all-zero vector when the hazard itself is non-finite. `rel_gradient()` called it as it was, so a score it could not evaluate passed `all(is.finite(g))`. It then recorded a small or zero relative gradient, skipped the polish and printed "met". `.hzr_gradient_multiphase()` now takes `sanitize = TRUE`. The acceptance check asks for `sanitize = FALSE` and gets `NA` for an unevaluable component, never a pass. The optimizer's own steps still use the sanitised gradient.
- **The finite-difference check straddled `m = 0`** (thread on `R/optimizer.R` ~184). Under Conservation of Events the check differences the objective with a step of about 6e-6. For a free multiphase `m` closer to 0 than that, the stencil straddled the cusp where the two families meet (#251). The positions of the free `m` components are now passed in, and their stencil stays on one side.
- **The NEWS headline overpromised** (thread on `NEWS.md`). It said every converged fit meets SAS/C's test. The census leaves failing stops, and a Conservation of Events fit can end honestly unmet. It now says converged fits are checked against the test and continued with `nlm()` when they fail it.

## One more fix, found by the gates
The first cut added `sanitize = TRUE` to the base `gradient_fn` in `.hzr_optim_multiphase()`, but not to the two wrappers that redefine it (Conservation of Events and fixed parameters). `R CMD check` reported "multiple local function definitions for 'gradient_fn' with different formal arguments". The wrappers already forwarded `sanitize` through `...`, so behaviour was right. They now take it as a formal argument and pass it on explicitly (`0e896c7`).

## Gates on `0e896c7`
- `document()`: no changes. lintr: 0 lints. spelling: 0 words.
- codetools on `.hzr_optim_multiphase` with `R CMD check`'s options: clean. On the commit before `0e896c7` it reported the mismatch.
- Full `NOT_CRAN=true devtools::test()` with the study volume mounted: **0 failed, 0 errors, 4383 passed, 6 skipped**. The skips are the `bh.dead` and weighted-parity fixtures and the C binary. `test-sas-gradient-check.R`: 66 passed, 0 skipped.
- `R CMD check --as-cran` **with the manual**, from a clean `git archive` export: **Status: OK** (0/0/0) in 400 s. The tarball is 3.2 MB with no CLAUDE or AGENTS files.

## Mutation checks
- Reverting `optimizer.R` and `likelihood-multiphase.R` to `main`, with the new tests kept, fails 6 tests and errors 2 across five of them: the unsanitised score, NA rather than zeros, a multiphase fit reaching the raw gradient, the `m = 0` stencil, and which positions are sign-bounded.
- Dropping `sanitize = sanitize` from the fixed-parameter wrapper (one line) fails exactly the test that the acceptance check reaches the gradient unsanitised.

It merges cleanly with the current `main`. #256 touched only translator files, and `NEWS.md` merges on its own.

Related: #261 (the Conservation of Events objective jumps at `jevent <= 0`) is still open and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)