### PR TITLE
fix(predict): survival se.fit is the SE of S, not of H

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,21 @@
 
 ## Bug fixes
 
+* **`predict(type = "survival", se.fit = TRUE)` now reports the standard
+  error of the survival probability.** The `se.fit` column held the standard
+  error of the cumulative hazard, `se(H)`, bit-identical to the column that
+  `type = "cumulative_hazard"` returns, under a survival label. It now holds
+  `S * se(H)`, the delta-method standard error of `S = exp(-H)`, which is
+  what `summary.survfit()` reports as `std.err`. For a Weibull fit of
+  `Surv(int_dead, dead) ~ age + mal` to `na.omit(avc)`, at `time = 5`,
+  `age = 60`, `mal = 1`, where `S = 0.700`, the old column read 0.0706
+  against the correct 0.0495.
+  Every path was affected: all four single distributions, multiphase fits,
+  and `hzr_read_outhaz()` objects. The confidence limits were already right
+  and have not changed, so the `PROC HAZPRED` parity of `lower` and `upper`
+  still holds. `PROC HAZPRED` prints no standard error, so there was no SAS
+  value for this column to reproduce.
+
 * **The multiphase gradient and Hessian are now right when an early phase's
   `m` is near 0.** Both differentiate in `m` by finite differences, and
   their stencils straddled 0: the gradient's (half-width about 6e-6)

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -1123,7 +1123,12 @@ hazard <- function(formula = NULL,
 #' @return When `se.fit = FALSE` (default), a numeric vector of predictions.
 #'   When `se.fit = TRUE`, a data frame with columns `fit`, `se.fit`, `lower`,
 #'   `upper` (delta-method point estimate, standard error, and confidence
-#'   limits at `level`). For multiphase `type = "cumulative_hazard"` with
+#'   limits at `level`). `se.fit` is always the standard error of `fit` on
+#'   its own scale: for `type = "survival"` that is `S * se(H)`, the delta
+#'   method applied to `S = exp(-H)`. The survival limits are built from
+#'   `se(H)` on the `conf.type` scale, so they are not `fit +/- z * se.fit`.
+#'   `PROC HAZPRED` prints no standard error, only the limits.
+#'   For multiphase `type = "cumulative_hazard"` with
 #'   `decompose = TRUE`, a long data frame (`time`, `component`, `fit`,
 #'   `se.fit`, `lower`, `upper`); with `decompose = TRUE` and `se.fit = FALSE`,
 #'   a wide data frame of per-phase contributions.

--- a/R/predict-cl.R
+++ b/R/predict-cl.R
@@ -389,7 +389,8 @@ NULL
 #'
 #'   type = "cumulative_hazard" -> target = H, log-scale CL
 #'   type = "survival"          -> target = H, log-log-survival CL
-#'                                 (final `fit` is exp(-H))
+#'                                 (final `fit` is exp(-H); reported
+#'                                 `se.fit` is S * se(H), the SE of S)
 #'   type = "hazard"            -> target = exp(eta) (single-dist only),
 #'                                 log-scale CL
 #'   type = "linear_predictor"  -> target = eta, natural-scale CL
@@ -472,7 +473,11 @@ NULL
   if (type == "survival") {
     fit <- exp(-target)
     surv_scale <- if (conf_type == "logit") "logit_survival" else "loglog_survival"
-    .hzr_predict_cl_from_se(fit, se_target, level, surv_scale)
+    res <- .hzr_predict_cl_from_se(fit, se_target, level, surv_scale)
+    # The limits need se(H); the reported SE is of `fit` = S itself.
+    # dS/dH = -S, so se(S) = S * se(H), as summary.survfit's std.err.
+    res$se.fit <- fit * se_target
+    res
   } else if (type == "cumulative_hazard" || type == "hazard") {
     .hzr_predict_cl_from_se(target, se_target, level, "log")
   } else if (type == "linear_predictor") {

--- a/man/dot-hzr_predict_with_se.Rd
+++ b/man/dot-hzr_predict_with_se.Rd
@@ -60,7 +60,8 @@ the CL scale the type uses:
 
 type = "cumulative_hazard" -> target = H, log-scale CL
 type = "survival"          -> target = H, log-log-survival CL
-(final \code{fit} is exp(-H))
+(final \code{fit} is exp(-H); reported
+\code{se.fit} is S * se(H), the SE of S)
 type = "hazard"            -> target = exp(eta) (single-dist only),
 log-scale CL
 type = "linear_predictor"  -> target = eta, natural-scale CL

--- a/man/predict.hazard.Rd
+++ b/man/predict.hazard.Rd
@@ -86,7 +86,12 @@ HAZPRED). Only used when \code{se.fit = TRUE}.}
 When \code{se.fit = FALSE} (default), a numeric vector of predictions.
 When \code{se.fit = TRUE}, a data frame with columns \code{fit}, \code{se.fit}, \code{lower},
 \code{upper} (delta-method point estimate, standard error, and confidence
-limits at \code{level}). For multiphase \code{type = "cumulative_hazard"} with
+limits at \code{level}). \code{se.fit} is always the standard error of \code{fit} on
+its own scale: for \code{type = "survival"} that is \code{S * se(H)}, the delta
+method applied to \code{S = exp(-H)}. The survival limits are built from
+\code{se(H)} on the \code{conf.type} scale, so they are not \verb{fit +/- z * se.fit}.
+\verb{PROC HAZPRED} prints no standard error, only the limits.
+For multiphase \code{type = "cumulative_hazard"} with
 \code{decompose = TRUE}, a long data frame (\code{time}, \code{component}, \code{fit},
 \code{se.fit}, \code{lower}, \code{upper}); with \code{decompose = TRUE} and \code{se.fit = FALSE},
 a wide data frame of per-phase contributions.

