### PR TITLE
Fix six silent wrong answers in formula, bootstrap and stepwise handling (#226, #273, #275, #277, #278, #279)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,10 +220,12 @@ Rscript ~/Documents/GitHub/house-style/compose-house-style.R --repo TemporalHaza
 
 - **Censoring status is coded `-1` left, `0` right, `1` event, `2` interval.** `survival::Surv()`
   uses *different* integers for the same meanings — under `type = "interval"` it is `0`/`1`/`2`/`3`
-  for right/event/left/interval. The formula path translates in `.hzr_parse_formula()`; the
-  vector path does not. Never carry one coding into the other. Passing them through unchanged
-  is a real bug this package shipped: `Surv(type = "left")` read left-censored rows as
-  *right*-censored, a wrong answer with no error.
+  for right/event/left/interval. Both interfaces translate through `.hzr_surv_response()`: the
+  formula path for its `Surv()` left-hand side, and the vector path when `status` is a `Surv`
+  (#226). A plain `status` vector is read as this package's codes. Never carry one coding into
+  the other. Passing them through unchanged is a real bug this package shipped:
+  `Surv(type = "left")` read left-censored rows as *right*-censored, a wrong answer with no
+  error.
 - **Two interfaces, not interchangeable in the details.** `hazard(formula, data)` stores an
   unevaluated call; `hazard(time =, status =)` stores evaluated vectors. Anything that
   rewrites or resamples a stored call has to handle both — this asymmetry has produced three

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,19 @@
   not a `PROC HAZARD` refusal, so it is kept apart from the existing
   "selects no phase" stop.
 
+* **A multiphase formula that names a phase as a function is now an error**
+  (#275). `hazard(Surv(int_dead, dead) ~ constant(age), dist = "multiphase",
+  phases = ...)` read `constant(age)` as a phase-scoped term, then replaced
+  the whole right-hand side with `~ 1`, and nothing sent the term to its
+  phase. The fit converged without an `age` coefficient, with no error and
+  no warning. `hazard()` now stops, names the phase or phases it found, and points to
+  `hzr_phase(..., formula = ~ var)`, which is where a phase's covariates
+  belong. Code that relied on the old behaviour was fitting a model without
+  those covariates; drop the terms from the formula to keep that model, or
+  move them into `hzr_phase()` to get the one the formula described.
+  Formulas that call an ordinary function such as `log()`, and plain global
+  covariates, are unaffected.
+
 ## New features
 
 * **Every fit now says what it did not do** (#242, following #197). A

--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,21 @@
   log-logistic and log-normal fits are unaffected; they report on the scale
   they are optimised on.
 
+* **A `survival::Surv()` object passed as `status` is now translated, as the
+  formula interface always did** (#226). `Surv()` codes censoring with
+  different integers from this package, and the vector interface took the
+  object's second column unchanged. Under `type = "left"` a left-censored row
+  was fitted as right-censored; under `"interval"` and `"counting"` the
+  second column is not the status at all, so the fit read `time2` or `stop`
+  as status codes. There was no error and no warning, and
+  `objective = "sas"` could not see a left-censored row to refuse it. Both
+  interfaces now read the `Surv` through one internal helper, driven by its
+  `type`, so they store the same status and bounds and give the same fit.
+  The bounds a `Surv` carries are taken from it; a `time`, `time_lower` or
+  `time_upper` that disagrees with them is an error rather than being
+  silently replaced. `hzr_bootstrap()` resamples those bounds too, although
+  they never appear in the stored call.
+
 # TemporalHazard 1.2.10
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,12 @@
   select-mode `scope`, and reads variables from the terms, so `log(age)`
   needs only the column `age`. A constant outside `data`, such as `pi`, a
   cutoff or a knots vector, is still allowed. The error names the
-  variables; add them to `data` and refit.
+  variables; add them to `data` and refit. A scope variable that only the
+  scope formula's own frame can see, which the refits could never test, is
+  refused the same way. So is a vector-interface fit whose design matrix
+  was passed directly as `x`: it was re-evaluated without resampling in
+  every replicate, or in select mode dropped from the candidate refits, so
+  all of them succeeded and the interval was wrong.
 
 * **`hzr_stepwise()` now refuses a base fit written as `Surv(...) ~ .`**
   (#279). It read the base model's terms without the data, which cannot

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,18 @@
   cutoff or a knots vector, is still allowed. The error names the
   variables; add them to `data` and refit.
 
+* **`hzr_stepwise()` now refuses a base fit written as `Surv(...) ~ .`**
+  (#279). It read the base model's terms without the data, which cannot
+  expand `.`, and treated the failure as a model with no terms: the screen
+  reported zero steps, which looks the same as finding nothing to drop. It
+  now stops before printing anything and asks for the base model's terms to
+  be written out. A `scope` of `~ .`, which used to give a screen with no
+  candidates, stops the same way, and so does a multiphase base fit whose
+  global formula uses `.` while a phase has no formula of its own and so
+  inherits it. A screen whose base model has its terms written out is
+  unchanged, as is a multiphase screen in which every phase has its own
+  formula.
+
 ## New features
 
 * **Every fit now says what it did not do** (#242, following #197). A

--- a/NEWS.md
+++ b/NEWS.md
@@ -141,13 +141,26 @@
   the formula written out in full. A `data` with no other column gives a
   model with no covariates, and there `.` beside other terms is an error.
   **Estimates from an earlier `~ .` fit change**, and so does the length of
-  `theta` it needs. `hzr_phase(formula
-  = ~ .)` is not changed by this fix. A right-hand-side variable that is not
+  `theta` it needs. A `.` in
+  `hzr_phase(formula = )` is fixed separately (#277). A right-hand-side variable that is not
   a column of `data` is now looked up where the formula was written, so a
   variable local to the calling function resolves instead of failing with
   "object not found". `hzr_bootstrap()` resamples only the rows of `data`,
   not such a variable: at `fraction = 1` its interval is wrong, and below 1
   every replicate fails. Keep every covariate you will bootstrap in `data`.
+
+* **`hzr_phase(formula = ~ .)` no longer puts the response in the phase
+  design** (#277). A phase formula's `.` was expanded by `model.frame()`
+  against every column of `data`, including the columns of the `Surv()`
+  term, so the outcome was fitted as a phase covariate and the fit
+  converged with no error. `hazard()` now writes `.` out once, before
+  fitting, the same way as for the global formula (#273): every column the
+  `Surv()` term does not use. The fitted object stores the written-out
+  formula, so `predict(newdata = )` no longer needs the response columns.
+  On the vector interface (`time =`, `status =`) no `Surv()` term says which
+  columns hold the response, so a phase formula with `.` is now an error
+  there; write the phase's terms out. **Estimates from an earlier fit with
+  `.` in a phase formula change.**
 
 # TemporalHazard 1.2.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -115,6 +115,27 @@
   silently replaced. `hzr_bootstrap()` resamples those bounds too, although
   they never appear in the stored call.
 
+* **`.` in a `hazard()` formula no longer puts the response in the design**
+  (#273). `Surv(int_dead, dead) ~ .` expanded `.` to every column of `data`,
+  including `int_dead` and `dead`, so the outcome was fitted as a predictor.
+  With starting values sized for those extra columns the fit converged, with
+  no error and a log-likelihood far above the correct model's. With starting
+  values sized for the
+  real covariates it stopped with "non-conformable arguments", which did not
+  name the cause, and `predict(newdata = )` demanded the response columns.
+  `.` now means every column the `Surv()` term does not use, as in
+  `survival::coxph()`, so a `~ .` fit gives the same design and estimates as
+  the formula written out in full. A `data` with no other column gives a
+  model with no covariates, and there `.` beside other terms is an error.
+  **Estimates from an earlier `~ .` fit change**, and so does the length of
+  `theta` it needs. `hzr_phase(formula
+  = ~ .)` is not changed by this fix. A right-hand-side variable that is not
+  a column of `data` is now looked up where the formula was written, so a
+  variable local to the calling function resolves instead of failing with
+  "object not found". `hzr_bootstrap()` resamples only the rows of `data`,
+  not such a variable: at `fraction = 1` its interval is wrong, and below 1
+  every replicate fails. Keep every covariate you will bootstrap in `data`.
+
 # TemporalHazard 1.2.10
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,18 @@
   Formulas that call an ordinary function such as `log()`, and plain global
   covariates, are unaffected.
 
+* **`hzr_bootstrap()` now refuses a fit whose formula uses a per-row
+  variable that is not a column of its `data`** (#278). Replicates resample
+  the rows of `data`, so such a variable was held fixed while the rows moved
+  under it. The interval was wrong, and every replicate still reported
+  success, with no warning: on `avc`, a copy of `age` kept outside `data`
+  gave an interval that excluded its own estimate. The check covers the
+  response, the covariates of the global and phase formulas, and a
+  select-mode `scope`, and reads variables from the terms, so `log(age)`
+  needs only the column `age`. A constant outside `data`, such as `pi`, a
+  cutoff or a knots vector, is still allowed. The error names the
+  variables; add them to `data` and refit.
+
 ## New features
 
 * **Every fit now says what it did not do** (#242, following #197). A
@@ -145,9 +157,8 @@
   `hzr_phase(formula = )` is fixed separately (#277). A right-hand-side variable that is not
   a column of `data` is now looked up where the formula was written, so a
   variable local to the calling function resolves instead of failing with
-  "object not found". `hzr_bootstrap()` resamples only the rows of `data`,
-  not such a variable: at `fraction = 1` its interval is wrong, and below 1
-  every replicate fails. Keep every covariate you will bootstrap in `data`.
+  "object not found". `hzr_bootstrap()`, which resamples only the rows
+  of `data`, refuses such a fit (#278).
 
 * **`hzr_phase(formula = ~ .)` no longer puts the response in the phase
   design** (#277). A phase formula's `.` was expanded by `model.frame()`

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1558,7 +1558,12 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     # evaluate against the original data, so row i's time gets paired with
     # row j's status or interval bound. That is silent corruption producing
     # plausible numbers, not an error.
-    passed <- vec_args[vapply(vec_args, function(a) !is.null(cl[[a]]), logical(1))]
+    # A Surv passed as `status` supplies its bounds without naming them in
+    # the call (#226), so a stored bound counts as passed too. Leaving it out
+    # refits every replicate with no censoring bounds at all.
+    passed <- vec_args[vapply(vec_args, function(a) {
+      !is.null(cl[[a]]) || !is.null(object$data[[a]])
+    }, logical(1))]
     have   <- vapply(vec_orig, function(v) !is.null(v) && length(v) == n_obs,
                      logical(1))
     missing_vecs <- passed[!have[passed]]

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1515,9 +1515,6 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
       all.vars(scope)
     } else if (is.character(scope) && length(scope) > 0L) {
       all.vars(stats::reformulate(scope))
-    } else if (is.list(scope)) {
-      unlist(lapply(Filter(function(f) inherits(f, "formula"), scope),
-                    all.vars))
     }
     phase_formulas <- Filter(function(f) inherits(f, "formula"),
                              lapply(object$spec$phases, function(ph) {
@@ -1535,7 +1532,23 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
       unlist(lapply(phase_formulas, function(f) {
         outside_in(all.vars(f), environment(f) %||% call_env)
       })),
-      outside_in(scope_vars, base_env %||% call_env)
+      outside_in(scope_vars, base_env %||% call_env),
+      # A multiphase scope is refit through .hzr_phase_update_formula(): into
+      # the phase's own formula, keeping its environment, or, for a phase
+      # without one, into a fresh formula whose lookups reach this package's
+      # namespace and the search path. Each phase's scope is checked there.
+      if (is.list(scope)) {
+        unlist(lapply(names(scope), function(p) {
+          sc <- scope[[p]]
+          if (!inherits(sc, "formula")) return(character())
+          pf <- object$spec$phases[[p]]$formula
+          outside_in(all.vars(sc), if (is.null(pf)) {
+            environment(.hzr_parse_formula)
+          } else {
+            environment(pf)
+          })
+        }))
+      }
     )
     outside <- unique(outside)
     if (length(outside) > 0L) {

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1533,6 +1533,13 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
         outside_in(all.vars(f), environment(f) %||% call_env)
       })),
       outside_in(scope_vars, base_env %||% call_env),
+      # A scope variable that only the scope formula's own frame can see
+      # never reaches the refit, so the screen could not test it: that was
+      # reported once, up front, then silently absent from every replicate.
+      # It is refused too.
+      if (inherits(scope, "formula")) {
+        outside_in(scope_vars, environment(scope) %||% call_env)
+      },
       # A multiphase scope is refit through .hzr_phase_update_formula(): into
       # the phase's own formula, keeping its environment, or, for a phase
       # without one, into a fresh formula whose lookups reach this package's
@@ -1542,11 +1549,12 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
           sc <- scope[[p]]
           if (!inherits(sc, "formula")) return(character())
           pf <- object$spec$phases[[p]]$formula
-          outside_in(all.vars(sc), if (is.null(pf)) {
+          c(outside_in(all.vars(sc), if (is.null(pf)) {
             environment(.hzr_parse_formula)
           } else {
             environment(pf)
-          })
+          }),
+          outside_in(all.vars(sc), environment(sc) %||% call_env))
         }))
       }
     )
@@ -1562,7 +1570,21 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
     }
   }
 
-  # Seeded after the refusal above, so a refused call leaves the caller's
+  # A design matrix passed directly as `x` on the vector interface is never
+  # resampled. A fixed refit re-evaluated it without resampling in every
+  # replicate, pairing resampled outcomes with the original design; a
+  # select-mode refit reused it for the base model and dropped it from the
+  # candidates. Every replicate reported success either way, so it is
+  # refused.
+  if (is.null(cl$formula) && !is.null(cl$time) && !is.null(cl$x)) {
+    stop("hzr_bootstrap(): this fit's design matrix was passed directly as ",
+         "`x`, which replicates cannot resample with the rows: each would ",
+         "pair resampled outcomes with the original design. Refit with the ",
+         "formula interface (Surv(...) ~ ..., data = ...) and bootstrap ",
+         "that.", call. = FALSE)
+  }
+
+  # Seeded after the refusals above, so a refused call leaves the caller's
   # random number stream alone.
   if (!is.null(seed)) set.seed(seed)
 
@@ -1647,8 +1669,8 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   #
   # The evaluated vectors are already stored on the object, so they can be
   # resampled by the same index and rewired the same way `data` and `weights`
-  # are. `x` is excluded deliberately: a design matrix supplied that way is
-  # rebuilt from `data`/`scope` per replicate.
+  # are. `x` is not among them: a design matrix passed directly is refused
+  # above, before seeding.
   vector_interface <- is.null(cl$formula) && !is.null(cl$time)
   vec_args <- c("time", "status", "time_lower", "time_upper")
   vec_orig <- if (vector_interface) {

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1438,8 +1438,6 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
          call. = FALSE)
   }
 
-  if (!is.null(seed)) set.seed(seed)
-
   # hzr_stepwise() is always called below with trace = FALSE (per-step
   # stepwise output would be too noisy across n_boot replicates; `verbose`
   # controls bootstrap-level progress instead). Strip `trace` from `...`
@@ -1461,6 +1459,73 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
   } else {
     eval(cl$data, envir = parent.frame())
   }
+  # A per-row variable that is not a column of `data` is never resampled:
+  # each replicate paired the original vector with resampled rows, so the
+  # interval was wrong while every replicate reported success (#278). Refuse
+  # it, naming the variables. They come from the terms of the global formula
+  # (response included), the phase formulas and a select-mode `scope`, so
+  # `log(age)` reads the column `age`. A name outside `data` that does not
+  # hold one value per row -- `pi`, a cutoff, a knots vector -- is a constant,
+  # rightly the same in every replicate, and is left alone.
+  if (is.data.frame(orig_data)) {
+    per_row <- function(v, env) {
+      val <- get0(v, envir = env, inherits = TRUE)
+      !is.null(val) && !is.function(val) && NROW(val) == nrow(orig_data)
+    }
+    outside_in <- function(vars, env) {
+      vars <- setdiff(vars, c(names(orig_data), "."))
+      vars[vapply(vars, per_row, logical(1), env = env)]
+    }
+    call_env <- object$call_env %||% parent.frame()
+    stored <- .hzr_stored_formula(object, "`object`")
+    # Candidate refits build their formulas in the stored formula's
+    # environment (.hzr_formula_update()), so covariates and `scope`
+    # variables resolve there. The Surv() term does not: .hzr_parse_formula()
+    # evaluates it in `data`, then this package's namespace and the search
+    # path, so the response is looked up that way.
+    base_env <- if (is.null(stored)) call_env else environment(stored)
+    scope_vars <- if (inherits(scope, "formula")) {
+      all.vars(scope)
+    } else if (is.character(scope) && length(scope) > 0L) {
+      all.vars(stats::reformulate(scope))
+    } else if (is.list(scope)) {
+      unlist(lapply(Filter(function(f) inherits(f, "formula"), scope),
+                    all.vars))
+    }
+    phase_formulas <- Filter(function(f) inherits(f, "formula"),
+                             lapply(object$spec$phases, function(ph) {
+                               ph$formula
+                             }))
+    outside <- c(
+      if (length(stored) == 3L) {
+        outside_in(all.vars(stored[[2L]]), environment(.hzr_parse_formula))
+      },
+      if (!is.null(stored)) {
+        outside_in(all.vars(stats::delete.response(
+          stats::terms(stored, data = orig_data)
+        )), base_env %||% call_env)
+      },
+      unlist(lapply(phase_formulas, function(f) {
+        outside_in(all.vars(f), environment(f) %||% call_env)
+      })),
+      outside_in(scope_vars, base_env %||% call_env)
+    )
+    outside <- unique(outside)
+    if (length(outside) > 0L) {
+      one <- length(outside) == 1L
+      stop("hzr_bootstrap() resamples the rows of the fit's `data`, but the ",
+           "model uses ", paste0("'", outside, "'", collapse = ", "),
+           if (one) ", which is not a column" else ", which are not columns",
+           " of it. Each replicate would hold ", if (one) "it" else "them",
+           " fixed, and the interval would be wrong. Add ",
+           if (one) "it" else "them", " to `data` and refit.", call. = FALSE)
+    }
+  }
+
+  # Seeded after the refusal above, so a refused call leaves the caller's
+  # random number stream alone.
+  if (!is.null(seed)) set.seed(seed)
+
   n_obs <- nrow(orig_data)
   sample_size <- max(1L, as.integer(n_obs * fraction))
 

--- a/R/formula-helpers.R
+++ b/R/formula-helpers.R
@@ -60,8 +60,27 @@
   # Parse RHS (predictors)
   x <- NULL
   if (!is.null(rhs)) {
-    # Reconstruct as a formula for model.matrix()
-    rhs_formula <- formula(paste("~", deparse(rhs)))
+    # One-sided formula for model.matrix(), with `.` expanded here, against
+    # `data` without the Surv() variables, as survival::coxph() does:
+    # terms() drops every column the left-hand side uses. Pasting the RHS
+    # into `~ ...` expanded `.` to every column, so the response was fitted
+    # as a predictor (#273).
+    rhs_formula <- stats::formula(
+      stats::delete.response(stats::terms(formula, data = data))
+    )
+    # When the response uses every column, terms() has nothing to put in
+    # place of `.` and leaves it, and model.matrix() would then expand it
+    # against all of `data`, response included. Alone, `.` then stands for
+    # no column and the model has no covariates. Beside other terms it is
+    # refused: replacing the RHS would drop those terms without a word.
+    if ("." %in% all.vars(rhs_formula)) {
+      if (!identical(all.vars(rhs_formula), ".")) {
+        stop("`.` in the formula stands for no column: `data` holds only ",
+             "the variables of the Surv() response. Remove `.`, or add the ",
+             "covariates to `data`.", call. = FALSE)
+      }
+      rhs_formula <- stats::reformulate("1", env = environment(rhs_formula))
+    }
     tryCatch({
       x <- stats::model.matrix(rhs_formula, data = data)
       # Remove intercept column if present

--- a/R/formula-helpers.R
+++ b/R/formula-helpers.R
@@ -60,27 +60,9 @@
   # Parse RHS (predictors)
   x <- NULL
   if (!is.null(rhs)) {
-    # One-sided formula for model.matrix(), with `.` expanded here, against
-    # `data` without the Surv() variables, as survival::coxph() does:
-    # terms() drops every column the left-hand side uses. Pasting the RHS
-    # into `~ ...` expanded `.` to every column, so the response was fitted
-    # as a predictor (#273).
-    rhs_formula <- stats::formula(
-      stats::delete.response(stats::terms(formula, data = data))
-    )
-    # When the response uses every column, terms() has nothing to put in
-    # place of `.` and leaves it, and model.matrix() would then expand it
-    # against all of `data`, response included. Alone, `.` then stands for
-    # no column and the model has no covariates. Beside other terms it is
-    # refused: replacing the RHS would drop those terms without a word.
-    if ("." %in% all.vars(rhs_formula)) {
-      if (!identical(all.vars(rhs_formula), ".")) {
-        stop("`.` in the formula stands for no column: `data` holds only ",
-             "the variables of the Surv() response. Remove `.`, or add the ",
-             "covariates to `data`.", call. = FALSE)
-      }
-      rhs_formula <- stats::reformulate("1", env = environment(rhs_formula))
-    }
+    # One-sided formula for model.matrix(), with `.` expanded against `data`
+    # without the Surv() variables (#273). See .hzr_expand_rhs().
+    rhs_formula <- .hzr_expand_rhs(formula, data)
     tryCatch({
       x <- stats::model.matrix(rhs_formula, data = data)
       # Remove intercept column if present
@@ -103,6 +85,41 @@
     x = x,
     surv_type = resp$surv_type
   )
+}
+
+
+#' Write out `.` in a model formula's right-hand side
+#'
+#' Returns the right-hand side of a two-sided `Surv(...) ~ ...` formula as a
+#' one-sided formula, with `.` expanded to every column of `data` that the
+#' left-hand side does not use, as `survival::coxph()` does: `terms()` drops
+#' those columns itself. Both the global formula (`.hzr_parse_formula()`,
+#' #273) and each `hzr_phase(formula = )` (`hazard()`, #277) go through here,
+#' so `.` means the same thing in both.
+#'
+#' @param formula A two-sided formula with the `Surv()` term on the left.
+#' @param data The data frame `.` is expanded against.
+#' @return A one-sided formula in `environment(formula)`, with no `.` left.
+#' @keywords internal
+#' @noRd
+.hzr_expand_rhs <- function(formula, data) {
+  rhs_formula <- stats::formula(
+    stats::delete.response(stats::terms(formula, data = data))
+  )
+  # When the response uses every column, terms() has nothing to put in
+  # place of `.` and leaves it, and model.matrix() would then expand it
+  # against all of `data`, response included. Alone, `.` then stands for
+  # no column and the model has no covariates. Beside other terms it is
+  # refused: replacing the RHS would drop those terms without a word.
+  if ("." %in% all.vars(rhs_formula)) {
+    if (!identical(all.vars(rhs_formula), ".")) {
+      stop("`.` in the formula stands for no column: `data` holds only ",
+           "the variables of the Surv() response. Remove `.`, or add the ",
+           "covariates to `data`.", call. = FALSE)
+    }
+    rhs_formula <- stats::reformulate("1", env = environment(rhs_formula))
+  }
+  rhs_formula
 }
 
 

--- a/R/formula-helpers.R
+++ b/R/formula-helpers.R
@@ -55,6 +55,58 @@
     stop("Formula LHS must return a Surv object.", call. = FALSE)
   }
 
+  resp <- .hzr_surv_response(surv_obj)
+
+  # Parse RHS (predictors)
+  x <- NULL
+  if (!is.null(rhs)) {
+    # Reconstruct as a formula for model.matrix()
+    rhs_formula <- formula(paste("~", deparse(rhs)))
+    tryCatch({
+      x <- stats::model.matrix(rhs_formula, data = data)
+      # Remove intercept column if present
+      if (ncol(x) > 0 && colnames(x)[1L] == "(Intercept)") {
+        x <- x[, -1L, drop = FALSE]
+      }
+      if (ncol(x) == 0) {
+        x <- NULL
+      }
+    }, error = function(e) {
+      stop("Failed to parse formula RHS: ", e$message, call. = FALSE)
+    })
+  }
+
+  list(
+    time = resp$time,
+    status = resp$status,
+    time_lower = resp$time_lower,
+    time_upper = resp$time_upper,
+    x = x,
+    surv_type = resp$surv_type
+  )
+}
+
+
+#' Read a Surv object into this package's response vectors
+#'
+#' The one place a `survival::Surv()` object is translated, called by both
+#' interfaces: `.hzr_parse_formula()` for the formula's left-hand side, and
+#' `hazard()` when a `Surv` is passed as `status`. Keeping a single copy is
+#' the point -- the vector path used to take the second column unchanged,
+#' which misread left-censored rows as right-censored, and for `"interval"`
+#' and `"counting"` is not the status column at all (#226).
+#'
+#' The translation is driven by `attr(surv_obj, "type")`, never by the codes
+#' observed: a right-censored vector and a `"left"` one both hold only 0 and
+#' 1, with different meanings. `type = "interval2"` arrives here as
+#' `"interval"`, because `Surv()` converts it.
+#'
+#' @param surv_obj A `Surv` object.
+#' @return A list with `time`, `status`, `time_lower`, `time_upper` (either
+#'   bound may be `NULL`) and `surv_type`.
+#' @keywords internal
+#' @noRd
+.hzr_surv_response <- function(surv_obj) {
   surv_type <- attr(surv_obj, "type")
   surv_mat <- unclass(surv_obj)
 
@@ -102,31 +154,11 @@
     stop("Unsupported Surv() type: ", surv_type, call. = FALSE)
   }
 
-  # Parse RHS (predictors)
-  x <- NULL
-  if (!is.null(rhs)) {
-    # Reconstruct as a formula for model.matrix()
-    rhs_formula <- formula(paste("~", deparse(rhs)))
-    tryCatch({
-      x <- stats::model.matrix(rhs_formula, data = data)
-      # Remove intercept column if present
-      if (ncol(x) > 0 && colnames(x)[1L] == "(Intercept)") {
-        x <- x[, -1L, drop = FALSE]
-      }
-      if (ncol(x) == 0) {
-        x <- NULL
-      }
-    }, error = function(e) {
-      stop("Failed to parse formula RHS: ", e$message, call. = FALSE)
-    })
-  }
-
   list(
     time = time,
     status = status,
     time_lower = time_lower,
     time_upper = time_upper,
-    x = x,
     surv_type = surv_type
   )
 }

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -499,23 +499,31 @@ hazard <- function(formula = NULL,
       stop("'data' is required when 'formula' is provided.", call. = FALSE)
     }
 
-    # For multiphase models, the formula RHS may contain phase-scoped terms of
-    # the form `phase_name(var1 + var2)`.  These are not valid R expressions
-    # so model.matrix() would fail.  Strip them here: replace the RHS with `1`
-    # (no global predictors) so that .hzr_parse_formula only extracts
-    # time/status from the LHS.  Covariate routing is handled per-phase via
-    # hzr_phase(formula = ...) and resolved inside .hzr_optim_multiphase().
-    formula_for_parse <- formula
-    if (!is.null(phases) && length(formula) >= 3L) {
-      # Check if RHS contains phase-scoped calls of the form `phase_name(...)`.
-      # Use a parse-tree walk (not string regex) to avoid false positives when
-      # a phase name coincides with a base-R function (e.g., "log", "exp").
-      if (.hzr_formula_has_phase_scope(formula[[3L]], names(phases))) {
-        formula_for_parse <- stats::reformulate("1", response = formula[[2L]])
+    # A multiphase formula RHS may name a phase as a function, as in
+    # `constant(age)`. Such a term is refused, not routed (#275): it used to
+    # be stripped with the rest of the RHS and never reached its phase, so
+    # the fit converged without it. A phase's covariates belong in
+    # hzr_phase(formula = ...). The parse-tree walk (not a string regex)
+    # keeps a base-R call such as `log(age)` from matching.
+    if (identical(dist, "multiphase") && !is.null(phases) &&
+          length(formula) >= 3L) {
+      scoped <- Filter(
+        function(nm) .hzr_formula_has_phase_scope(formula[[3L]], nm),
+        names(phases)
+      )
+      if (length(scoped) > 0L) {
+        stop("The formula names ",
+             if (length(scoped) > 1L) "phases " else "phase ",
+             paste0("'", scoped, "'", collapse = ", "),
+             " as a function, as in `", scoped[[1L]], "(var)`. hazard() ",
+             "does not route such terms to a phase, so they would be ",
+             "dropped. Give the phase its covariates with ",
+             "hzr_phase(..., formula = ~ var) instead, and leave them out ",
+             "of the formula.", call. = FALSE)
       }
     }
 
-    parsed <- .hzr_parse_formula(formula = formula_for_parse, data = data)
+    parsed <- .hzr_parse_formula(formula = formula, data = data)
     time <- parsed$time
     status <- parsed$status
     time_lower <- parsed$time_lower

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -167,8 +167,9 @@ NULL
 #'   (`type = "interval"` or `"interval2"`) and counting-process
 #'   (`Surv(start, stop, event)`) forms are all accepted. `Surv()` codes
 #'   censoring status with different integers than this package does; the
-#'   formula path translates them, so write `Surv()`'s codes here and this
-#'   package's codes when passing `status` directly.
+#'   formula path translates them, so write `Surv()`'s codes here. A plain
+#'   `status` vector takes this package's codes; a `Surv` passed as `status`
+#'   is translated the same way as here.
 #'   A `.` on the right-hand side stands for every column of `data` that the
 #'   `Surv()` term does not use, as in `survival::coxph()`.
 #'   When provided, overrides direct time/status/x arguments and extracts from data.

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -133,6 +133,8 @@ NULL
 #'   censoring status with different integers than this package does; the
 #'   formula path translates them, so write `Surv()`'s codes here and this
 #'   package's codes when passing `status` directly.
+#'   A `.` on the right-hand side stands for every column of `data` that the
+#'   `Surv()` term does not use, as in `survival::coxph()`.
 #'   When provided, overrides direct time/status/x arguments and extracts from data.
 #'   Example: `hazard(Surv(time, status) ~ x1 + x2, data = df, dist = "weibull", fit = TRUE)`.
 #' @param data Optional data frame. On the formula path it supplies the model

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -757,6 +757,28 @@ hazard <- function(formula = NULL,
            "Supply a list of hzr_phase() specifications.", call. = FALSE)
     }
     phases <- .hzr_validate_phases(phases)
+    # `.` in a phase formula is written out here, once, before anything reads
+    # it (#277). The likelihood, the score test, predict() and the stored
+    # spec all build the phase design with model.frame(ph$formula, data),
+    # which would expand `.` to every column, response included. It is
+    # expanded as the global formula's is, against `data` without the Surv()
+    # variables. The vector interface has no Surv() term to name those
+    # columns, so there `.` is refused.
+    for (nm in names(phases)) {
+      pf <- phases[[nm]]$formula
+      if (is.null(pf) || !"." %in% all.vars(pf)) next
+      if (is.null(formula)) {
+        stop("Phase '", nm, "' uses `.` in its formula, which needs the ",
+             "formula interface: with `time =` and `status =`, hazard() ",
+             "cannot tell which columns of `data` hold the response. Write ",
+             "the phase's terms out, or use hazard(Surv(...) ~ ..., ",
+             "data = ...).", call. = FALSE)
+      }
+      two_sided <- stats::as.formula(
+        call("~", formula[[2L]], pf[[length(pf)]]), env = environment(pf)
+      )
+      phases[[nm]]$formula <- .hzr_expand_rhs(two_sided, data)
+    }
   } else if (!is.null(phases)) {
     warning("'phases' is ignored when dist != 'multiphase'.")
     phases <- NULL

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -133,7 +133,10 @@ NULL
 #' }
 #'
 #' @param time Numeric follow-up time vector.
-#' @param status Numeric or logical event indicator vector.
+#' @param status Numeric or logical event indicator vector, or a
+#'   [survival::Surv()] object. A `Surv` is read by its `type`, exactly as the
+#'   formula interface reads it, and a `time`, `time_lower` or `time_upper`
+#'   that disagrees with it is an error.
 #' @param time_lower Optional numeric vector whose role depends on `status`.
 #'   Supplying it explicitly is **not** a no-op.
 #'   * `status == 2` (interval-censored): the lower bound of the censoring

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -597,9 +597,35 @@ hazard <- function(formula = NULL,
     stop("'status' must have the same length as 'time'.", call. = FALSE)
   }
 
-  # Convert Surv object status to numeric if needed (after formula parsing)
+  # A Surv object passed as `status` is read exactly as the formula path reads
+  # it (#226). Its codes are not this package's, and under "interval" and
+  # "counting" its second column is not the status at all, so taking that
+  # column unchanged fitted left-censored rows as right-censored. The Surv
+  # defines the bounds it carries; `time` and any bound the caller also gave
+  # must agree with it rather than be silently overridden.
   if (inherits(status, "Surv")) {
-    status <- unclass(status)[, 2L]
+    resp <- .hzr_surv_response(status)
+    if (!identical(as.numeric(time), as.numeric(resp$time))) {
+      stop("'time' does not match the times in the Surv object passed as ",
+           "'status'. Pass time = unclass(status)[, 1] -- the stop column, ",
+           "[, 2], for Surv(start, stop, event) -- or use the formula ",
+           "interface.", call. = FALSE)
+    }
+    surv_bound <- function(given, from_surv, arg) {
+      if (is.null(from_surv)) {
+        return(given)
+      }
+      if (!is.null(given) &&
+            !identical(as.numeric(given), as.numeric(from_surv))) {
+        stop("'", arg, "' does not match the Surv object passed as ",
+             "'status'. Omit it and the bound is taken from the Surv.",
+             call. = FALSE)
+      }
+      from_surv
+    }
+    time_lower <- surv_bound(time_lower, resp$time_lower, "time_lower")
+    time_upper <- surv_bound(time_upper, resp$time_upper, "time_upper")
+    status <- resp$status
   }
 
   # Optional censoring bounds:

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -495,18 +495,6 @@
 #' offenders.  Indices are reported against the **data**, not against the
 #' interval subset the inner guard sees.
 #'
-#' **This guards the codes it is given, not the ones the user meant.**  On the
-#' vector interface a `survival::Surv()` object is unclassed without
-#' translation, so its codes reach here meaning something else entirely, and
-#' what goes wrong depends on `type`:  under `type = "left"` a left-censored
-#' row is coded `0` and so arrives as this package's *right-censored*, and is
-#' fitted as one;  under `type = "interval"` it is coded `2` and arrives as
-#' *interval*, where this check rejects it for having zero width.  A genuine
-#' interval row is coded `3`, which no branch of `.hzr_logl_multiphase()`
-#' matches, so it contributes nothing at all.  The formula path translates in
-#' `.hzr_parse_formula()` and is guarded correctly.  That asymmetry is a
-#' pre-existing defect of the vector path, not of this check;  see #226.
-#'
 #' @param status Numeric event indicator.
 #' @param time Event/censoring times.
 #' @param time_lower,time_upper Optional censoring bounds; `NULL` means `time`.

--- a/R/stepwise-formula.R
+++ b/R/stepwise-formula.R
@@ -39,6 +39,15 @@
   if (!inherits(formula, "formula")) {
     stop("formula must be a `formula` object.", call. = FALSE)
   }
+  # `.` can only be expanded against data, and this reader has none. terms()
+  # errors on it, and the tryCatch() below turned that into "no terms", so a
+  # `~ .` base model reported a finished screen of zero steps (#279).
+  if ("." %in% all.vars(formula)) {
+    stop("hzr_stepwise() cannot expand `.` in `",
+         paste(deparse(formula), collapse = " "), "`: write the terms out, ",
+         "as in `~ age + mal`. A base model written with `.` must be refit ",
+         "that way; a `scope` can list its variables.", call. = FALSE)
+  }
   # terms() needs a formula with no empty LHS/RHS; ~ 1 has one intercept term.
   tt <- tryCatch(stats::terms(formula),
                  error = function(e) NULL)
