### PR TITLE
fix(hzr_gof): place each subject at the Kaplan-Meier time survfit gave it (#286)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -253,6 +253,15 @@
     uses the exit-time window. E/O came out 1.052 on a Weibull fit that
     conserves events.
 
+* **`hzr_gof()` places each subject at the Kaplan-Meier time `survfit()`
+  gave it** (#286). `survfit()` merges exit times that are closer together
+  than its tolerance. The per-subject tallies added above for #254 matched
+  each subject's raw time instead, so a merged subject fell off the default
+  grid and out of both tallies. On a fit with entry times, 55 of 68 events
+  were counted and E/O read 1.22. This came in with the #254 change and
+  never shipped. `hzr_gof()` now also warns when a subject cannot be placed
+  on the default grid, rather than leaving it out silently.
+
 * **A Weibull fit with one masked variance reported the others on the wrong
   scale.** When the Hessian inverse has a non-positive variance, its row and
   column are set to `NA`. The delta-method transform from the internal

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -469,11 +469,22 @@ hzr_gof <- function(object, time_grid = NULL) {
   } else {
     ifelse(km_entry > 0 & km_entry < obs_time, km_entry, 0)
   }
-  km_fit <- if (any(km_entry > 0)) {
-    survival::survfit(survival::Surv(km_entry, obs_time, obs_status) ~ 1)
+  km_y <- if (any(km_entry > 0)) {
+    survival::Surv(km_entry, obs_time, obs_status)
   } else {
-    survival::survfit(survival::Surv(obs_time, obs_status) ~ 1)
+    survival::Surv(obs_time, obs_status)
   }
+  km_fit <- survival::survfit(km_y ~ 1)
+  # survfit() applies timefix: exit times closer together than its tolerance
+  # are merged into one Kaplan-Meier time. The per-subject tallies below
+  # place each subject by those same adjusted times, or a
+  # subject merged onto a neighbour's time matches no grid point and drops
+  # out of both tallies (#286). Expected events still use the raw times,
+  # which are what the likelihood fits.
+  km_adj <- unclass(survival::aeqSurv(km_y))
+  counting <- ncol(km_adj) == 3
+  tally_exit <- km_adj[, if (counting) "stop" else "time"]
+  tally_exit[is.na(tally_exit)] <- obs_time[is.na(tally_exit)]
 
   # survfit output: time, n.risk, n.event, n.censor, surv
   km_times   <- km_fit$time
@@ -482,6 +493,7 @@ hzr_gof <- function(object, time_grid = NULL) {
   km_surv    <- km_fit$surv
 
   # --- Decide time grid -----------------------------------------------------
+  default_grid <- is.null(time_grid)
   if (is.null(time_grid)) {
     time_grid <- km_times
   } else {
@@ -634,10 +646,24 @@ hzr_gof <- function(object, time_grid = NULL) {
   subject_expected <- obs_weights * (h_exit - h_entry)
   subject_observed <- obs_weights * obs_status
 
-  uniq_time <- unique(obs_time)
-  subject_grid <- vapply(uniq_time, grid_index,
-                         integer(1))[match(obs_time, uniq_time)]
+  # Each subject is placed by its timefix-adjusted exit time, which is a
+  # Kaplan-Meier time, or by its raw time when a custom grid holds the raw
+  # value instead.
+  grid_of <- function(t) {
+    u <- unique(t)
+    vapply(u, grid_index, integer(1))[match(t, u)]
+  }
+  subject_grid <- grid_of(tally_exit)
+  off <- is.na(subject_grid)
+  subject_grid[off] <- grid_of(obs_time[off])
   on_grid <- !is.na(subject_grid)
+  # On the default grid every subject should land on its Kaplan-Meier time;
+  # say so rather than drop anyone from the tallies silently.
+  if (default_grid && !all(on_grid)) {
+    warning("hzr_gof(): ", sum(!on_grid), " of ", n_total, " subjects did ",
+            "not match a Kaplan-Meier time and are left out of ",
+            "cum_observed and cum_expected.", call. = FALSE)
+  }
   interval_observed <- rep(0, length(time_grid))
   interval_expected <- rep(0, length(time_grid))
   if (any(on_grid)) {

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -348,14 +348,19 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' form in which a weighted fit conserves events.  The `n_risk`, `n_event`,
 #' `n_censor` and Kaplan-Meier columns are unweighted.
 #'
-#' With a custom `time_grid`, a patient is counted in both tallies only if
-#' their follow-up time falls on a grid point.
+#' Each patient is placed at the Kaplan-Meier time [survival::survfit()]
+#' gives them, which merges exit times closer together than its tolerance.
+#' On the default grid every patient lands on a grid point, and `hzr_gof()`
+#' warns if one cannot be placed.  With a custom `time_grid`, a patient is
+#' counted in both tallies only if that time, or failing it their own
+#' follow-up time, falls on a grid point.
 #'
 #' @param object A fitted `hazard` object (with `fit = TRUE`).
 #' @param time_grid Optional numeric vector of time points at which to
 #'   evaluate the parametric model.
 #'   If `NULL` (default), uses the distinct Kaplan-Meier times of the
-#'   fitted data, which are the event times and the censoring times.
+#'   fitted data: the event and censoring times, with any closer together
+#'   than [survival::survfit()]'s tolerance merged into one.
 #'   A supplied grid must hold finite, non-negative times.  It is sorted
 #'   and exact repeats dropped, because the cumulative columns accumulate in
 #'   time order.

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -12,7 +12,8 @@ hzr_gof(object, time_grid = NULL)
 \item{time_grid}{Optional numeric vector of time points at which to
 evaluate the parametric model.
 If \code{NULL} (default), uses the distinct Kaplan-Meier times of the
-fitted data, which are the event times and the censoring times.
+fitted data: the event and censoring times, with any closer together
+than \code{\link[survival:survfit]{survival::survfit()}}'s tolerance merged into one.
 A supplied grid must hold finite, non-negative times.  It is sorted
 and exact repeats dropped, because the cumulative columns accumulate in
 time order.}
@@ -111,8 +112,12 @@ are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
 form in which a weighted fit conserves events.  The \code{n_risk}, \code{n_event},
 \code{n_censor} and Kaplan-Meier columns are unweighted.
 
-With a custom \code{time_grid}, a patient is counted in both tallies only if
-their follow-up time falls on a grid point.
+Each patient is placed at the Kaplan-Meier time \code{\link[survival:survfit]{survival::survfit()}}
+gives them, which merges exit times closer together than its tolerance.
+On the default grid every patient lands on a grid point, and \code{hzr_gof()}
+warns if one cannot be placed.  With a custom \code{time_grid}, a patient is
+counted in both tallies only if that time, or failing it their own
+follow-up time, falls on a grid point.
 }
 \examples{
 \donttest{

--- a/tests/testthat/test-gof-timefix.R
+++ b/tests/testthat/test-gof-timefix.R
@@ -1,0 +1,95 @@
+# #286: survfit()'s timefix merges near-tied exit times into one
+# Kaplan-Meier time. hzr_gof() matched each subject's raw exit time to the
+# grid, so a subject merged onto a neighbour's time matched no point on the
+# default grid and dropped out of both tallies, with no warning. Each test
+# failed on 2daa3e1 (main after #285); main before #285 counted every event.
+
+.near_tie_data <- function(t0, gap, n = 40) {
+  set.seed(1)
+  data.frame(
+    time = c(t0, t0 * (1 + gap), round(stats::rexp(n - 2, 0.5) + 0.05, 2)),
+    status = c(1, 1, stats::rbinom(n - 2, 1, 0.6))
+  )
+}
+
+test_that("near-tied exits merged by survfit stay in both tallies", {
+  for (case in list(c(t0 = 1, gap = 1e-12), c(t0 = 200, gap = 1e-12))) {
+    d <- .near_tie_data(case[["t0"]], case[["gap"]])
+    km <- survival::survfit(survival::Surv(d$time, d$status) ~ 1)
+    # The scenario: survfit merged the pair into one Kaplan-Meier time.
+    expect_equal(sum(abs(km$time - case[["t0"]]) < 1e-6 * case[["t0"]]), 1)
+    fit <- suppressWarnings(hazard(time = d$time, status = d$status,
+                                   dist = "weibull", theta = c(0.5, 1),
+                                   fit = TRUE,
+                                   control = list(reltol = 1e-12)))
+    g <- hzr_gof(fit)
+    s <- attr(g, "summary")
+    expect_equal(s$total_observed, sum(d$status), info = paste("t0 =", case[["t0"]]))
+    expect_equal(sum(g$n_event), sum(d$status), info = paste("t0 =", case[["t0"]]))
+    # A Weibull fit conserves events, so E/O is 1 when every subject counts.
+    expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-5,
+                 info = paste("t0 =", case[["t0"]]))
+  }
+})
+
+test_that("entry-time fits count every event (#286's case)", {
+  data(avc, envir = environment())
+  d <- stats::na.omit(avc)
+  d$entry <- ifelse(seq_len(nrow(d)) %% 2 == 0, pmin(0.1, d$int_dead / 2), 0)
+  fit <- suppressWarnings(hazard(
+    time = d$int_dead, status = d$dead, time_lower = d$entry,
+    x = cbind(age = d$age), dist = "weibull",
+    theta = c(mu = 0.01, nu = 0.5, beta_age = 0), fit = TRUE))
+  s <- attr(hzr_gof(fit), "summary")
+  expect_equal(s$total_observed, sum(d$dead))
+  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-5)
+})
+
+test_that("a multiphase fit with entry times and conservation counts every event", {
+  skip_on_cran()
+  data(avc, envir = environment())
+  d <- stats::na.omit(avc)
+  d$entry <- ifelse(seq_len(nrow(d)) %% 2 == 0, pmin(0.1, d$int_dead / 2), 0)
+  ph <- list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                               fixed = "shapes"),
+             constant = hzr_phase("constant"))
+  fit <- suppressWarnings(suppressMessages(hazard(
+    time = d$int_dead, status = d$dead, time_lower = d$entry,
+    dist = "multiphase", phases = ph, fit = TRUE)))
+  s <- attr(hzr_gof(fit), "summary")
+  expect_equal(s$total_observed, sum(d$dead))
+  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-5)
+})
+
+test_that("a custom grid of the raw exit times still counts every event", {
+  d <- .near_tie_data(1, 1e-12)
+  fit <- suppressWarnings(hazard(time = d$time, status = d$status,
+                                 dist = "weibull", theta = c(0.5, 1),
+                                 fit = TRUE))
+  g <- hzr_gof(fit, time_grid = sort(unique(d$time)))
+  expect_equal(attr(g, "summary")$total_observed, sum(d$status))
+  # A grid holding the raw 1 + 1e-12 but not the merged time 1: that
+  # subject is still found by its raw time. The subject exiting at exactly 1
+  # has no grid point and is left out, as documented for custom grids.
+  grid <- sort(unique(d$time[d$time != 1]))
+  g <- hzr_gof(fit, time_grid = grid)
+  expect_equal(attr(g, "summary")$total_observed, sum(d$status) - 1)
+})
+
+test_that("a subject the default grid cannot place is reported, not dropped silently", {
+  # An exit at time 0 in entry-time data is Surv(0, 0), which survfit turns
+  # into NA, so that subject has no Kaplan-Meier time.
+  set.seed(2861)
+  n <- 60
+  stop_t <- stats::rexp(n, 0.4) + 0.1
+  start_t <- ifelse(stats::runif(n) < 0.5, stop_t * stats::runif(n, 0.1, 0.8), 0)
+  stop_t[1] <- 0
+  start_t[1] <- 0
+  status <- stats::rbinom(n, 1, 0.7)
+  fit <- suppressWarnings(hazard(time = stop_t, status = status,
+                                 time_lower = start_t, dist = "exponential",
+                                 theta = c(log_rate = log(0.3)), fit = TRUE))
+  g <- suppressWarnings(hzr_gof(fit))
+  expect_warning(hzr_gof(fit), "1 of 60 subjects did not match")
+  expect_equal(attr(g, "summary")$total_observed, sum(status[-1]))
+})

--- a/tests/testthat/test-gof-timefix.R
+++ b/tests/testthat/test-gof-timefix.R
@@ -1,8 +1,11 @@
 # #286: survfit()'s timefix merges near-tied exit times into one
 # Kaplan-Meier time. hzr_gof() matched each subject's raw exit time to the
 # grid, so a subject merged onto a neighbour's time matched no point on the
-# default grid and dropped out of both tallies, with no warning. Each test
-# failed on 2daa3e1 (main after #285); main before #285 counted every event.
+# default grid and dropped out of both tallies, with no warning. The first
+# five tests failed on 2daa3e1 (main after #285) apart from the custom-grid
+# guard; main before #285 counted every event. The n_risk check, the gap
+# sweep and the grid a few ulps off come from the #263/#264 session's
+# parallel fix (09fb34a).
 
 .near_tie_data <- function(t0, gap, n = 40) {
   set.seed(1)
@@ -10,6 +13,13 @@
     time = c(t0, t0 * (1 + gap), round(stats::rexp(n - 2, 0.5) + 0.05, 2)),
     status = c(1, 1, stats::rbinom(n - 2, 1, 0.6))
   )
+}
+
+.gof_tf_avc <- function() {
+  data(avc, package = "TemporalHazard", envir = environment())
+  d <- stats::na.omit(avc)
+  d$entry <- ifelse(seq_len(nrow(d)) %% 2 == 0, pmin(0.1, d$int_dead / 2), 0)
+  d
 }
 
 test_that("near-tied exits merged by survfit stay in both tallies", {
@@ -24,41 +34,50 @@ test_that("near-tied exits merged by survfit stay in both tallies", {
                                    control = list(reltol = 1e-12)))
     g <- hzr_gof(fit)
     s <- attr(g, "summary")
-    expect_equal(s$total_observed, sum(d$status), info = paste("t0 =", case[["t0"]]))
-    expect_equal(sum(g$n_event), sum(d$status), info = paste("t0 =", case[["t0"]]))
+    info <- paste("t0 =", case[["t0"]])
+    expect_equal(s$total_observed, sum(d$status), info = info)
+    expect_equal(sum(g$n_event), sum(d$status), info = info)
+    # The risk set agrees with survfit()'s at its own (merged) times.
+    expect_equal(g$n_risk, km$n.risk, info = info)
     # A Weibull fit conserves events, so E/O is 1 when every subject counts.
     expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-5,
-                 info = paste("t0 =", case[["t0"]]))
+                 info = info)
   }
 })
 
 test_that("entry-time fits count every event (#286's case)", {
-  data(avc, envir = environment())
-  d <- stats::na.omit(avc)
-  d$entry <- ifelse(seq_len(nrow(d)) %% 2 == 0, pmin(0.1, d$int_dead / 2), 0)
+  d <- .gof_tf_avc()
+  # The case that lost 13 of 68 events: survfit() merges some of these exit
+  # times onto neighbours.
+  km <- survival::survfit(survival::Surv(d$entry, d$int_dead, d$dead) ~ 1)
+  expect_gt(sum(!(unique(d$int_dead) %in% km$time)), 0)
   fit <- suppressWarnings(hazard(
     time = d$int_dead, status = d$dead, time_lower = d$entry,
     x = cbind(age = d$age), dist = "weibull",
     theta = c(mu = 0.01, nu = 0.5, beta_age = 0), fit = TRUE))
-  s <- attr(hzr_gof(fit), "summary")
+  g <- hzr_gof(fit)
+  s <- attr(g, "summary")
   expect_equal(s$total_observed, sum(d$dead))
+  expect_equal(g$cum_observed[nrow(g)], sum(d$dead))
   expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-5)
 })
 
 test_that("a multiphase fit with entry times and conservation counts every event", {
   skip_on_cran()
-  data(avc, envir = environment())
-  d <- stats::na.omit(avc)
-  d$entry <- ifelse(seq_len(nrow(d)) %% 2 == 0, pmin(0.1, d$int_dead / 2), 0)
-  ph <- list(early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
-                               fixed = "shapes"),
-             constant = hzr_phase("constant"))
+  d <- .gof_tf_avc()
   fit <- suppressWarnings(suppressMessages(hazard(
     time = d$int_dead, status = d$dead, time_lower = d$entry,
-    dist = "multiphase", phases = ph, fit = TRUE)))
+    x = cbind(age = d$age), dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE, control = list(conserve = TRUE))))
+  expect_true(isTRUE(fit$spec$control$conserve_applied))
   s <- attr(hzr_gof(fit), "summary")
   expect_equal(s$total_observed, sum(d$dead))