--- a/tests/testthat/test-predict-cl.R
+++ b/tests/testthat/test-predict-cl.R
@@ -500,3 +500,73 @@ test_that("the SAS level narrows a band by the z ratio, on the CL's own scale", 
   # does not match it.
   expect_true(all(d95$upper > sas$upper))
 })
+
+# ---------------------------------------------------------------------------
+# (9) Survival se.fit is the SE of S, not of H
+# ---------------------------------------------------------------------------
+
+# `fit` is S = exp(-H), so its delta-method SE is |dS/dH| se(H) = S se(H).
+# The column used to carry se(H) itself -- bit-identical to the
+# cumulative-hazard se.fit -- under the survival label. The limits are still
+# built from se(H) on the conf.type scale, so they must not move.
+expect_survival_se_is_se_of_s <- function(fit, nd, info) {
+  ch <- predict(fit, newdata = nd, type = "cumulative_hazard", se.fit = TRUE)
+  z <- stats::qnorm(0.975)
+  for (ct in c("log-log", "logit")) {
+    sv <- predict(fit, newdata = nd, type = "survival", se.fit = TRUE,
+                  conf.type = ct)
+    s <- exp(-ch$fit)
+    expect_equal(sv$fit, s, tolerance = 1e-12, info = info)
+    expect_equal(sv$se.fit, s * ch$se.fit, tolerance = 1e-10, info = info)
+    # Not vacuous: S is well below 1 on the grid, so S se(H) != se(H).
+    expect_lt(min(sv$fit), 0.8, label = info)
+    expect_false(isTRUE(all.equal(sv$se.fit, ch$se.fit)), info = info)
+  }
+  # Both limit transforms still come from se(H): log-log through
+  # se(log H) = se(H) / H, logit through se(logit(1 - S)) = se(H) / (1 - S).
+  ll <- predict(fit, newdata = nd, type = "survival", se.fit = TRUE)
+  expect_equal(ll$lower, exp(-ch$fit * exp(z * ch$se.fit / ch$fit)),
+               tolerance = 1e-10, info = info)
+  expect_equal(ll$upper, exp(-ch$fit * exp(-z * ch$se.fit / ch$fit)),
+               tolerance = 1e-10, info = info)
+  lg <- predict(fit, newdata = nd, type = "survival", se.fit = TRUE,
+                conf.type = "logit")
+  zl <- log(expm1(ch$fit))
+  se_zl <- ch$se.fit / (1 - exp(-ch$fit))
+  expect_equal(lg$lower, stats::plogis(-(zl + z * se_zl)),
+               tolerance = 1e-10, info = info)
+  expect_equal(lg$upper, stats::plogis(-(zl - z * se_zl)),
+               tolerance = 1e-10, info = info)
+}
+
+test_that("survival se.fit is S * se(H) for the single distributions", {
+  skip_on_cran()
+  df <- make_toy()
+  nd <- data.frame(time = c(0.5, 2, 6), x = 0)
+  for (dist in c("weibull", "exponential", "loglogistic", "lognormal")) {
+    theta_init <- switch(
+      dist,
+      weibull = c(0.5, 1, 0),
+      exponential = c(log(0.3), 0),
+      loglogistic = c(0, 0, 0),
+      lognormal = c(0, 0, 0)
+    )
+    fit <- hazard(survival::Surv(time, status) ~ x, data = df, dist = dist,
+                  theta = theta_init, fit = TRUE)
+    expect_survival_se_is_se_of_s(fit, nd, info = dist)
+  }
+})
+
+test_that("survival se.fit is S * se(H) for a multiphase fit", {
+  skip_on_cran()
+  df <- make_toy()
+  phases <- list(
+    early = hzr_phase("cdf", t_half = 0.3, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+  fit <- hazard(survival::Surv(time, status) ~ 1, data = df,
+                dist = "multiphase", phases = phases, fit = TRUE,
+                control = list(n_starts = 2))
+  expect_survival_se_is_se_of_s(fit, data.frame(time = c(0.5, 2, 6)),
+                                info = "multiphase")
+})

--- a/tests/testthat/test-predict-outhaz.R
+++ b/tests/testthat/test-predict-outhaz.R
@@ -193,7 +193,9 @@ test_that("se.fit maps the OUTHAZ covariance onto this package's scale", {
                  se.fit = TRUE, conf.type = "logit")
   expect_s3_class(got, "data.frame")
   expect_equal(got$fit, exp(-fixture_cumhaz(tt, est)))
-  expect_equal(got$se.fit, want_se, tolerance = 1e-6)
+  # want_se is se(H); the survival column is se(S) = S * se(H).
+  expect_equal(got$se.fit, exp(-fixture_cumhaz(tt, est)) * want_se,
+               tolerance = 1e-6)
   expect_true(all(got$lower < got$fit & got$fit < got$upper))
 })
 
@@ -336,7 +338,9 @@ test_that("se.fit maps the late block's covariance onto this scale", {
   got <- predict(obj, newdata = data.frame(time = tt), type = "survival",
                  se.fit = TRUE, conf.type = "logit")
   expect_equal(got$fit, exp(-late_cumhaz(tt, est)))
-  expect_equal(got$se.fit, want_se, tolerance = 1e-6)
+  # want_se is se(H); the survival column is se(S) = S * se(H).
+  expect_equal(got$se.fit, exp(-late_cumhaz(tt, est)) * want_se,
+               tolerance = 1e-6)
 })
 
 test_that(".hzr_outhaz_late_composite() matches hzd_late_p2t.c", {
@@ -527,7 +531,9 @@ test_that("a plain-log late shape IS mapped -- the gate is not blanket refusal",
   got <- predict(obj, newdata = data.frame(time = tt), type = "survival",
                  se.fit = TRUE, conf.type = "logit")
   expect_equal(got$fit, exp(-late_cumhaz(tt, est)))
-  expect_equal(got$se.fit, want_se, tolerance = 1e-6)
+  # want_se is se(H); the survival column is se(S) = S * se(H).
+  expect_equal(got$se.fit, exp(-late_cumhaz(tt, est)) * want_se,
+               tolerance = 1e-6)
 })
 
 # predict.hzr_outhaz() and predict.hazard() are two methods of one generic in


### PR DESCRIPTION
## The defect

`predict(type = "survival", se.fit = TRUE)` returned **se(H)** in the `se.fit` column, bit-identical to the column `type = "cumulative_hazard"` returns, under a survival label. A hollow output: a populated, plausible column that was a different quantity.

Weibull `Surv(int_dead, dead) ~ age + mal` on `na.omit(avc)`, `time = 5`, `age = 60`, `mal = 1` (three starts, same optimum, objective −218.5972):

| | S | se.fit |
|---|---|---|
| `type = "cumulative_hazard"` | — | 0.0706 = se(H) |
| `type = "survival"`, before | 0.7004 | **0.0706** (se(H)) |
| `type = "survival"`, after | 0.7004 | **0.0495** = S · se(H) |

## Which scale, and why

- **SAS has no value to reproduce.** `PROC HAZPRED` writes `_SURVIV`, `_CLLSURV`, `_CLUSURV` and no SE variable (`hazard/src/hazpred/addvars.c`); its SE exists only inside `hzp_calc_srv_CL.c` as the logit-scale `seZ`.
- **Natural scale, S · se(H).** A column named `se.fit` beside `fit = S` is conventionally the SE of `fit` itself (`summary.survfit()` `std.err`, `predict.glm(type = "response")`). A transform-scale SE would also change with `conf.type`.
- **The limits do not move.** They are still built from se(H) on the log-log or logit scale, so HAZPRED parity of `lower`/`upper` is unaffected.

## Change

- `R/predict-cl.R` `.hzr_predict_with_se()`: after building the survival CLs from se(H), report `se.fit = S * se(H)`. This one path serves every caller: the four single distributions, multiphase fits, and `hzr_read_outhaz()` objects. Missing vcov still gives NA; `decompose = TRUE` is still refused for survival.
- `?predict.hazard` `@return` states what `se.fit` is per type, and that survival limits are not `fit ± z·se.fit`.
- NEWS bullet under 1.2.11 (no version bump).

## Tests that can fail

- New section (9) in `test-predict-cl.R`, for weibull, exponential, loglogistic, lognormal and multiphase, under both `conf.type` values:
  - asserts `se.fit == exp(-H) * se(H)` derived by hand from the cumulative-hazard call;
  - asserts it differs from se(H), with S < 0.8 on the grid so that check is not vacuous;
  - asserts the log-log and logit limits equal closed forms built from se(H).
- Seen red before the fix: 10+ failures, e.g. loglogistic 0.0343/0.0828/0.1711 vs 0.0311/0.0562/0.0662.
- Mutant killed: feeding se(S) into the CL computation gives 10 failures.
- **Three existing tests pinned the bug.** In `test-predict-outhaz.R`, "se.fit maps the OUTHAZ covariance…", "…late block's covariance…" and "a plain-log late shape IS mapped" each compared a hand-built **se(H)** with the survival column. Their covariance-mapping purpose is intact; they now compare against `S · se(H)`, with S taken from each test's own independent `exp(-cumhaz)`.

## Gates (at `c98d6dc`)

- `devtools::document()`: no diff
- `lintr::lint_package()`: 0
- `spelling::spell_check_package()`: 0
- `R CMD check --as-cran` with the manual, from a clean `git archive HEAD` in a `mktemp` dir: **Status: OK**; tests 149s, vignettes 69s, both measured under CPU contention and not a timing measurement; no CLAUDE/AGENTS files in the tarball.
- `NOT_CRAN=true devtools::test()` at `c98d6dc`, with `/Volumes/qhsstudies` mounted and a clean tree: **0 failures, 6 skips, 4586 passes, 0 errors**. The six skips are the expected fixture/binary ones: bh.dead SAS fixture (3), legacy C binary exit 126 (1), `weighted-avc-fractional.rds` (2). An earlier run with the volume unmounted gave 0 / 12 / 4460; the extra 126 passes are the volume-gated parity tests, which pass with this change.
- `r-reviewer`: no code defect.
  - It flagged the NEWS example numbers. I re-derived them from three starts and they hold; its figures came from a different objective, which means different data. The last digit is corrected to 0.0495.
  - It flagged missing independent logit-limit assertions (added) and a missing `info` label (added).

## Merged with `main` at its turn

The queue ahead of this PR has landed: #291 (#224), #294 and #293 (#284). `main` (`4b68020`) is merged in as `db12a67` with **no conflicts**. `NEWS.md` keeps this entry, and the merge adds no bullet without a blank line above it (checked against `main`).

The earlier red `house-style` check was stale, not a defect here. `main` recomposed `.claude/house-style.md` in `734cb70`, after this branch was cut from `1e1bd27`, and this PR never touches that file. After the merge the file is identical to `main`'s.

Local gates at `db12a67`, with `/Volumes/qhsstudies` mounted:
  - `devtools::document()`: no changes; `lintr::lint_package()`: 0 lints; `spelling::spell_check_package()`: 0; `devtools::test()` with `NOT_CRAN=true`: **0 failures, 5224 passes, 631 warnings, 6 skips** (testthat `passed`; the six skips are the known unsatisfiable ones: three `bh.dead` fixture, the C binary, two weighted-parity fixture). A figure of 5855 posted here earlier counted warnings as passes (`nb - failed - skipped`); it was recounted from every testthat column on the same tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