@@ -212,13 +221,12 @@
 #' \code{formula[[3L]]}) and returns \code{TRUE} if any call node has a
 #' function symbol that exactly matches one of \code{phase_names}.
 #'
-#' This is stricter than a string-regex approach: a phase named \code{"log"}
-#' will NOT produce a false positive when the formula contains \code{log(age)},
-#' because \code{log} would also appear in \code{phase_names} only if the user
-#' deliberately named a phase \code{"log"}.  Conversely, the function only
-#' fires when the call head is an exact match to a known phase name -- standard
-#' R functions that happen to share names with phases do not trigger the check
-#' unless those names are actually phase names.
+#' This is stricter than a string-regex approach, which would fire on any
+#' \code{log(} in the text: the walk fires only when a call's head exactly
+#' matches a phase name, so \code{log(age)} is not taken for a phase unless a
+#' phase is actually named \code{"log"}.  When one is, \code{log(age)} does
+#' match, and \code{hazard()} refuses the formula (#275); write
+#' \code{base::log(age)} to use the function.
 #'
 #' @param rhs  A language object (the RHS of a formula, typically
 #'   \code{formula[[3L]]}).

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -262,6 +262,19 @@ hzr_stepwise <- function(fit,
          call. = FALSE)
   }
 
+  # Read the base model's terms once, before any output, so a `~ .` base
+  # formula stops here with its remedy rather than after the header (#279).
+  # A multiphase screen is exempt only when every phase has its own formula,
+  # which hazard() has already written out (#277). A phase without one
+  # inherits the global design, and each candidate refit would re-expand a
+  # global `.` against the screen's data.
+  own_formulas <- identical(fit$spec$dist, "multiphase") &&
+    all(vapply(fit$spec$phases, function(ph) !is.null(ph$formula),
+               logical(1)))
+  if (!own_formulas) {
+    .hzr_formula_rhs_terms(.hzr_stored_formula(fit))
+  }
+
   # The score (Q) statistic is evaluated at the base model's fitted MLE, so a
   # base that did not converge (or was never fitted, leaving an empty theta)
   # has nothing to score.  Catch that here with an actionable message rather