-  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-5)
+  expect_lt(abs(s$total_expected / s$total_observed - 1), 1e-6)
 })
 
 test_that("a custom grid of the raw exit times still counts every event", {
@@ -90,6 +109,44 @@ test_that("a subject the default grid cannot place is reported, not dropped sile
                                  time_lower = start_t, dist = "exponential",
                                  theta = c(log_rate = log(0.3)), fit = TRUE))
   g <- suppressWarnings(hzr_gof(fit))
-  expect_warning(hzr_gof(fit), "1 of 60 subjects did not match")
+  # Surv() warns about the NA it creates for that row; only hzr_gof()'s own
+  # warning is under test.
+  expect_warning(
+    withCallingHandlers(hzr_gof(fit), warning = function(w) {
+      if (grepl("NA created", conditionMessage(w), fixed = TRUE)) {
+        invokeRestart("muffleWarning")
+      }
+    }),
+    "1 of 60 subjects did not match")
   expect_equal(attr(g, "summary")$total_observed, sum(status[-1]))
+})
+
+test_that("no gap around survfit's merge threshold loses an event", {
+  # Relative gaps from well inside to well outside survfit()'s merge
+  # tolerance (about 1.5e-8 relative), at a small and a large time.
+  for (t0 in c(1, 150)) {
+    for (gap in 10^seq(-14, -6, by = 0.5)) {
+      t <- c(t0, t0 * (1 + gap), t0 + seq_len(20))
+      fit <- suppressWarnings(hazard(time = t, status = rep(1, 22),
+                                     dist = "weibull",
+                                     theta = c(mu = 1 / t0, nu = 1),
+                                     fit = TRUE))
+      expect_equal(attr(hzr_gof(fit), "summary")$total_observed, 22,
+                   label = sprintf("t0 = %g, relative gap = %g", t0, gap))
+    }
+  }
+})
+
+test_that("a supplied grid a few ulps off the exit times counts them all", {
+  d <- .gof_tf_avc()
+  # The fit's Hessian is ill-conditioned this far from 0; only the counting
+  # matters here.
+  fit <- suppressWarnings(hazard(time = d$int_dead + 1e4, status = d$dead,
+                                 dist = "weibull",
+                                 theta = c(mu = 1e-4, nu = 1), fit = TRUE))
+  exits <- sort(unique(d$int_dead + 1e4))
+  grid <- exits * (1 + 2 * .Machine$double.eps)   # about two ulps above
+  expect_true(all(grid != exits))
+  expect_equal(attr(hzr_gof(fit, time_grid = grid), "summary")$total_observed,
+               sum(d$dead))
 })

