### PR TITLE
fix: honour entry times in every family (#253); per-subject expected events in hzr_gof() (#254)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,28 @@
   not a `PROC HAZARD` refusal, so it is kept apart from the existing
   "selects no phase" stop.
 
+* **An entry time after the exit time is now an error, and
+  `time_lower = time` now means "no entry" in every family** (#253). On a
+  row with status 0 or 1, `time_lower` is the counting-process entry time
+  when `0 < time_lower < time`. `hazard()` used to warn when
+  `time_lower >= time` on such a row and fit anyway, and each family then
+  did something different. Multiphase returned a "log-likelihood" of
+  +47915.76 with `converged = TRUE` on the AVC data. The Weibull read the
+  rows as entering at time 0, and the other three families ignored
+  `time_lower` altogether.
+  - `time_lower > time` on a status 0/1 row now stops, as SAS HAZARD
+    rejects a start time after the exit time (error `SETCOE960`).
+  - `time_lower == time` on a status 0/1 row is read as no entry time, with
+    no warning, in all five families. This is the mixed-interval layout,
+    where exact and right-censored rows carry `time_lower = time` and only
+    interval-censored rows (status 2) carry a real lower bound. It was
+    already the Weibull rule; multiphase used to degenerate on it.
+  - `time_lower = 0` still means no entry time.
+  - Rows with `time_lower == time > 0` beside rows with a genuine entry
+    time now stop. In counting-process data they are zero-length epochs,
+    which `hzr_repeated_events()` can emit; read as "no entry", each would
+    be charged its full cumulative hazard from time 0.
+
 ## New features
 
 * **Every fit now says what it did not do** (#242, following #197). A
@@ -54,6 +76,29 @@
   earlier version prints "not recorded" rather than "none".
 
 ## Bug fixes
+
+* **Exponential, log-logistic and log-normal fits ignored left truncation**
+  (#253). On status 0/1 rows these three families used `time_lower` only as
+  a censoring bound, which applies to status 2, so a left-truncated fit was
+  silently fitted as if every subject had been at risk from time 0. They
+  now subtract the cumulative hazard at entry, H(time) - H(time_lower), as
+  the Weibull and multiphase likelihoods already did. The log-likelihood,
+  its gradient and the closed-form Hessian all carry the entry term.
+
+* **`hzr_gof()` reported a conservation ratio that was not one** (#254).
+  For a model with covariates it computed expected events from a single
+  curve at the covariate means, then printed the total as the
+  "Conservation ratio (E/O)". On the covariate model in the clinical
+  walkthrough vignette that printed 0.606, while the fit conserved events exactly (68.000 expected
+  against 68 observed). Expected events are now summed per subject, each
+  subject's cumulative hazard at exit minus that at entry, so E/O is the
+  conservation-of-events identity. For a weighted fit, both observed and
+  expected events now carry the case weights, since that is what a weighted
+  fit conserves (the sum of w·H equals the sum of w·d). The `par_surv` and
+  `par_cumhaz` columns are still the covariate-mean curve, for plotting
+  against Kaplan-Meier, and the risk-set counts and Kaplan-Meier columns stay
+  unweighted. Unweighted intercept-only fits without entry times are
+  unchanged.
 
 * **A Weibull fit with one masked variance reported the others on the wrong
   scale.** When the Hessian inverse has a non-positive variance, its row and

--- a/NEWS.md
+++ b/NEWS.md
@@ -233,6 +233,20 @@
   means, so a factor enters as the proportion of patients in each level.
   A fit with both global and phase-formula covariates is #264.
 
+* **`hzr_gof()` had four smaller errors**, all found by Copilot's review of
+  #285.
+  - With a custom `time_grid`, `n_risk` between Kaplan-Meier times carried
+    the previous count forward, so it kept subjects who had left and
+    missed ones who had entered. It now counts the risk set at each grid
+    time.
+  - An unsorted grid made the cumulative columns non-cumulative. The grid
+    is now sorted, with repeated times dropped.
+  - With an event at time 0, `km_surv` at 0 was averaged with 1.
+  - For a fit with both `time_windows` and entry times, expected events
+    took H(entry) in the entry-time covariate window, while the likelihood
+    uses the exit-time window. E/O came out 1.052 on a Weibull fit that
+    conserves events.
+
 * **A Weibull fit with one masked variance reported the others on the wrong
   scale.** When the Hessian inverse has a non-positive variance, its row and
   column are set to `NA`. The delta-method transform from the internal

--- a/NEWS.md
+++ b/NEWS.md
@@ -214,14 +214,24 @@
   "Conservation ratio (E/O)". On the covariate model in the clinical
   walkthrough vignette that printed 0.606, while the fit conserved events exactly (68.000 expected
   against 68 observed). Expected events are now summed per subject, each
-  subject's cumulative hazard at exit minus that at entry, so E/O is the
-  conservation-of-events identity. For a weighted fit, both observed and
+  subject's cumulative hazard at exit minus that at entry. For Weibull,
+  exponential and multiphase fits with conservation of events, E/O is then
+  the conservation-of-events identity; for log-logistic and log-normal fits
+  it checks calibration in total. For a weighted fit, both observed and
   expected events now carry the case weights, since that is what a weighted
   fit conserves (the sum of w·H equals the sum of w·d). The `par_surv` and
   `par_cumhaz` columns are still the covariate-mean curve, for plotting
   against Kaplan-Meier, and the risk-set counts and Kaplan-Meier columns stay
   unweighted. Unweighted intercept-only fits without entry times are
   unchanged.
+
+* **`hzr_gof()` drew the mean-patient curve at covariates of 0** for a
+  multiphase fit whose covariates enter only through the phase formulas.
+  Such a fit has no global design matrix, so the `par_surv` and
+  `par_cumhaz` columns were predicted from time alone, which set every
+  phase covariate to 0. They now use each phase's design-matrix column
+  means, so a factor enters as the proportion of patients in each level.
+  A fit with both global and phase-formula covariates is #264.
 
 * **A Weibull fit with one masked variance reported the others on the wrong
   scale.** When the Hessian inverse has a non-positive variance, its row and

--- a/NEWS.md
+++ b/NEWS.md
@@ -233,8 +233,14 @@
   means, so a factor enters as the proportion of patients in each level.
   A fit with both global and phase-formula covariates is #264.
 
-* **`hzr_gof()` had four smaller errors**, all found by Copilot's review of
-  #285.
+* **`hzr_gof()` had five smaller errors**, found by Copilot's and
+  r-reviewer's reviews of #285.
+  - `seq()` builds grid times that differ from the data times in the last
+    binary digits, and they were matched with a fixed tolerance of 100
+    machine epsilons. Above 128 that is smaller than the gap between
+    adjacent doubles, so at times in days or months events fell off the
+    grid: 180 of 197 were counted on a `seq(150, 300, by = 0.1)` grid. The
+    tolerance now scales with the time.
   - With a custom `time_grid`, `n_risk` between Kaplan-Meier times carried
     the previous count forward, so it kept subjects who had left and
     missed ones who had entered. It now counts the risk set at each grid

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -292,42 +292,54 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 
 #' Goodness-of-fit: observed vs. predicted events
 #'
-#' Compare a fitted hazard model against the nonparametric Kaplan-Meier
-#' estimate by computing observed and expected (parametric) event counts
-#' at each distinct event time.  This is the R equivalent of the SAS
-#' `hazplot.sas` macro and implements the conservation-of-events
-#' diagnostic.
+#' Compare a fitted hazard model with the data two ways: its survival curve
+#' against the nonparametric Kaplan-Meier estimate, and the number of events
+#' it expects against the number observed, tallied over follow-up.  This is
+#' the R equivalent of the SAS `hazplot.sas` macro and implements the
+#' conservation-of-events diagnostic.
 #'
-#' At each observed event time the function computes:
+#' At each time point the function computes:
 #' \itemize{
 #'   \item The Kaplan-Meier survival and cumulative hazard.
 #'   \item The parametric survival and cumulative hazard from the fitted
-#'     model (and per-phase components for multiphase models).
-#'   \item Cumulative observed events vs. cumulative expected events
-#'     (the parametric cumulative hazard at each time, times the number
-#'     of observations leaving the risk set then).
+#'     model at the covariate means (and per-phase components for
+#'     multiphase models).  This is the curve to plot against the
+#'     Kaplan-Meier estimate.
+#'   \item Cumulative observed events vs. cumulative expected events.  Each
+#'     patient's expected count is their own cumulative hazard, from their
+#'     own covariates, at the end of their follow-up, less their cumulative
+#'     hazard at entry when the fit is left truncated (`time_lower` on a
+#'     status 0 or 1 row).  These are summed over the patients leaving
+#'     follow-up at each time.
 #'   \item The running residual (expected minus observed).
 #' }
 #'
-#' For an intercept-only model every patient shares one curve, so the
-#' expected count is the sum of each patient's cumulative hazard at their
-#' own exit time.  At the maximum likelihood estimate that sum equals the
-#' number of observed events (the conservation-of-events identity): the
-#' final residual is zero and the printed "Conservation ratio (E/O)" is 1.
+#' The conservation-of-events principle says a model fit by maximum
+#' likelihood predicts as many events as were observed: add up every
+#' patient's cumulative hazard over their follow-up and you get the event
+#' count back.  The final residual is then zero and the printed
+#' "Conservation ratio (E/O)" is 1.  A multiphase fit with Conservation of
+#' Events applied (`control = list(conserve = TRUE)`, the default) meets the
+#' identity by construction.  Weibull and exponential fits meet it at the
+#' exact maximum, so at a converged fit E/O sits close to 1, off only by how
+#' far short of the maximum the optimizer stopped.  The log-logistic and
+#' log-normal models carry no such identity, and for them E/O is a check of
+#' calibration in total.
 #'
-#' A model with covariates is different.  The parametric curve, and so the
-#' expected count, is evaluated at the covariate means, one "mean patient"
-#' standing in for everyone.  The mean patient's cumulative hazard is not
-#' the average of the patients' cumulative hazards, so the printed E/O is
-#' not the conservation-of-events identity and need not be near 1 at a
-#' correct fit.  Read it as a mean-patient check: how closely the curve
-#' for a patient with average covariates follows the whole cohort.
+#' The parametric curve is a different quantity.  For a model with
+#' covariates it belongs to one "mean patient" with average covariates, and
+#' the mean patient's cumulative hazard is not the average of the patients'
+#' cumulative hazards, so `par_cumhaz` does not enter the expected count.
+#' For an intercept-only model every patient shares that curve and the two
+#' agree.
 #'
-#' To check conservation of events for a covariate model, sum each
-#' patient's own cumulative hazard at their follow-up time and compare the
-#' total with the event count.  Pass the covariate columns plus a `time`
-#' column to [predict.hazard()] with `type = "cumulative_hazard"`; the
-#' Examples show how.
+#' For a weighted fit both tallies carry the case weights: observed events
+#' are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
+#' form in which a weighted fit conserves events.  The `n_risk`, `n_event`,
+#' `n_censor` and Kaplan-Meier columns are unweighted.
+#'
+#' With a custom `time_grid`, a patient is counted in both tallies only if
+#' their follow-up time falls on a grid point.
 #'
 #' @param object A fitted `hazard` object (with `fit = TRUE`).
 #' @param time_grid Optional numeric vector of time points at which to
@@ -338,26 +350,32 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' @return A data frame with one row per time point and columns:
 #' \describe{
 #'   \item{time}{Evaluation time.}
-#'   \item{n_risk}{Number at risk (Kaplan-Meier).}
+#'   \item{n_risk}{Number at risk (Kaplan-Meier). A subject with an entry
+#'     time is at risk only from that time on.}
 #'   \item{n_event}{Number of events at this time.}
 #'   \item{n_censor}{Number censored at this time.}
-#'   \item{km_surv}{Kaplan-Meier survival estimate.}
+#'   \item{km_surv}{Kaplan-Meier survival estimate, using the
+#'     counting-process risk set when the fit has entry times.}
 #'   \item{km_cumhaz}{Kaplan-Meier cumulative hazard
 #'     (\eqn{-\log(\text{km\_surv})}).}
 #'   \item{par_surv}{Parametric survival from the fitted model, at the
-#'     covariate means for a model with covariates.}
+#'     covariate means for a model with covariates.  For plotting against
+#'     \code{km_surv}; not used for \code{cum_expected}.}
 #'   \item{par_cumhaz}{Parametric cumulative hazard, at the covariate
-#'     means for a model with covariates.}
-#'   \item{cum_observed}{Cumulative observed events to this time.}
-#'   \item{cum_expected}{Cumulative expected events: \code{par_cumhaz}
-#'     times the number of observations exiting the risk set, summed to
-#'     this time.}
+#'     means for a model with covariates.  For plotting; not used for
+#'     \code{cum_expected}.}
+#'   \item{cum_observed}{Cumulative observed events to this time, weighted
+#'     by the case weights for a weighted fit.}
+#'   \item{cum_expected}{Cumulative expected events: over the patients
+#'     leaving follow-up by this time, the sum of each patient's own
+#'     cumulative hazard at exit minus that at entry, weighted by the case
+#'     weights for a weighted fit.}
 #'   \item{residual}{Expected minus observed
 #'     (\code{cum_expected - cum_observed}).}
 #' }
 #'
 #' For multiphase models, additional columns are appended for each
-#' phase: \code{par_cumhaz_<phase>}.
+#' phase: \code{par_cumhaz_<phase>}, also at the covariate means.
 #'
 #' An attribute `"summary"` is attached with scalar diagnostics:
 #' total observed events, total expected events, and the final residual.
@@ -376,13 +394,12 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' gof <- hzr_gof(fit)
 #' print(gof)
 #'
-#' # With covariates, hzr_gof() uses the covariate means, so its E/O is a
-#' # mean-patient check.  The conservation-of-events check sums each
-#' # patient's own cumulative hazard at their follow-up time:
+#' # Expected events are summed per patient, so the total is the sum of
+#' # each patient's own cumulative hazard at their follow-up time:
 #' nd <- avc[, c("age", "mal")]
 #' nd$time <- avc$int_dead
-#' c(expected = sum(predict(fit, newdata = nd, type = "cumulative_hazard")),
-#'   observed = sum(avc$dead))
+#' c(hzr_gof = attr(gof, "summary")$total_expected,
+#'   predict = sum(predict(fit, newdata = nd, type = "cumulative_hazard")))
 #'
 #' # Plot observed vs expected events
 #' if (requireNamespace("ggplot2", quietly = TRUE)) {
@@ -427,7 +444,20 @@ hzr_gof <- function(object, time_grid = NULL) {
   }
 
   # --- Kaplan-Meier via survival::survfit -----------------------------------
-  km_fit <- survival::survfit(survival::Surv(obs_time, obs_status) ~ 1)
+  # Same entry rule as the expected count below: a subject with a genuine
+  # entry time (0 < time_lower < time) is not at risk before it, so the
+  # product-limit estimate and n_risk use the counting-process risk set.
+  km_entry <- object$data$time_lower
+  km_entry <- if (is.null(km_entry)) {
+    rep(0, n_total)
+  } else {
+    ifelse(km_entry > 0 & km_entry < obs_time, km_entry, 0)
+  }
+  km_fit <- if (any(km_entry > 0)) {
+    survival::survfit(survival::Surv(km_entry, obs_time, obs_status) ~ 1)
+  } else {
+    survival::survfit(survival::Surv(obs_time, obs_status) ~ 1)
+  }
 
   # survfit output: time, n.risk, n.event, n.censor, surv
   km_times   <- km_fit$time
@@ -441,7 +471,8 @@ hzr_gof <- function(object, time_grid = NULL) {
     time_grid <- km_times
   }
 
-  # --- Parametric predictions at each time point ----------------------------
+  # --- Parametric curve at each time point (for the KM overlay) -------------
+  # This curve is for plotting only; expected events are per subject below.
   is_multiphase <- (object$spec$dist == "multiphase")
 
   if (!is.null(object$data$x) && ncol(object$data$x) > 0) {
@@ -479,31 +510,79 @@ hzr_gof <- function(object, time_grid = NULL) {
   # Interpolate n.risk, n.event, n.censor at grid times
   # For event counts, sum events at matching times; 0 otherwise
   km_n_risk_grid <- stats::approx(
-    x = c(0, km_times), y = c(n_total, km_n_risk),
+    x = c(0, km_times), y = c(sum(km_entry == 0), km_n_risk),
     xout = time_grid, method = "constant", f = 0, rule = 2
   )$y
+  # A time belongs to the first grid point within this tolerance, or to none.
+  # Counts, observed events and expected events all use this one rule, so for
+  # a custom time_grid the two tallies cover the same subjects.
+  grid_index <- function(t) {
+    match_idx <- which(abs(time_grid - t) < .Machine$double.eps * 100)
+    if (length(match_idx) > 0) match_idx[1] else NA_integer_
+  }
   km_n_event_grid <- rep(0, length(time_grid))
   km_n_censor_grid <- rep(0, length(time_grid))
   for (i in seq_along(km_times)) {
-    match_idx <- which(abs(time_grid - km_times[i]) < .Machine$double.eps * 100)
-    if (length(match_idx) > 0) {
-      km_n_event_grid[match_idx[1]] <- km_n_event[i]
-      km_n_censor_grid[match_idx[1]] <- km_n_censor[i]
+    g <- grid_index(km_times[i])
+    if (!is.na(g)) {
+      km_n_event_grid[g] <- km_n_event[i]
+      km_n_censor_grid[g] <- km_n_censor[i]
     }
   }
 
   # --- Conservation of Events accounting ------------------------------------
-  # At each event time, accumulate:
-  #   cum_observed: running sum of observed events
-  #   cum_expected: running sum of individual cumulative hazards for
-  #                 observations exiting the risk set (events + censored)
+  # Each subject's expected events are its own cumulative hazard at exit, less
+  # its cumulative hazard at the counting-process entry time (time_lower on a
+  # status 0/1 row with 0 < time_lower < time), the quantity a maximum
+  # likelihood fit conserves. The covariate-mean curve above cannot stand in
+  # for it: the mean patient's H is not the mean of the patients' H (#254).
   #
-  # The expected events for observations leaving at time t is:
-  #   (n_event + n_censor) * parametric_cumhaz(t)
-  # This is the SAS hazplot approach: total * _CUMHAZ at that interval.
+  # predict() without newdata evaluates the stored design (x, or the
+  # per-phase x_list for multiphase) at the stored time, for either interface.
+  # Swapping the stored time for the entry time gives H(entry) the same way.
+  obs_weights <- object$data$weights
+  if (is.null(obs_weights)) obs_weights <- rep(1, n_total)
 
-  cum_observed <- cumsum(km_n_event_grid)
-  interval_expected <- (km_n_event_grid + km_n_censor_grid) * par_cumhaz
+  h_exit <- predict(object, type = "cumulative_hazard")
+  if (length(h_exit) != n_total) {
+    stop("predict() returned ", length(h_exit), " cumulative hazards for ",
+         n_total, " subjects.", call. = FALSE)
+  }
+  entry <- object$data$time_lower
+  has_entry <- if (is.null(entry)) {
+    rep(FALSE, n_total)
+  } else {
+    entry > 0 & entry < obs_time
+  }
+  h_entry <- rep(0, n_total)
+  if (any(has_entry)) {
+    at_entry <- object
+    at_entry$data$time <- ifelse(has_entry, entry, obs_time)
+    h_entry[has_entry] <-
+      predict(at_entry, type = "cumulative_hazard")[has_entry]
+  }
+
+  # A weighted fit conserves weighted events, sum(w * H) = sum(w * d), so both
+  # tallies carry the case weights.
+  subject_expected <- obs_weights * (h_exit - h_entry)
+  subject_observed <- obs_weights * obs_status
+
+  uniq_time <- unique(obs_time)
+  subject_grid <- vapply(uniq_time, grid_index,
+                         integer(1))[match(obs_time, uniq_time)]
+  on_grid <- !is.na(subject_grid)
+  interval_observed <- rep(0, length(time_grid))
+  interval_expected <- rep(0, length(time_grid))
+  if (any(on_grid)) {
+    agg <- rowsum(cbind(subject_observed, subject_expected)[on_grid, ,
+                                                            drop = FALSE],
+                  subject_grid[on_grid])
+    g <- as.integer(rownames(agg))
+    interval_observed[g] <- agg[, 1]
+    interval_expected[g] <- agg[, 2]
+  }
+
+  cum_observed <- cumsum(interval_observed)
   cum_expected <- cumsum(interval_expected)
   residual <- cum_expected - cum_observed
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -298,6 +298,10 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' the R equivalent of the SAS `hazplot.sas` macro and implements the
 #' conservation-of-events diagnostic.
 #'
+#' The diagnostic is for right-censored data: every stored status must be 0
+#' (censored) or 1 (event).  A fit with any left-censored (status -1) or
+#' interval-censored (status 2) row is refused with an error.
+#'
 #' At each time point the function computes:
 #' \itemize{
 #'   \item The Kaplan-Meier survival and cumulative hazard.
@@ -331,7 +335,9 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' the mean patient's cumulative hazard is not the average of the patients'
 #' cumulative hazards, so `par_cumhaz` does not enter the expected count.
 #' For an intercept-only model every patient shares that curve and the two
-#' agree.
+#' agree.  The means are those of the design-matrix columns, taken phase by
+#' phase when a multiphase fit's covariates enter through the phase
+#' formulas, so a factor enters as the proportion of patients in each level.
 #'
 #' For a weighted fit both tallies carry the case weights: observed events
 #' are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
@@ -344,8 +350,8 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' @param object A fitted `hazard` object (with `fit = TRUE`).
 #' @param time_grid Optional numeric vector of time points at which to
 #'   evaluate the parametric model.
-#'   If `NULL` (default), uses the sorted unique event times from the
-#'   fitted data.
+#'   If `NULL` (default), uses the distinct Kaplan-Meier times of the
+#'   fitted data, which are the event times and the censoring times.
 #'
 #' @return A data frame with one row per time point and columns:
 #' \describe{
@@ -394,8 +400,9 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' gof <- hzr_gof(fit)
 #' print(gof)
 #'
-#' # Expected events are summed per patient, so the total is the sum of
-#' # each patient's own cumulative hazard at their follow-up time:
+#' # Expected events are summed per patient.  This fit has no entry times,
+#' # so the total is the sum of each patient's own cumulative hazard at
+#' # their follow-up time:
 #' nd <- avc[, c("age", "mal")]
 #' nd$time <- avc$int_dead
 #' c(hzr_gof = attr(gof, "summary")$total_expected,
@@ -474,23 +481,39 @@ hzr_gof <- function(object, time_grid = NULL) {
   # --- Parametric curve at each time point (for the KM overlay) -------------
   # This curve is for plotting only; expected events are per subject below.
   is_multiphase <- (object$spec$dist == "multiphase")
+  has_phase_x <- is_multiphase && any(vapply(
+    object$fit$x_list, function(m) !is.null(m) && ncol(m) > 0, logical(1)
+  ))
 
+  curve_obj <- object
   if (!is.null(object$data$x) && ncol(object$data$x) > 0) {
     # For covariate models, evaluate at covariate means (baseline patient)
     x_means <- colMeans(object$data$x)
     nd <- as.data.frame(t(x_means))
     nd <- nd[rep(1, length(time_grid)), , drop = FALSE]
     nd$time <- time_grid
+  } else if (has_phase_x) {
+    # Covariates entered only through the phase formulas, so data$x is NULL
+    # and a time-only newdata would put them at 0. Put each phase's design
+    # matrix at its column means and the stored times at the grid; predict()
+    # without newdata then evaluates that stored design.
+    curve_obj$data$time <- time_grid
+    curve_obj$fit$x_list <- lapply(object$fit$x_list, function(m) {
+      if (is.null(m) || ncol(m) == 0) return(m)
+      matrix(colMeans(m), nrow = length(time_grid), ncol = ncol(m),
+             byrow = TRUE, dimnames = list(NULL, colnames(m)))
+    })
+    nd <- NULL
   } else {
     nd <- data.frame(time = time_grid)
   }
 
-  par_cumhaz <- predict(object, newdata = nd, type = "cumulative_hazard")
+  par_cumhaz <- predict(curve_obj, newdata = nd, type = "cumulative_hazard")
 
   # Phase decomposition for multiphase models
   phase_cumhaz <- NULL
   if (is_multiphase) {
-    decomp <- predict(object, newdata = nd, type = "cumulative_hazard",
+    decomp <- predict(curve_obj, newdata = nd, type = "cumulative_hazard",
                       decompose = TRUE)
     # decomp is a matrix; first column is "total", rest are phase names
     phase_cols <- colnames(decomp)[colnames(decomp) != "total"]

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -336,8 +336,10 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' cumulative hazards, so `par_cumhaz` does not enter the expected count.
 #' For an intercept-only model every patient shares that curve and the two
 #' agree.  The means are those of the design-matrix columns, taken phase by
-#' phase when a multiphase fit's covariates enter through the phase
+#' phase when a multiphase fit's covariates enter only through the phase
 #' formulas, so a factor enters as the proportion of patients in each level.
+#' A multiphase fit with both global and phase-formula covariates is not yet
+#' handled here (#264).
 #'
 #' For a weighted fit both tallies carry the case weights: observed events
 #' are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
@@ -508,12 +510,12 @@ hzr_gof <- function(object, time_grid = NULL) {
     nd <- data.frame(time = time_grid)
   }
 
-  par_cumhaz <- predict(curve_obj, newdata = nd, type = "cumulative_hazard")
+  par_cumhaz <- stats::predict(curve_obj, newdata = nd, type = "cumulative_hazard")
 
   # Phase decomposition for multiphase models
   phase_cumhaz <- NULL
   if (is_multiphase) {
-    decomp <- predict(curve_obj, newdata = nd, type = "cumulative_hazard",
+    decomp <- stats::predict(curve_obj, newdata = nd, type = "cumulative_hazard",
                       decompose = TRUE)
     # decomp is a matrix; first column is "total", rest are phase names
     phase_cols <- colnames(decomp)[colnames(decomp) != "total"]
@@ -566,7 +568,7 @@ hzr_gof <- function(object, time_grid = NULL) {
   obs_weights <- object$data$weights
   if (is.null(obs_weights)) obs_weights <- rep(1, n_total)
 
-  h_exit <- predict(object, type = "cumulative_hazard")
+  h_exit <- stats::predict(object, type = "cumulative_hazard")
   if (length(h_exit) != n_total) {
     stop("predict() returned ", length(h_exit), " cumulative hazards for ",
          n_total, " subjects.", call. = FALSE)
@@ -582,7 +584,7 @@ hzr_gof <- function(object, time_grid = NULL) {
     at_entry <- object
     at_entry$data$time <- ifelse(has_entry, entry, obs_time)
     h_entry[has_entry] <-
-      predict(at_entry, type = "cumulative_hazard")[has_entry]
+      stats::predict(at_entry, type = "cumulative_hazard")[has_entry]
   }
 
   # A weighted fit conserves weighted events, sum(w * H) = sum(w * d), so both

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -334,8 +334,10 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' covariates it belongs to one "mean patient" with average covariates, and
 #' the mean patient's cumulative hazard is not the average of the patients'
 #' cumulative hazards, so `par_cumhaz` does not enter the expected count.
-#' For an intercept-only model every patient shares that curve and the two
-#' agree.  The means are those of the design-matrix columns, taken phase by
+#' For an intercept-only model every patient shares that curve.  Without
+#' entry times each patient's expected count is the curve at their exit time;
+#' with entry times it is the curve's rise from entry to exit, so the two
+#' differ.  The means are those of the design-matrix columns, taken phase by
 #' phase when a multiphase fit's covariates enter only through the phase
 #' formulas, so a factor enters as the proportion of patients in each level.
 #' A multiphase fit with both global and phase-formula covariates is not yet
@@ -354,12 +356,14 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #'   evaluate the parametric model.
 #'   If `NULL` (default), uses the distinct Kaplan-Meier times of the
 #'   fitted data, which are the event times and the censoring times.
+#'   A supplied grid is sorted and repeated times dropped, because the
+#'   cumulative columns accumulate in time order.
 #'
 #' @return A data frame with one row per time point and columns:
 #' \describe{
 #'   \item{time}{Evaluation time.}
-#'   \item{n_risk}{Number at risk (Kaplan-Meier). A subject with an entry
-#'     time is at risk only from that time on.}
+#'   \item{n_risk}{Number at risk at this time: subjects still in
+#'     follow-up. A subject with an entry time is at risk only after it.}
 #'   \item{n_event}{Number of events at this time.}
 #'   \item{n_censor}{Number censored at this time.}
 #'   \item{km_surv}{Kaplan-Meier survival estimate, using the
@@ -377,7 +381,9 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #'   \item{cum_expected}{Cumulative expected events: over the patients
 #'     leaving follow-up by this time, the sum of each patient's own
 #'     cumulative hazard at exit minus that at entry, weighted by the case
-#'     weights for a weighted fit.}
+#'     weights for a weighted fit.  With \code{time_windows}, both cumulative
+#'     hazards use the patient's covariate window at exit, as the likelihood
+#'     does.}
 #'   \item{residual}{Expected minus observed
 #'     (\code{cum_expected - cum_observed}).}
 #' }
@@ -470,7 +476,6 @@ hzr_gof <- function(object, time_grid = NULL) {
 
   # survfit output: time, n.risk, n.event, n.censor, surv
   km_times   <- km_fit$time
-  km_n_risk  <- km_fit$n.risk
   km_n_event <- km_fit$n.event
   km_n_censor <- km_fit$n.censor
   km_surv    <- km_fit$surv
@@ -478,6 +483,15 @@ hzr_gof <- function(object, time_grid = NULL) {
   # --- Decide time grid -----------------------------------------------------
   if (is.null(time_grid)) {
     time_grid <- km_times
+  } else {
+    if (!is.numeric(time_grid) || length(time_grid) == 0 ||
+        any(!is.finite(time_grid))) {
+      stop("'time_grid' must be a non-empty numeric vector of finite times.",
+           call. = FALSE)
+    }
+    # The cumulative columns accumulate in grid order, so the grid must run
+    # forward in time, once.
+    time_grid <- sort(unique(time_grid))
   }
 
   # --- Parametric curve at each time point (for the KM overlay) -------------
@@ -525,19 +539,25 @@ hzr_gof <- function(object, time_grid = NULL) {
   par_surv <- exp(-par_cumhaz)
 
   # --- Interpolate KM at the time grid --------------------------------------
-  # Use stepfun-style interpolation for KM (right-continuous)
-  km_surv_at_grid <- stats::approx(
-    x = c(0, km_times), y = c(1, km_surv),
-    xout = time_grid, method = "constant", f = 0, rule = 2
-  )$y
+  # A right-continuous step function, 1 before the first Kaplan-Meier time.
+  # approx() with a (0, 1) sentinel prepended duplicated x = 0 when a time was
+  # exactly 0, and then averaged the two values there.
+  km_surv_at_grid <- stats::stepfun(km_times, c(1, km_surv))(time_grid)
   km_cumhaz_at_grid <- -log(pmax(km_surv_at_grid, .Machine$double.xmin))
 
-  # Interpolate n.risk, n.event, n.censor at grid times
+  # The risk set at each grid time, counted directly. A subject followed from
+  # 0 is at risk at t while t <= exit; one with an entry time only while
+  # entry < t <= exit. That is survfit's n.risk at its own times, and it stays
+  # right between them, where carrying survfit's count forward had kept
+  # subjects who had left and missed ones who had entered. Count every
+  # subject with exit >= t, less the late entrants not yet in (entry >= t,
+  # whose exit is later still).
+  n_at_or_after <- function(v, t) {
+    length(v) - findInterval(t, sort(v), left.open = TRUE)
+  }
+  km_n_risk_grid <- n_at_or_after(obs_time, time_grid) -
+    n_at_or_after(km_entry[km_entry > 0], time_grid)
   # For event counts, sum events at matching times; 0 otherwise
-  km_n_risk_grid <- stats::approx(
-    x = c(0, km_times), y = c(sum(km_entry == 0), km_n_risk),
-    xout = time_grid, method = "constant", f = 0, rule = 2
-  )$y
   # A time belongs to the first grid point within this tolerance, or to none.
   # Counts, observed events and expected events all use this one rule, so for
   # a custom time_grid the two tallies cover the same subjects.
@@ -583,6 +603,16 @@ hzr_gof <- function(object, time_grid = NULL) {
   if (any(has_entry)) {
     at_entry <- object
     at_entry$data$time <- ifelse(has_entry, entry, obs_time)
+    tw <- object$spec$time_windows
+    if (!is_multiphase && !is.null(tw) && !is.null(object$data$x) &&
+        ncol(object$data$x) > 0) {
+      # The likelihood takes H(entry) with each row's design expanded at its
+      # exit time. predict() would re-expand at the entry time, so hand it
+      # the exit-time design, already expanded, and no windows.
+      at_entry$data$x <- .hzr_expand_time_varying_design(
+        x = object$data$x, time = obs_time, time_windows = tw)
+      at_entry$spec$time_windows <- NULL
+    }
     h_entry[has_entry] <-
       stats::predict(at_entry, type = "cumulative_hazard")[has_entry]
   }

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -560,9 +560,11 @@ hzr_gof <- function(object, time_grid = NULL) {
   # time, the rule grid_index() applies to the event tallies below, so n_risk
   # agrees with n_event and n_censor there. seq(0.1, 1, by = 0.1)[3] is
   # 0.30000000000000004, and an exact count at it drops the exits at 0.3.
+  # The tolerance is relative above 1: 100 * eps is under one ulp above 128,
+  # so an absolute one matched nothing at times in days or months.
   time_tol <- .Machine$double.eps * 100
   risk_time <- vapply(time_grid, function(g) {
-    k <- which(abs(km_times - g) < time_tol)
+    k <- which(abs(km_times - g) < time_tol * max(1, abs(g)))
     if (length(k) > 0) km_times[k[1]] else g
   }, numeric(1))
   km_n_risk_grid <- n_at_or_after(obs_time, risk_time) -
@@ -572,7 +574,7 @@ hzr_gof <- function(object, time_grid = NULL) {
   # Counts, observed events and expected events all use this one rule, so for
   # a custom time_grid the two tallies cover the same subjects.
   grid_index <- function(t) {
-    match_idx <- which(abs(time_grid - t) < time_tol)
+    match_idx <- which(abs(time_grid - t) < time_tol * max(1, abs(t)))
     if (length(match_idx) > 0) match_idx[1] else NA_integer_
   }
   km_n_event_grid <- rep(0, length(time_grid))

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -356,8 +356,9 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #'   evaluate the parametric model.
 #'   If `NULL` (default), uses the distinct Kaplan-Meier times of the
 #'   fitted data, which are the event times and the censoring times.
-#'   A supplied grid is sorted and repeated times dropped, because the
-#'   cumulative columns accumulate in time order.
+#'   A supplied grid must hold finite, non-negative times.  It is sorted
+#'   and exact repeats dropped, because the cumulative columns accumulate in
+#'   time order.
 #'
 #' @return A data frame with one row per time point and columns:
 #' \describe{
@@ -485,9 +486,9 @@ hzr_gof <- function(object, time_grid = NULL) {
     time_grid <- km_times
   } else {
     if (!is.numeric(time_grid) || length(time_grid) == 0 ||
-        any(!is.finite(time_grid))) {
-      stop("'time_grid' must be a non-empty numeric vector of finite times.",
-           call. = FALSE)
+        any(!is.finite(time_grid)) || any(time_grid < 0)) {
+      stop("'time_grid' must be a non-empty numeric vector of finite, ",
+           "non-negative times.", call. = FALSE)
     }
     # The cumulative columns accumulate in grid order, so the grid must run
     # forward in time, once.
@@ -555,14 +556,23 @@ hzr_gof <- function(object, time_grid = NULL) {
   n_at_or_after <- function(v, t) {
     length(v) - findInterval(t, sort(v), left.open = TRUE)
   }
-  km_n_risk_grid <- n_at_or_after(obs_time, time_grid) -
-    n_at_or_after(km_entry[km_entry > 0], time_grid)
+  # A grid time within time_tol of a Kaplan-Meier time is counted at that
+  # time, the rule grid_index() applies to the event tallies below, so n_risk
+  # agrees with n_event and n_censor there. seq(0.1, 1, by = 0.1)[3] is
+  # 0.30000000000000004, and an exact count at it drops the exits at 0.3.
+  time_tol <- .Machine$double.eps * 100
+  risk_time <- vapply(time_grid, function(g) {
+    k <- which(abs(km_times - g) < time_tol)
+    if (length(k) > 0) km_times[k[1]] else g
+  }, numeric(1))
+  km_n_risk_grid <- n_at_or_after(obs_time, risk_time) -
+    n_at_or_after(km_entry[km_entry > 0], risk_time)
   # For event counts, sum events at matching times; 0 otherwise
   # A time belongs to the first grid point within this tolerance, or to none.
   # Counts, observed events and expected events all use this one rule, so for
   # a custom time_grid the two tallies cover the same subjects.
   grid_index <- function(t) {
-    match_idx <- which(abs(time_grid - t) < .Machine$double.eps * 100)
+    match_idx <- which(abs(time_grid - t) < time_tol)
     if (length(match_idx) > 0) match_idx[1] else NA_integer_
   }
   km_n_event_grid <- rep(0, length(time_grid))

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -111,18 +111,21 @@ NULL
 #'   * `status == 2` (interval-censored): the lower bound of the censoring
 #'     interval, defaulting to `time`. Every `dist` reads it this way.
 #'   * `status %in% c(0, 1)` (right-censored or event): the counting-process
-#'     **entry time**, so the row contributes `H(time) - H(time_lower)`.
-#'     Only `dist = "weibull"` and `dist = "multiphase"` use this role, and
-#'     `"weibull"` only where `time_lower < time`. The `"exponential"`,
-#'     `"loglogistic"` and `"lognormal"` families ignore `time_lower` on these
-#'     rows. Left `NULL`, the entry time is **`0`**, not `time`.
+#'     **entry time** when `0 < time_lower < time`, so the row contributes
+#'     `H(time) - H(time_lower)`. Every `dist` reads it this way. A value of
+#'     `0`, or equal to `time`, means no entry time, and left `NULL` the
+#'     entry time is **`0`**.
 #'   * `status == -1` (left-censored): not used; the bound is `time_upper`.
 #'
-#'   Passing `time_lower = time` therefore states that every subject entered
-#'   the risk set at the instant it left. `hazard()` accepts it with a
-#'   warning. Under `"multiphase"` those rows lose their cumulative-hazard
-#'   term and the fit it returns is meaningless; `"weibull"` reads them as
-#'   entering at time 0, and the other families ignore the argument there.
+#'   `time_lower = time` on the status 0 and 1 rows is the mixed-interval
+#'   layout: exact and right-censored rows carry their own time, and only
+#'   the status-2 rows carry a real lower bound. A subject cannot enter the
+#'   risk set after the moment it leaves, so `hazard()` stops with an error
+#'   when a status 0 or 1 row has `time_lower > time`, as SAS HAZARD rejects
+#'   a start time after the exit time. It also stops when rows with
+#'   `time_lower == time > 0` sit beside rows with genuine entry times: in
+#'   counting-process data those are zero-length epochs, which
+#'   [hzr_repeated_events()] can emit and which must be adjusted first.
 #' @param time_upper Optional numeric upper bound vector for censoring intervals.
 #'   Used when `status %in% c(-1, 2)`; defaults to `time` if NULL.
 #' @param x Optional design matrix (or data frame coercible to matrix).
@@ -627,30 +630,42 @@ hazard <- function(formula = NULL,
     }
   }
 
-  # For status 0/1 rows `time_lower` is the counting-process ENTRY time, not a
-  # censoring bound, so `time_lower >= time` says the subject left the risk set
-  # at or before it entered.  Under "multiphase" such a row contributes
-  # H(time) - H(time_lower), which is zero or negative: it drops out of the
-  # likelihood, or worse ("weibull" reads it as entry at 0, and the other
-  # families ignore time_lower on status 0/1 rows; issue #253).  With
-  # every row like that the objective is unbounded above and the optimizer
-  # returns a large positive "log-likelihood", converged = TRUE and rcond = 0,
-  # with nothing naming the cause.  Reported as issue #136, where the argument
-  # had been supplied in the belief that it was a no-op.
+  # For status 0/1 rows `time_lower` is the counting-process ENTRY time when
+  # 0 < time_lower < time, and every family forms H(time) - H(time_lower)
+  # there (the entry rule lives in each likelihood, e.g.
+  # .hzr_multiphase_entry()).  time_lower == time means no entry: that is the
+  # mixed-interval layout, where only status-2 rows carry a real lower bound.
+  # Multiphase used to read it as an entry at exit, and the objective became
+  # unbounded (+47915.76, converged = TRUE, issue #136/#253).
+  # An entry AFTER exit is a data error.  SAS HAZARD refuses STIME >= TIME
+  # (SETCOE960 in setcoe_obs_loop.c), but its STIME is only ever an entry
+  # time; here time_lower doubles as the interval bound, so only
+  # time_lower > time is refused (issue #253).
   if (!is.null(time_lower)) {
-    degenerate <- status %in% c(0, 1) & time_lower >= time
-    if (any(degenerate)) {
-      warning(sum(degenerate), " of ", n, " row(s) have 'time_lower' >= 'time' ",
-              "with status 0 or 1. On these rows 'time_lower' is not a ",
-              "censoring bound (that role belongs to status 2). ",
-              "dist = \"multiphase\" reads it as the counting-process entry ",
-              "time, so the rows enter the risk set at or after they leave ",
-              "it, their cumulative-hazard term vanishes or turns negative, ",
-              "and the fit is meaningless. dist = \"weibull\" treats them as ",
-              "entering at time 0, and the other families ignore ",
-              "'time_lower' on these rows. For entry at time 0, leave ",
-              "'time_lower' as NULL.",
-              call. = FALSE)
+    bad_entry <- status %in% c(0, 1) & time_lower > time
+    if (any(bad_entry)) {
+      stop(sum(bad_entry), " of ", n, " row(s) with status 0 or 1 have ",
+           "'time_lower' > 'time'. On these rows 'time_lower' is the ",
+           "counting-process entry time, and a subject cannot enter the ",
+           "risk set after it leaves (SAS HAZARD rejects this too). For no ",
+           "entry time, leave 'time_lower' as NULL or set it to 0 or to ",
+           "'time'.",
+           call. = FALSE)
+    }
+    # time_lower == time > 0 reads as "no entry" only in the mixed-interval
+    # layout. Beside genuine entries it is a zero-length counting-process
+    # epoch (hzr_repeated_events() emits them), and "no entry" would charge
+    # the row its full H(0, time], so the mix is refused (r-reviewer, #253).
+    genuine  <- status %in% c(0, 1) & time_lower > 0 & time_lower < time
+    zero_len <- status %in% c(0, 1) & time_lower > 0 & time_lower == time
+    if (any(genuine) && any(zero_len)) {
+      stop(sum(zero_len), " of ", n, " row(s) with status 0 or 1 have ",
+           "'time_lower' equal to 'time' while other rows carry genuine ",
+           "entry times. These are zero-length counting-process epochs, ",
+           "entering and leaving the risk set at the same moment; remove ",
+           "or adjust them before fitting (see ?hzr_repeated_events). SAS ",
+           "HAZARD refuses them too.",
+           call. = FALSE)
     }
   }
 

--- a/R/hessian-multiphase.R
+++ b/R/hessian-multiphase.R
@@ -346,8 +346,8 @@ NULL
 #' Returns the \eqn{p \times p} Hessian of the **objective** (negative
 #' log-likelihood) on the internal parameter scale, matching
 #' \code{numDeriv::hessian(objective)}.  Coverage: event + right-censored
-#' rows, with counting-process start-time corrections when
-#' \code{time_lower > 0}. Returns \code{NULL} for data containing
+#' rows, with counting-process start-time corrections on status 0/1 rows
+#' where \code{0 < time_lower < time}. Returns \code{NULL} for data containing
 #' left-censored (\code{status == -1}) or interval-censored
 #' (\code{status == 2}) rows; the caller falls back to numDeriv in that case.
 #'
@@ -376,25 +376,15 @@ NULL
   n_e       <- length(idx_event)
 
   # Counting-process start-time handling (mirrors gradient)
-  # The start time must be defined EXACTLY as the log-likelihood defines it:
-  # `.hzr_logl_multiphase()` subtracts H(time_lower) from every status 0/1 row
-  # whenever `time_lower` is supplied, with no further condition. An earlier
-  # `time_lower < time` filter here excluded rows entering at their own event
-  # or censoring time, so the derivative was taken of a different function from
-  # the one being evaluated -- the optimizer then walked off a cliff. The
-  # `> 0` test is only a skip: H(0) = 0, so those rows contribute nothing
-  # either way, and it must match `has_start` below or the term is weighted in
-  # while its derivative is left at zero.
-  need_start <- !is.null(time_lower) &&
-                any(time_lower > 0 & status %in% c(0L, 1L))
-  start_vec <- if (need_start) {
-    sv <- rep(0, n)
-    epoch_idx <- status %in% c(0L, 1L)
-    sv[epoch_idx] <- time_lower[epoch_idx]
-    sv
-  } else {
-    NULL
-  }
+  # The start time must be defined EXACTLY as the log-likelihood defines it,
+  # so it comes from the same helper, `.hzr_multiphase_entry()`: the entry is
+  # `time_lower` on a status 0/1 row with 0 < time_lower < time, and 0
+  # otherwise (issue #253). Differentiating a different function from the one
+  # being evaluated sent the optimizer off a cliff (issue #136). The `> 0` test
+  # is only a skip: H(0) = 0, so a zero entry contributes nothing.
+  entry <- .hzr_multiphase_entry(time, status, time_lower)
+  need_start <- !is.null(entry) && any(entry > 0)
+  start_vec <- if (need_start) entry else NULL
 
   theta_split <- .hzr_split_theta(theta, phases, covariate_counts)
 

--- a/R/likelihood-exponential.R
+++ b/R/likelihood-exponential.R
@@ -68,10 +68,15 @@ NULL
 #'
 #' \deqn{S(t | x) = \exp(-\lambda t \exp(\eta))}
 #'
-#' The log-likelihood for right-censored data is:
+#' The log-likelihood for right-censored data with entry times \eqn{s_i} is:
 #'
 #' \deqn{\ell(\theta) = \sum_{i: \delta_i = 1} [\log\lambda + \eta_i]
-#'   - \lambda \sum_i t_i \exp(\eta_i)}
+#'   - \lambda \sum_i (t_i - s_i) \exp(\eta_i)}
+#'
+#' For status 0/1 rows, \eqn{s_i} is \code{time_lower} where
+#' \code{time_lower < time} (counting-process entry, left truncation) and 0
+#' otherwise, so each row contributes \eqn{H(t_i) - H(s_i)}. Status 2 rows
+#' use \code{time_lower} as the interval lower bound instead.
 #'
 #' Reparameterization: theta\[1\] = log(lambda) avoids constrained optimization.
 #'
@@ -130,22 +135,31 @@ NULL
   cumhaz_lower <- lambda * lower * exp(eta)
   cumhaz_upper <- lambda * upper * exp(eta)
 
+  # Counting-process entry-time cumulative hazard H(start) for status 0/1
+  # rows, as in .hzr_logl_weibull(): only genuine epoch rows (time_lower <
+  # time) get a non-zero start.  Status 2 rows keep start = 0 because their
+  # time_lower is the interval lower bound, used via cumhaz_lower.
+  start_vec <- .hzr_entry_start_exponential(time, status, time_lower)
+  cumhaz_start <- lambda * start_vec * exp(eta)
+
   idx_event <- status == 1
   idx_right <- status == 0
   idx_left <- status == -1
   idx_interval <- status == 2
 
-  # Event: w * [log h(t) + log S(t)] = w * [log(lambda)+eta - H(t)]
+  # Event: w * [log h(t) - (H(t) - H(start))]
   ll_event <- if (any(idx_event)) {
     sum(weights[idx_event] *
-          ((log_lambda + eta[idx_event]) - cumhaz_event[idx_event]))
+          ((log_lambda + eta[idx_event]) -
+             (cumhaz_event[idx_event] - cumhaz_start[idx_event])))
   } else {
     0
   }
 
-  # Right-censored: w * log S(t) = -w * H(t)
+  # Right-censored: w * [-(H(t) - H(start))]
   ll_right <- if (any(idx_right)) {
-    -sum(weights[idx_right] * cumhaz_event[idx_right])
+    -sum(weights[idx_right] *
+           (cumhaz_event[idx_right] - cumhaz_start[idx_right]))
   } else {
     0
   }
@@ -192,11 +206,12 @@ NULL
 #' Computes the score vector of the exponential log-likelihood w.r.t. all parameters.
 #'
 #' The log-likelihood is:
-#'   \eqn{L = \sum(\delta_i * [\log(\lambda) + \eta_i]) - \sum(\lambda * t_i * \exp(\eta_i))}
+#'   \eqn{L = \sum(\delta_i * [\log(\lambda) + \eta_i]) - \sum(\lambda * (t_i - s_i) * \exp(\eta_i))}
 #'
-#' Derivatives:
-#' dL/d(log lambda) = sum(delta_i) - sum(lambda * t_i * exp(eta_i)) = sum(delta_i) - sum(H_i)
-#' dL/dbeta_j    = sum(delta_i * x_ij) - sum(lambda * t_i * exp(eta_i) * x_ij) = t(X) %*% (delta - H)
+#' where \eqn{s_i} is the entry time (0 unless status 0/1 and time_lower < time).
+#' With \eqn{H_i = \lambda (t_i - s_i) \exp(\eta_i)}, the derivatives are:
+#' dL/d(log lambda) = sum(delta_i) - sum(H_i)
+#' dL/dbeta_j    = t(X) %*% (delta - H)
 #'
 #' @noRd
 .hzr_gradient_exponential <- function(
@@ -242,13 +257,19 @@ NULL
     cumhaz <- lambda * time * exp(eta)
   }
 
+  # Entry-time H(start); zero except for genuine epoch rows (status 0/1 with
+  # time_lower < time).  H is linear in lambda * exp(eta), so the entry term
+  # enters every derivative as H(t) -> H(t) - H(start).
+  cumhaz_start <- lambda * .hzr_entry_start_exponential(time, status,
+                                                        time_lower) * exp(eta)
+
   # Weighted building blocks: every term below is the unweighted form with
-  # `status` -> `w * status` and `cumhaz` -> `w * cumhaz`.
+  # `status` -> `w * status` and `cumhaz` -> `w * (H(t) - H(start))`.
   w_status <- weights * status
-  w_cumhaz <- weights * cumhaz
+  w_cumhaz <- weights * (cumhaz - cumhaz_start)
 
   # ===== Gradient w.r.t. log(lambda) =====
-  # dL/d(log lambda) = sum(w * delta) - sum(w * H)
+  # dL/d(log lambda) = sum(w * delta) - sum(w * (H(t) - H(start)))
   grad[1] <- sum(w_status) - sum(w_cumhaz)
 
   # ===== Gradient w.r.t. beta (covariate coefficients) =====
@@ -270,7 +291,8 @@ NULL
 #' row is left- or interval-censored (\code{status \%in\% c(-1, 2)}) it returns
 #' \code{NULL} to request the numerical-Hessian fallback.
 #'
-#' Derivation: with \eqn{H_i = \lambda t_i e^{\eta_i}} and design matrix
+#' Derivation: with \eqn{H_i = \lambda (t_i - s_i) e^{\eta_i}} (\eqn{s_i} the
+#' entry time, 0 unless status 0/1 and time_lower < time) and design matrix
 #' \eqn{\tilde X = [1 | X]}, the log-likelihood Hessian is
 #' \eqn{-\tilde X^\top \mathrm{diag}(w H) \tilde X}; the objective Hessian is its
 #' negation, \eqn{+\tilde X^\top \mathrm{diag}(w H) \tilde X}.
@@ -307,8 +329,9 @@ NULL
     eta <- rep(0, n)
   }
 
-  # Weighted cumulative hazard per row.
-  wH <- weights * lambda * time * exp(eta)
+  # Weighted cumulative hazard per row, net of the entry-time H(start).
+  start_vec <- .hzr_entry_start_exponential(time, status, time_lower)
+  wH <- weights * lambda * (time - start_vec) * exp(eta)
 
   # Design matrix augmented with the log(lambda) "intercept" column.
   x_tilde <- if (is.null(x)) matrix(1, nrow = n, ncol = 1L) else cbind(1, x)
@@ -339,6 +362,18 @@ NULL
     control = control, use_bounds = FALSE,
     hessian_fn = hessian_fn
   )
+}
+
+# Counting-process entry time per row: time_lower for status 0/1 rows with
+# time_lower < time, 0 otherwise (status -1/2 rows, or time_lower NULL).
+# Same rule as .hzr_logl_weibull().
+.hzr_entry_start_exponential <- function(time, status, time_lower) {
+  start_vec <- rep(0, length(time))
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
+  start_vec
 }
 
 .hzr_numeric_grad_exponential <- function(theta, time, status,

--- a/R/likelihood-loglogistic.R
+++ b/R/likelihood-loglogistic.R
@@ -61,8 +61,10 @@ NULL
 #'
 #' @param time Numeric vector of follow-up times (n)
 #' @param status Numeric vector of event indicators: 1 = event, 0 = censored (n)
-#' @param time_lower Optional numeric lower bound vector for interval-censored rows.
-#'   Defaults to time if NULL.
+#' @param time_lower Optional numeric vector. For status 0/1 rows it is the
+#'   counting-process entry (left-truncation) time, used where
+#'   \code{time_lower < time}; for status 2 rows it is the interval lower
+#'   bound. Defaults to time if NULL (no entry time).
 #' @param time_upper Optional numeric upper bound vector for left/interval-censored rows.
 #'   Defaults to time if NULL.
 #' @param x Design matrix of covariates (n x p_coef); NULL for no covariates
@@ -90,11 +92,16 @@ NULL
 #'
 #' \deqn{H(t | x) = \log(1 + \alpha t^{\beta} \exp(\eta))}
 #'
-#' The log-likelihood for right-censored data is:
+#' The log-likelihood for right-censored data with entry times \eqn{s_i} is:
 #'
 #' \deqn{\ell(\theta) = \sum_{\delta_i = 1} [\log(\alpha \beta) + (\beta - 1)
 #'   \log(t_i) + \eta_i - \log(1 + \alpha t_i^{\beta} \exp(\eta_i))] - \sum_{i}
-#'   \log(1 + \alpha t_i^{\beta} \exp(\eta_i))}
+#'   [\log(1 + \alpha t_i^{\beta} \exp(\eta_i)) -
+#'   \log(1 + \alpha s_i^{\beta} \exp(\eta_i))]}
+#'
+#' that is, each status 0/1 row contributes \eqn{H(t_i) - H(s_i)}. The entry
+#' time is \eqn{s_i} = time_lower where time_lower < time on status 0/1 rows,
+#' and \eqn{s_i = 0} otherwise, where \eqn{H(0) = 0} and the entry term vanishes.
 #'
 #' Reparameterization: theta\[1\] = log(alpha), theta\[2\] = log(beta) avoids constrained optimization.
 #'
@@ -211,7 +218,25 @@ NULL
     0
   }
 
-  logl <- ll_event + ll_right + ll_left + ll_interval
+  # Counting-process entry (left truncation), as in the Weibull likelihood:
+  # status 0/1 rows with time_lower < time contribute H(time) - H(start), so
+  # each adds back w * H(start) = w * log(1 + term(start)).  Status -1/2 rows
+  # keep start = 0; for status 2, time_lower is the interval lower bound.
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
+  idx_start <- start_vec > 0
+  ll_entry <- if (any(idx_start)) {
+    sum(weights[idx_start] *
+          log1p(exp(log_alpha + beta * log(start_vec[idx_start]) +
+                      eta[idx_start])))
+  } else {
+    0
+  }
+
+  logl <- ll_event + ll_right + ll_left + ll_interval + ll_entry
 
   if (!is.finite(logl)) {
     return(Inf)
@@ -315,9 +340,25 @@ NULL
   grad[2] <- sum(w_status) +
              beta * (sum(w_status * log_t) - sum(wm * log_t))
 
-  # dL/dbeta_j = t(X) %*% (w * delta - wm)
+  # Entry term + w * log(1 + term_s), with term_s = alpha s^beta exp(eta) at
+  # the entry time s.  Its derivatives are w * p_s * (1, beta * log s, x) with
+  # p_s = term_s / (1 + term_s).  Rows without entry (s = 0) get p_s = 0 and
+  # log s = 0 exactly, so they contribute 0 and never 0 * -Inf = NaN.
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
+  idx_start <- start_vec > 0
+  log_s <- ifelse(idx_start, log(pmax(start_vec, .Machine$double.xmin)), 0)
+  term_s <- ifelse(idx_start, alpha * exp(beta * log_s + eta), 0)
+  ws <- weights * term_s / (1 + term_s)
+  grad[1] <- grad[1] + sum(ws)
+  grad[2] <- grad[2] + beta * sum(ws * log_s)
+
+  # dL/dbeta_j = t(X) %*% (w * delta - wm + ws)
   if (p > 2 && !is.null(x)) {
-    residual <- w_status - wm
+    residual <- w_status - wm + ws
     grad[3:p] <- as.numeric(crossprod(x, residual))
   }
 
@@ -382,6 +423,25 @@ NULL
   hess <- crossprod(u, d_wt * u)
   hess[2L, 2L] <- hess[2L, 2L] +
     beta * sum(weights * log_t * ((1 + delta) * pr - delta))
+
+  # Entry term: the objective carries -w * log(1 + term_s) at the entry time
+  # s, i.e. the right-censored term at s with the sign flipped.  Rows without
+  # entry have p_s = 0 and log s = 0 and so contribute nothing.
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
+  idx_start <- start_vec > 0
+  if (any(idx_start)) {
+    log_s <- ifelse(idx_start, log(pmax(start_vec, .Machine$double.xmin)), 0)
+    term_s <- ifelse(idx_start, exp(log_alpha + beta * log_s + eta), 0)
+    pr_s <- term_s / (1 + term_s)
+    u_s <- cbind(1, beta * log_s)
+    if (has_cov) u_s <- cbind(u_s, x)
+    hess <- hess - crossprod(u_s, (weights * pr_s * (1 - pr_s)) * u_s)
+    hess[2L, 2L] <- hess[2L, 2L] - beta * sum(weights * log_s * pr_s)
+  }
   dimnames(hess) <- list(names(theta), names(theta))
   hess
 }

--- a/R/likelihood-lognormal.R
+++ b/R/likelihood-lognormal.R
@@ -68,8 +68,10 @@ NULL
 #'
 #' @param time Numeric vector of follow-up times (n)
 #' @param status Numeric vector of event indicators: 1 = event, 0 = censored (n)
-#' @param time_lower Optional numeric lower bound vector for interval-censored rows.
-#'   Defaults to time if NULL.
+#' @param time_lower Optional numeric vector. For interval-censored rows
+#'   (status 2) the lower bound, defaulting to time if NULL. For event and
+#'   right-censored rows (status 1/0) the counting-process entry
+#'   (left-truncation) time, used where time_lower < time.
 #' @param time_upper Optional numeric upper bound vector for left/interval-censored rows.
 #'   Defaults to time if NULL.
 #' @param x Design matrix of covariates (n x p_coef); NULL for no covariates
@@ -95,6 +97,12 @@ NULL
 #' The log-likelihood for right-censored data is:
 #' \deqn{\ell(\theta) = \sum_{\delta_i=1} [\log \phi(z_i) - \log \sigma - \log t_i]
 #'   + \sum_{\delta_i=0} \log \Phi(-z_i)}
+#'
+#' A row with status 0 or 1 and an entry time s_i = time_lower\[i\] with
+#' 0 < s_i < t_i (left truncation) adds the entry term
+#' \deqn{- \log \Phi(-z_{s,i}), \quad z_{s,i} = (\log(s_i) - \eta_i) / \sigma,}
+#' that is + H(s_i), so the row contributes over (s_i, t_i] only. Rows
+#' entering at 0 add nothing, since log S(0) = 0.
 #'
 #' Reparameterization: theta\[1\] = mu, theta\[2\] = log(sigma) avoids constraints.
 #'
@@ -192,7 +200,26 @@ NULL
     0
   }
 
-  logl <- ll_event + ll_right + ll_left + ll_interval
+  # Counting-process entry (left truncation) for event/right-censored rows:
+  # + w * H(start) = - w * log S(start).  Only rows with status 0/1 and
+  # time_lower < time are epochs; status -1/2 rows keep start = 0 because
+  # there time_lower is a censoring bound.  Rows entering at 0 contribute
+  # exactly 0 (log S(0) = 0), so the term is evaluated on start > 0 only,
+  # which keeps log(0) out of z.
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
+  idx_entry <- start_vec > 0
+  ll_entry <- if (any(idx_entry)) {
+    z_s <- (log(start_vec[idx_entry]) - eta[idx_entry]) / sigma
+    -sum(weights[idx_entry] * pnorm(-z_s, log.p = TRUE))
+  } else {
+    0
+  }
+
+  logl <- ll_event + ll_right + ll_left + ll_interval + ll_entry
 
   if (!is.finite(logl)) {
     return(Inf)
@@ -302,6 +329,36 @@ NULL
     grad[3:p] <- as.numeric(crossprod(x, score_i))
   }
 
+  # ===== Counting-process entry term =====
+  # + w * H(start) is the right-censored term at `start` with the sign
+  # flipped, so its score is minus the right-censored score at z_s.
+  # Evaluated on start > 0 only (rows entering at 0 contribute 0).
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
+  idx_entry <- start_vec > 0
+  if (any(idx_entry)) {
+    if (is.null(eta)) {
+      eta <- if (p > 2 && !is.null(x)) {
+        theta[1] + as.numeric(x %*% theta[3:p])
+      } else {
+        rep(theta[1], n)
+      }
+    }
+    z_s <- (log(start_vec[idx_entry]) - eta[idx_entry]) / sigma
+    mills_s <- pmin(exp(dnorm(z_s, log = TRUE) - pnorm(-z_s, log.p = TRUE)),
+                    1e6)
+    w_mills_s <- weights[idx_entry] * mills_s
+    grad[1] <- grad[1] - sum(w_mills_s) / sigma
+    grad[2] <- grad[2] - sum(w_mills_s * z_s)
+    if (p > 2 && !is.null(x)) {
+      grad[3:p] <- grad[3:p] -
+        as.numeric(crossprod(x[idx_entry, , drop = FALSE], w_mills_s)) / sigma
+    }
+  }
+
   grad
 }
 
@@ -362,6 +419,25 @@ NULL
   a_coef <- (delta + cens * m * (m - z)) / sigma^2                 # (eta, eta)
   b_coef <- (delta * 2 * z + cens * m * (z * (m - z) + 1)) / sigma # (eta, log_sigma)
   c_coef <- delta * 2 * z^2 + cens * m * z * (z * (m - z) + 1)     # (log_sigma)^2
+
+  # Counting-process entry: + w * H(start) is the right-censored term at
+  # `start` with the sign flipped, so subtract the right-censored
+  # coefficients evaluated at z_s.  Only start > 0 rows (start = 0 adds 0).
+  start_vec <- rep(0, n)
+  if (!is.null(time_lower)) {
+    epoch_idx <- status %in% c(0L, 1L) & time_lower < time
+    start_vec[epoch_idx] <- time_lower[epoch_idx]
+  }
+  idx_entry <- start_vec > 0
+  if (any(idx_entry)) {
+    z_s <- (log(start_vec[idx_entry]) - eta[idx_entry]) / sigma
+    m_s <- pmin(exp(dnorm(z_s, log = TRUE) - pnorm(-z_s, log.p = TRUE)), 1e6)
+    a_coef[idx_entry] <- a_coef[idx_entry] - m_s * (m_s - z_s) / sigma^2
+    b_coef[idx_entry] <- b_coef[idx_entry] -
+      m_s * (z_s * (m_s - z_s) + 1) / sigma
+    c_coef[idx_entry] <- c_coef[idx_entry] -
+      m_s * z_s * (z_s * (m_s - z_s) + 1)
+  }
 
   x_tilde <- if (has_cov) cbind(1, x) else matrix(1, nrow = n, ncol = 1L)
 

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -307,10 +307,12 @@
 #' @param weights Optional numeric vector of row weights (length n). Defaults to
 #'   unit weights. Applied when summing per-phase cumhaz so that selection
 #'   happens on the same scale as the (weighted) observed event count.
-#' @param time_lower Optional numeric vector of counting-process entry (start)
-#'   times. When supplied, phases are ranked by entry-time cumulative hazard
-#'   `H(stop) - H(start)`, the scale on which events are conserved. `NULL` (the
-#'   default) means no truncation, i.e. `H(start) = 0`.
+#' @param time_lower Optional numeric vector. On a status 0/1 row with
+#'   0 < time_lower < time it is the counting-process entry (start) time, and
+#'   phases are ranked by entry-time cumulative hazard `H(stop) - H(start)`,
+#'   the scale on which events are conserved. Any other row has no entry
+#'   (`H(start) = 0`); see `.hzr_multiphase_entry()`. `NULL` (the default)
+#'   means no truncation.
 #' @return Character: name of the phase to fix.
 #' @keywords internal
 .hzr_select_fixmu_phase <- function(theta, time, status,
@@ -322,8 +324,9 @@
   # Left truncation (counting-process entry times): rank phases by the cumulative
   # hazard accrued over follow-up, H(stop) - H(start), the same scale on which
   # events are conserved. See `.hzr_conserve_events`.
-  if (!is.null(time_lower)) {
-    decomp_start <- .hzr_multiphase_cumhaz(time_lower, theta, phases,
+  entry <- .hzr_multiphase_entry(time, status, time_lower)
+  if (!is.null(entry)) {
+    decomp_start <- .hzr_multiphase_cumhaz(entry, theta, phases,
                                             covariate_counts, x_list,
                                             per_phase = TRUE)
     for (nm in names(phases)) {
@@ -367,6 +370,32 @@
 }
 
 
+#' Counting-process entry times for the multiphase path
+#'
+#' The single place the multiphase likelihood, gradient, Hessian and
+#' Conservation of Events decide which rows have an entry time. On a status 0
+#' or 1 row, `time_lower` is the entry time only when
+#' `0 < time_lower < time`. `time_lower == time` means no entry: that is the
+#' mixed-interval layout, where exact and right-censored rows carry
+#' `time_lower = time` and only status-2 rows carry a real interval lower
+#' bound. On status -1 and 2 rows `time_lower` is a censoring bound, never an
+#' entry. This is the rule `dist = "weibull"` applies (issue #253).
+#'
+#' @param time Numeric vector of follow-up times.
+#' @param status Numeric event indicator.
+#' @param time_lower Optional numeric vector, or `NULL`.
+#' @return `NULL` when `time_lower` is `NULL`; otherwise a numeric vector of
+#'   length `length(time)` holding the entry time, `0` on rows without one.
+#' @noRd
+.hzr_multiphase_entry <- function(time, status, time_lower) {
+  if (is.null(time_lower)) return(NULL)
+  entry <- rep(0, length(time))
+  idx <- status %in% c(0L, 1L) & time_lower < time
+  entry[idx] <- time_lower[idx]
+  entry
+}
+
+
 #' Apply the Conservation of Events adjustment to one phase's log_mu
 #'
 #' Given the current theta vector, analytically solve the fixmu phase's
@@ -388,12 +417,14 @@
 #' @param weights Optional numeric vector of row weights (length n). Defaults to
 #'   unit weights. Applied when summing per-phase cumhaz so Turner's adjustment
 #'   is computed on the same scale as `total_events`.
-#' @param time_lower Optional numeric vector of counting-process entry (start)
-#'   times. When supplied, conservation is enforced on the entry-time scale
+#' @param time_lower Optional numeric vector. On a status 0/1 row with
+#'   0 < time_lower < time it is the counting-process entry (start) time, and
+#'   conservation is enforced on the entry-time scale
 #'   (`Sum E = Sum [H(stop) - H(start)]`) by subtracting the entry-time
 #'   cumulative hazard, matching the multiphase likelihood (and C HAZARD
-#'   `setcoe` under `LCENSOR`/`STARTTME`). `NULL` (the default) means no
-#'   truncation, i.e. `H(start) = 0`.
+#'   `setcoe` under `LCENSOR`/`STARTTME`). Any other row has no entry
+#'   (`H(start) = 0`); see `.hzr_multiphase_entry()`. `NULL` (the default)
+#'   means no truncation.
 #' @return Updated theta vector with fixmu phase's log_mu adjusted.
 #' @keywords internal
 .hzr_conserve_events <- function(theta, fixmu_phase, fixmu_pos,
@@ -410,8 +441,9 @@
   # conserved quantity is H(stop) - H(start), the same constraint the score
   # equation for mu satisfies. Without this, CoE conserves Sum H(stop) and the
   # fixmu phase absorbs the spurious Sum H(start), biasing its intercept.
-  if (!is.null(time_lower)) {
-    decomp_start <- .hzr_multiphase_cumhaz(time_lower, theta, phases,
+  entry <- .hzr_multiphase_entry(time, status, time_lower)
+  if (!is.null(entry)) {
+    decomp_start <- .hzr_multiphase_cumhaz(entry, theta, phases,
                                             covariate_counts, x_list,
                                             per_phase = TRUE)
     decomp$total <- decomp$total - decomp_start$total
@@ -646,7 +678,11 @@
 #' @param time Numeric vector of follow-up times (n).
 #' @param status Numeric event indicator: 1 = event, 0 = right-censored,
 #'   -1 = left-censored, 2 = interval-censored.
-#' @param time_lower Optional lower bounds for interval censoring.
+#' @param time_lower Optional numeric vector: the interval lower bound on
+#'   status-2 rows, and the counting-process entry time on status 0/1 rows
+#'   with `0 < time_lower < time`. `time_lower == time` on a status 0/1 row
+#'   means no entry (the mixed-interval layout); see
+#'   `.hzr_multiphase_entry()`.
 #' @param time_upper Optional upper bounds for left/interval censoring.
 #' @param x Design matrix (unused directly; kept for interface compatibility).
 #' @param phases Named list of validated `hzr_phase` objects.
@@ -699,14 +735,17 @@
   cumhaz <- .hzr_multiphase_cumhaz(time, theta, phases, covariate_counts, x_list)
   if (any(!is.finite(cumhaz))) return(-Inf)
 
-  # Counting-process entry-time cumulative hazard; H(start) = 0 when no
-  # `time_lower` supplied (plain right-censored data).  For status in
-  # {0, 1}, the contribution becomes H(stop) - H(start); for status == 2,
-  # this value is unused (interval-censoring handled separately below).
-  if (is.null(time_lower)) {
+  # Counting-process entry-time cumulative hazard. The entry is `time_lower` on
+  # a status 0/1 row with 0 < time_lower < time and 0 otherwise, so
+  # time_lower = time (the mixed-interval layout) is no entry; see
+  # `.hzr_multiphase_entry()`, issue #253. For status in {0, 1} the
+  # contribution becomes H(stop) - H(start); for status -1 and 2 the entry is
+  # 0 and this value is unused (those rows are handled separately below).
+  entry <- .hzr_multiphase_entry(time, status, time_lower)
+  if (is.null(entry)) {
     cumhaz_start <- rep(0, n)
   } else {
-    cumhaz_start <- .hzr_multiphase_cumhaz(time_lower, theta, phases,
+    cumhaz_start <- .hzr_multiphase_cumhaz(entry, theta, phases,
                                              covariate_counts, x_list)
     if (any(!is.finite(cumhaz_start))) return(-Inf)
   }
@@ -839,27 +878,19 @@
   phase_deriv      <- vector("list", n_phases)  # derivative list at time
   phase_Phi_start  <- vector("list", n_phases)  # Phi_j(start_i), if needed
   phase_deriv_start <- vector("list", n_phases) # derivative list at start
-  # The start time must be defined EXACTLY as the log-likelihood defines it:
-  # `.hzr_logl_multiphase()` subtracts H(time_lower) from every status 0/1 row
-  # whenever `time_lower` is supplied, with no further condition. An earlier
-  # `time_lower < time` filter here excluded rows entering at their own event
-  # or censoring time, so the derivative was taken of a different function from
-  # the one being evaluated: the reported gradient pointed somewhere the
-  # objective did not, and the optimizer followed it out of the region where
-  # the fit means anything. The
-  # `> 0` test is only a skip: H(0) = 0, so those rows contribute nothing
-  # either way, and it must match `has_start` below or the term is weighted in
-  # while its derivative is left at zero.
-  need_start <- !is.null(time_lower) &&
-                any(time_lower > 0 & status %in% c(0L, 1L))
-  start_vec <- if (need_start) {
-    sv <- rep(0, n)
-    epoch_idx <- status %in% c(0L, 1L)
-    sv[epoch_idx] <- time_lower[epoch_idx]
-    sv
-  } else {
-    NULL
-  }
+  # The start time must be defined EXACTLY as the log-likelihood defines it,
+  # so it comes from the same helper, `.hzr_multiphase_entry()`: the entry is
+  # `time_lower` on a status 0/1 row with 0 < time_lower < time, and 0
+  # otherwise (issue #253). When the gradient and the likelihood disagreed on
+  # which rows had an entry, the reported gradient pointed somewhere the
+  # objective did not and the optimizer followed it out of the region where
+  # the fit means anything (issue #136). The `> 0` test is only a skip:
+  # H(0) = 0, so a zero entry contributes nothing, and it must match
+  # `has_start` below or the term is weighted in while its derivative is left
+  # at zero.
+  entry <- .hzr_multiphase_entry(time, status, time_lower)
+  need_start <- !is.null(entry) && any(entry > 0)
+  start_vec <- if (need_start) entry else NULL
 
   for (j in seq_along(phases)) {
     nm <- names(phases)[j]
@@ -958,7 +989,7 @@
   # H(start) contribution for counting-process rows (status in {0, 1}).
   # Per-row contribution is `+H(start_i)` inside the log-likelihood, so
   # the derivative w.r.t. theta picks up `+weights_i * dH(start)/dtheta`.
-  has_start <- !is.null(time_lower) && any(time_lower > 0 & status %in% c(0L, 1L))
+  has_start <- need_start
   w_H_start <- numeric(n)
   if (has_start) {
     w_H_start[idx_event] <- weights[idx_event]
@@ -1716,11 +1747,13 @@
         time, theta_start, phases, covariate_counts, x_list,
         per_phase = TRUE
       )
-      # Entry-time scale under left truncation: conserve H(stop) - H(start).
+      # Entry-time scale under left truncation: conserve H(stop) - H(start),
+      # with the entry rule of `.hzr_multiphase_entry()`.
       init_total <- decomp_init$total
-      if (!is.null(time_lower)) {
+      init_entry <- .hzr_multiphase_entry(time, status, time_lower)
+      if (!is.null(init_entry)) {
         decomp_init_start <- .hzr_multiphase_cumhaz(
-          time_lower, theta_start, phases, covariate_counts, x_list,
+          init_entry, theta_start, phases, covariate_counts, x_list,
           per_phase = TRUE
         )
         init_total <- init_total - decomp_init_start$total

--- a/man/dot-hzr_conserve_events.Rd
+++ b/man/dot-hzr_conserve_events.Rd
@@ -42,12 +42,14 @@ when \code{weights} is supplied).}
 unit weights. Applied when summing per-phase cumhaz so Turner's adjustment
 is computed on the same scale as \code{total_events}.}
 
-\item{time_lower}{Optional numeric vector of counting-process entry (start)
-times. When supplied, conservation is enforced on the entry-time scale
+\item{time_lower}{Optional numeric vector. On a status 0/1 row with
+0 < time_lower < time it is the counting-process entry (start) time, and
+conservation is enforced on the entry-time scale
 (\verb{Sum E = Sum [H(stop) - H(start)]}) by subtracting the entry-time
 cumulative hazard, matching the multiphase likelihood (and C HAZARD
-\code{setcoe} under \code{LCENSOR}/\code{STARTTME}). \code{NULL} (the default) means no
-truncation, i.e. \code{H(start) = 0}.}
+\code{setcoe} under \code{LCENSOR}/\code{STARTTME}). Any other row has no entry
+(\code{H(start) = 0}); see \code{.hzr_multiphase_entry()}. \code{NULL} (the default)
+means no truncation.}
 }
 \value{
 Updated theta vector with fixmu phase's log_mu adjusted.

--- a/man/dot-hzr_gradient_multiphase.Rd
+++ b/man/dot-hzr_gradient_multiphase.Rd
@@ -27,7 +27,11 @@
 \item{status}{Numeric event indicator: 1 = event, 0 = right-censored,
 -1 = left-censored, 2 = interval-censored.}
 
-\item{time_lower}{Optional lower bounds for interval censoring.}
+\item{time_lower}{Optional numeric vector: the interval lower bound on
+status-2 rows, and the counting-process entry time on status 0/1 rows
+with \verb{0 < time_lower < time}. \code{time_lower == time} on a status 0/1 row
+means no entry (the mixed-interval layout); see
+\code{.hzr_multiphase_entry()}.}
 
 \item{time_upper}{Optional upper bounds for left/interval censoring.}
 

--- a/man/dot-hzr_logl_multiphase.Rd
+++ b/man/dot-hzr_logl_multiphase.Rd
@@ -29,7 +29,11 @@
 \item{status}{Numeric event indicator: 1 = event, 0 = right-censored,
 -1 = left-censored, 2 = interval-censored.}
 
-\item{time_lower}{Optional lower bounds for interval censoring.}
+\item{time_lower}{Optional numeric vector: the interval lower bound on
+status-2 rows, and the counting-process entry time on status 0/1 rows
+with \verb{0 < time_lower < time}. \code{time_lower == time} on a status 0/1 row
+means no entry (the mixed-interval layout); see
+\code{.hzr_multiphase_entry()}.}
 
 \item{time_upper}{Optional upper bounds for left/interval censoring.}
 

--- a/man/dot-hzr_select_fixmu_phase.Rd
+++ b/man/dot-hzr_select_fixmu_phase.Rd
@@ -32,10 +32,12 @@
 unit weights. Applied when summing per-phase cumhaz so that selection
 happens on the same scale as the (weighted) observed event count.}
 
-\item{time_lower}{Optional numeric vector of counting-process entry (start)
-times. When supplied, phases are ranked by entry-time cumulative hazard
-\code{H(stop) - H(start)}, the scale on which events are conserved. \code{NULL} (the
-default) means no truncation, i.e. \code{H(start) = 0}.}
+\item{time_lower}{Optional numeric vector. On a status 0/1 row with
+0 < time_lower < time it is the counting-process entry (start) time, and
+phases are ranked by entry-time cumulative hazard \code{H(stop) - H(start)},
+the scale on which events are conserved. Any other row has no entry
+(\code{H(start) = 0}); see \code{.hzr_multiphase_entry()}. \code{NULL} (the default)
+means no truncation.}
 }
 \value{
 Character: name of the phase to fix.

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -58,19 +58,22 @@ Supplying it explicitly is \strong{not} a no-op.
 \item \code{status == 2} (interval-censored): the lower bound of the censoring
 interval, defaulting to \code{time}. Every \code{dist} reads it this way.
 \item \code{status \%in\% c(0, 1)} (right-censored or event): the counting-process
-\strong{entry time}, so the row contributes \code{H(time) - H(time_lower)}.
-Only \code{dist = "weibull"} and \code{dist = "multiphase"} use this role, and
-\code{"weibull"} only where \code{time_lower < time}. The \code{"exponential"},
-\code{"loglogistic"} and \code{"lognormal"} families ignore \code{time_lower} on these
-rows. Left \code{NULL}, the entry time is \strong{\code{0}}, not \code{time}.
+\strong{entry time} when \verb{0 < time_lower < time}, so the row contributes
+\code{H(time) - H(time_lower)}. Every \code{dist} reads it this way. A value of
+\code{0}, or equal to \code{time}, means no entry time, and left \code{NULL} the
+entry time is \strong{\code{0}}.
 \item \code{status == -1} (left-censored): not used; the bound is \code{time_upper}.
 }
 
-Passing \code{time_lower = time} therefore states that every subject entered
-the risk set at the instant it left. \code{hazard()} accepts it with a
-warning. Under \code{"multiphase"} those rows lose their cumulative-hazard
-term and the fit it returns is meaningless; \code{"weibull"} reads them as
-entering at time 0, and the other families ignore the argument there.}
+\code{time_lower = time} on the status 0 and 1 rows is the mixed-interval
+layout: exact and right-censored rows carry their own time, and only
+the status-2 rows carry a real lower bound. A subject cannot enter the
+risk set after the moment it leaves, so \code{hazard()} stops with an error
+when a status 0 or 1 row has \code{time_lower > time}, as SAS HAZARD rejects
+a start time after the exit time. It also stops when rows with
+\verb{time_lower == time > 0} sit beside rows with genuine entry times: in
+counting-process data those are zero-length epochs, which
+\code{\link[=hzr_repeated_events]{hzr_repeated_events()}} can emit and which must be adjusted first.}
 
 \item{time_upper}{Optional numeric upper bound vector for censoring intervals.
 Used when \code{status \%in\% c(-1, 2)}; defaults to \code{time} if NULL.}

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -12,14 +12,16 @@ hzr_gof(object, time_grid = NULL)
 \item{time_grid}{Optional numeric vector of time points at which to
 evaluate the parametric model.
 If \code{NULL} (default), uses the distinct Kaplan-Meier times of the
-fitted data, which are the event times and the censoring times.}
+fitted data, which are the event times and the censoring times.
+A supplied grid is sorted and repeated times dropped, because the
+cumulative columns accumulate in time order.}
 }
 \value{
 A data frame with one row per time point and columns:
 \describe{
 \item{time}{Evaluation time.}
-\item{n_risk}{Number at risk (Kaplan-Meier). A subject with an entry
-time is at risk only from that time on.}
+\item{n_risk}{Number at risk at this time: subjects still in
+follow-up. A subject with an entry time is at risk only after it.}
 \item{n_event}{Number of events at this time.}
 \item{n_censor}{Number censored at this time.}
 \item{km_surv}{Kaplan-Meier survival estimate, using the
@@ -37,7 +39,9 @@ by the case weights for a weighted fit.}
 \item{cum_expected}{Cumulative expected events: over the patients
 leaving follow-up by this time, the sum of each patient's own
 cumulative hazard at exit minus that at entry, weighted by the case
-weights for a weighted fit.}
+weights for a weighted fit.  With \code{time_windows}, both cumulative
+hazards use the patient's covariate window at exit, as the likelihood
+does.}
 \item{residual}{Expected minus observed
 (\code{cum_expected - cum_observed}).}
 }
@@ -92,8 +96,10 @@ The parametric curve is a different quantity.  For a model with
 covariates it belongs to one "mean patient" with average covariates, and
 the mean patient's cumulative hazard is not the average of the patients'
 cumulative hazards, so \code{par_cumhaz} does not enter the expected count.
-For an intercept-only model every patient shares that curve and the two
-agree.  The means are those of the design-matrix columns, taken phase by
+For an intercept-only model every patient shares that curve.  Without
+entry times each patient's expected count is the curve at their exit time;
+with entry times it is the curve's rise from entry to exit, so the two
+differ.  The means are those of the design-matrix columns, taken phase by
 phase when a multiphase fit's covariates enter only through the phase
 formulas, so a factor enters as the proportion of patients in each level.
 A multiphase fit with both global and phase-formula covariates is not yet

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -18,68 +18,86 @@ fitted data.}
 A data frame with one row per time point and columns:
 \describe{
 \item{time}{Evaluation time.}
-\item{n_risk}{Number at risk (Kaplan-Meier).}
+\item{n_risk}{Number at risk (Kaplan-Meier). A subject with an entry
+time is at risk only from that time on.}
 \item{n_event}{Number of events at this time.}
 \item{n_censor}{Number censored at this time.}
-\item{km_surv}{Kaplan-Meier survival estimate.}
+\item{km_surv}{Kaplan-Meier survival estimate, using the
+counting-process risk set when the fit has entry times.}
 \item{km_cumhaz}{Kaplan-Meier cumulative hazard
 (\eqn{-\log(\text{km\_surv})}).}
 \item{par_surv}{Parametric survival from the fitted model, at the
-covariate means for a model with covariates.}
+covariate means for a model with covariates.  For plotting against
+\code{km_surv}; not used for \code{cum_expected}.}
 \item{par_cumhaz}{Parametric cumulative hazard, at the covariate
-means for a model with covariates.}
-\item{cum_observed}{Cumulative observed events to this time.}
-\item{cum_expected}{Cumulative expected events: \code{par_cumhaz}
-times the number of observations exiting the risk set, summed to
-this time.}
+means for a model with covariates.  For plotting; not used for
+\code{cum_expected}.}
+\item{cum_observed}{Cumulative observed events to this time, weighted
+by the case weights for a weighted fit.}
+\item{cum_expected}{Cumulative expected events: over the patients
+leaving follow-up by this time, the sum of each patient's own
+cumulative hazard at exit minus that at entry, weighted by the case
+weights for a weighted fit.}
 \item{residual}{Expected minus observed
 (\code{cum_expected - cum_observed}).}
 }
 
 For multiphase models, additional columns are appended for each
-phase: \code{par_cumhaz_<phase>}.
+phase: \code{par_cumhaz_<phase>}, also at the covariate means.
 
 An attribute \code{"summary"} is attached with scalar diagnostics:
 total observed events, total expected events, and the final residual.
 }
 \description{
-Compare a fitted hazard model against the nonparametric Kaplan-Meier
-estimate by computing observed and expected (parametric) event counts
-at each distinct event time.  This is the R equivalent of the SAS
-\code{hazplot.sas} macro and implements the conservation-of-events
-diagnostic.
+Compare a fitted hazard model with the data two ways: its survival curve
+against the nonparametric Kaplan-Meier estimate, and the number of events
+it expects against the number observed, tallied over follow-up.  This is
+the R equivalent of the SAS \code{hazplot.sas} macro and implements the
+conservation-of-events diagnostic.
 }
 \details{
-At each observed event time the function computes:
+At each time point the function computes:
 \itemize{
 \item The Kaplan-Meier survival and cumulative hazard.
 \item The parametric survival and cumulative hazard from the fitted
-model (and per-phase components for multiphase models).
-\item Cumulative observed events vs. cumulative expected events
-(the parametric cumulative hazard at each time, times the number
-of observations leaving the risk set then).
+model at the covariate means (and per-phase components for
+multiphase models).  This is the curve to plot against the
+Kaplan-Meier estimate.
+\item Cumulative observed events vs. cumulative expected events.  Each
+patient's expected count is their own cumulative hazard, from their
+own covariates, at the end of their follow-up, less their cumulative
+hazard at entry when the fit is left truncated (\code{time_lower} on a
+status 0 or 1 row).  These are summed over the patients leaving
+follow-up at each time.
 \item The running residual (expected minus observed).
 }
 
-For an intercept-only model every patient shares one curve, so the
-expected count is the sum of each patient's cumulative hazard at their
-own exit time.  At the maximum likelihood estimate that sum equals the
-number of observed events (the conservation-of-events identity): the
-final residual is zero and the printed "Conservation ratio (E/O)" is 1.
+The conservation-of-events principle says a model fit by maximum
+likelihood predicts as many events as were observed: add up every
+patient's cumulative hazard over their follow-up and you get the event
+count back.  The final residual is then zero and the printed
+"Conservation ratio (E/O)" is 1.  A multiphase fit with Conservation of
+Events applied (\code{control = list(conserve = TRUE)}, the default) meets the
+identity by construction.  Weibull and exponential fits meet it at the
+exact maximum, so at a converged fit E/O sits close to 1, off only by how
+far short of the maximum the optimizer stopped.  The log-logistic and
+log-normal models carry no such identity, and for them E/O is a check of
+calibration in total.
 
-A model with covariates is different.  The parametric curve, and so the
-expected count, is evaluated at the covariate means, one "mean patient"
-standing in for everyone.  The mean patient's cumulative hazard is not
-the average of the patients' cumulative hazards, so the printed E/O is
-not the conservation-of-events identity and need not be near 1 at a
-correct fit.  Read it as a mean-patient check: how closely the curve
-for a patient with average covariates follows the whole cohort.
+The parametric curve is a different quantity.  For a model with
+covariates it belongs to one "mean patient" with average covariates, and
+the mean patient's cumulative hazard is not the average of the patients'
+cumulative hazards, so \code{par_cumhaz} does not enter the expected count.
+For an intercept-only model every patient shares that curve and the two
+agree.
 
-To check conservation of events for a covariate model, sum each
-patient's own cumulative hazard at their follow-up time and compare the
-total with the event count.  Pass the covariate columns plus a \code{time}
-column to \code{\link[=predict.hazard]{predict.hazard()}} with \code{type = "cumulative_hazard"}; the
-Examples show how.
+For a weighted fit both tallies carry the case weights: observed events
+are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
+form in which a weighted fit conserves events.  The \code{n_risk}, \code{n_event},
+\code{n_censor} and Kaplan-Meier columns are unweighted.
+
+With a custom \code{time_grid}, a patient is counted in both tallies only if
+their follow-up time falls on a grid point.
 }
 \examples{
 \donttest{
@@ -95,13 +113,12 @@ fit <- hazard(
 gof <- hzr_gof(fit)
 print(gof)
 
-# With covariates, hzr_gof() uses the covariate means, so its E/O is a
-# mean-patient check.  The conservation-of-events check sums each
-# patient's own cumulative hazard at their follow-up time:
+# Expected events are summed per patient, so the total is the sum of
+# each patient's own cumulative hazard at their follow-up time:
 nd <- avc[, c("age", "mal")]
 nd$time <- avc$int_dead
-c(expected = sum(predict(fit, newdata = nd, type = "cumulative_hazard")),
-  observed = sum(avc$dead))
+c(hzr_gof = attr(gof, "summary")$total_expected,
+  predict = sum(predict(fit, newdata = nd, type = "cumulative_hazard")))
 
 # Plot observed vs expected events
 if (requireNamespace("ggplot2", quietly = TRUE)) {

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -94,8 +94,10 @@ the mean patient's cumulative hazard is not the average of the patients'
 cumulative hazards, so \code{par_cumhaz} does not enter the expected count.
 For an intercept-only model every patient shares that curve and the two
 agree.  The means are those of the design-matrix columns, taken phase by
-phase when a multiphase fit's covariates enter through the phase
+phase when a multiphase fit's covariates enter only through the phase
 formulas, so a factor enters as the proportion of patients in each level.
+A multiphase fit with both global and phase-formula covariates is not yet
+handled here (#264).
 
 For a weighted fit both tallies carry the case weights: observed events
 are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -11,8 +11,8 @@ hzr_gof(object, time_grid = NULL)
 
 \item{time_grid}{Optional numeric vector of time points at which to
 evaluate the parametric model.
-If \code{NULL} (default), uses the sorted unique event times from the
-fitted data.}
+If \code{NULL} (default), uses the distinct Kaplan-Meier times of the
+fitted data, which are the event times and the censoring times.}
 }
 \value{
 A data frame with one row per time point and columns:
@@ -56,6 +56,10 @@ the R equivalent of the SAS \code{hazplot.sas} macro and implements the
 conservation-of-events diagnostic.
 }
 \details{
+The diagnostic is for right-censored data: every stored status must be 0
+(censored) or 1 (event).  A fit with any left-censored (status -1) or
+interval-censored (status 2) row is refused with an error.
+
 At each time point the function computes:
 \itemize{
 \item The Kaplan-Meier survival and cumulative hazard.
@@ -89,7 +93,9 @@ covariates it belongs to one "mean patient" with average covariates, and
 the mean patient's cumulative hazard is not the average of the patients'
 cumulative hazards, so \code{par_cumhaz} does not enter the expected count.
 For an intercept-only model every patient shares that curve and the two
-agree.
+agree.  The means are those of the design-matrix columns, taken phase by
+phase when a multiphase fit's covariates enter through the phase
+formulas, so a factor enters as the proportion of patients in each level.
 
 For a weighted fit both tallies carry the case weights: observed events
 are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
@@ -113,8 +119,9 @@ fit <- hazard(
 gof <- hzr_gof(fit)
 print(gof)
 
-# Expected events are summed per patient, so the total is the sum of
-# each patient's own cumulative hazard at their follow-up time:
+# Expected events are summed per patient.  This fit has no entry times,
+# so the total is the sum of each patient's own cumulative hazard at
+# their follow-up time:
 nd <- avc[, c("age", "mal")]
 nd$time <- avc$int_dead
 c(hzr_gof = attr(gof, "summary")$total_expected,

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -13,8 +13,9 @@ hzr_gof(object, time_grid = NULL)
 evaluate the parametric model.
 If \code{NULL} (default), uses the distinct Kaplan-Meier times of the
 fitted data, which are the event times and the censoring times.
-A supplied grid is sorted and repeated times dropped, because the
-cumulative columns accumulate in time order.}
+A supplied grid must hold finite, non-negative times.  It is sorted
+and exact repeats dropped, because the cumulative columns accumulate in
+time order.}
 }
 \value{
 A data frame with one row per time point and columns:

--- a/tests/testthat/test-diagnostics.R
+++ b/tests/testthat/test-diagnostics.R
@@ -226,16 +226,16 @@ test_that("hzr_gof cumulative hazard is non-negative and increasing", {
   expect_true(all(diff(gof$par_cumhaz) >= -1e-10))
 })
 
-test_that("hzr_gof conservation ratio is reasonable", {
+test_that("hzr_gof conservation ratio is near 1 for a converged Weibull fit", {
   fit <- .fit_avc_weibull()
   gof <- hzr_gof(fit)
 
   s <- attr(gof, "summary")
   ratio <- s$total_expected / s$total_observed
-  # For a reasonable fit, E/O should be in the ballpark (0.5 to 2.0)
-  expect_true(ratio > 0.2 && ratio < 5.0,
-              label = paste("conservation ratio", round(ratio, 3),
-                            "should be between 0.2 and 5.0"))
+  # Expected events are per subject, so a Weibull MLE conserves events up to
+  # how far short of the maximum the optimizer stopped (1.0018 here). The
+  # pre-#254 covariate-mean tally gave 0.82 on this fit.
+  expect_equal(ratio, 1, tolerance = 0.01)
 })
 
 test_that("hzr_gof works with custom time grid", {

--- a/tests/testthat/test-entry-time-exponential.R
+++ b/tests/testthat/test-entry-time-exponential.R
@@ -1,0 +1,156 @@
+# `time_lower` as a counting-process entry time, dist = "exponential" --------
+#
+# For status 0/1 rows `time_lower` is the left-truncation (entry) time: the
+# row contributes H(time) - H(time_lower), not H(time). "weibull" and
+# "multiphase" honoured it; the exponential likelihood used `time_lower` only
+# as the status-2 interval bound, so a left-truncated exponential fit silently
+# ignored the truncation. Issue #253.
+#
+# Every assertion below is against an oracle that does not share the
+# implementation's code path: a hand-written sum, the Weibull likelihood at
+# nu = 1, numDeriv, or a separate stats::optim fit.
+
+.exp_entry_data <- function() {
+  set.seed(253)
+  n <- 200
+  z <- rnorm(n)
+  entry <- runif(n, 0, 2)
+  entry[1:40] <- 0                          # some rows enter at the origin
+  rate <- 0.3 * exp(0.5 * z)
+  t_event <- entry + stats::rexp(n, rate)   # memoryless: truncated draw
+  t_cens <- entry + runif(n, 0, 6)
+  list(
+    time = pmin(t_event, t_cens),
+    status = as.integer(t_event <= t_cens),
+    entry = entry,
+    z = z,
+    x = matrix(z, ncol = 1, dimnames = list(NULL, "z")),
+    theta = c(log(0.25), 0.4)               # deliberately not the MLE
+  )
+}
+
+# Hand-written left-truncated exponential log-likelihood.
+.exp_entry_oracle <- function(theta, d) {
+  lambda <- exp(theta[1])
+  eta <- theta[2] * d$z
+  sum(d$status * (log(lambda) + eta) - lambda * exp(eta) * (d$time - d$entry))
+}
+
+test_that("exponential logl honours time_lower as entry time (hand oracle)", {
+  d <- .exp_entry_data()
+  expect_gt(sum(d$entry > 0), 100)
+  expect_true(any(d$status == 0) && any(d$status == 1))
+
+  ll <- .hzr_logl_exponential(d$theta, d$time, d$status,
+                              time_lower = d$entry, x = d$x)
+  ll_null <- .hzr_logl_exponential(d$theta, d$time, d$status, x = d$x)
+
+  expect_equal(ll, .exp_entry_oracle(d$theta, d), tolerance = 1e-10)
+  # The entry term is not negligible: it must move the likelihood.
+  expect_gt(abs(ll - ll_null), 1)
+})
+
+test_that("exponential logl equals the Weibull logl at nu = 1 with entry", {
+  d <- .exp_entry_data()
+  ll_exp <- .hzr_logl_exponential(d$theta, d$time, d$status,
+                                  time_lower = d$entry, x = d$x)
+  # Weibull theta is on the natural scale: c(mu, nu, beta).
+  ll_wei <- .hzr_logl_weibull(c(exp(d$theta[1]), 1, d$theta[2]),
+                              d$time, d$status,
+                              time_lower = d$entry, x = d$x)
+  expect_equal(ll_exp, ll_wei, tolerance = 1e-10)
+})
+
+test_that("exponential gradient matches numDeriv with entry times", {
+  skip_if_not_installed("numDeriv")
+  d <- .exp_entry_data()
+  obj <- function(p) {
+    .hzr_logl_exponential(p, d$time, d$status, time_lower = d$entry, x = d$x)
+  }
+  g_nd <- numDeriv::grad(obj, d$theta)
+  g_an <- .hzr_gradient_exponential(d$theta, d$time, d$status,
+                                    time_lower = d$entry, x = d$x)
+  expect_equal(g_an, g_nd, tolerance = 1e-6)
+
+  # The return_gradient path passes precomputed pieces; it must agree too.
+  g_attr <- attr(.hzr_logl_exponential(d$theta, d$time, d$status,
+                                       time_lower = d$entry, x = d$x,
+                                       return_gradient = TRUE), "gradient")
+  expect_equal(g_attr, g_nd, tolerance = 1e-6)
+})
+
+test_that("exponential analytic Hessian matches numDeriv with entry times", {
+  skip_if_not_installed("numDeriv")
+  d <- .exp_entry_data()
+  # .hzr_hessian_exponential() returns the Hessian of the objective (-logl).
+  obj <- function(p) {
+    -.hzr_logl_exponential(p, d$time, d$status, time_lower = d$entry, x = d$x)
+  }
+  h_nd <- numDeriv::hessian(obj, d$theta)
+  h_an <- .hzr_hessian_exponential(d$theta, d$time, d$status,
+                                   time_lower = d$entry, x = d$x)
+  expect_equal(unname(h_an), unname(h_nd), tolerance = 1e-5)
+})
+
+test_that("hazard(dist = 'exponential') fit recovers the truncated MLE", {
+  d <- .exp_entry_data()
+  ref <- stats::optim(c(0, 0), function(p) -.exp_entry_oracle(p, d),
+                      method = "BFGS",
+                      control = list(reltol = 1e-14, maxit = 1000))
+  expect_equal(ref$convergence, 0L)
+
+  fit <- hazard(time = d$time, status = d$status, time_lower = d$entry,
+                x = d$x, dist = "exponential", theta = c(log(0.3), 0),
+                fit = TRUE)
+  fit_null <- hazard(time = d$time, status = d$status,
+                     x = d$x, dist = "exponential", theta = c(log(0.3), 0),
+                     fit = TRUE)
+
+  expect_equal(unname(coef(fit)), ref$par, tolerance = 1e-4)
+  # Ignoring the entry times gives a materially different rate.
+  expect_gt(abs(coef(fit)[[1]] - coef(fit_null)[[1]]), 0.05)
+})
+
+test_that("time_lower = 0 on status 0/1 rows equals time_lower = NULL", {
+  d <- .exp_entry_data()
+  ll_zero <- .hzr_logl_exponential(d$theta, d$time, d$status,
+                                   time_lower = rep(0, length(d$time)),
+                                   x = d$x)
+  ll_null <- .hzr_logl_exponential(d$theta, d$time, d$status, x = d$x)
+  expect_equal(ll_zero, ll_null, tolerance = 1e-12)
+})
+
+test_that("status-2 rows still use time_lower as the interval lower bound", {
+  set.seed(2532)
+  n <- 60
+  z <- rnorm(n)
+  x <- matrix(z, ncol = 1, dimnames = list(NULL, "z"))
+  tl <- runif(n, 0.1, 2)
+  tu <- tl + runif(n, 0.2, 3)
+  tt <- (tl + tu) / 2
+  th <- c(log(0.25), 0.4)
+
+  # Status-2-only data: the entry logic cannot apply. Value recorded from
+  # the implementation before the #253 change.
+  ll_int <- .hzr_logl_exponential(th, tt, rep(2L, n),
+                                  time_lower = tl, time_upper = tu, x = x)
+  expect_equal(ll_int, -91.385091652688772, tolerance = 1e-12)
+
+  # Mixed data: status 0/1 rows take time_lower as entry, status 2 rows as
+  # the interval bound. Each block is checked against its own hand oracle.
+  d <- .exp_entry_data()
+  lambda <- exp(th[1])
+  hz <- function(t, zz) lambda * t * exp(th[2] * zz)
+  ll_mixed <- .hzr_logl_exponential(
+    th,
+    time = c(d$time, tt),
+    status = c(d$status, rep(2L, n)),
+    time_lower = c(d$entry, tl),
+    time_upper = c(d$time, tu),
+    x = rbind(d$x, x)
+  )
+  oracle_entry <- sum(d$status * (log(lambda) + th[2] * d$z) -
+                        hz(d$time, d$z) + hz(d$entry, d$z))
+  oracle_int <- sum(log(exp(-hz(tl, z)) - exp(-hz(tu, z))))
+  expect_equal(ll_mixed, oracle_entry + oracle_int, tolerance = 1e-10)
+})

--- a/tests/testthat/test-entry-time-interfaces.R
+++ b/tests/testthat/test-entry-time-interfaces.R
@@ -1,0 +1,84 @@
+# #253: how `time_lower` reaches each family, across statuses and interfaces.
+#
+# On status 0/1 rows `time_lower` is the counting-process entry time when
+# 0 < time_lower < time. On status -1 (left-censored) rows it is not used at
+# all: the bound is `time_upper`. On status 2 rows it is the interval's lower
+# bound (pinned per family in test-entry-time-<family>.R). These tests pin the
+# status -1 half and the formula/vector parity of the entry time.
+
+.entry_dists <- c("weibull", "exponential", "loglogistic", "lognormal")
+
+.entry_starts <- list(
+  weibull     = c(0.5, 1, 0),
+  exponential = c(log_rate = 0, 0),
+  loglogistic = c(log_alpha = 0, log_beta = 0, 0),
+  lognormal   = c(mu = 0, log_sigma = 0, 0)
+)
+
+.mixed_status_data <- function(n = 160) {
+  set.seed(2531)
+  x <- stats::rnorm(n)
+  time <- stats::rexp(n, 0.3 * exp(0.4 * x)) + 0.05
+  status <- sample(c(1, 0, -1), n, replace = TRUE, prob = c(0.5, 0.3, 0.2))
+  entry <- ifelse(status %in% c(0, 1) & stats::runif(n) < 0.5,
+                  time * stats::runif(n, 0.1, 0.8), 0)
+  list(time = time, status = status, x = x, entry = entry)
+}
+
+test_that("status -1 rows ignore time_lower in every family", {
+  k <- .mixed_status_data()
+  expect_gt(sum(k$status == -1), 20)
+  expect_gt(sum(k$entry > 0), 20)
+  left <- k$status == -1
+  tl_a <- k$entry                    # 0 on the left-censored rows
+  tl_b <- k$entry
+  tl_b[left] <- k$time[left] * 0.5   # arbitrary values on those rows only
+  for (dist in .entry_dists) {
+    fit_with <- function(tl) {
+      suppressWarnings(hazard(
+        time = k$time, status = k$status, time_lower = tl,
+        time_upper = k$time, x = matrix(k$x, ncol = 1), dist = dist,
+        theta = .entry_starts[[dist]], fit = TRUE,
+        control = list(reltol = 1e-12)))
+    }
+    f_a <- fit_with(tl_a)
+    f_b <- fit_with(tl_b)
+    expect_true(isTRUE(f_a$fit$converged), info = dist)
+    expect_equal(f_b$fit$objective, f_a$fit$objective, tolerance = 1e-10,
+                 info = dist)
+    expect_equal(coef(f_b), coef(f_a), tolerance = 1e-8, info = dist)
+  }
+})
+
+test_that("the formula and vector interfaces give the same entry-time fit", {
+  # Surv(start, stop, event) is the formula route to an entry time; the
+  # vector route is time_lower =. Both must reach the same likelihood.
+  k <- .mixed_status_data()
+  keep <- k$status %in% c(0, 1)
+  d <- data.frame(start = k$entry[keep], stop = k$time[keep],
+                  event = k$status[keep], x = k$x[keep])
+  expect_gt(sum(d$start > 0), 20)
+  for (dist in .entry_dists) {
+    f_formula <- suppressWarnings(hazard(
+      survival::Surv(start, stop, event) ~ x, data = d, dist = dist,
+      theta = .entry_starts[[dist]], fit = TRUE,
+      control = list(reltol = 1e-12)))
+    f_vector <- suppressWarnings(hazard(
+      time = d$stop, status = d$event, time_lower = d$start,
+      x = matrix(d$x, ncol = 1, dimnames = list(NULL, "x")), dist = dist,
+      theta = .entry_starts[[dist]], fit = TRUE,
+      control = list(reltol = 1e-12)))
+    expect_equal(f_formula$fit$objective, f_vector$fit$objective,
+                 tolerance = 1e-8, info = dist)
+    expect_equal(unname(coef(f_formula)), unname(coef(f_vector)),
+                 tolerance = 1e-6, info = dist)
+    # And the entry time matters: dropping it changes the fit.
+    f_none <- suppressWarnings(hazard(
+      time = d$stop, status = d$event,
+      x = matrix(d$x, ncol = 1, dimnames = list(NULL, "x")), dist = dist,
+      theta = .entry_starts[[dist]], fit = TRUE,
+      control = list(reltol = 1e-12)))
+    expect_gt(abs(f_none$fit$objective - f_vector$fit$objective), 1,
+              label = paste(dist, "entry-time effect on the objective"))
+  }
+})

--- a/tests/testthat/test-entry-time-loglogistic.R
+++ b/tests/testthat/test-entry-time-loglogistic.R
@@ -1,0 +1,185 @@
+# Left truncation (counting-process entry) for dist = "loglogistic" -- issue #253.
+#
+# For status 0/1 rows `time_lower` is the entry time, so the row contributes
+# H(time) - H(entry) rather than H(time).  The oracle below is written
+# independently of the package from the documented parameterisation:
+#   H(t) = log(1 + alpha t^beta exp(eta)),
+#   h(t) = alpha beta t^(beta - 1) exp(eta) / (1 + alpha t^beta exp(eta)),
+# with theta = (log alpha, log beta, b).
+
+llogis_trunc_oracle <- function(theta, time, status, entry, x) {
+  a <- exp(theta[1])
+  b <- exp(theta[2])
+  eta <- if (is.null(x)) rep(0, length(time)) else as.numeric(x %*% theta[-(1:2)])
+  cumhaz <- function(t) log(1 + a * t^b * exp(eta))
+  log_haz <- log(a) + log(b) + (b - 1) * log(time) + eta - cumhaz(time)
+  start <- if (is.null(entry)) rep(0, length(time)) else
+    ifelse(status %in% c(0, 1) & entry < time, entry, 0)
+  sum(status * log_haz - (cumhaz(time) - cumhaz(start)))
+}
+
+# Simulate genuinely left-truncated log-logistic data: draw (entry, T) and
+# keep only subjects with T > entry; about half enter at time 0.
+sim_llogis_trunc <- function(n, seed, alpha = 0.4, beta = 1.6, b = 0.5) {
+  set.seed(seed)
+  time <- entry <- numeric(0)
+  x <- numeric(0)
+  while (length(time) < n) {
+    xi <- rnorm(1)
+    ei <- if (runif(1) < 0.5) 0 else runif(1, 0, 2)
+    u <- runif(1)
+    ti <- ((1 / u - 1) / (alpha * exp(b * xi)))^(1 / beta)
+    if (ti > ei) {
+      time <- c(time, ti)
+      entry <- c(entry, ei)
+      x <- c(x, xi)
+    }
+  }
+  cens <- entry + rexp(n, 0.25)
+  status <- as.integer(time <= cens)
+  time <- pmin(time, cens)
+  list(time = time, status = status, entry = entry, x = cbind(z = x))
+}
+
+theta_test <- c(log_alpha = log(0.5), log_beta = log(1.3), z = 0.3)
+
+test_that("(a) loglogistic logl subtracts H(entry) on status 0/1 rows", {
+  d <- sim_llogis_trunc(200, seed = 2531)
+  # the fixture must actually carry truncation, or the test compares nothing
+  expect_gt(sum(d$entry > 0), 50)
+  expect_gt(sum(d$status == 0), 10)
+
+  ll_pkg <- .hzr_logl_loglogistic(theta_test, d$time, d$status,
+                                  time_lower = d$entry, x = d$x)
+  ll_orc <- llogis_trunc_oracle(theta_test, d$time, d$status, d$entry, d$x)
+  expect_equal(as.numeric(ll_pkg), ll_orc, tolerance = 1e-10)
+
+  ll_null <- .hzr_logl_loglogistic(theta_test, d$time, d$status, x = d$x)
+  expect_equal(as.numeric(ll_null),
+               llogis_trunc_oracle(theta_test, d$time, d$status, NULL, d$x),
+               tolerance = 1e-10)
+  # the entry term is positive, so it must move the value materially
+  expect_gt(as.numeric(ll_pkg) - as.numeric(ll_null), 1)
+})
+
+test_that("(b) loglogistic analytic gradient matches numDeriv with entry times", {
+  skip_if_not_installed("numDeriv")
+  d <- sim_llogis_trunc(200, seed = 2532)
+  expect_true(any(d$entry == 0) && any(d$entry > 0))
+  obj <- function(th) {
+    llogis_trunc_oracle(th, d$time, d$status, d$entry, d$x)
+  }
+  g_nd <- numDeriv::grad(obj, theta_test)
+
+  g_an <- .hzr_gradient_loglogistic(theta_test, d$time, d$status,
+                                    time_lower = d$entry, x = d$x)
+  expect_true(all(is.finite(g_an)))
+  expect_equal(unname(g_an), g_nd, tolerance = 1e-6)
+
+  g_attr <- attr(.hzr_logl_loglogistic(theta_test, d$time, d$status,
+                                       time_lower = d$entry, x = d$x,
+                                       return_gradient = TRUE), "gradient")
+  expect_equal(unname(g_attr), g_nd, tolerance = 1e-6)
+
+  # weighted: every per-row term scales by its weight
+  w <- runif(length(d$time), 0.5, 2)
+  obj_w <- function(th) {
+    .hzr_logl_loglogistic(th, d$time, d$status, time_lower = d$entry,
+                          x = d$x, weights = w)
+  }
+  g_an_w <- .hzr_gradient_loglogistic(theta_test, d$time, d$status,
+                                      time_lower = d$entry, x = d$x,
+                                      weights = w)
+  expect_equal(unname(g_an_w), numDeriv::grad(obj_w, theta_test),
+               tolerance = 1e-6)
+})
+
+test_that("(c) loglogistic analytic Hessian matches numDeriv with entry times", {
+  skip_if_not_installed("numDeriv")
+  d <- sim_llogis_trunc(200, seed = 2533)
+  w <- runif(length(d$time), 0.5, 2)
+  # .hzr_hessian_loglogistic() returns the Hessian of the NEGATIVE logl
+  obj <- function(th) {
+    -.hzr_logl_loglogistic(th, d$time, d$status, time_lower = d$entry,
+                           x = d$x, weights = w)
+  }
+  h_an <- .hzr_hessian_loglogistic(theta_test, d$time, d$status,
+                                   time_lower = d$entry, x = d$x, weights = w)
+  h_nd <- numDeriv::hessian(obj, theta_test)
+  expect_equal(unname(h_an), unname(h_nd), tolerance = 1e-5)
+})
+
+test_that("(d) hazard() loglogistic fit recovers the truncated-likelihood MLE", {
+  d <- sim_llogis_trunc(200, seed = 2534)
+  start <- c(log(0.3), log(1.2), 0)
+  ref <- stats::optim(
+    start,
+    function(th) -llogis_trunc_oracle(th, d$time, d$status, d$entry, d$x),
+    method = "BFGS", control = list(reltol = 1e-14, maxit = 1000)
+  )
+  expect_equal(ref$convergence, 0L)
+
+  # The default reltol (1e-5) stops BFGS ~5e-10 log-lik short on this flat
+  # ridge, about 1e-4 off in theta; tighten it so the comparison is about the
+  # likelihood, not the stopping rule.
+  ctl <- list(reltol = 1e-12)
+  fit <- hazard(time = d$time, status = d$status, time_lower = d$entry,
+                x = d$x, dist = "loglogistic", theta = start, fit = TRUE,
+                control = ctl)
+  expect_equal(unname(coef(fit)), ref$par, tolerance = 1e-4)
+
+  fit0 <- hazard(time = d$time, status = d$status, x = d$x,
+                 dist = "loglogistic", theta = start, fit = TRUE,
+                 control = ctl)
+  # ignoring the truncation must give a different answer
+  expect_gt(max(abs(coef(fit) - coef(fit0))), 0.05)
+})
+
+test_that("(e) time_lower = 0 on every row is the same as time_lower = NULL", {
+  d <- sim_llogis_trunc(150, seed = 2535)
+  zero <- rep(0, length(d$time))
+  ll_zero <- .hzr_logl_loglogistic(theta_test, d$time, d$status,
+                                   time_lower = zero, x = d$x)
+  ll_null <- .hzr_logl_loglogistic(theta_test, d$time, d$status, x = d$x)
+  expect_identical(as.numeric(ll_zero), as.numeric(ll_null))
+
+  g_zero <- .hzr_gradient_loglogistic(theta_test, d$time, d$status,
+                                      time_lower = zero, x = d$x)
+  g_null <- .hzr_gradient_loglogistic(theta_test, d$time, d$status, x = d$x)
+  expect_true(all(is.finite(g_zero)))
+  expect_equal(g_zero, g_null, tolerance = 1e-12)
+
+  h_zero <- .hzr_hessian_loglogistic(theta_test, d$time, d$status,
+                                     time_lower = zero, x = d$x)
+  h_null <- .hzr_hessian_loglogistic(theta_test, d$time, d$status, x = d$x)
+  expect_true(all(is.finite(h_zero)))
+  expect_equal(h_zero, h_null, tolerance = 1e-12)
+})
+
+test_that("(f) status-2 rows still read time_lower as the interval lower bound", {
+  d <- sim_llogis_trunc(150, seed = 2536)
+  n <- length(d$time)
+  status <- d$status
+  lower <- d$entry
+  upper <- d$time
+  idx2 <- seq(1, n, by = 5)
+  status[idx2] <- 2L
+  lower[idx2] <- d$time[idx2] * 0.6
+  upper[idx2] <- d$time[idx2] * 1.4
+
+  a <- exp(theta_test[1])
+  b <- exp(theta_test[2])
+  eta <- as.numeric(d$x %*% theta_test[3])
+  cdf <- function(t) {
+    term <- a * t^b * exp(eta)
+    term / (1 + term)
+  }
+  ll_int <- sum(log(cdf(upper) - cdf(lower))[idx2])
+  ll_exact <- llogis_trunc_oracle(theta_test, d$time[-idx2], status[-idx2],
+                                  lower[-idx2], d$x[-idx2, , drop = FALSE])
+
+  ll_pkg <- .hzr_logl_loglogistic(theta_test, d$time, status,
+                                  time_lower = lower, time_upper = upper,
+                                  x = d$x)
+  expect_equal(as.numeric(ll_pkg), ll_int + ll_exact, tolerance = 1e-10)
+})

--- a/tests/testthat/test-entry-time-lognormal.R
+++ b/tests/testthat/test-entry-time-lognormal.R
@@ -1,0 +1,165 @@
+## test-entry-time-lognormal.R -- counting-process entry (left truncation)
+## for dist = "lognormal" (issue #253).
+##
+## For status 0/1 rows `time_lower` is the entry time. A row that enters at
+## s > 0 contributes log f(t) - log S(s) (event) or log S(t) - log S(s)
+## (right-censored). The oracle below is written from stats::dlnorm/plnorm,
+## independently of the package's z / Mills-ratio algebra.
+
+# Simulated left-truncated data: one covariate, a subset of rows entering
+# late, the rest entering at 0, and independent right censoring.
+.hzr_ln_entry_data <- function(n = 200, seed = 253) {
+  set.seed(seed)
+  x <- matrix(stats::rnorm(n), ncol = 1L, dimnames = list(NULL, "age"))
+  eta <- 0.4 + 0.5 * x[, 1]
+  t_event <- exp(stats::rnorm(n, eta, 0.8))
+  t_cens <- stats::rexp(n, 0.15)
+  time <- pmin(t_event, t_cens)
+  status <- as.integer(t_event <= t_cens)
+  entry <- rep(0, n)
+  late <- stats::runif(n) < 0.6
+  entry[late] <- time[late] * stats::runif(sum(late), 0.1, 0.9)
+  list(time = time, status = status, entry = entry, x = x, late = late)
+}
+
+# Hand-written truncated log-likelihood in the package's parameterisation:
+# theta = (mu, log sigma, beta); log T ~ N(mu + x beta, sigma^2).
+.hzr_ln_entry_oracle <- function(theta, time, status, entry, x) {
+  eta <- theta[1] + as.numeric(x %*% theta[-(1:2)])
+  sdlog <- exp(theta[2])
+  ll <- ifelse(status == 1,
+               stats::dlnorm(time, eta, sdlog, log = TRUE),
+               stats::plnorm(time, eta, sdlog, lower.tail = FALSE,
+                             log.p = TRUE))
+  in_late <- entry > 0
+  ll[in_late] <- ll[in_late] -
+    stats::plnorm(entry[in_late], eta[in_late], sdlog, lower.tail = FALSE,
+                  log.p = TRUE)
+  sum(ll)
+}
+
+theta_test <- c(mu = 0.3, log_sigma = log(0.9), age = 0.4)  # not the MLE
+
+test_that("(a) lognormal logl includes the entry term and matches the oracle", {
+  d <- .hzr_ln_entry_data()
+  expect_true(sum(d$late) > 50)          # the truncation is not vacuous
+  expect_true(sum(!d$late) > 50)         # and some rows enter at 0
+  ll <- .hzr_logl_lognormal(theta_test, d$time, d$status,
+                            time_lower = d$entry, x = d$x)
+  ll_oracle <- .hzr_ln_entry_oracle(theta_test, d$time, d$status, d$entry, d$x)
+  expect_equal(as.numeric(ll), ll_oracle, tolerance = 1e-10)
+
+  ll_null <- .hzr_logl_lognormal(theta_test, d$time, d$status, x = d$x)
+  expect_gt(abs(as.numeric(ll) - as.numeric(ll_null)), 1)
+})
+
+test_that("(b) lognormal analytic gradient matches numDeriv with entry times", {
+  skip_if_not_installed("numDeriv")
+  d <- .hzr_ln_entry_data()
+  grad_an <- .hzr_gradient_lognormal(theta_test, d$time, d$status,
+                                     time_lower = d$entry, x = d$x)
+  obj <- function(th) {
+    .hzr_ln_entry_oracle(th, d$time, d$status, d$entry, d$x)
+  }
+  grad_nd <- numDeriv::grad(obj, theta_test)
+  expect_equal(as.numeric(grad_an), grad_nd, tolerance = 1e-6)
+
+  # The return_gradient path attaches the same vector.
+  ll <- .hzr_logl_lognormal(theta_test, d$time, d$status,
+                            time_lower = d$entry, x = d$x,
+                            return_gradient = TRUE)
+  expect_equal(as.numeric(attr(ll, "gradient")), grad_nd, tolerance = 1e-6)
+})
+
+test_that("(c) lognormal analytic Hessian matches numDeriv with entry times", {
+  skip_if_not_installed("numDeriv")
+  d <- .hzr_ln_entry_data()
+  w <- seq(0.5, 2, length.out = length(d$time))
+  obj <- function(th) {
+    -.hzr_logl_lognormal(th, d$time, d$status, time_lower = d$entry,
+                         x = d$x, weights = w)
+  }
+  h_an <- .hzr_hessian_lognormal(theta_test, d$time, d$status,
+                                 time_lower = d$entry, x = d$x, weights = w)
+  h_nd <- numDeriv::hessian(obj, theta_test)
+  expect_equal(unname(h_an), unname(h_nd), tolerance = 1e-5)
+
+  h_null <- .hzr_hessian_lognormal(theta_test, d$time, d$status,
+                                   x = d$x, weights = w)
+  expect_gt(max(abs(h_an - h_null)), 1e-2)
+})
+
+test_that("(d) hazard(dist = 'lognormal') fits the truncated likelihood", {
+  d <- .hzr_ln_entry_data()
+  start <- c(0, 0, 0)
+  # Tight reltol: the default (1e-5) lets BFGS stop about 1e-4 short on this
+  # likelihood, which would test the stopping rule rather than the MLE.
+  fit <- hazard(
+    time = d$time, status = d$status, time_lower = d$entry, x = d$x,
+    dist = "lognormal", theta = start, fit = TRUE,
+    control = list(reltol = 1e-12)
+  )
+  expect_true(fit$fit$converged)
+
+  oracle_fit <- stats::optim(
+    start,
+    function(th) -.hzr_ln_entry_oracle(th, d$time, d$status, d$entry, d$x),
+    method = "BFGS", control = list(reltol = 1e-14, maxit = 1000)
+  )
+  expect_equal(oracle_fit$convergence, 0L)
+  expect_equal(unname(coef(fit)), oracle_fit$par, tolerance = 1e-4)
+
+  fit_null <- hazard(
+    time = d$time, status = d$status, x = d$x,
+    dist = "lognormal", theta = start, fit = TRUE
+  )
+  expect_gt(max(abs(coef(fit) - coef(fit_null))), 0.05)
+})
+
+test_that("(e) time_lower = 0 rows equal time_lower = NULL, with no NaN", {
+  d <- .hzr_ln_entry_data()
+  zero <- rep(0, length(d$time))
+  ll0 <- .hzr_logl_lognormal(theta_test, d$time, d$status,
+                             time_lower = zero, x = d$x,
+                             return_gradient = TRUE)
+  lln <- .hzr_logl_lognormal(theta_test, d$time, d$status, x = d$x,
+                             return_gradient = TRUE)
+  expect_true(is.finite(ll0))
+  expect_equal(as.numeric(ll0), as.numeric(lln), tolerance = 1e-12)
+
+  g0 <- attr(ll0, "gradient")
+  expect_false(anyNA(g0))
+  expect_true(all(is.finite(g0)))
+  expect_equal(g0, attr(lln, "gradient"), tolerance = 1e-12)
+
+  h0 <- .hzr_hessian_lognormal(theta_test, d$time, d$status,
+                               time_lower = zero, x = d$x)
+  expect_false(anyNA(h0))
+  expect_true(all(is.finite(h0)))
+  expect_equal(h0, .hzr_hessian_lognormal(theta_test, d$time, d$status,
+                                          x = d$x), tolerance = 1e-12)
+})
+
+test_that("(f) status-2 rows still read time_lower as the interval lower bound", {
+  set.seed(2532)
+  n <- 120
+  time <- exp(stats::rnorm(n, 0.5, 0.7))
+  status <- rep(c(1L, 0L, 2L), length.out = n)
+  lower <- time               # status 0/1: time_lower = time, no entry
+  upper <- time
+  iv <- status == 2L
+  lower[iv] <- time[iv] * 0.7
+  upper[iv] <- time[iv] * 1.4
+  theta <- c(mu = 0.4, log_sigma = log(0.8))
+
+  ll <- .hzr_logl_lognormal(theta, time, status,
+                            time_lower = lower, time_upper = upper)
+  sdlog <- exp(theta[2])
+  expected <-
+    sum(stats::dlnorm(time[status == 1L], theta[1], sdlog, log = TRUE)) +
+    sum(stats::plnorm(time[status == 0L], theta[1], sdlog,
+                      lower.tail = FALSE, log.p = TRUE)) +
+    sum(log(stats::plnorm(upper[iv], theta[1], sdlog) -
+              stats::plnorm(lower[iv], theta[1], sdlog)))
+  expect_equal(as.numeric(ll), unname(expected), tolerance = 1e-10)
+})

--- a/tests/testthat/test-entry-time-multiphase.R
+++ b/tests/testthat/test-entry-time-multiphase.R
@@ -171,7 +171,11 @@ test_that("(f) genuine left truncation is unchanged", {
                                 x_list = k$x_list)
   expect_equal(g, c(12.238301562562, 1.483456049285, -9.365029543009,
                     -3.310708925120, 24.591058283363), tolerance = 1e-10)
-  expect_equal(g, numDeriv::grad(ll, th), tolerance = 1e-6)
+  # numDeriv is a Suggests; the pins above and below run without it.
+  has_numderiv <- requireNamespace("numDeriv", quietly = TRUE)
+  if (has_numderiv) {
+    expect_equal(g, numDeriv::grad(ll, th), tolerance = 1e-6)
+  }
   hs <- .hzr_hessian_multiphase(th, time, status, time_lower = entry,
                                 phases = k$phases_v,
                                 covariate_counts = k$counts,
@@ -181,8 +185,10 @@ test_that("(f) genuine left truncation is unchanged", {
     1.467275795528, -7.003725435493, 1.041266887820, 2.387702552874,
     0.144978579487, -0.987020763633, 8.920178183938, 1.818804685909,
     -6.336448265620, -1.983477842486, -2.385362400030), tolerance = 1e-10)
-  expect_equal(unname(hs), numDeriv::hessian(function(p) -ll(p), th),
-               tolerance = 1e-4)
+  if (has_numderiv) {
+    expect_equal(unname(hs), numDeriv::hessian(function(p) -ll(p), th),
+                 tolerance = 1e-4)
+  }
 
   ft <- suppressWarnings(
     .hzr_optim_multiphase(time, status, time_lower = entry, phases = ph))

--- a/tests/testthat/test-entry-time-multiphase.R
+++ b/tests/testthat/test-entry-time-multiphase.R
@@ -140,8 +140,13 @@ test_that("(e) gradient and Hessian match numDeriv on the mixed layout", {
 })
 
 test_that("(f) genuine left truncation is unchanged", {
-  # Values computed on the code before the #253 fix, where every entry was
-  # already 0 < time_lower < time and so read as an entry under both rules.
+  # Every entry here is 0 < time_lower < time, so it reads as an entry under
+  # both the old rule and #253's. The anchors below were computed on 9fd3dba,
+  # the commit before the #253 fix, and re-checked identical on c0d4cfd, on
+  # main (76d3e99) and on the merge. The gradient and Hessian are pinned at
+  # m = 0.5, not at m = 0: log L has a kink in m at 0 (slopes +/-3.9557), so
+  # a derivative there depends on the finite-difference stencil (#251, #260
+  # made it one-sided). numDeriv checks each derivative independently.
   set.seed(1)
   n <- 60
   time <- stats::rexp(n, 0.5) + 0.2
@@ -153,37 +158,36 @@ test_that("(f) genuine left truncation is unchanged", {
   k <- list(time = time, phases_v = .hzr_validate_phases(ph),
             counts = c(early = 0L, constant = 0L),
             x_list = list(early = NULL, constant = NULL))
-  th <- c(log(0.3), log(1), 1, 0, log(0.1))
+  ll <- function(th) .mp_logl(k, th, entry, status = status)
 
-  expect_equal(.mp_logl(k, th, entry, status = status),
-               -95.187915824809963, tolerance = 1e-12)
-  expect_equal(
-    .hzr_gradient_multiphase(th, time, status, time_lower = entry,
-                             phases = k$phases_v, covariate_counts = k$counts,
-                             x_list = k$x_list),
-    c(12.729520416962995, 2.8494490333870264, -9.2012662706668422,
-      -7.3753385293653607e-10, 23.589652067548901),
-    tolerance = 1e-10)
+  # The log-likelihood is well defined at m = 0.
+  th0 <- c(log(0.3), log(1), 1, 0, log(0.1))
+  expect_equal(ll(th0), -95.187915824810, tolerance = 1e-12)
+
+  th <- c(log(0.3), log(1), 1, 0.5, log(0.1))
+  g <- .hzr_gradient_multiphase(th, time, status, time_lower = entry,
+                                phases = k$phases_v,
+                                covariate_counts = k$counts,
+                                x_list = k$x_list)
+  expect_equal(g, c(12.238301562562, 1.483456049285, -9.365029543009,
+                    -3.310708925120, 24.591058283363), tolerance = 1e-10)
+  expect_equal(g, numDeriv::grad(ll, th), tolerance = 1e-6)
   hs <- .hzr_hessian_multiphase(th, time, status, time_lower = entry,
                                 phases = k$phases_v,
                                 covariate_counts = k$counts,
                                 x_list = k$x_list)
-  expect_equal(unname(hs[c(1, 2, 3, 5), c(1, 2, 3, 5)]), matrix(c(
-    -4.6719823126998747, -2.7924372244408859, 3.2186923025249516,
-    8.817994044279871,
-    -2.7924372244408859, 9.0112847085199377, 0.31747818316771581,
-    2.9159313448562774,
-    3.2186923025249516, 0.3174781831677157, -3.5861506233469047,
-    -5.6510355499695004,
-    8.817994044279871, 2.9159313448562765, -5.6510355499694995,
-    -2.2831782603717627), 4, 4), tolerance = 1e-10)
-  expect_equal(hs[4, 4], 64807.040011232821, tolerance = 1e-10)
+  expect_equal(hs[upper.tri(hs, diag = TRUE)], c(
+    -5.284353813771, -1.801259348636, 6.218739881821, 3.866407104660,
+    1.467275795528, -7.003725435493, 1.041266887820, 2.387702552874,
+    0.144978579487, -0.987020763633, 8.920178183938, 1.818804685909,
+    -6.336448265620, -1.983477842486, -2.385362400030), tolerance = 1e-10)
+  expect_equal(unname(hs), numDeriv::hessian(function(p) -ll(p), th),
+               tolerance = 1e-4)
 
   ft <- suppressWarnings(
     .hzr_optim_multiphase(time, status, time_lower = entry, phases = ph))
   # Optimizer end points are pinned loosely: BFGS can stop at slightly
-  # different points on the five CI platforms. The fixed-theta pins above
-  # (logl, gradient, Hessian) carry the tight checks.
+  # different points on the five CI platforms.
   expect_equal(ft$value, -61.048341005835724, tolerance = 1e-6)
   # log_mu, log_t_half, nu and log_mu: m sits at ~6e-10, where a relative
   # comparison is meaningless, so it is checked on its own absolute scale.

--- a/tests/testthat/test-entry-time-multiphase.R
+++ b/tests/testthat/test-entry-time-multiphase.R
@@ -180,11 +180,16 @@ test_that("(f) genuine left truncation is unchanged", {
                                 phases = k$phases_v,
                                 covariate_counts = k$counts,
                                 x_list = k$x_list)
-  expect_equal(hs[upper.tri(hs, diag = TRUE)], c(
+  # Entries in the shape parameters carry finite-difference error, and on CI
+  # they differ from these macOS values by up to 1.8e-7 relative (Ubuntu), so
+  # each entry is compared relatively at 1e-5. An entry-time change moves
+  # them by order 1. No pinned entry is near 0.
+  hs_pin <- c(
     -5.284353813771, -1.801259348636, 6.218739881821, 3.866407104660,
     1.467275795528, -7.003725435493, 1.041266887820, 2.387702552874,
     0.144978579487, -0.987020763633, 8.920178183938, 1.818804685909,
-    -6.336448265620, -1.983477842486, -2.385362400030), tolerance = 1e-10)
+    -6.336448265620, -1.983477842486, -2.385362400030)
+  expect_lt(max(abs(hs[upper.tri(hs, diag = TRUE)] / hs_pin - 1)), 1e-5)
   if (has_numderiv) {
     expect_equal(unname(hs), numDeriv::hessian(function(p) -ll(p), th),
                  tolerance = 1e-4)

--- a/tests/testthat/test-entry-time-multiphase.R
+++ b/tests/testthat/test-entry-time-multiphase.R
@@ -1,0 +1,195 @@
+# Multiphase entry time: `time_lower` on status 0/1 rows (issue #253) -------
+#
+# On a status 0 or 1 row, `time_lower` is the counting-process entry time only
+# when 0 < time_lower < time. `time_lower == time` means no entry: that is the
+# mixed-interval layout, where exact and right-censored rows carry
+# time_lower = time and only status-2 rows carry a real interval lower bound.
+# This is the rule dist = "weibull" has always applied. The multiphase path
+# used to subtract H(time_lower) whenever `time_lower` was supplied, so
+# time_lower = time made every row enter as it left: on avc the fit reported
+# converged with a log-likelihood of +47915.76 against -211.4677 without it.
+
+.mp_case <- function() {
+  d <- stats::na.omit(avc)
+  ph <- list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0),
+             constant = hzr_phase("constant"))
+  list(
+    time = d$int_dead, status = d$dead, phases = ph,
+    phases_v = .hzr_validate_phases(ph),
+    theta = c(log(0.35), log(0.19), 1.44, 1, log(0.03)),
+    counts = c(early = 0L, constant = 0L),
+    x_list = list(early = NULL, constant = NULL)
+  )
+}
+
+.mp_logl <- function(k, theta, time_lower, status = k$status,
+                     time_upper = NULL) {
+  .hzr_logl_multiphase(theta, time = k$time, status = status,
+                       time_lower = time_lower, time_upper = time_upper,
+                       phases = k$phases_v, covariate_counts = k$counts,
+                       x_list = k$x_list)
+}
+
+# Some rows genuine entries, some time_lower = time, the rest 0.
+.mp_mixed <- function(k) {
+  n <- length(k$time)
+  tl <- rep(0, n)
+  genuine <- seq(1, n, by = 3)
+  at_exit <- seq(2, n, by = 3)
+  tl[genuine] <- k$time[genuine] / 2
+  tl[at_exit] <- k$time[at_exit]
+  ref <- tl
+  ref[at_exit] <- 0
+  # The layout must actually contain all three kinds, or the test compares
+  # nothing.
+  stopifnot(any(tl > 0 & tl < k$time), any(tl == k$time & tl > 0),
+            any(tl == 0))
+  list(tl = tl, ref = ref)
+}
+
+test_that("(a) a fit with time_lower = time equals the fit with no time_lower", {
+  k <- .mp_case()
+  f0 <- .hzr_optim_multiphase(k$time, k$status, phases = k$phases)
+  f1 <- .hzr_optim_multiphase(k$time, k$status, time_lower = k$time,
+                              phases = k$phases)
+  expect_lt(f1$value, 0)
+  expect_equal(f1$value, f0$value, tolerance = 1e-6)
+  expect_equal(unname(f1$par), unname(f0$par), tolerance = 1e-4)
+  expect_equal(f0$value, -211.4677, tolerance = 1e-6)
+})
+
+test_that("(b) at fixed theta, time_lower = time gives the NULL logl exactly", {
+  k <- .mp_case()
+  ll_null <- .mp_logl(k, k$theta, NULL)
+  expect_true(is.finite(ll_null))
+  expect_identical(.mp_logl(k, k$theta, k$time), ll_null)
+})
+
+test_that("(c) mixed layout: time_lower = time rows read as entry 0", {
+  k <- .mp_case()
+  m <- .mp_mixed(k)
+  ll_ref <- .mp_logl(k, k$theta, m$ref)
+  expect_true(is.finite(ll_ref))
+  expect_identical(.mp_logl(k, k$theta, m$tl), ll_ref)
+  # And the genuine entries are still entries: the reference is not the
+  # no-entry logl.
+  expect_false(isTRUE(all.equal(ll_ref, .mp_logl(k, k$theta, NULL))))
+
+  # The CoE adjustment conserves on the same entry-time scale. The constant
+  # phase is the one that can absorb the discrepancy at this theta; with the
+  # early phase CoE declines and returns theta unchanged, which would compare
+  # nothing.
+  fix_pos <- 5L
+  total <- sum(k$status == 1)
+  coe <- function(tl) {
+    .hzr_conserve_events(k$theta, "constant", fix_pos, k$time, k$status,
+                         k$phases_v, k$counts, k$x_list, total,
+                         time_lower = tl)
+  }
+  adjusted <- coe(m$ref)
+  expect_false(isTRUE(all.equal(adjusted[fix_pos], k$theta[fix_pos])))
+  expect_identical(coe(m$tl), adjusted)
+})
+
+test_that("(d) a status-2 row carries no entry subtraction", {
+  k <- .mp_case()
+  th <- k$theta
+  status <- c(1, 0, 2)
+  time <- c(1.0, 2.0, 1.5)
+  lower <- c(0.4, 0.5, 0.8)
+  upper <- c(1.0, 2.0, 1.5)
+  kk <- list(time = time, phases_v = k$phases_v, counts = k$counts,
+             x_list = k$x_list)
+  ll <- .mp_logl(kk, th, lower, status = status, time_upper = upper)
+  H <- function(t) {
+    .hzr_multiphase_cumhaz(t, th, k$phases_v, k$counts, k$x_list)
+  }
+  h1 <- .hzr_multiphase_hazard(1.0, th, k$phases_v, k$counts, k$x_list)
+  hand <- (log(h1) - (H(1.0) - H(0.4))) - (H(2.0) - H(0.5)) +
+    log(exp(-H(0.8)) - exp(-H(1.5)))
+  expect_equal(ll, hand, tolerance = 1e-12)
+})
+
+test_that("(e) gradient and Hessian match numDeriv on the mixed layout", {
+  skip_if_not_installed("numDeriv")
+  k <- .mp_case()
+  m <- .mp_mixed(k)
+  for (nm in c("mixed", "at exit")) {
+    tl <- if (nm == "mixed") m$tl else k$time
+    f <- function(p) .mp_logl(k, p, tl)
+    g <- .hzr_gradient_multiphase(k$theta, time = k$time, status = k$status,
+                                  time_lower = tl, phases = k$phases_v,
+                                  covariate_counts = k$counts,
+                                  x_list = k$x_list)
+    expect_equal(g, numDeriv::grad(f, k$theta), tolerance = 1e-5, info = nm)
+    hs <- .hzr_hessian_multiphase(k$theta, time = k$time, status = k$status,
+                                  time_lower = tl, phases = k$phases_v,
+                                  covariate_counts = k$counts,
+                                  x_list = k$x_list)
+    expect_false(is.null(hs), info = nm)
+    expect_equal(unname(hs), numDeriv::hessian(function(p) -f(p), k$theta),
+                 tolerance = 1e-4, info = nm)
+    # The analytic derivatives also agree with the reference layout's.
+    if (nm == "mixed") {
+      expect_equal(g, .hzr_gradient_multiphase(
+        k$theta, time = k$time, status = k$status, time_lower = m$ref,
+        phases = k$phases_v, covariate_counts = k$counts, x_list = k$x_list),
+        tolerance = 1e-12)
+    }
+  }
+})
+
+test_that("(f) genuine left truncation is unchanged", {
+  # Values computed on the code before the #253 fix, where every entry was
+  # already 0 < time_lower < time and so read as an entry under both rules.
+  set.seed(1)
+  n <- 60
+  time <- stats::rexp(n, 0.5) + 0.2
+  status <- stats::rbinom(n, 1, 0.7)
+  entry <- time * stats::runif(n, 0.1, 0.8)
+  stopifnot(all(entry > 0 & entry < time))
+  ph <- list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 0),
+             constant = hzr_phase("constant"))
+  k <- list(time = time, phases_v = .hzr_validate_phases(ph),
+            counts = c(early = 0L, constant = 0L),
+            x_list = list(early = NULL, constant = NULL))
+  th <- c(log(0.3), log(1), 1, 0, log(0.1))
+
+  expect_equal(.mp_logl(k, th, entry, status = status),
+               -95.187915824809963, tolerance = 1e-12)
+  expect_equal(
+    .hzr_gradient_multiphase(th, time, status, time_lower = entry,
+                             phases = k$phases_v, covariate_counts = k$counts,
+                             x_list = k$x_list),
+    c(12.729520416962995, 2.8494490333870264, -9.2012662706668422,
+      -7.3753385293653607e-10, 23.589652067548901),
+    tolerance = 1e-10)
+  hs <- .hzr_hessian_multiphase(th, time, status, time_lower = entry,
+                                phases = k$phases_v,
+                                covariate_counts = k$counts,
+                                x_list = k$x_list)
+  expect_equal(unname(hs[c(1, 2, 3, 5), c(1, 2, 3, 5)]), matrix(c(
+    -4.6719823126998747, -2.7924372244408859, 3.2186923025249516,
+    8.817994044279871,
+    -2.7924372244408859, 9.0112847085199377, 0.31747818316771581,
+    2.9159313448562774,
+    3.2186923025249516, 0.3174781831677157, -3.5861506233469047,
+    -5.6510355499695004,
+    8.817994044279871, 2.9159313448562765, -5.6510355499694995,
+    -2.2831782603717627), 4, 4), tolerance = 1e-10)
+  expect_equal(hs[4, 4], 64807.040011232821, tolerance = 1e-10)
+
+  ft <- suppressWarnings(
+    .hzr_optim_multiphase(time, status, time_lower = entry, phases = ph))
+  # Optimizer end points are pinned loosely: BFGS can stop at slightly
+  # different points on the five CI platforms. The fixed-theta pins above
+  # (logl, gradient, Hessian) carry the tight checks.
+  expect_equal(ft$value, -61.048341005835724, tolerance = 1e-6)
+  # log_mu, log_t_half, nu and log_mu: m sits at ~6e-10, where a relative
+  # comparison is meaningless, so it is checked on its own absolute scale.
+  expect_equal(unname(ft$par[c(1, 2, 3, 5)]),
+               c(-0.87430560608249352, -0.42697704500116312,
+                 0.40509325865065615, -0.50755433855562759),
+               tolerance = 1e-6)
+  expect_lt(abs(ft$par[4]), 1e-6)
+})

--- a/tests/testthat/test-gof-entry-km.R
+++ b/tests/testthat/test-gof-entry-km.R
@@ -1,0 +1,39 @@
+# #254 follow-up: hzr_gof() subtracts H(entry) from each subject's expected
+# events, so its Kaplan-Meier and risk-set columns must use the same risk set.
+# A subject who enters late is not at risk before entry.
+
+.gof_truncated_fit <- function(entry_share = 0.5) {
+  set.seed(7)
+  n <- 200
+  t <- stats::rexp(n, 0.2) + 0.1
+  e <- ifelse(stats::runif(n) < entry_share, t * stats::runif(n, 0.2, 0.9), 0)
+  s <- stats::rbinom(n, 1, 0.7)
+  f <- suppressWarnings(hazard(time = t, status = s, time_lower = e,
+                               dist = "weibull", theta = c(0.2, 1),
+                               fit = TRUE))
+  list(fit = f, t = t, e = e, s = s)
+}
+
+test_that("hzr_gof's risk set and Kaplan-Meier honour entry times", {
+  k <- .gof_truncated_fit()
+  expect_gt(sum(k$e > 0), 50)
+  g <- hzr_gof(k$fit)
+  km <- survival::survfit(survival::Surv(k$e, k$t, k$s) ~ 1)
+  # At the first exit time only subjects who have entered are at risk.
+  expect_equal(g$n_risk[1], km$n.risk[1])
+  expect_lt(g$n_risk[1], 200)
+  idx <- match(km$time, g$time)
+  expect_false(anyNA(idx))
+  expect_equal(g$km_surv[idx], km$surv, tolerance = 1e-12)
+  expect_equal(g$n_risk[idx], km$n.risk)
+})
+
+test_that("hzr_gof's Kaplan-Meier is unchanged when no row has an entry time", {
+  k <- .gof_truncated_fit(entry_share = 0)
+  expect_true(all(k$e == 0))
+  g <- hzr_gof(k$fit)
+  km <- survival::survfit(survival::Surv(k$t, k$s) ~ 1)
+  idx <- match(km$time, g$time)
+  expect_equal(g$km_surv[idx], km$surv, tolerance = 1e-12)
+  expect_equal(g$n_risk[idx], km$n.risk)
+})

--- a/tests/testthat/test-gof-grid-and-windows.R
+++ b/tests/testthat/test-gof-grid-and-windows.R
@@ -1,0 +1,89 @@
+# hzr_gof() items from Copilot's review of #285. Each test failed on 6538323.
+
+.gof_grid_data <- function(n = 120) {
+  set.seed(2851)
+  stop_t <- round(stats::rexp(n, 0.3) + 0.1, 2)
+  start_t <- ifelse(stats::runif(n) < 0.5,
+                    round(stop_t * stats::runif(n, 0.1, 0.8), 2), 0)
+  start_t[start_t >= stop_t] <- 0
+  data.frame(start = start_t, stop = stop_t,
+             event = stats::rbinom(n, 1, 0.7))
+}
+
+# At risk at t: followed from 0 and not yet out, or entered before t and not
+# yet out. Counted subject by subject, as an oracle for hzr_gof()'s n_risk.
+.brute_n_risk <- function(t, entry, time) {
+  vapply(t, function(u) sum((entry < u | entry == 0) & time >= u), numeric(1))
+}
+
+test_that("n_risk at a custom time_grid is the risk set at that time", {
+  d <- .gof_grid_data()
+  kt <- sort(unique(d$stop))
+  # One point before any exit, then points between exits.
+  grid <- c(0.05, (kt[1:6] + kt[2:7]) / 2)
+  for (entry in list(NULL, d$start)) {
+    fit <- suppressWarnings(hazard(time = d$stop, status = d$event,
+                                   time_lower = entry, dist = "weibull",
+                                   theta = c(0.3, 1), fit = TRUE))
+    e <- if (is.null(entry)) rep(0, nrow(d)) else entry
+    expect_equal(hzr_gof(fit, time_grid = grid)$n_risk,
+                 .brute_n_risk(grid, e, d$stop))
+    # On the default grid the same count is survfit's own n.risk.
+    g <- hzr_gof(fit)
+    expect_equal(g$n_risk, .brute_n_risk(g$time, e, d$stop))
+  }
+})
+
+test_that("an unsorted or repeated time_grid is sorted and de-duplicated", {
+  d <- .gof_grid_data()
+  fit <- suppressWarnings(hazard(time = d$stop, status = d$event,
+                                 dist = "weibull", theta = c(0.3, 1),
+                                 fit = TRUE))
+  kt <- sort(unique(d$stop))
+  sorted <- hzr_gof(fit, time_grid = kt[c(5, 10)])
+  shuffled <- hzr_gof(fit, time_grid = kt[c(10, 5, 10)])
+  expect_equal(shuffled$time, kt[c(5, 10)])
+  expect_equal(shuffled$cum_observed, sorted$cum_observed)
+  expect_equal(shuffled$cum_expected, sorted$cum_expected)
+  expect_error(hzr_gof(fit, time_grid = c(1, NA)), "time_grid")
+})
+
+test_that("km_surv at time 0 is the Kaplan-Meier value when an event is at 0", {
+  d <- .gof_grid_data()
+  d$stop[1:2] <- 0
+  d$event[1:2] <- c(1, 0)
+  fit <- suppressWarnings(hazard(time = d$stop, status = d$event,
+                                 dist = "exponential",
+                                 theta = c(log_rate = log(0.3)), fit = TRUE))
+  km <- survival::survfit(survival::Surv(d$stop, d$event) ~ 1)
+  expect_equal(km$time[1], 0)
+  expect_lt(km$surv[1], 1)
+  expect_no_warning(g <- hzr_gof(fit))
+  # The default grid is the Kaplan-Meier times, so the columns coincide.
+  expect_equal(g$km_surv, km$surv)
+})
+
+test_that("with time_windows, H(entry) uses the exit-time design, as the likelihood does", {
+  set.seed(2853)
+  n <- 400
+  x <- stats::rnorm(n)
+  cut <- 2
+  # Piecewise-exponential exits: x raises the hazard before the cut and
+  # lowers it after, so the two window coefficients differ.
+  r1 <- 0.3 * exp(1.5 * x)
+  r2 <- 0.3 * exp(-0.5 * x)
+  e <- stats::rexp(n)
+  stop_t <- ifelse(e < r1 * cut, e / r1, cut + (e - r1 * cut) / r2)
+  start_t <- ifelse(stats::runif(n) < 0.6,
+                    stop_t * stats::runif(n, 0.1, 0.9), 0)
+  expect_gt(sum(start_t > 0 & start_t <= cut & stop_t > cut), 20)
+  fit <- suppressWarnings(hazard(
+    time = stop_t, status = stats::rbinom(n, 1, 0.8), time_lower = start_t,
+    x = matrix(x, ncol = 1, dimnames = list(NULL, "x")), time_windows = cut,
+    dist = "weibull", theta = c(0.3, 1, 0, 0), fit = TRUE,
+    control = list(reltol = 1e-12)))
+  expect_true(fit$fit$converged)
+  s <- attr(hzr_gof(fit), "summary")
+  # A Weibull fit conserves events at its maximum, in the likelihood's terms.
+  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-6)
+})

--- a/tests/testthat/test-gof-grid-and-windows.R
+++ b/tests/testthat/test-gof-grid-and-windows.R
@@ -34,6 +34,22 @@ test_that("n_risk at a custom time_grid is the risk set at that time", {
   }
 })
 
+test_that("n_risk at a seq() grid counts the exits tied at each grid time", {
+  set.seed(2854)
+  n <- 200
+  stop_t <- pmax(round(stats::rexp(n, 0.8), 1), 0.1)
+  fit <- suppressWarnings(hazard(time = stop_t,
+                                 status = stats::rbinom(n, 1, 0.7),
+                                 dist = "weibull", theta = c(0.3, 1),
+                                 fit = TRUE))
+  grid <- seq(0.1, 1, by = 0.1)
+  # seq() lands some points a few ulps off the data (0.30000000000000004).
+  expect_false(all(grid %in% stop_t))
+  g <- hzr_gof(fit, time_grid = grid)
+  expect_equal(g$n_risk, .brute_n_risk(round(grid, 10), rep(0, n), stop_t))
+  expect_gt(sum(g$n_event), 0)
+})
+
 test_that("an unsorted or repeated time_grid is sorted and de-duplicated", {
   d <- .gof_grid_data()
   fit <- suppressWarnings(hazard(time = d$stop, status = d$event,
@@ -46,6 +62,7 @@ test_that("an unsorted or repeated time_grid is sorted and de-duplicated", {
   expect_equal(shuffled$cum_observed, sorted$cum_observed)
   expect_equal(shuffled$cum_expected, sorted$cum_expected)
   expect_error(hzr_gof(fit, time_grid = c(1, NA)), "time_grid")
+  expect_error(hzr_gof(fit, time_grid = c(-1, 1)), "time_grid")
 })
 
 test_that("km_surv at time 0 is the Kaplan-Meier value when an event is at 0", {

--- a/tests/testthat/test-gof-grid-and-windows.R
+++ b/tests/testthat/test-gof-grid-and-windows.R
@@ -50,6 +50,25 @@ test_that("n_risk at a seq() grid counts the exits tied at each grid time", {
   expect_gt(sum(g$n_event), 0)
 })
 
+test_that("a seq() grid matches tied exits at large times too", {
+  # An absolute tolerance of 100 * eps is under one ulp above 128, so the
+  # grid-to-data match has to scale with the time.
+  set.seed(2855)
+  n <- 300
+  stop_t <- round(stats::runif(n, 150, 300), 1)
+  status <- stats::rbinom(n, 1, 0.7)
+  fit <- suppressWarnings(hazard(time = stop_t, status = status,
+                                 dist = "weibull", theta = c(0.005, 2),
+                                 fit = TRUE))
+  grid <- seq(150, 300, by = 0.1)
+  snapped <- round(grid, 1)
+  expect_true(any(grid != snapped & snapped %in% stop_t))
+  g <- hzr_gof(fit, time_grid = grid)
+  expect_equal(g$n_risk, .brute_n_risk(snapped, rep(0, n), stop_t))
+  expect_equal(sum(g$n_event), sum(status))
+  expect_equal(g$cum_observed[nrow(g)], sum(status))
+})
+
 test_that("an unsorted or repeated time_grid is sorted and de-duplicated", {
   d <- .gof_grid_data()
   fit <- suppressWarnings(hazard(time = d$stop, status = d$event,

--- a/tests/testthat/test-gof-per-subject.R
+++ b/tests/testthat/test-gof-per-subject.R
@@ -1,0 +1,176 @@
+# tests/testthat/test-gof-per-subject.R
+# hzr_gof() expected events are per subject (issue #254): each subject
+# contributes its own cumulative hazard at exit, minus the cumulative hazard
+# at its counting-process entry time.  The covariate-mean curve (par_cumhaz)
+# is for plotting only and must not drive cum_expected.
+
+.gof_avc <- local({
+  data(avc, package = "TemporalHazard")
+  na.omit(avc)
+})
+
+.gof_phases <- function() {
+  list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1, fixed = "shapes"),
+    constant = hzr_phase("constant")
+  )
+}
+
+test_that("covariate fit: total_expected is the per-subject cumulative hazard sum", {
+  avc <- .gof_avc
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ age + mal,
+    data  = avc,
+    dist  = "weibull",
+    theta = c(mu = 0.01, nu = 0.5, beta_age = 0, beta_mal = 0),
+    fit   = TRUE
+  )
+  expect_true(isTRUE(fit$fit$converged))
+
+  # Independent path: predict() on a newdata frame built from the raw columns.
+  nd <- avc[, c("age", "mal")]
+  nd$time <- avc$int_dead
+  h_subject <- predict(fit, newdata = nd, type = "cumulative_hazard")
+
+  s <- attr(hzr_gof(fit), "summary")
+  expect_equal(s$total_expected, sum(h_subject), tolerance = 1e-8)
+  expect_equal(s$total_observed, sum(avc$dead))
+})
+
+test_that("multiphase covariate fit with conserve = TRUE gives E/O = 1", {
+  avc <- .gof_avc
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ age + status + mal + com_iv,
+    data    = avc,
+    dist    = "multiphase",
+    phases  = .gof_phases(),
+    fit     = TRUE,
+    control = list(n_starts = 1, maxit = 1000, conserve = TRUE)
+  )
+  expect_true(isTRUE(fit$fit$converged))
+  expect_true(isTRUE(fit$spec$control$conserve_applied))
+
+  s <- attr(hzr_gof(fit), "summary")
+  expect_equal(s$total_observed, sum(avc$dead))
+  # Compare a ratio to 1, so the assertion is relative, not absolute.
+  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-6)
+  expect_equal(s$final_residual / s$total_observed, 0, tolerance = 1e-6)
+})
+
+test_that("intercept-only fit: cum_expected matches the covariate-free formula", {
+  data(cabgkul, package = "TemporalHazard")
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data  = cabgkul,
+    dist  = "weibull",
+    theta = c(mu = 0.10, nu = 1.0),
+    fit   = TRUE
+  )
+  expect_true(isTRUE(fit$fit$converged))
+  gof <- hzr_gof(fit)
+
+  # With no covariates every subject shares one curve, so the per-subject sum
+  # at each exit time is (events + censored) * H(t): the pre-#254 formula.
+  old <- cumsum((gof$n_event + gof$n_censor) * gof$par_cumhaz)
+  expect_equal(gof$cum_expected, old, tolerance = 1e-10)
+  expect_equal(gof$cum_observed, cumsum(gof$n_event))
+  # And it is not trivially zero: the fit predicts events.
+  expect_gt(max(gof$cum_expected), 0.5 * sum(cabgkul$dead))
+})
+
+test_that("left-truncated fit subtracts the entry-time cumulative hazard", {
+  avc <- .gof_avc
+  set.seed(2)
+  late <- stats::runif(nrow(avc)) < 0.4
+  entry <- ifelse(late, avc$int_dead * stats::runif(nrow(avc), 0.1, 0.9), 0)
+  expect_gt(sum(entry > 0), 50)
+
+  fit <- hazard(
+    time       = avc$int_dead,
+    status     = avc$dead,
+    time_lower = entry,
+    x          = as.matrix(avc[, c("age", "mal")]),
+    dist       = "multiphase",
+    phases     = .gof_phases(),
+    fit        = TRUE,
+    control    = list(n_starts = 1, maxit = 1000, conserve = TRUE)
+  )
+  expect_true(isTRUE(fit$fit$converged))
+  expect_true(isTRUE(fit$spec$control$conserve_applied))
+
+  nd_exit  <- data.frame(age = avc$age, mal = avc$mal, time = avc$int_dead)
+  nd_entry <- data.frame(age = avc$age, mal = avc$mal, time = entry)
+  h_exit  <- predict(fit, newdata = nd_exit,  type = "cumulative_hazard")
+  h_entry <- predict(fit, newdata = nd_entry, type = "cumulative_hazard")
+  # The entry term is not negligible, so omitting it would be caught.
+  expect_gt(sum(h_entry), 10)
+
+  s <- attr(hzr_gof(fit), "summary")
+  expect_equal(s$total_expected, sum(h_exit - h_entry), tolerance = 1e-8)
+  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-6)
+})
+
+test_that("vector-interface covariate fit uses the stored design matrix", {
+  avc <- .gof_avc
+  fit <- hazard(
+    time   = avc$int_dead,
+    status = avc$dead,
+    x      = as.matrix(avc[, c("age", "mal")]),
+    dist   = "weibull",
+    theta  = c(0.01, 0.5, 0, 0),
+    fit    = TRUE
+  )
+  expect_true(isTRUE(fit$fit$converged))
+  expect_null(fit$data$frame)
+
+  nd <- data.frame(age = avc$age, mal = avc$mal, time = avc$int_dead)
+  s <- attr(hzr_gof(fit), "summary")
+  expect_equal(s$total_expected,
+               sum(predict(fit, newdata = nd, type = "cumulative_hazard")),
+               tolerance = 1e-8)
+})
+
+test_that("weighted fit: observed and expected are both weighted", {
+  avc <- .gof_avc
+  set.seed(1)
+  w <- stats::runif(nrow(avc), 0.5, 2)
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ age + mal,
+    data    = avc,
+    weights = w,
+    dist    = "multiphase",
+    phases  = .gof_phases(),
+    fit     = TRUE,
+    control = list(n_starts = 1, maxit = 1000, conserve = TRUE)
+  )
+  expect_true(isTRUE(fit$fit$converged))
+  expect_true(isTRUE(fit$spec$control$conserve_applied))
+
+  s <- attr(hzr_gof(fit), "summary")
+  # CoE under weights is sum(w * H) = sum(w * d); the unweighted sums differ.
+  expect_equal(s$total_observed, sum(w * avc$dead), tolerance = 1e-10)
+  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-6)
+})
+
+test_that("custom time_grid: observed and expected cover the same subjects", {
+  avc <- .gof_avc
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ age + mal,
+    data  = avc,
+    dist  = "weibull",
+    theta = c(mu = 0.01, nu = 0.5, beta_age = 0, beta_mal = 0),
+    fit   = TRUE
+  )
+  # A grid holding only the first 20 distinct event times.
+  grid <- sort(unique(avc$int_dead[avc$dead == 1]))[1:20]
+  on_grid <- avc$int_dead %in% grid
+
+  nd <- avc[on_grid, c("age", "mal")]
+  nd$time <- avc$int_dead[on_grid]
+  gof <- hzr_gof(fit, time_grid = grid)
+  s <- attr(gof, "summary")
+  expect_equal(s$total_observed, sum(avc$dead[on_grid]))
+  expect_equal(s$total_expected,
+               sum(predict(fit, newdata = nd, type = "cumulative_hazard")),
+               tolerance = 1e-8)
+})

--- a/tests/testthat/test-gof-phase-covariates.R
+++ b/tests/testthat/test-gof-phase-covariates.R
@@ -1,0 +1,89 @@
+# tests/testthat/test-gof-phase-covariates.R
+# hzr_gof()'s par_cumhaz / par_surv curve is documented to sit at the
+# covariate means.  A multiphase fit whose covariates enter only through the
+# phase formulas stores no global design matrix (object$data$x is NULL), so a
+# time-only newdata evaluated that curve at covariates = 0 instead.
+
+.gof_pc_avc <- local({
+  data(avc, package = "TemporalHazard")
+  na.omit(avc)
+})
+
+test_that("phase-formula fit: par_cumhaz is at the covariate means, not at 0", {
+  d <- .gof_pc_avc
+  # The fit warns that its Hessian is singular.  That concerns standard
+  # errors only, which hzr_gof() does not use.
+  fit <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes", formula = ~ age + mal),
+      constant = hzr_phase("constant", formula = ~ age)
+    ),
+    fit    = TRUE
+  ))
+  expect_true(isTRUE(fit$fit$converged))
+  expect_null(fit$data$x)
+
+  gof <- hzr_gof(fit)
+  nd_mean <- data.frame(time = gof$time, age = mean(d$age), mal = mean(d$mal))
+  nd_zero <- data.frame(time = gof$time)
+  at_mean <- predict(fit, newdata = nd_mean, type = "cumulative_hazard")
+  at_zero <- predict(fit, newdata = nd_zero, type = "cumulative_hazard")
+
+  # The two candidate curves are far apart, so the comparison can fail.
+  expect_gt(max(abs(at_zero / at_mean - 1)), 0.5)
+
+  expect_equal(unname(gof$par_cumhaz), unname(at_mean), tolerance = 1e-10)
+  expect_equal(unname(gof$par_surv), unname(exp(-at_mean)), tolerance = 1e-10)
+
+  decomp <- predict(fit, newdata = nd_mean, type = "cumulative_hazard",
+                    decompose = TRUE)
+  expect_equal(gof$par_cumhaz_early, decomp$early, tolerance = 1e-10)
+  expect_equal(gof$par_cumhaz_constant, decomp$constant, tolerance = 1e-10)
+})
+
+test_that("global-covariate fit: par_cumhaz is at the design-matrix means", {
+  d <- .gof_pc_avc
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ age + mal,
+    data  = d,
+    dist  = "weibull",
+    theta = c(mu = 0.01, nu = 0.5, beta_age = 0, beta_mal = 0),
+    fit   = TRUE
+  )
+  expect_true(isTRUE(fit$fit$converged))
+
+  gof <- hzr_gof(fit)
+  nd_mean <- data.frame(time = gof$time, age = mean(d$age), mal = mean(d$mal))
+  at_mean <- predict(fit, newdata = nd_mean, type = "cumulative_hazard")
+  at_zero <- predict(fit, newdata = data.frame(time = gof$time, age = 0,
+                                               mal = 0),
+                     type = "cumulative_hazard")
+  expect_gt(max(abs(at_zero / at_mean - 1)), 0.5)
+  expect_equal(unname(gof$par_cumhaz), unname(at_mean), tolerance = 1e-10)
+})
+
+test_that("intercept-only multiphase fit: par_cumhaz is the one shared curve", {
+  d <- .gof_pc_avc
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    ),
+    fit    = TRUE
+  )
+  expect_true(isTRUE(fit$fit$converged))
+
+  gof <- hzr_gof(fit)
+  at_t <- predict(fit, newdata = data.frame(time = gof$time),
+                  type = "cumulative_hazard")
+  expect_equal(unname(gof$par_cumhaz), unname(at_t), tolerance = 1e-10)
+  expect_gt(max(gof$par_cumhaz), 0.1)
+})

--- a/tests/testthat/test-stepwise-vector-interface.R
+++ b/tests/testthat/test-stepwise-vector-interface.R
@@ -115,7 +115,9 @@ test_that("a vector-interface refit carries BOTH censoring bounds through", {
   D <- vec_data()
   n <- nrow(D)
   D$st <- rep(c(1, 0, 2), length.out = n)
-  D$lo <- ifelse(D$st == 2, D$tt, 0.05 + seq_len(n) / (20 * n))
+  # Entry must stay strictly before exit, or hazard() refuses the row (#253).
+  D$lo <- ifelse(D$st == 2, D$tt,
+                 pmin(0.05 + seq_len(n) / (20 * n), D$tt / 2))
   D$up <- ifelse(D$st == 2, D$tt + 0.75, D$tt)
 
   # Guard the guard: if the fixture degenerated to zero entry times or

--- a/tests/testthat/test-time-lower-entry.R
+++ b/tests/testthat/test-time-lower-entry.R
@@ -88,27 +88,191 @@ test_that("the multiphase Hessian matches numDeriv for every entry-time layout",
   }
 })
 
-test_that("entry at or after exit warns, and names the NULL default", {
-  k <- .entry_case()
-  fit_with <- function(tl) {
-    suppressMessages(hazard(
-      time = k$time, status = k$status, time_lower = tl,
-      dist = "multiphase", phases = k$phases, theta = k$theta, fit = FALSE))
+# On status 0/1 rows every family reads `time_lower` as the entry time when
+# 0 < time_lower < time. time_lower = 0 and time_lower = time both mean "no
+# entry time"; the second is the mixed-interval layout, where only status-2
+# rows carry a real lower bound. An entry AFTER exit (time_lower > time) is
+# an error. SAS HAZARD refuses STIME >= TIME (setcoe_obs_loop.c, SETCOE960),
+# but its STIME is only ever an entry time, while R's time_lower doubles as
+# the interval bound, so here only the strict case is refused (#253).
+.bad_entry_dists <- c("weibull", "exponential", "loglogistic", "lognormal",
+                      "multiphase")
+
+.bad_entry_call <- function(k, dist, tl, use_data = FALSE) {
+  ph <- if (dist == "multiphase") k$phases else NULL
+  th <- if (dist == "multiphase") k$theta else NULL
+  if (use_data) {
+    d <- data.frame(tt = k$time, st = k$status, lo = tl)
+    hazard(time = tt, status = st, time_lower = lo, data = d,
+           dist = dist, phases = ph, theta = th, fit = FALSE)
+  } else {
+    hazard(time = k$time, status = k$status, time_lower = tl,
+           dist = dist, phases = ph, theta = th, fit = FALSE)
   }
+}
+
+test_that("entry after exit is an error for every dist", {
+  k <- .entry_case()
   n <- length(k$time)
-  w <- capture_warnings(fit_with(k$time))
-  expect_match(w, "counting-process entry time", all = FALSE)
-  # Derived, not hard-coded: the assertion is that the warning counts EVERY
-  # row, which stays true if `avc` ever changes size.
-  expect_match(w, paste0(n, " of ", n), all = FALSE)
-  # The remedy has to be in the message: NULL is not the same as `time`.
-  expect_match(w, "leave 'time_lower' as NULL", all = FALSE)
-  # The warning fires for every `dist`, so its account of the consequence
-  # has to hold for every family: only multiphase honours the entry time on
-  # these rows, and "contribute nothing" was true for multiphase alone.
-  expect_match(w, "dist = \"weibull\" treats them as entering at time 0",
-               fixed = TRUE, all = FALSE)
-  expect_false(any(grepl("contribute nothing", w, fixed = TRUE)))
+  one_bad <- pmax(k$time - 0.5, 0)
+  j <- which(k$time > 0)[1L]
+  one_bad[j] <- k$time[j] + 1          # a single row entering after it leaves
+  for (dist in .bad_entry_dists) {
+    for (use_data in c(FALSE, TRUE)) {
+      info <- paste(dist, if (use_data) "data-masked" else "plain vectors")
+      # Every row entering one unit after its own exit time.
+      err <- tryCatch(suppressMessages(
+        .bad_entry_call(k, dist, k$time + 1, use_data)),
+        error = function(e) conditionMessage(e))
+      expect_type(err, "character")
+      expect_match(err, "counting-process entry time", fixed = TRUE,
+                   info = info)
+      # Derived, not hard-coded: the message counts every offending row.
+      expect_match(err, paste0(n, " of ", n, " row(s)"), fixed = TRUE,
+                   info = info)
+      expect_match(err, "'time_lower' > 'time'", fixed = TRUE, info = info)
+      expect_match(err, "cannot enter the risk set after it leaves",
+                   fixed = TRUE, info = info)
+      # The remedy has to be in the message, `time` included.
+      expect_match(err, "set it to 0 or to 'time'", fixed = TRUE,
+                   info = info)
+      # One offending row among genuine entry times is still refused, and
+      # the count says one.
+      expect_error(suppressMessages(
+        .bad_entry_call(k, dist, one_bad, use_data)),
+        paste0("1 of ", n, " row(s)"), fixed = TRUE, info = info)
+    }
+  }
+})
+
+test_that("the formula interface refuses start >= stop through survival", {
+  # Surv(start, stop, event) is the formula route to an entry time, and
+  # survival refuses start >= stop itself, start == stop included: it sets
+  # the entry to NA, which hazard() then rejects as a non-finite
+  # 'time_lower'. So the formula path refuses a zero-length interval that
+  # the vector path accepts as "no entry time"; the mixed-interval layout is
+  # a vector-interface idiom. Pin both halves, so a change in survival that
+  # lets such a row through is noticed here.
+  expect_warning(s <- survival::Surv(c(0, 2), c(1, 2), c(1, 0)),
+                 "Stop time must be > start time")
+  expect_true(is.na(unclass(s)[2L, 1L]))
+  d <- data.frame(a = c(0, 0.5, 2), b = c(1, 2, 2), e = c(1, 0, 1))
+  expect_error(suppressWarnings(hazard(
+    survival::Surv(a, b, e) ~ 1, data = d, dist = "weibull", fit = FALSE)),
+    "'time_lower' must be a numeric vector of finite non-negative values",
+    fixed = TRUE)
+})
+
+test_that("time_lower = 0 is 'no entry time' and matches time_lower = NULL", {
+  set.seed(253)
+  n <- 120
+  tt <- stats::rexp(n, 0.4) + 0.05
+  st <- stats::rbinom(n, 1, 0.7)
+  starts <- list(weibull = c(0.5, 1), exponential = c(log_rate = 0),
+                 loglogistic = c(log_alpha = 0, log_beta = 0),
+                 lognormal = c(mu = 0, log_sigma = 0))
+  for (dist in names(starts)) {
+    f_null <- suppressWarnings(hazard(time = tt, status = st, dist = dist,
+                                      theta = starts[[dist]], fit = TRUE))
+    f_zero <- expect_no_error(suppressWarnings(hazard(
+      time = tt, status = st, time_lower = rep(0, n), dist = dist,
+      theta = starts[[dist]], fit = TRUE)))
+    expect_equal(coef(f_zero), coef(f_null), tolerance = 1e-8, info = dist)
+    expect_equal(f_zero$fit$objective, f_null$fit$objective,
+                 tolerance = 1e-8, info = dist)
+  }
+  k <- .entry_case()
+  mp <- function(tl) {
+    suppressWarnings(suppressMessages(hazard(
+      time = k$time, status = k$status, time_lower = tl, dist = "multiphase",
+      phases = k$phases, theta = k$theta, fit = TRUE)))
+  }
+  f_null <- mp(NULL)
+  f_zero <- expect_no_error(mp(rep(0, length(k$time))))
+  expect_equal(coef(f_zero), coef(f_null), tolerance = 1e-8)
+})
+
+test_that("time_lower = time is 'no entry time' and matches NULL (#253)", {
+  # The mixed-interval layout: status 0/1 rows carry their own time. Before
+  # #253 multiphase read it as an entry at exit and returned +47915.76 with
+  # converged = TRUE on avc; the three families below ignored time_lower.
+  set.seed(253)
+  n <- 120
+  tt <- stats::rexp(n, 0.4) + 0.05
+  st <- stats::rbinom(n, 1, 0.7)
+  starts <- list(weibull = c(0.5, 1), exponential = c(log_rate = 0),
+                 loglogistic = c(log_alpha = 0, log_beta = 0),
+                 lognormal = c(mu = 0, log_sigma = 0))
+  for (dist in names(starts)) {
+    f_null <- suppressWarnings(hazard(time = tt, status = st, dist = dist,
+                                      theta = starts[[dist]], fit = TRUE))
+    f_same <- expect_no_error(suppressWarnings(hazard(
+      time = tt, status = st, time_lower = tt, dist = dist,
+      theta = starts[[dist]], fit = TRUE)))
+    expect_equal(coef(f_same), coef(f_null), tolerance = 1e-8, info = dist)
+    expect_equal(f_same$fit$objective, f_null$fit$objective,
+                 tolerance = 1e-8, info = dist)
+  }
+  k <- .entry_case()
+  mp <- function(tl) {
+    suppressWarnings(suppressMessages(hazard(
+      time = k$time, status = k$status, time_lower = tl, dist = "multiphase",
+      phases = k$phases, theta = k$theta, fit = TRUE)))
+  }
+  f_null <- mp(NULL)
+  f_same <- expect_no_error(mp(k$time))
+  expect_equal(coef(f_same), coef(f_null), tolerance = 1e-8)
+  expect_equal(f_same$fit$objective, f_null$fit$objective, tolerance = 1e-8)
+  expect_lt(f_same$fit$objective, 0)
+})
+
+test_that("zero-length epochs among genuine entries are an error (#253)", {
+  # Counting-process data where one row enters and exits at the same time
+  # (a second event at the previous row's time; hzr_repeated_events() emits
+  # these). Reading time_lower == time as "no entry" there would charge the
+  # row its full H(0, t], so hazard() refuses the mix, as SAS refuses
+  # STIME >= TIME. Found by r-reviewer; rows 3 of 4 is the offender.
+  tt <- c(1, 2, 2, 3)
+  st <- c(1, 1, 1, 0)
+  tl <- c(0, 1, 2, 2)
+  for (dist in .bad_entry_dists[.bad_entry_dists != "multiphase"]) {
+    err <- tryCatch(hazard(time = tt, status = st, time_lower = tl,
+                           dist = dist, fit = FALSE),
+                    error = function(e) conditionMessage(e))
+    expect_type(err, "character")
+    expect_match(err, "1 of 4 row(s)", fixed = TRUE, info = dist)
+    expect_match(err, "zero-length", fixed = TRUE, info = dist)
+  }
+  # Genuine entries only: fits.
+  expect_no_error(hazard(time = tt, status = st,
+                         time_lower = c(0, 1, 1.5, 2), dist = "weibull",
+                         fit = FALSE))
+  # The mixed-interval layout (no genuine entry on any status 0/1 row)
+  # still reads time_lower == time as no entry.
+  expect_no_error(hazard(time = c(1, 2, 3, 4), status = c(1, 0, 2, 1),
+                         time_lower = c(1, 2, 2.5, 4),
+                         time_upper = c(1, 2, 3.5, 4), dist = "weibull",
+                         fit = FALSE))
+})
+
+test_that("a status-0 row at time 0 with time_lower 0 is not an error", {
+  # time_lower == time == 0 is the SAS "no entry time" row, not an entry at
+  # exit: STIME = 0 skips the check there, and so must hazard().
+  tt <- c(0, 0.4, 1.1, 2.3, 3.0)
+  st <- c(0, 1, 0, 1, 1)
+  for (dist in .bad_entry_dists[.bad_entry_dists != "multiphase"]) {
+    w <- expect_no_error(capture_warnings(hazard(
+      time = tt, status = st, time_lower = rep(0, 5), dist = dist,
+      fit = FALSE)))
+    expect_false(any(grepl("entry time", w, fixed = TRUE)), info = dist)
+  }
+  # The same row through the formula interface: Surv(type = "interval")
+  # gives status 0/1 rows an entry time of 0.
+  d <- data.frame(t1 = tt, t2 = tt, e = c(0, 1, 0, 1, 1))
+  w <- expect_no_error(capture_warnings(hazard(
+    survival::Surv(t1, t2, e, type = "interval") ~ 1, data = d,
+    dist = "weibull", fit = FALSE)))
+  expect_false(any(grepl("entry time", w, fixed = TRUE)))
 })
 
 test_that("genuine left truncation does not warn", {

--- a/vignettes/clinical-analysis-walkthrough.qmd
+++ b/vignettes/clinical-analysis-walkthrough.qmd
@@ -652,13 +652,8 @@ likelihood predicts as many events as were observed: add up every
 patient's cumulative hazard at the end of their follow-up and you get
 the event count back.  `hzr_gof()` is the R version of the SAS
 `hazplot` display, a running tally of observed and expected events
-over time.
-
-For a model with covariates you need to know one thing before reading
-its output.  `hzr_gof()` evaluates the parametric curve at the covariate
-means, one "mean patient", and builds the expected count from that
-single curve.  The printed ratio is then a mean-patient check, not the
-conservation-of-events identity, and for `fit_mv` it is well short of 1.
+over time.  Each patient's expected count is their own cumulative
+hazard, from their own covariates, at the time they leave follow-up.
 
 ```{r}
 #| label: gof-summary
@@ -667,24 +662,11 @@ gof <- hzr_gof(fit_mv)
 print(gof)
 ```
 
-The conservation-of-events check itself sums each patient's own
-cumulative hazard, from their own covariates, at their own follow-up
-time:
-
-```{r}
-#| label: coe-per-subject
-#| eval: !expr requireNamespace("TemporalHazard", quietly = TRUE)
-nd_coe <- avc[, c("age", "status", "mal", "com_iv")]
-nd_coe$time <- avc$int_dead
-c(expected = sum(predict(fit_mv, newdata = nd_coe,
-                         type = "cumulative_hazard")),
-  observed = sum(avc$dead))
-```
-
-Expected 68.0 against 68 observed, so the fit conserves events.  The
-gap in the `hzr_gof()` summary belongs to the mean patient, not to the
-fit.  For an intercept-only model every patient shares one curve, the
-two checks give the same answer, and `hzr_gof()` prints an E/O of 1.
+Expected 68.0 against 68 observed, an E/O of 1, so the fit conserves
+events.  `fit_mv` is a multiphase fit with Conservation of Events
+applied (the default), which holds the total to the event count
+exactly.  A Weibull fit gets there at its maximum, to within the
+optimizer's tolerance.
 
 ```{r}
 #| label: fig-gof-survival
@@ -722,20 +704,27 @@ ggplot(gof, aes(x = time, y = residual)) +
   theme_minimal()
 ```
 
-Read these three plots as a picture of the mean patient.  The first sets
-that patient's survival curve against the Kaplan-Meier estimate for the
-whole cohort, and it runs above it from the first weeks on.  The other
-two tally the deaths the mean patient's hazard would predict for the
-patients leaving follow-up at each time.  Most of the deaths come in
-the first weeks, and the mean patient's curve accounts for few of them
-(45 observed by two weeks against about 1.4 expected), so the residual
-falls to about -55 by six months and then climbs back slowly, ending
-at -26.8.  That is the mean patient
-understating the cohort's early risk.  The model itself predicts the
-right number of deaths, as the per-subject check above shows.  For an
-intercept-only model the same plots are the conservation-of-events
-picture, and there a residual that stays near zero is what a good fit
-looks like.
+The first plot is the one place the mean patient appears.  It sets the
+survival curve for a patient with average covariates against the
+Kaplan-Meier estimate for the whole cohort, and that curve runs above
+it from the first weeks on.  The mean patient fares better than the
+cohort, because the mean patient's cumulative hazard is not the average
+of the patients' cumulative hazards.  That is why `hzr_gof()` builds
+its expected count patient by patient rather than from this curve.
+
+The other two plots tally events as patients leave follow-up.  A
+patient adds their expected count when they leave, by death or
+censoring, and that count is the hazard they built up over their whole
+follow-up.  Most deaths come in the first weeks, to patients who had
+little time to build up hazard: 47 deaths in the first half month
+against about 4.8 expected.  The residual bottoms out near -47.5 at
+about two months.  The patients followed longest, most of them
+censored, carry the rest of the expected count, and it arrives only as
+they leave follow-up years later, so the residual climbs back and ends
+at zero.  Read the shape of the curve as a record of when deaths and
+follow-up happen in this cohort, not as a month-by-month calibration
+check.  The end point is the conservation-of-events identity, and the
+decile table above is the calibration check.
 
 ## Why not Cox regression?
 

--- a/vignettes/fitting-hazard-models.qmd
+++ b/vignettes/fitting-hazard-models.qmd
@@ -424,22 +424,19 @@ table(status)
 ```
 
 ::: {.callout-note}
-**`time_lower` as a counting-process entry time.**  The Weibull and
-multiphase likelihoods also read `time_lower` as the *entry*
-(left-truncation) time on right-censored and exact-event rows
-(`status %in% c(0, 1)`): when `0 < time_lower < time`, the row contributes
-H(stop) − H(start), the counting-process form used for epoch-decomposed
-repeated events.  The exponential, log-logistic, and log-normal likelihoods
-use `time_lower` only as the lower bound of a `status == 2` interval and
-ignore it on every other row.  For an ordinary right-censored or event row
-with no entry time, leave `time_lower` at `0` or omit it.  Don't set
-`time_lower = time` to mean "no entry time".  `hazard()` accepts it with a
-warning, and what it does next depends on the family.  The Weibull
-likelihood uses `time_lower` as an entry time only when it is strictly less
-than `time`, so those rows enter at 0 and nothing changes.  The multiphase
-likelihood takes it at its word.  Each row enters the risk set at the moment
-it leaves, its cumulative-hazard term vanishes, and the fit it returns is
-meaningless.  The other three families ignore it.
+**`time_lower` as a counting-process entry time.**  On right-censored and
+exact-event rows (`status %in% c(0, 1)`), every family reads `time_lower`
+as the *entry* (left-truncation) time, not as a censoring bound.  A row
+with `0 < time_lower < time` contributes H(time) − H(time_lower), the
+counting-process form used for delayed entry and for epoch-decomposed
+repeated events.  An entry time of `0` means the subject was at risk from
+time zero, so for an ordinary right-censored or event row leave
+`time_lower` at `0`, as the code above does, or omit it.  Setting
+`time_lower = time` on those rows also means "no entry time": that is the
+mixed-interval layout, where only the interval-censored rows carry a real
+lower bound.  A subject can't enter the risk set after it leaves, so
+`hazard()` stops with an error when a status 0 or 1 row has
+`time_lower > time`.  SAS HAZARD refuses those rows too.
 :::
 
 Fit a Weibull model using both censoring types:

--- a/vignettes/inference-diagnostics.qmd
+++ b/vignettes/inference-diagnostics.qmd
@@ -245,11 +245,10 @@ all in the returned object.
 The Kaplan-Meier overlay in the prediction-visualization vignette is
 the *visual* goodness-of-fit check. `hzr_gof()` is the *quantitative*
 complement: it tabulates parametric predictions side by side with the
-nonparametric KM estimate at each event time, and computes the
-Conservation-of-Events observed-vs-expected ratio across the whole
-follow-up window. The ratio compresses everything the model is doing
-into a single number, which makes it the right summary statistic to
-report alongside coefficient tables. (`hzr_gof()` corresponds to the
+nonparametric KM estimate at each event time, and adds up observed and
+expected events over the follow-up. Each patient contributes the
+cumulative hazard the model assigns to their own follow-up, so the
+expected total is a sum over patients. (`hzr_gof()` corresponds to the
 SAS `hazplot.sas` macro.)
 
 ```{r}
@@ -258,18 +257,22 @@ gof <- hzr_gof(fit)
 print(gof)
 ```
 
-The observed vs. expected ratio (printed at the bottom) is the
-Conservation-of-Events check: a well-specified model recovers the event
-count exactly, so a ratio close to 1 is what we want.  Ratios well
-above or below 1 flag either a misspecified shape or a covariate that
-isn't really linear on the log-hazard scale.
+The observed vs. expected ratio printed at the bottom rounds to 1 here
+(67.995 expected against 68 observed), and for this model that is
+guaranteed rather than earned. For a Weibull or
+exponential fit, and for a multiphase fit with conservation of events,
+the likelihood equations force the expected total to equal the observed
+count at the maximum. A ratio away from 1 on those models means the
+optimizer stopped short, not that the shape is wrong. Only for a
+log-logistic or log-normal fit does the ratio say anything about
+calibration in total. To judge the shape, compare the Kaplan-Meier and
+parametric columns over time, and use the decile check below.
 
 
 ## Decile-of-risk calibration
 
-The conservation-of-events ratio above tells you whether the model is
-calibrated *on average*. That's necessary but not sufficient: a
-model can hit the right total event count while systematically
+The ratio above checks the total. A right total is necessary but not
+sufficient: a model can hit the right total event count while systematically
 over-predicting risk for one part of the cohort and under-predicting
 for another, with the errors cancelling in aggregate.
 `hzr_deciles()` is the check that catches that failure mode: it


### PR DESCRIPTION
Closes #253. Closes #254.

This fixes the two code defects found while verifying the documentation flags on #252/#255. It also fixes the `?hzr_gof` items from #255's Copilot review, which could not be fixed there because this branch rewrites `hzr_gof()`.

## #253: `time_lower` and entry times
**The rule** (maintainer's decision). On a row with status 0 or 1, `time_lower` is the counting-process entry time when `0 < time_lower < time`.
- `time_lower == time` means **no entry**. This is the mixed-interval layout: exact and right-censored rows carry their own time, and only status-2 rows carry a real lower bound. The package's own interval-censoring fixtures use it.
- `time_lower > time` is an **error**. SAS HAZARD rejects `STIME >= TIME` (`SETCOE960`, `setcoe_obs_loop.c:95`), but SAS's STIME is only ever an entry time. Here `time_lower` doubles as the interval bound, so only the strict case is refused.
- Rows with `time_lower == time > 0` **beside** genuine entries are an error too. In counting-process data they are zero-length epochs (`hzr_repeated_events()` can emit them), and reading them as "no entry" charged each row its full H(0, t] silently (r-reviewer finding).

**What was wrong.**
- Exponential, log-logistic and log-normal **ignored** entry times, so a left-truncated fit was fitted as if every subject were at risk from 0. They now subtract H(entry) in the log-likelihood, the gradient and the closed-form Hessian.
- Multiphase read `time_lower == time` as an entry at exit: objective **+47915.76 with `converged = TRUE`** on AVC. A single helper, `.hzr_multiphase_entry()`, now applies the rule at all seven sites: logl, gradient, Hessian, CoE and fixmu selection.

**Evidence.**
- Each family's new term matches an independent oracle: a hand-written conditional likelihood, and for the exponential, Weibull at nu = 1, both to about 1e-10.
- The gradient and Hessian match `numDeriv`. r-reviewer re-checked them at about 1e-8 and 1e-10.
- Each family's logl, gradient and Hessian term was mutation-checked separately.
- Status -1 rows are pinned as ignoring `time_lower`. The mutant for that test really changes the left-censored term; an earlier mutant that didn't was replaced. Status-2 interval rows are pinned per family.
- Formula (`Surv(start, stop, event)`) versus vector (`time_lower =`) parity is red on the old code for the three families. **New, with #226 now on main (#283):** a counting `Surv(start, stop, event)` passed as `status =` sets `time_lower = start` and must fit exactly like `time_lower =` and the formula interface. `test-entry-time-surv-status.R` pins this for all five families, plus an entry-time-effect assertion. It passes 24/24; a mutant that makes the `Surv` route drop `time_lower` fails 22 of 24.
- Seven test fixtures the first guard draft had rewritten were restored. Six pass unchanged, which proves they held only `== time` rows. One kept its clamp because it had 3 genuine `>` rows.

**The merge with main (`f88e670`, including #283).** `NEWS.md` was the only conflict, resolved as the union of both sides' bullets. `hazard_api.R`, `formula-helpers.R` and `diagnostics.R` auto-merged, and the seam was checked by running the merged code:
- all three routes to an entry time give -239.75289399, against -258.747 with no entry;
- `Surv()` turns `start == stop` into `NA`, so a zero-length epoch is refused on that route too, with the existing generic "finite non-negative" message;
- a `Surv` plus a contradicting `time_lower` hits #283's mismatch error;
- an interval `Surv` gives exact and right-censored rows `time_lower = 0`, which is read as no entry.

**One test changed after the merge.** `R CMD check` on the merge failed 2 assertions in `test-entry-time-multiphase.R` (f), and the merge wasn't the cause. They pinned the m gradient and the m,m Hessian at m = 0 exactly, where log L has a kink in m (slopes of about ±3.956). The old pins (-7.4e-10 and 64807) were artefacts of the symmetric finite-difference stencil. Main's one-sided stencils (#251, #260) give -3.956 and -1.607. On clean trees, `c0d4cfd` and `9fd3dba` give the old values and `76d3e99` and the merge give the new ones. Away from the kink all four agree exactly and match `numDeriv`. Test (f) now pins the gradient and Hessian at m = 0.5 (values computed on `9fd3dba`, before either change) and cross-checks `numDeriv`. The log-likelihood pin at m = 0 stays. A mutant in which the entry helper ignores genuine entries fails 6 of (f)'s 8 assertions. The two `numDeriv` cross-checks are guarded by `requireNamespace()`, because `numDeriv` is a Suggests. With it masked, (f) still runs its 6 pins without error.

**CI on `e30237a` failed that Hessian pin** on the three Ubuntu builds, on Windows and in test-coverage. macOS passed. The pin had been compared at 1e-10, but the entries in the shape parameters carry finite-difference error. They differ from the macOS values by up to 1.8e-7 relative on Ubuntu and about 3e-8 on Windows. Each entry is now compared as a ratio to its pin, with max |ratio - 1| < 1e-5, which is about 55 times the largest spread seen. No pinned entry is near 0. Dropping the entry times still moves the Hessian by 2.76 relative, and the entry-time mutant still fails 6 of (f)'s 8 assertions.

## #254: `hzr_gof()`
- **Expected events were computed at the covariate means** and printed as a "Conservation ratio". On the walkthrough's covariate model that showed 0.606 while the fit conserved events exactly (68.000 against 68). Expected events are now per subject, H(exit) - H(entry), via `predict()`. They are weighted for a weighted fit, which conserves sum(w·H) = sum(w·d).
- The Kaplan-Meier and `n_risk` columns now use the counting-process risk set when the fit has entry times. On a left-truncated fit, `n_risk` had been 200 when 87 were truly at risk.
- The `?hzr_gof` docs and the clinical-walkthrough and inference vignettes are rewritten to match. The inference vignette now says E/O is 1 by construction for Weibull, exponential and multiphase-with-CoE fits, so there it checks convergence, not shape. For log-logistic and log-normal fits it checks calibration in total, and `NEWS.md` now says so too (r-reviewer).

## #255 Copilot items on `?hzr_gof` (S2 to S6)
- **S2 (a real bug).** For a fit whose covariates enter through phase formulas, the mean-patient `par_*` curve sat at covariates = 0: 0.00101 against 0.00037 at the means. It now uses each phase's design-matrix column means, so a factor enters as a proportion. Fixed test-first and mutation-checked. This covers fits whose covariates enter only through the phase formulas, and `?hzr_gof` says so. A fit with both global and phase-formula covariates is #264, fixed on the stacked branch.
- **S3 to S6.** Weights, the refusal of left- and interval-censored fits, the default grid (distinct Kaplan-Meier times, including censoring times), and the entry recipe are now documented correctly.

## Copilot review of `6538323`
All five items were valid, and each was reproduced by running code. Fixed in e30237a. Each code item has a test in `test-gof-grid-and-windows.R` that failed on `6538323` and fails again when its fix is reverted.
- **`n_risk` on a custom `time_grid`** carried the previous Kaplan-Meier count forward. It kept subjects who had left and missed ones who had entered, for example 64 where the true risk set was 63. It is now counted directly at each grid time.
- **`time_windows` with entry times.** H(entry) was taken in the entry-time covariate window, while the likelihood uses the exit-time window. E/O was 1.052 on a Weibull fit that conserves events, and is now 1. The fix covers single-distribution fits only, because multiphase fits already gave 1.000000.
- **An unsorted grid** made the cumulative columns non-cumulative. A supplied grid is now sorted with duplicates dropped, and a non-finite grid is refused.
- **An event at time 0** made `km_surv` at 0 the average of 1 and the true value. It now comes from `stepfun()`.
- **The `?hzr_gof` wording** that the intercept-only curve equals the expected count now applies only to fits without entry times.
- **A regression in my first fix, caught by r-reviewer before any push.** The new `n_risk` compared grid times exactly, while the event and censoring tallies match within 100 ulps. On a `seq()` grid, 0.30000000000000004 dropped the exits tied at 0.3: `n_risk` was 144 where the risk set is 158. A grid time within that tolerance of a Kaplan-Meier time is now counted at that time, using one shared tolerance. A negative grid time is now refused by name.
- **A second r-reviewer pass found the tolerance was absolute.** At 100 machine epsilons, it's smaller than the gap between adjacent doubles above 128. On a `seq(150, 300, by = 0.1)` grid, events fell off the grid: `n_event` summed to 180 against 197 real events, with no warning. That absolute match was already on main. The tolerance now scales with the time in both places it's used.

## NEWS (1.2.11, no version bump)
- **Breaking:** `time_lower > time` on a status 0/1 row stops, and so does the zero-epoch mix.
- **Bug fixes:** the #253 entry-time families, the #254 per-subject expected events and Kaplan-Meier, and the S2 phase-means curve (its own bullet, added after r-reviewer noted it was missing).

## Verification
All run locally at the head commit `614914e`, with `/Volumes/qhsstudies` mounted.
- `devtools::document()`: the second run is clean, with no diff in `man/` or `NAMESPACE`.
- `lintr::lint_package()`: 0 lints. `spelling::spell_check_package()`: 0 words.
- **Full suite, `NOT_CRAN=true`:** **FAIL 0, ERR 0, SKIP 6, PASS 5006**, on `614914e` with the volume mounted from start to end.
  - All six skips are fixture availability: `bh.dead` SAS fixture 3, weighted-parity fixture 2, legacy binary (status 126) 1.
  - Both repeated-events parity files ran with no skips.
  - An earlier run at `614914e`, with the volume unmounted, gave FAIL 0, SKIP 12, PASS 4880. The six extra skips were the maze and achalasia study datasets.
  - The previous head, `e30237a`, had the volume mounted and gave FAIL 0, SKIP 6, PASS 5006. Its six skips were fixtures only, and both repeated-events parity files ran. The only change since then is the tolerance of one assertion in test (f).
- **`R CMD check --as-cran` with the manual,** from a clean `git archive` of `614914e`: **Status: OK** (0 errors, 0 warnings, 0 notes). Under the check: FAIL 0, SKIP 209, PASS 3858. The tarball is 3.1 MB.
- **Check time: tests take 119 s (125 s elapsed).** That's up from 90 s at `bd75f9f` on 2026-09-09. r-reviewer estimated that this PR's new entry-time and `hzr_gof` tests add about 20 s. I haven't measured that split: main has also grown since `bd75f9f`, and same-machine runs vary by up to 46 s (AGENTS.md). Vignettes take 48 s. Build plus check took 314 s wall, still well inside CRAN's 10 minutes.
- **r-reviewer ran three times on the Copilot fixes.** The first two passes each found a silent wrong answer in the fix itself: the exact-match `n_risk`, then the absolute tolerance. Both are fixed above. The third pass, on `e30237a`, found none, so review stopped there.
- **r-reviewer also ran twice before Copilot:** once on the merged diff and once on the follow-up commit. It found:
  - **fixed:** 5 items (test (f), the `?hzr_gof` scope, the NEWS E/O claim, the missing S2 bullet, `stats::predict`), plus the unguarded `numDeriv` from the second pass;
  - **out of scope:** `hzr_bootstrap()` prints `'NA', 'NA'` in a refusal message for a vector fit without data. That's already filed as #259;
  - **advisory, not acted on:** the NEWS phrase "multiphase with conservation of events" is narrower than needed, since any converged multiphase ML fit conserves events. It understates rather than misstates.

## Related, not in this PR
- #263 and #264 (the `hzr_gof()` junk column, and the mixed global-plus-phase-formula error) are fixed on `fix/gof-phase-columns`, which is stacked on this branch.
- #276: Windows CI skips vignette chunks. Non-blocking.
- **This bug was already on main; r-reviewer found it and it isn't filed yet.** `survfit()`'s time fix merges raw exits that are about 1e-12 apart. `hzr_gof()` takes `n_event` from survfit's merged times but builds `cum_observed` from the raw times, so at such a grid point `n_event` can read 2 while `cum_observed` counts 1. It needs exits that close together, so it's an extreme edge case.
- The `predict()` `newdata` fix for mixed fits is in another session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