--- a/man/dot-hzr_check_sas_data.Rd
+++ b/man/dot-hzr_check_sas_data.Rd
@@ -37,17 +37,5 @@ Bounds are normalised here exactly as \code{.hzr_logl_multiphase()} normalises
 them, so the check cannot disagree with the objective about which rows are
 offenders.  Indices are reported against the \strong{data}, not against the
 interval subset the inner guard sees.
-
-\strong{This guards the codes it is given, not the ones the user meant.}  On the
-vector interface a \code{survival::Surv()} object is unclassed without
-translation, so its codes reach here meaning something else entirely, and
-what goes wrong depends on \code{type}:  under \code{type = "left"} a left-censored
-row is coded \code{0} and so arrives as this package's \emph{right-censored}, and is
-fitted as one;  under \code{type = "interval"} it is coded \code{2} and arrives as
-\emph{interval}, where this check rejects it for having zero width.  A genuine
-interval row is coded \code{3}, which no branch of \code{.hzr_logl_multiphase()}
-matches, so it contributes nothing at all.  The formula path translates in
-\code{.hzr_parse_formula()} and is guarded correctly.  That asymmetry is a
-pre-existing defect of the vector path, not of this check;  see #226.
 }
 \keyword{internal}

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -32,6 +32,8 @@ Right-censored (\code{Surv(time, status)}), left-censored
 censoring status with different integers than this package does; the
 formula path translates them, so write \code{Surv()}'s codes here and this
 package's codes when passing \code{status} directly.