--- a/tests/testthat/test-gof-timefix.R
+++ b/tests/testthat/test-gof-timefix.R
@@ -93,6 +93,12 @@ test_that("a custom grid of the raw exit times still counts every event", {
   grid <- sort(unique(d$time[d$time != 1]))
   g <- hzr_gof(fit, time_grid = grid)
   expect_equal(attr(g, "summary")$total_observed, sum(d$status) - 1)
+  # A grid holding only the merged time 1 counts both near-tied subjects,
+  # once each, where survfit put them; n_event agrees. Matching the custom
+  # grid on raw times alone would count 1 of these 2 events.
+  g <- hzr_gof(fit, time_grid = 1)
+  expect_equal(attr(g, "summary")$total_observed, 2)
+  expect_equal(g$n_event, 2)
 })
 
 test_that("a subject the default grid cannot place is reported, not dropped silently", {


### PR DESCRIPTION
Closes #286.

**This fixes a regression from #285. It never shipped, but it blocks the v1.2.11 tag (John, 2026-09-12).** `hzr_gof()` silently dropped subjects from its observed and expected totals. On #286's entry-time fit it counted 55 of 68 events and printed E/O 1.2186 on a fit that conserves events. Main before #285 (`76d3e99`) counted all 68.

## Cause
`survival::survfit()` applies `timefix`, which merges exit times closer together than its tolerance into one Kaplan-Meier time. #285's per-subject tallies matched each subject's raw exit time to the grid, within `100 * .Machine$double.eps * max(1, |t|)`. A subject whose exit survfit had merged onto a neighbour's time matched no point on the default grid, so it left both `cum_observed` and `cum_expected`, while `n_event`, which comes from survfit, still counted it. It happens without entry times too: exits at 1 and 1 + 1e-12 gave 21 of 22 events. With `timefix = FALSE`, none of the 270 exit times in #286's case are missing from the Kaplan-Meier times; with it on, 4 are.

## Fix
- **Placement:** each subject is placed by its `survival::aeqSurv()`-adjusted exit time. That's the same adjustment survfit makes, applied to the same `Surv` object. For a custom grid of raw times, placement falls back to the raw time.
- **Expected events** still use the raw times, which are what the likelihood fits.
- **Warning:** on the default grid, a subject that still can't be placed now draws a warning with the count, instead of silently dropping out of the tallies. A time-0 row in entry-time data is `Surv(0, 0)`, which survfit turns into NA, so it triggers this.
- **`n_risk` stays on the raw times.** `aeqSurv()` maps each merged cluster to its smallest member, which preserves every `>=` comparison in the risk-set count. Moving it would change no result, so I didn't.

## Tests
`test-gof-timefix.R` has 7 tests and 59 expectations and runs in about 2 s:
- near-ties with no entry times at t = 1 and t = 200, with `n_risk` equal to survfit's `n.risk`;
- #286's Weibull entry-time case, with a guard that survfit really merges some of its exits;
- a multiphase fit with a covariate, entry times and conservation of events;
- custom grids: raw times, one holding the raw near-tie but not the merged time, one holding only the merged time (2 of 2 events counted, `n_event` 2), and one a few ulps off the exits near 1e4;
- the new warning;
- a sweep of relative gaps from 1e-14 to 1e-6 at t = 1 and t = 150.

The `n_risk` check, the gap sweep and the grid a few ulps off come from the #263/#264 session's parallel fix, `09fb34a`. John chose to keep this PR and fold those cases in. That commit is being dropped from its branch.

On `2daa3e1`, six of the seven tests fail, including 26 of the 34 gap-sweep cases. The grid a few ulps off passes there and serves as a guard. Each of three mutants (tallying on raw times, no raw fallback, no warning) fails its own test.

## Copilot review of `7efc3c4`
- **Inline, the `?hzr_gof` custom-grid sentence (valid, fixed in 119e234).** The details paragraph now describes placement at the merged Kaplan-Meier time, the raw-time fallback on a custom grid, and the default-grid warning. `@param time_grid` says near-ties merge into one default grid time, a point the #263/#264 session's reviewer also raised.
- **Suppressed: use raw times only on a custom grid (declined, with evidence in a PR comment).** With exits at 1 and 1 + 1e-12 and `time_grid = 1`, raw-only matching counts 1 of 2 events while `n_event` says 2. That's #286 again on custom grids. A test now pins 2 of 2.

## Verification
All run locally at the head commit `119e234`, with `/Volumes/qhsstudies` mounted. Since `7efc3c4`, the changes are to tests and roxygen only; `R/diagnostics.R` changed in comments alone. The first commit, `7efc3c4`, had already passed the same gates: suite FAIL 0, SKIP 6, PASS 5022, and `R CMD check` Status OK.
- `devtools::document()` leaves `man/` and `NAMESPACE` unchanged. `lintr::lint_package()`: 0 lints. `spelling::spell_check_package()`: 0 words.
- **Full suite, `NOT_CRAN=true`:** **FAIL 0, ERR 0, SKIP 6, PASS 5065**, with the volume mounted from start to end.
  - All six skips are fixture availability: `bh.dead` SAS fixture 3, weighted-parity fixture 2, legacy binary (status 126) 1.
  - Both repeated-events parity files ran with no skips.
- **`R CMD check --as-cran` with the manual,** from a clean `git archive` of `119e234`: **Status: OK** (0 errors, 0 warnings, 0 notes). Rd cross-references and the PDF manual pass with the new `[survival::survfit()]` link. Under the check: FAIL 0, SKIP 210, PASS 3914. The new multiphase test is `skip_on_cran()`. Tests take 121 s (127 s elapsed), vignettes 46 s, and build plus check 309 s wall. The tarball is 3.1 MB.
- **r-reviewer on the diff found no silent wrong answers.** Its checks:
  - **Placement:** every subject lands on the default grid for right-censored and counting-process data, including entries and exits within 1e-12 of another row's exit, weighted fits, and a chain of six exits 0.9e-8 apart. `aeqSurv()` uses survfit's own tolerance and representative value, so the adjusted times match the Kaplan-Meier times exactly. `n_risk` equals survfit's `n.risk` in all of these.
  - **`n_risk` on raw times holds on the default grid.** Raw and adjusted counts can differ only at a custom grid point strictly inside a merged cluster, which was already true before this change.
  - **The custom-grid fallback** can't place a subject twice.
  - **Cosmetic, fixed in the test commit:** the warning test let `Surv()`'s own "NA created" warning through, so the file's run showed WARN 1. That one warning is now muffled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