+A \code{.} on the right-hand side stands for every column of \code{data} that the
+\code{Surv()} term does not use, as in \code{survival::coxph()}.
 When provided, overrides direct time/status/x arguments and extracts from data.
 Example: \code{hazard(Surv(time, status) ~ x1 + x2, data = df, dist = "weibull", fit = TRUE)}.}
 

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -52,7 +52,10 @@ path reaches \code{weights} and stops with \verb{'weights' must be non-negative 
 
 \item{time}{Numeric follow-up time vector.}
 
-\item{status}{Numeric or logical event indicator vector.}
+\item{status}{Numeric or logical event indicator vector, or a
+\code{\link[survival:Surv]{survival::Surv()}} object. A \code{Surv} is read by its \code{type}, exactly as the
+formula interface reads it, and a \code{time}, \code{time_lower} or \code{time_upper}
+that disagrees with it is an error.}
 
 \item{time_lower}{Optional numeric vector whose role depends on \code{status}.
 Supplying it explicitly is \strong{not} a no-op.

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -30,8 +30,9 @@ Right-censored (\code{Surv(time, status)}), left-censored
 (\code{type = "interval"} or \code{"interval2"}) and counting-process
 (\code{Surv(start, stop, event)}) forms are all accepted. \code{Surv()} codes
 censoring status with different integers than this package does; the
-formula path translates them, so write \code{Surv()}'s codes here and this
-package's codes when passing \code{status} directly.
+formula path translates them, so write \code{Surv()}'s codes here. A plain
+\code{status} vector takes this package's codes; a \code{Surv} passed as \code{status}
+is translated the same way as here.
 A \code{.} on the right-hand side stands for every column of \code{data} that the
 \code{Surv()} term does not use, as in \code{survival::coxph()}.
 When provided, overrides direct time/status/x arguments and extracts from data.

--- a/tests/testthat/test-bootstrap-data-columns.R
+++ b/tests/testthat/test-bootstrap-data-columns.R
@@ -90,6 +90,39 @@ test_that("a select-mode scope variable outside `data` is refused", {
   }
 })
 
+test_that("a multiphase scope is checked where its phase refit reads it", {
+  # A phase's scope is refit into that phase's own formula, so a per-row
+  # vector written beside the phase formula reaches the refit even though
+  # the base formula cannot see it. A phase with no formula gets a fresh
+  # one whose lookups reach the search path.
+  mk_phases <- function() {
+    zz <- avc_278$age + sin(seq_len(nrow(avc_278))) # nolint: object_usage_linter.
+    list(
+      early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                           fixed = "m", formula = ~ mal),
+      constant = hzr_phase("constant")
+    )
+  }
+  base <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = avc_278, dist = "multiphase",
+    phases = mk_phases(), fit = TRUE,
+    control = list(n_starts = 1L, conserve = FALSE)
+  ))
+  expect_error(
+    hzr_bootstrap(base, n_boot = 3, seed = 1, scope = list(early = ~ zz),
+                  criterion = "wald", slentry = 0.99),
+    "uses 'zz', which is not a column"
+  )
+  assign("zz_mp_278", avc_278$age, envir = globalenv())
+  withr::defer(rm("zz_mp_278", envir = globalenv()))
+  expect_error(
+    hzr_bootstrap(base, n_boot = 3, seed = 1,
+                  scope = list(constant = ~ zz_mp_278),
+                  criterion = "wald", slentry = 0.99),
+    "uses 'zz_mp_278', which is not a column"
+  )
+})
+
 test_that("constants outside `data` are not refused", {
   # One value, or a few, is the same in every replicate by design: only a
   # per-row vector is data the resample would miss.

--- a/tests/testthat/test-bootstrap-data-columns.R
+++ b/tests/testthat/test-bootstrap-data-columns.R
@@ -1,0 +1,121 @@
+# tests/testthat/test-bootstrap-data-columns.R
+# hzr_bootstrap() resamples the rows of the fit's `data`. A formula variable
+# that is not a column of `data` was never resampled, so each replicate paired
+# the original vector with resampled rows: a wrong interval, with every
+# replicate reported as a success and no warning (#278). It is now refused.
+
+avc_278 <- na.omit(avc[, c("int_dead", "dead", "age", "mal")])
+
+weibull_278 <- function(formula, theta = c(0.3, 1, 0)) {
+  hazard(formula, data = avc_278, dist = "weibull", theta = theta,
+         fit = TRUE)
+}
+
+test_that("a function-local covariate is refused, not bootstrapped", {
+  # The 40-replicate case from the #273 review: 40 successes, an interval
+  # that excluded its own estimate, and no warning.
+  local_fit <- function() {
+    zz <- avc_278$age
+    weibull_278(survival::Surv(int_dead, dead) ~ zz)
+  }
+  fit <- local_fit()
+  expect_true(fit$fit$converged)
+  expect_error(hzr_bootstrap(fit, n_boot = 40, seed = 1),
+               "uses 'zz', which is not a column.*Add it to `data`")
+})
+
+test_that("a workspace covariate is refused, and only it is named", {
+  assign("zz_ws_278", avc_278$age, envir = globalenv())
+  withr::defer(rm("zz_ws_278", envir = globalenv()))
+  fit <- weibull_278(survival::Surv(int_dead, dead) ~ zz_ws_278 + mal,
+                     theta = c(0.3, 1, 0, 0))
+  expect_error(hzr_bootstrap(fit, n_boot = 5, seed = 1),
+               "uses 'zz_ws_278', which is not a column")
+})
+
+test_that("a phase-formula covariate outside `data` is refused", {
+  local_mp <- function() {
+    zz <- avc_278$age
+    hazard(survival::Surv(int_dead, dead) ~ 1, data = avc_278,
+           dist = "multiphase",
+           phases = list(
+             early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                                  fixed = "m", formula = ~ zz + mal),
+             constant = hzr_phase("constant")
+           ),
+           fit = TRUE, control = list(n_starts = 1L, conserve = FALSE))
+  }
+  expect_error(hzr_bootstrap(suppressWarnings(local_mp()), n_boot = 2,
+                             seed = 1),
+               "uses 'zz', which is not a column")
+})
+
+test_that("a response variable outside `data` is refused", {
+  # The times held fixed while `dead` and `age` were resampled. A workspace
+  # variable: the Surv() term is evaluated with `data` in front of the
+  # search path, so a function-local one does not reach the fit at all.
+  assign("tt_ws_278", avc_278$int_dead, envir = globalenv())
+  withr::defer(rm("tt_ws_278", envir = globalenv()))
+  fit <- weibull_278(survival::Surv(tt_ws_278, dead) ~ age)
+  expect_error(hzr_bootstrap(fit, n_boot = 5, seed = 1),
+               "uses 'tt_ws_278', which is not a column")
+})
+
+test_that("the response is checked where the fit evaluates it", {
+  # The Surv() term is evaluated in `data`, then the search path, never in
+  # the formula's environment, so a local of the same name must not hide
+  # the per-row vector the fit actually used.
+  assign("tt_g_278", avc_278$int_dead, envir = globalenv())
+  withr::defer(rm("tt_g_278", envir = globalenv()))
+  shadowed <- function() {
+    tt_g_278 <- 5 # nolint: object_usage_linter.
+    weibull_278(survival::Surv(tt_g_278, dead) ~ age)
+  }
+  expect_error(hzr_bootstrap(shadowed(), n_boot = 3, seed = 1),
+               "uses 'tt_g_278', which is not a column")
+})
+
+test_that("a select-mode scope variable outside `data` is refused", {
+  # Candidate refits resolve a scope's variables where the base model's
+  # formula was written, so `zz` here does reach the refits.
+  local_base <- function() {
+    zz <- avc_278$age # nolint: object_usage_linter.
+    weibull_278(survival::Surv(int_dead, dead) ~ 1, theta = c(0.3, 1))
+  }
+  base <- local_base()
+  for (sc in list(~ zz + mal, "zz", "log(zz)")) {
+    expect_error(hzr_bootstrap(base, n_boot = 5, seed = 1, scope = sc,
+                               criterion = "wald"),
+                 "uses 'zz', which is not a column")
+  }
+})
+
+test_that("constants outside `data` are not refused", {
+  # One value, or a few, is the same in every replicate by design: only a
+  # per-row vector is data the resample would miss.
+  cutoff <- 60
+  kn <- c(40, 60)
+  fits <- list(
+    weibull_278(survival::Surv(int_dead, dead) ~ I(age * pi)),
+    weibull_278(survival::Surv(int_dead, dead) ~ I(age > cutoff)),
+    weibull_278(survival::Surv(int_dead, dead) ~ splines::ns(age, knots = kn),
+                theta = c(0.3, 1, 0, 0, 0))
+  )
+  for (fit in fits) {
+    b <- suppressWarnings(hzr_bootstrap(fit, n_boot = 4, seed = 1))
+    expect_equal(b$n_success, 4)
+  }
+})
+
+test_that("a bootstrap over columns of `data` still runs and varies", {
+  # `log(age)` reads the column `age`: the check works on the variables of
+  # the terms, not on the term labels.
+  fit <- weibull_278(survival::Surv(int_dead, dead) ~ log(age) + mal,
+                     theta = c(0.3, 1, 0, 0))
+  b <- suppressWarnings(hzr_bootstrap(fit, n_boot = 10, seed = 1))
+  expect_equal(b$n_success, 10)
+  expect_equal(b$n_failed, 0)
+  row <- b$summary[b$summary$parameter == "log(age)", ]
+  expect_equal(nrow(row), 1L)
+  expect_gt(row$sd, 0)
+})

--- a/tests/testthat/test-bootstrap-data-columns.R
+++ b/tests/testthat/test-bootstrap-data-columns.R
@@ -123,6 +123,71 @@ test_that("a multiphase scope is checked where its phase refit reads it", {
   )
 })
 
+test_that("a scope variable only the scope's own frame can see is refused", {
+  # The refit cannot resolve `zl`, so the screen could never test it: after
+  # one warning up front, it silently dropped out of every replicate's
+  # candidates.
+  mk_scope <- function() {
+    zl <- avc_278$age # nolint: object_usage_linter.
+    ~ zl + mal
+  }
+  base <- weibull_278(survival::Surv(int_dead, dead) ~ 1, theta = c(0.3, 1))
+  expect_error(hzr_bootstrap(base, n_boot = 3, seed = 1, scope = mk_scope(),
+                             criterion = "wald"),
+               "uses 'zl', which is not a column")
+
+  # The same for a phase with no formula of its own.
+  mp <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = avc_278, dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                           fixed = "m"),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE, control = list(n_starts = 1L, conserve = FALSE)
+  ))
+  mk_mscope <- function() {
+    zl <- avc_278$age # nolint: object_usage_linter.
+    list(constant = ~ zl)
+  }
+  expect_error(hzr_bootstrap(mp, n_boot = 2, seed = 1, scope = mk_mscope(),
+                             criterion = "wald", slentry = 0.99),
+               "uses 'zl', which is not a column")
+})
+
+test_that("a vector-interface fit with a direct `x` is refused", {
+  # `x` was re-evaluated unresampled in every replicate: 20 of 20 succeeded,
+  # and the interval for `age` excluded its own estimate.
+  fit <- hazard(data = avc_278, time = int_dead, status = dead,
+                x = as.matrix(avc_278["age"]), dist = "weibull",
+                theta = c(0.3, 1, 0), fit = TRUE)
+  # Refused before seeding, so the caller's random number stream is left
+  # alone.
+  set.seed(42)
+  before <- .Random.seed
+  expect_error(hzr_bootstrap(fit, n_boot = 3, seed = 1),
+               "passed directly as `x`")
+  expect_identical(.Random.seed, before)
+
+  # Select mode too: the base refits reused the original `x` and the
+  # candidate refits dropped it, so the `age` terms vanished from every
+  # replicate while all of them reported success.
+  mp <- suppressWarnings(hazard(
+    data = avc_278, time = int_dead, status = dead,
+    x = as.matrix(avc_278["age"]), dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                           fixed = "m"),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE, control = list(n_starts = 1L, conserve = FALSE)
+  ))
+  expect_error(hzr_bootstrap(mp, n_boot = 3, seed = 1,
+                             scope = list(early = ~ mal),
+                             criterion = "wald", slentry = 0.99),
+               "passed directly as `x`")
+})
+
 test_that("constants outside `data` are not refused", {
   # One value, or a few, is the same in every replicate by design: only a
   # per-row vector is data the resample would miss.

--- a/tests/testthat/test-formula-helpers.R
+++ b/tests/testthat/test-formula-helpers.R
@@ -228,3 +228,79 @@ test_that("unknown predictor in RHS raises an informative error", {
     "Failed to parse formula RHS"
   )
 })
+
+# ---------------------------------------------------------------------------
+# `.` on the right-hand side (#273)
+# ---------------------------------------------------------------------------
+# `.` stands for every column the Surv() response does not use, as in
+# survival::coxph(). It used to expand to every column of `data`, so the
+# outcome entered the design as a predictor and the fit still converged.
+
+avc_dot <- na.omit(avc[, c("int_dead", "dead", "age", "mal")])
+
+fit_avc_dot <- function(formula) {
+  hazard(formula, data = avc_dot, dist = "weibull",
+         theta = c(0.3, 1, 0, 0), fit = TRUE)
+}
+
+test_that("`.` excludes the Surv() response columns from the design", {
+  dot <- parse(survival::Surv(int_dead, dead) ~ ., data = avc_dot)
+  explicit <- parse(survival::Surv(int_dead, dead) ~ age + mal,
+                    data = avc_dot)
+  expect_identical(colnames(dot$x), c("age", "mal"))
+  expect_identical(dot$x, explicit$x)
+})
+
+test_that("`. - mal` gives the `~ age` design", {
+  dot <- parse(survival::Surv(int_dead, dead) ~ . - mal, data = avc_dot)
+  explicit <- parse(survival::Surv(int_dead, dead) ~ age, data = avc_dot)
+  expect_identical(colnames(dot$x), "age")
+  expect_identical(dot$x, explicit$x)
+})
+
+test_that("`.` over a data frame holding only the response adds nothing", {
+  # terms() leaves `.` unexpanded here; model.matrix() must not expand it.
+  df <- data.frame(t = c(1, 2, 3, 4), d = c(1, 0, 1, 1))
+  out <- parse(survival::Surv(t, d) ~ ., data = df)
+  expect_null(out$x)
+})
+
+test_that("an empty `.` beside other terms stops rather than dropping them", {
+  df <- data.frame(t = c(1, 2, 3, 4), d = c(1, 0, 1, 1))
+  age <- c(50, 60, 70, 80)
+  # terms() itself warns on this shape; the error is what matters here.
+  expect_error(
+    suppressWarnings(parse(survival::Surv(t, d) ~ . + age, data = df)),
+    "stands for no column"
+  )
+})
+
+test_that("a `~ .` fit is the explicit fit, not one on the response", {
+  fit_dot <- fit_avc_dot(survival::Surv(int_dead, dead) ~ .)
+  fit_exp <- fit_avc_dot(survival::Surv(int_dead, dead) ~ age + mal)
+
+  expect_identical(colnames(fit_dot$data$x), c("age", "mal"))
+  expect_true(fit_exp$fit$converged)
+  expect_true(fit_dot$fit$converged)
+  expect_equal(fit_dot$fit$objective, fit_exp$fit$objective,
+               tolerance = 1e-8)
+  # A ratio, not a difference: mu is about 2e-4, small enough that
+  # expect_equal() would compare it on an absolute scale and pass anything.
+  expect_equal(unname(coef(fit_dot) / coef(fit_exp)), rep(1, 4),
+               tolerance = 1e-6)
+  # With the outcome as a predictor the log-likelihood rose to about -37.
+  expect_lt(fit_dot$fit$objective, -200)
+})
+
+test_that("predict() on a `~ .` fit needs no response columns in newdata", {
+  fit_dot <- fit_avc_dot(survival::Surv(int_dead, dead) ~ .)
+  fit_exp <- fit_avc_dot(survival::Surv(int_dead, dead) ~ age + mal)
+  nd <- data.frame(time = 1, age = 60, mal = 1)
+
+  s_dot <- predict(fit_dot, newdata = nd, type = "survival")
+  expect_length(s_dot, 1L)
+  expect_gt(s_dot, 0)
+  expect_lt(s_dot, 1)
+  expect_equal(s_dot, predict(fit_exp, newdata = nd, type = "survival"),
+               tolerance = 1e-8)
+})

--- a/tests/testthat/test-multiphase-hessian.R
+++ b/tests/testthat/test-multiphase-hessian.R
@@ -239,7 +239,7 @@ test_that(".hzr_hessian_multiphase matches numDeriv (2-phase with covariates)", 
     constant = hzr_phase("constant")
   )
   fit <- hazard(
-    survival::Surv(int_dead, dead) ~ early(age + com_iv),
+    survival::Surv(int_dead, dead) ~ 1,
     data    = avc,
     dist    = "multiphase",
     phases  = phases,
@@ -382,10 +382,10 @@ test_that("multiphase SEs are invariant to covariate rescaling (log-mu z-stat)",
   avc2 <- avc
   avc2$age <- avc$age / 10  # rescaled covariate
 
-  f1 <- hazard(survival::Surv(int_dead, dead) ~ early(age),
+  f1 <- hazard(survival::Surv(int_dead, dead) ~ 1,
                data = avc,  dist = "multiphase", phases = phases_base, fit = TRUE,
                control = list(n_starts = 1, conserve = FALSE))
-  f2 <- hazard(survival::Surv(int_dead, dead) ~ early(age),
+  f2 <- hazard(survival::Surv(int_dead, dead) ~ 1,
                data = avc2, dist = "multiphase", phases = phases_base, fit = TRUE,
                control = list(n_starts = 1, conserve = FALSE))
 
@@ -416,8 +416,7 @@ test_that("13-parameter multiphase anchor: stable SEs and rcond (supersedes plac
     constant = hzr_phase("constant")
   )
   fit <- hazard(
-    survival::Surv(int_dead, dead) ~
-      early(age + com_iv + mal + opmos + op_age + status),
+    survival::Surv(int_dead, dead) ~ 1,
     data = avc, dist = "multiphase", phases = phases_hd, fit = TRUE,
     control = list(n_starts = 3, maxit = 800, conserve = TRUE)
   )

--- a/tests/testthat/test-phase-specific-covariates.R
+++ b/tests/testthat/test-phase-specific-covariates.R
@@ -241,3 +241,77 @@ test_that("formula with base-R function name matching phase name is not wrongly 
     label = "early() call correctly detected as phase scope"
   )
 })
+
+# ---------------------------------------------------------------------------
+# Phase-scoped terms in the global formula are refused (#275)
+# ---------------------------------------------------------------------------
+# `constant(age)` in the global formula was stripped with the rest of the
+# right-hand side and never reached its phase, so the fit converged without
+# it. hazard() now stops instead of routing the term.
+
+avc_275 <- na.omit(avc[, c("int_dead", "dead", "age", "mal")])
+
+fit_275 <- function(formula, phase_formula = NULL) {
+  hazard(formula, data = avc_275, dist = "multiphase",
+         phases = list(
+           early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                                fixed = "m", formula = phase_formula),
+           constant = hzr_phase("constant", formula = phase_formula)
+         ),
+         fit = TRUE, control = list(n_starts = 1L, conserve = FALSE))
+}
+
+test_that("a phase-scoped term in the global formula stops, naming the phase", {
+  expect_error(fit_275(survival::Surv(int_dead, dead) ~ constant(age)),
+               "phase 'constant'.*hzr_phase\\(.*formula = ~")
+  expect_error(
+    fit_275(survival::Surv(int_dead, dead) ~ early(age) + constant(mal)),
+    "phases 'early', 'constant'"
+  )
+})
+
+test_that("the refusal does not fire when `phases` is ignored", {
+  # Outside dist = "multiphase" the phases are dropped with a warning, so a
+  # phase named `log` must not stop `log(age)` from being a covariate.
+  expect_warning(
+    fit <- hazard(survival::Surv(int_dead, dead) ~ log(age),
+                  data = avc_275, dist = "weibull",
+                  phases = list(log = hzr_phase("constant")),
+                  theta = c(0.3, 1, 0), fit = TRUE),
+    "'phases' is ignored"
+  )
+  expect_identical(colnames(fit$data$x), "log(age)")
+})
+
+# The next two guard the fits the refusal must leave alone. Each global-formula
+# fit is compared with the same model written through hzr_phase(formula = ),
+# an independent route to the same design, not with a recorded number: from
+# these starts BFGS stops short of the optimum, so a pinned log-likelihood
+# would record where it stopped rather than a property of the model.
+
+test_that("`~ log(age)`, with no phase named `log`, fits as a covariate", {
+  fit <- fit_275(survival::Surv(int_dead, dead) ~ log(age))
+  ref <- fit_275(survival::Surv(int_dead, dead) ~ 1,
+                 phase_formula = ~ log(age))
+  expect_true(fit$fit$converged)
+  expect_identical(
+    names(coef(fit)),
+    c("early.log_mu", "early.log_t_half", "early.nu", "early.m",
+      "early.log(age)", "constant.log_mu", "constant.log(age)")
+  )
+  expect_equal(fit$fit$objective, ref$fit$objective, tolerance = 1e-8)
+  expect_equal(unname(coef(fit) / coef(ref)), rep(1, 7), tolerance = 1e-6)
+})
+
+test_that("a plain global covariate in a multiphase fit is unchanged", {
+  fit <- fit_275(survival::Surv(int_dead, dead) ~ age)
+  ref <- fit_275(survival::Surv(int_dead, dead) ~ 1, phase_formula = ~ age)
+  expect_true(fit$fit$converged)
+  expect_identical(
+    names(coef(fit)),
+    c("early.log_mu", "early.log_t_half", "early.nu", "early.m",
+      "early.age", "constant.log_mu", "constant.age")
+  )
+  expect_equal(fit$fit$objective, ref$fit$objective, tolerance = 1e-8)
+  expect_equal(unname(coef(fit) / coef(ref)), rep(1, 7), tolerance = 1e-6)
+})

--- a/tests/testthat/test-phase-specific-covariates.R
+++ b/tests/testthat/test-phase-specific-covariates.R
@@ -315,3 +315,77 @@ test_that("a plain global covariate in a multiphase fit is unchanged", {
   expect_equal(fit$fit$objective, ref$fit$objective, tolerance = 1e-8)
   expect_equal(unname(coef(fit) / coef(ref)), rep(1, 7), tolerance = 1e-6)
 })
+
+# ---------------------------------------------------------------------------
+# `.` in a phase formula (#277)
+# ---------------------------------------------------------------------------
+# hzr_phase(formula = ~ .) was expanded against every column of `data`, so the
+# response entered the phase design and the fit converged on it. hazard() now
+# writes `.` out once, before fitting, against `data` without the Surv()
+# variables, so every later reader of the phase formula sees explicit terms.
+
+fit_277 <- function(phase_formula, data = avc_275) {
+  hazard(survival::Surv(int_dead, dead) ~ 1, data = data, dist = "multiphase",
+         phases = list(
+           early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                                fixed = "m", formula = phase_formula),
+           constant = hzr_phase("constant")
+         ),
+         fit = TRUE, control = list(n_starts = 1L, conserve = FALSE))
+}
+
+test_that("`.` in a phase formula excludes the Surv() response columns", {
+  fit <- fit_277(~ .)
+  expect_identical(colnames(fit$fit$x_list$early), c("age", "mal"))
+  expect_identical(all.vars(fit$spec$phases$early$formula), c("age", "mal"))
+})
+
+test_that("a `~ .` phase fit is the explicit phase fit", {
+  fit_dot <- fit_277(~ .)
+  fit_exp <- fit_277(~ age + mal)
+  expect_true(fit_exp$fit$converged)
+  expect_equal(fit_dot$fit$objective, fit_exp$fit$objective,
+               tolerance = 1e-8)
+  expect_equal(unname(coef(fit_dot) / coef(fit_exp)),
+               rep(1, length(coef(fit_exp))), tolerance = 1e-6)
+})
+
+test_that("`. - mal` in a phase formula gives the `~ age` phase design", {
+  fit <- fit_277(~ . - mal)
+  expect_identical(colnames(fit$fit$x_list$early), "age")
+})
+
+test_that("predict() on a `~ .` phase fit needs no response columns", {
+  fit_dot <- fit_277(~ .)
+  fit_exp <- fit_277(~ age + mal)
+  nd <- data.frame(time = 1, age = 60, mal = 1)
+  s_dot <- predict(fit_dot, newdata = nd, type = "survival")
+  expect_length(s_dot, 1L)
+  expect_equal(s_dot, predict(fit_exp, newdata = nd, type = "survival"),
+               tolerance = 1e-8)
+})
+
+test_that("`.` in a phase formula over response-only data", {
+  d0 <- avc_275[, c("int_dead", "dead")]
+  fit <- fit_277(~ ., data = d0)
+  expect_identical(unname(fit$fit$covariate_counts[["early"]]), 0L)
+  age <- avc_275$age
+  expect_error(suppressWarnings(fit_277(~ . + age, data = d0)),
+               "stands for no column")
+})
+
+test_that("`.` in a phase formula is refused on the vector interface", {
+  # With `time =` and `status =` there is no Surv() term to say which columns
+  # of `data` hold the response, so `.` cannot be expanded safely.
+  expect_error(
+    hazard(time = int_dead, status = dead, data = avc_275,
+           dist = "multiphase",
+           phases = list(
+             early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                                  fixed = "m", formula = ~ .),
+             constant = hzr_phase("constant")
+           ),
+           fit = TRUE, control = list(n_starts = 1L, conserve = FALSE)),
+    "formula interface"
+  )
+})

--- a/tests/testthat/test-stepwise-dot-formula.R
+++ b/tests/testthat/test-stepwise-dot-formula.R
@@ -1,0 +1,94 @@
+# tests/testthat/test-stepwise-dot-formula.R
+# hzr_stepwise() read a `~ .` base formula with terms() and no data. That
+# errors, the error was turned into "no terms", and the screen reported zero
+# steps as if it had finished (#279). It now stops and asks for the terms.
+
+avc_279 <- na.omit(avc[, c("int_dead", "dead", "age", "mal")])
+# Deterministic, and unrelated to survival: the screen should drop it.
+avc_279$noise <- sin(seq_len(nrow(avc_279)))
+
+test_that("a `~ .` base fit is refused before the screen prints anything", {
+  fit <- hazard(survival::Surv(int_dead, dead) ~ ., data = avc_279,
+                dist = "weibull", theta = c(0.3, 1, 0, 0, 0), fit = TRUE)
+  err <- NULL
+  out <- utils::capture.output(
+    err <- tryCatch(
+      hzr_stepwise(fit, data = avc_279, direction = "backward",
+                   criterion = "wald", slstay = 0.2, trace = TRUE),
+      error = conditionMessage
+    )
+  )
+  expect_match(err, "write the terms out")
+  expect_identical(out, character(0))
+})
+
+test_that("the term reader refuses `.` instead of returning no terms", {
+  expect_error(
+    .hzr_formula_rhs_terms(survival::Surv(int_dead, dead) ~ .),
+    "write the terms out"
+  )
+  expect_identical(.hzr_formula_rhs_terms(~ age + mal), c("age", "mal"))
+})
+
+test_that("a `scope` of `~ .` is refused rather than read as empty", {
+  # It used to give a screen with no candidates, and a zero-step result.
+  fit <- hazard(survival::Surv(int_dead, dead) ~ age, data = avc_279,
+                dist = "weibull", theta = c(0.3, 1, 0), fit = TRUE)
+  expect_error(
+    hzr_stepwise(fit, data = avc_279, scope = ~ ., direction = "forward",
+                 criterion = "wald", trace = FALSE),
+    "a `scope` can list its variables"
+  )
+})
+
+mp_279 <- function(early_formula = NULL, constant_formula = NULL) {
+  suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ .,
+    data = avc_279[, c("int_dead", "dead", "age")], dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1,
+                           fixed = "m", formula = early_formula),
+      constant = hzr_phase("constant", formula = constant_formula)
+    ),
+    fit = TRUE, control = list(n_starts = 1L, conserve = FALSE)
+  ))
+}
+
+test_that("a multiphase global `~ .` is refused when a phase inherits it", {
+  # A phase with no formula inherits the global design, and every candidate
+  # refit re-expands the global `.` against the screen's data: entering
+  # `mal` into `early` also put it in `constant`, and nothing said so.
+  expect_error(
+    hzr_stepwise(mp_279(), data = avc_279[, c("int_dead", "dead", "age",
+                                              "mal")],
+                 scope = list(early = ~ mal), direction = "forward",
+                 criterion = "wald", slentry = 0.99, trace = FALSE),
+    "write the terms out"
+  )
+})
+
+test_that("a multiphase global `~ .` runs when every phase has a formula", {
+  # Then no phase reads the global design, so its `.` changes nothing.
+  sw <- suppressWarnings(hzr_stepwise(
+    mp_279(~ age, ~ age),
+    data = avc_279[, c("int_dead", "dead", "age", "mal")],
+    scope = list(early = ~ mal), direction = "forward", criterion = "wald",
+    slentry = 0.99, trace = FALSE
+  ))
+  entered <- sw$steps[sw$steps$action == "enter", ]
+  expect_identical(entered$variable, "mal")
+  expect_identical(entered$phase, "early")
+  expect_true("early.mal" %in% names(coef(sw)))
+  expect_false("constant.mal" %in% names(coef(sw)))
+})
+
+test_that("the same screen with its terms written out drops noise", {
+  fit <- hazard(survival::Surv(int_dead, dead) ~ age + mal + noise,
+                data = avc_279, dist = "weibull",
+                theta = c(0.3, 1, 0, 0, 0), fit = TRUE)
+  sw <- hzr_stepwise(fit, data = avc_279, direction = "backward",
+                     criterion = "wald", slstay = 0.2, trace = FALSE)
+  expect_identical(sw$steps$action, "drop")
+  expect_identical(sw$steps$variable, "noise")
+  expect_identical(colnames(sw$data$x), c("age", "mal"))
+})

--- a/tests/testthat/test-vector-surv-status.R
+++ b/tests/testthat/test-vector-surv-status.R
@@ -1,0 +1,302 @@
+# ---------------------------------------------------------------------------
+# A Surv() object passed as `status` on the vector interface (#226)
+#
+# survival::Surv() and this package code censoring with different integers:
+#
+#   TemporalHazard   -1 left   0 right   1 event   2 interval
+#   Surv "left"                0 left    1 event
+#   Surv "interval"            0 right   1 event   2 left   3 interval
+#
+# The formula path always translated. The vector path unclassed the Surv and
+# took its second column unchanged, so a left-censored row was fitted as
+# right-censored, and for "interval" and "counting" the second column is not
+# even the status (it is time2 / stop). No error, no warning. Both paths now
+# read the Surv through one helper, so these tests assert the two agree.
+# ---------------------------------------------------------------------------
+
+surv_left_data <- function() {
+  set.seed(226)
+  n  <- 150
+  # An early-hazard component, so the multiphase early phase has something
+  # to estimate; without it that fit's Hessian is ill-conditioned.
+  tt <- ifelse(runif(n) < 0.3, rexp(n, rate = 4), rexp(n, rate = 0.3))
+  ev <- rep(1, n)
+  lc <- sample.int(n, 35)
+  ev[lc] <- 0                         # Surv "left": 0 = left-censored
+  tt[lc] <- tt[lc] + 0.5              # observed only as "before this time"
+  data.frame(tt = tt, ev = ev)
+}
+
+surv_interval_data <- function() {
+  set.seed(2261)
+  n  <- 150
+  tt <- rexp(n, rate = 0.3)
+  ev <- ifelse(tt >= 6, 0, 1)
+  tt <- pmin(tt, 6)
+  lo <- tt
+  hi <- rep(NA_real_, n)
+  idx_event <- which(ev == 1)
+  iv <- idx_event[1:25]               # event known only within a window
+  lf <- idx_event[26:40]              # event known only to precede a time
+  lo[iv] <- pmax(tt[iv] - 0.5, 1e-3)
+  hi[iv] <- tt[iv] + 0.5
+  ev[iv] <- 3                         # Surv "interval" code
+  lo[lf] <- tt[lf] + 0.5
+  ev[lf] <- 2                         # Surv "left" code under "interval"
+  data.frame(lo = lo, hi = hi, ev = ev)
+}
+
+surv_mp_phases <- function() {
+  list(
+    early    = hzr_phase("cdf", t_half = 0.3, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+}
+
+test_that("the #226 reproducer stores left-censored rows as -1", {
+  ph <- list(early = hzr_phase("cdf"), late = hzr_phase("constant"))
+  s  <- survival::Surv(c(1, 2, 3, 4, 5, 6), c(1, 0, 1, 1, 0, 1),
+                       type = "left")
+  f <- hazard(time = c(1, 2, 3, 4, 5, 6), status = s, dist = "multiphase",
+              phases = ph, fit = FALSE)
+
+  expect_equal(f$data$status, c(1, -1, 1, 1, -1, 1))
+  expect_equal(f$data$time_upper, c(1, 2, 3, 4, 5, 6))
+  expect_null(f$data$time_lower)
+})
+
+test_that("objective = 'sas' refuses a Surv left-censored row on both paths", {
+  ph <- list(early = hzr_phase("cdf"), late = hzr_phase("constant"))
+  d  <- data.frame(tt = c(1, 2, 3, 4, 5, 6), ev = c(1, 0, 1, 1, 0, 1))
+
+  err_vector <- tryCatch(
+    hazard(time = d$tt, status = survival::Surv(d$tt, d$ev, type = "left"),
+           dist = "multiphase", phases = ph, fit = FALSE, objective = "sas"),
+    error = conditionMessage
+  )
+  err_formula <- tryCatch(
+    hazard(survival::Surv(tt, ev, type = "left") ~ 1, data = d,
+           dist = "multiphase", phases = ph, fit = FALSE, objective = "sas"),
+    error = conditionMessage
+  )
+
+  expect_match(err_vector, "does not support left-censored rows",
+               fixed = TRUE)
+  expect_identical(err_vector, err_formula)
+})
+
+test_that("Surv 'interval' codes 0/1/2/3 map to 0/1/-1/2 on the vector path", {
+  lo <- c(1, 2, 3, 4)
+  hi <- c(NA, NA, NA, 6)
+  s  <- survival::Surv(lo, hi, c(0, 1, 2, 3), type = "interval")
+  f  <- hazard(time = lo, status = s, theta = c(mu = 0.5, nu = 1),
+               dist = "weibull", fit = FALSE)
+
+  expect_equal(f$data$status,     c(0, 1, -1, 2))
+  expect_equal(f$data$time_lower, c(0, 0, 0, 4))
+  expect_equal(f$data$time_upper, c(1, 2, 3, 6))
+})
+
+test_that("Surv 'interval' rows contribute to the vector-path likelihood", {
+  d  <- surv_interval_data()
+  iv <- d$ev == 3
+  fit_all <- hazard(time = d$lo,
+                    status = survival::Surv(d$lo, d$hi, d$ev,
+                                            type = "interval"),
+                    theta = c(mu = 0.5, nu = 1), dist = "weibull", fit = TRUE)
+  dk <- d[!iv, ]
+  fit_drop <- hazard(time = dk$lo,
+                     status = survival::Surv(dk$lo, dk$hi, dk$ev,
+                                             type = "interval"),
+                     theta = c(mu = 0.5, nu = 1), dist = "weibull", fit = TRUE)
+
+  expect_equal(sum(fit_all$data$status == 2), 25L)
+  expect_true(is.finite(fit_all$fit$objective))
+  expect_true(is.finite(fit_drop$fit$objective))
+  # Each interval row adds log(S(l) - S(u)) < 0, so dropping 25 of them has
+  # to move the log-likelihood by a visible amount.
+  expect_gt(abs(fit_all$fit$objective - fit_drop$fit$objective), 1)
+})
+
+# ---------------------------------------------------------------------------
+# Interface parity on real fits
+# ---------------------------------------------------------------------------
+
+surv_parity_fits <- function(type, dist) {
+  if (type == "left") {
+    d <- surv_left_data()
+    frm <- survival::Surv(tt, ev, type = "left") ~ 1
+    s <- survival::Surv(d$tt, d$ev, type = "left")
+    tm <- d$tt
+  } else {
+    d <- surv_interval_data()
+    frm <- survival::Surv(lo, hi, ev, type = "interval") ~ 1
+    s <- survival::Surv(d$lo, d$hi, d$ev, type = "interval")
+    tm <- d$lo
+  }
+  args <- if (dist == "weibull") {
+    list(dist = "weibull", theta = c(mu = 0.3, nu = 1))
+  } else {
+    list(dist = "multiphase", phases = surv_mp_phases(),
+         control = list(n_starts = 1, maxit = 2000))
+  }
+  list(
+    formula = do.call(hazard, c(list(frm, data = d, fit = TRUE), args)),
+    vector  = do.call(hazard, c(list(time = tm, status = s, fit = TRUE), args))
+  )
+}
+
+for (type in c("left", "interval")) {
+  for (dist in c("weibull", "multiphase")) {
+    test_that(sprintf("Surv '%s' gives the same %s fit on both interfaces",
+                      type, dist), {
+      fits <- surv_parity_fits(type, dist)
+      ff <- fits$formula
+      fv <- fits$vector
+
+      # The data must carry the censoring it claims before a fit is compared:
+      # a vector path that recoded nothing would still fit.
+      expected_left <- if (type == "left") 35L else 15L
+      expect_equal(sum(ff$data$status == -1), expected_left)
+
+      expect_identical(fv$data$status, ff$data$status)
+      expect_identical(fv$data$time, ff$data$time)
+      expect_identical(fv$data$time_lower, ff$data$time_lower)
+      expect_identical(fv$data$time_upper, ff$data$time_upper)
+
+      expect_true(is.finite(ff$fit$objective))
+      expect_true(is.finite(fv$fit$objective))
+      expect_equal(fv$fit$objective, ff$fit$objective, tolerance = 1e-8)
+      expect_equal(unname(coef(fv)), unname(coef(ff)), tolerance = 1e-6)
+    })
+  }
+}
+
+test_that("right and counting Surv give identical data on both interfaces", {
+  d <- data.frame(start = c(0, 1, 0, 2), stop = c(1, 3, 2, 5),
+                  ev = c(1, 0, 0, 1))
+
+  ff <- hazard(survival::Surv(stop, ev) ~ 1, data = d,
+               theta = c(mu = 0.5, nu = 1), dist = "weibull")
+  fv <- hazard(time = d$stop, status = survival::Surv(d$stop, d$ev),
+               theta = c(mu = 0.5, nu = 1), dist = "weibull")
+  expect_equal(fv$data$status, c(1, 0, 0, 1))
+  expect_identical(fv$data[c("time", "status", "time_lower", "time_upper")],
+                   ff$data[c("time", "status", "time_lower", "time_upper")])
+
+  ff <- hazard(survival::Surv(start, stop, ev) ~ 1, data = d,
+               theta = c(mu = 0.5, nu = 1), dist = "weibull")
+  fv <- hazard(time = d$stop,
+               status = survival::Surv(d$start, d$stop, d$ev),
+               theta = c(mu = 0.5, nu = 1), dist = "weibull")
+  # Column 2 of a counting Surv is `stop`, not the status.
+  expect_equal(fv$data$status, c(1, 0, 0, 1))
+  expect_equal(fv$data$time_lower, c(0, 1, 0, 2))
+  expect_identical(fv$data[c("time", "status", "time_lower", "time_upper")],
+                   ff$data[c("time", "status", "time_lower", "time_upper")])
+})
+
+test_that("an interval2 Surv, left-censored row included, matches the formula", {
+  # Surv() converts "interval2" to "interval". A left-censored row (lo = NA)
+  # stores its upper bound in time1, so `time` is 5 there, not NA.
+  d  <- data.frame(lo = c(NA, 2, 3, 1), hi = c(5, 2, NA, 4))
+  s  <- survival::Surv(d$lo, d$hi, type = "interval2")
+  ff <- hazard(survival::Surv(lo, hi, type = "interval2") ~ 1, data = d,
+               theta = c(mu = 0.5, nu = 1), dist = "weibull")
+  fv <- hazard(time = unclass(s)[, 1], status = s,
+               theta = c(mu = 0.5, nu = 1), dist = "weibull")
+
+  expect_equal(fv$data$status,     c(-1, 1, 0, 2))
+  expect_equal(fv$data$time,       c(5, 2, 3, 1))
+  expect_equal(fv$data$time_lower, c(0, 0, 0, 1))
+  expect_equal(fv$data$time_upper, c(5, 2, 3, 4))
+  expect_identical(fv$data[c("time", "status", "time_lower", "time_upper")],
+                   ff$data[c("time", "status", "time_lower", "time_upper")])
+})
+
+test_that("a vector Surv fit bootstraps with its Surv-supplied bounds", {
+  # The bounds come from the Surv, so they never appear in the stored call.
+  # hzr_bootstrap() used to rewire only arguments named there, and refitted
+  # every replicate with no bounds: 100% success over a different model, or
+  # over nothing (sd exactly 0). Compare replicates, not a summary of them.
+  di <- surv_interval_data()
+  set.seed(2262)
+  stop_t <- rexp(150, rate = 0.3) + 0.2
+  dc <- data.frame(st = stop_t * runif(150, 0, 0.5), sp = stop_t,
+                   e = rbinom(150, 1, 0.7))
+  cases <- list(
+    interval = list(
+      d = di, frm = survival::Surv(lo, hi, ev, type = "interval") ~ 1,
+      vec = function(d) {
+        hazard(time = lo,
+               status = survival::Surv(lo, hi, ev, type = "interval"),
+               data = d, theta = c(mu = 0.3, nu = 1),
+               dist = "weibull", fit = TRUE)
+      }),
+    counting = list(
+      d = dc, frm = survival::Surv(st, sp, e) ~ 1,
+      vec = function(d) {
+        hazard(time = sp, status = survival::Surv(st, sp, e),
+               data = d, theta = c(mu = 0.3, nu = 1),
+               dist = "weibull", fit = TRUE)
+      })
+  )
+  for (nm in names(cases)) {
+    d  <- cases[[nm]]$d
+    fv <- cases[[nm]]$vec(d)
+    ff <- hazard(cases[[nm]]$frm, data = d, theta = c(mu = 0.3, nu = 1),
+                 dist = "weibull", fit = TRUE)
+    bv <- suppressWarnings(hzr_bootstrap(fv, n_boot = 10, seed = 1))
+    bf <- suppressWarnings(hzr_bootstrap(ff, n_boot = 10, seed = 1))
+
+    expect_equal(bv$n_success, 10L, label = nm)
+    expect_equal(bv$replicates, bf$replicates, tolerance = 1e-8, label = nm)
+    sds <- tapply(bv$replicates$estimate, bv$replicates$parameter, stats::sd)
+    expect_true(all(sds > 0), label = nm)
+  }
+})
+
+test_that("an unsupported Surv type is refused identically on both paths", {
+  st <- factor(c("a", "b", "a"), levels = c("censor", "a", "b"))
+  d  <- data.frame(tt = c(1, 2, 3))
+  d$st <- st
+
+  err_vector <- tryCatch(
+    hazard(time = d$tt, status = survival::Surv(d$tt, st),
+           theta = c(mu = 0.5, nu = 1), dist = "weibull"),
+    error = conditionMessage
+  )
+  err_formula <- tryCatch(
+    hazard(survival::Surv(tt, st) ~ 1, data = d,
+           theta = c(mu = 0.5, nu = 1), dist = "weibull"),
+    error = conditionMessage
+  )
+  expect_match(err_vector, "Unsupported Surv() type: mright", fixed = TRUE)
+  expect_identical(err_vector, err_formula)
+})
+
+test_that("a Surv status whose times disagree with 'time' or a bound stops", {
+  s <- survival::Surv(c(1, 2, 3), c(1, 0, 1), type = "left")
+  expect_error(
+    hazard(time = c(1, 2, 4), status = s, theta = c(mu = 0.5, nu = 1),
+           dist = "weibull"),
+    "'time' does not match the times in the Surv object", fixed = TRUE
+  )
+  expect_error(
+    hazard(time = c(1, 2, 3), status = s, time_upper = c(1, 2, 9),
+           theta = c(mu = 0.5, nu = 1), dist = "weibull"),
+    "'time_upper' does not match the Surv object", fixed = TRUE
+  )
+  sc <- survival::Surv(c(0, 1), c(2, 3), c(1, 0))
+  expect_error(
+    hazard(time = c(2, 3), status = sc, time_lower = c(0, 0.5),
+           theta = c(mu = 0.5, nu = 1), dist = "weibull"),
+    "'time_lower' does not match the Surv object", fixed = TRUE
+  )
+  # A bound the Surv does not define is the caller's to supply: under
+  # "left" that is `time_lower`, the counting-process entry time.
+  f <- hazard(time = c(1, 2, 3), status = s, time_lower = c(0, 0.5, 0),
+              theta = c(mu = 0.5, nu = 1), dist = "weibull")
+  expect_equal(f$data$time_lower, c(0, 0.5, 0))
+  expect_equal(f$data$status, c(1, -1, 1))
+})


### PR DESCRIPTION
Six defects found in the v1.2.11 run-up, all converged or finished runs that gave a wrong answer with no error. Each is its own commit with its tests, merged with `main` at `e497a4a`.

Closes #226
Closes #273
Closes #275
Closes #277
Closes #278
Closes #279

## What changes

- **#226** A `survival::Surv()` passed as `status` on the vector interface is now read by its `type`, as the formula interface always did. It used to take the second column unchanged, so a left-censored row was fitted as right-censored, and `"interval"` / `"counting"` read `time2` / `stop` as status codes. Both interfaces now go through `.hzr_surv_response()`.
- **#273** `.` in a `hazard()` formula now means every column the `Surv()` term does not use, as in `survival::coxph()`. It used to put the response in the design, so the outcome was fitted as a predictor and the fit converged.
- **#275** A multiphase formula that names a phase as a function (`~ constant(age)`) is now refused. The term used to be stripped with the rest of the right-hand side and never reached its phase.
- **#277** `hzr_phase(formula = ~ .)` is now written out once in `hazard()`, before fitting, against `data` without the `Surv()` variables. The likelihood, the score test, `predict()` and the stored spec all see explicit terms.
- **#278** `hzr_bootstrap()` now refuses a fit whose response, covariates or select-mode `scope` use a per-row variable that is not a column of `data`. Such a variable was never resampled: on `avc`, 40 of 40 replicates succeeded, with no warning, and the interval excluded its own estimate. Constants outside `data` (`pi`, a cutoff, a knots vector) are still allowed.
- **#279** `hzr_stepwise()` now refuses a `~ .` base fit before printing anything. It used to read no terms and report a finished screen of zero steps.

## Breaking changes (calls that used to run now stop)

- `hazard(..., dist = "multiphase")` with a phase called as a function in the global formula (#275). Move the covariates into `hzr_phase(formula = ~ var)`.
- `hzr_bootstrap()` on a fit that uses a per-row variable outside `data` (#278). Add it to `data` and refit.
- `hzr_stepwise()` with a `~ .` base formula, a `scope = ~ .`, or a multiphase base whose global formula uses `.` while a phase inherits it (#279). Write the terms out.
- `.` in a phase formula on the vector interface (`time =`, `status =`), where no `Surv()` term says which columns hold the response (#277).
- `.` beside other terms when `data` holds only the response columns (#273).
- A `time`, `time_lower` or `time_upper` that disagrees with a `Surv` passed as `status` (#226).

**Estimates change** for any earlier fit that used `.` in the global or a phase formula (#273, #277), and so does the length of `theta` a `~ .` single-distribution fit needs.

## Gates (final tree, `384b668`)

- `devtools::document()`: `man/` and `NAMESPACE` clean on a second run (`git diff --exit-code`).
- `lintr::lint_package()`: 0 lints. `spelling::spell_check_package()`: no errors.
- `NOT_CRAN=true devtools::test()`, with `/Volumes/qhsstudies` mounted from start to end: **4674 passed, 0 failed, 6 skipped, 0 errors**. Both `test-repeated-events-parity.R` (5 tests) and `test-repeated-events-renewal-parity.R` (1 test) ran and passed. The skips:
  - `test-bhdead-sas-parity.R` x3: bh.dead SAS fixture not available;
  - `test-parity-c-binary.R` x1: the legacy binary exits with status 126;
  - `test-weights-sas-parity.R` x2: `weighted-avc-fractional.rds` not found.
- `R CMD check --as-cran` with the manual, from a clean `git archive` export: **Status OK (0/0/0)**, 228 s overall (tests 103 s, vignettes 42 s), tarball 3.20 MB, no `CLAUDE`/`AGENTS` files.
- Every fix was written test-first, and a mutation check reverted each fix and confirmed its tests fail.
- `r-reviewer` ran over each round (#273, #275, #277-#279, their follow-ups, and the merge with the doc commit). Each finding was reproduced before acting on it. The ones fixed:
  - the `.` edge cases;
  - the non-multiphase `dist` guard;
  - bootstrap false refusals of constants;
  - the response and select-mode `scope` checks, including the multiphase scope environment (`384b668`);
  - the multiphase `~ .` stepwise exemption;
  - NEWS figures that did not reproduce.

  The merge resolutions and the doc commit came back clean.

## Known, non-blocking

- `inst/dev/PLAN-hessian-analytic-multiphase.md` still shows the old `~ early(...)` global-formula syntax that #275 now refuses. It is a historical plan, excluded from the tarball.
- A phase named `log` makes `log(age)` in the global formula trigger the #275 refusal; `base::log(age)` fits. The helper's roxygen now says so.
- `hzr_bootstrap()`'s check works on variable names, so indirection such as `I(lst$a)` or `get("zz")` escapes it, and a constant vector whose length happens to equal the row count is refused. Both are rare; a value-based check would be a redesign.
- Pre-existing, not from this branch: adding a formula to a phase in a multiphase stepwise run drops the global covariate that phase inherited; and `document()` warns about an unresolved link at `R/likelihood-loglogistic.R:239`, which is identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
