### PR TITLE
fix(hzr_gof): mixed global + phase covariates (#264); no par_cumhaz_time column (#263)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -107,7 +107,10 @@
   covariates alone, so `predict()` found no `mal` column and stopped before
   the expected-event tally. The curve is now evaluated at the column means
   of each phase's own design matrix, for global, phase-formula and mixed
-  covariates alike. Separately, the `par_cumhaz_<phase>` columns were chosen
+  covariates alike. With `time_windows`, a multiphase fit's output had twice
+  as many rows as grid times. The mean patient now carries the covariate
+  means in the window that contains each time. Separately, the
+  `par_cumhaz_<phase>` columns were chosen
   by dropping `total` from the decomposition, which let its `time` column
   through as a phase; they are now chosen by phase name.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -246,8 +246,7 @@
   without `data`. A multiphase fit that dropped rows with a missing phase
   covariate is now refused: its design matrix is shorter than the data, and
   the per-subject tally recycled it and gave a wrong total with only a
-  length warning. Separately, the
-  `par_cumhaz_<phase>` columns were chosen
+  length warning. Separately, the `par_cumhaz_<phase>` columns were chosen
   by dropping `total` from the decomposition, which let its `time` column
   through as a phase; they are now chosen by phase name.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,17 @@
   unweighted. Unweighted intercept-only fits without entry times are
   unchanged.
 
+* **`hzr_gof()` stopped on a multiphase fit with both a global covariate and
+  phase-formula covariates, and every multiphase fit carried a
+  `par_cumhaz_time` column** (#263, #264). With `Surv(...) ~ age` and a phase
+  formula `~ mal`, the mean-patient curve was built from the global
+  covariates alone, so `predict()` found no `mal` column and stopped before
+  the expected-event tally. The curve is now evaluated at the column means
+  of each phase's own design matrix, for global, phase-formula and mixed
+  covariates alike. Separately, the `par_cumhaz_<phase>` columns were chosen
+  by dropping `total` from the decomposition, which let its `time` column
+  through as a phase; they are now chosen by phase name.
+
 * **A Weibull fit with one masked variance reported the others on the wrong
   scale.** When the Hessian inverse has a non-positive variance, its row and
   column are set to `NA`. The delta-method transform from the internal

--- a/NEWS.md
+++ b/NEWS.md
@@ -241,7 +241,12 @@
   of each phase's own design matrix, for global, phase-formula and mixed
   covariates alike. With `time_windows`, a multiphase fit's output had twice
   as many rows as grid times. The mean patient now carries the covariate
-  means in the window that contains each time. Separately, the
+  means in the window that contains each time, for every phase built on the
+  global covariates, including one whose formula the fit could not evaluate
+  without `data`. A multiphase fit that dropped rows with a missing phase
+  covariate is now refused: its design matrix is shorter than the data, and
+  the per-subject tally recycled it and gave a wrong total with only a
+  length warning. Separately, the
   `par_cumhaz_<phase>` columns were chosen
   by dropping `total` from the decomposition, which let its `time` column
   through as a phase; they are now chosen by phase name.

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -503,6 +503,21 @@ hzr_gof <- function(object, time_grid = NULL) {
     object$fit$x_list, function(m) !is.null(m) && ncol(m) > 0, logical(1)
   ))
 
+  # A multiphase fit drops rows with a missing phase covariate from that
+  # phase's design matrix but keeps every row's time and status. A
+  # per-subject prediction would then recycle the shorter design across the
+  # subjects, so refuse rather than tally over it.
+  short <- vapply(object$fit$x_list, function(m) {
+    !is.null(m) && NROW(m) != n_total
+  }, logical(1))
+  if (is_multiphase && any(short)) {
+    stop("hzr_gof() needs one design row per subject, but the fit dropped ",
+         "rows with missing covariates from phase ",
+         paste0("'", names(short)[short], "'", collapse = ", "),
+         ". Refit on complete cases, e.g. data = na.omit(data).",
+         call. = FALSE)
+  }
+
   curve_obj <- object
   if (has_phase_x) {
     # A multiphase fit stores each phase's own design matrix: the phase
@@ -511,13 +526,19 @@ hzr_gof <- function(object, time_grid = NULL) {
     # puts every covariate at 0. Put each phase's design matrix at its column
     # means and the stored times at the grid; predict() without newdata then
     # evaluates that stored design.
-    # With time_windows, a phase without a formula carries data$x expanded
-    # into one column per window, each on only in its own window. Its column
-    # means would switch every window on at once, so expand the means of
-    # data$x by the grid times instead.
-    phases <- object$fit$phases
-    if (is.null(phases)) phases <- object$spec$phases
+    # With time_windows, a phase that took the global x carries data$x
+    # expanded into one column per window, each on only in its own window.
+    # Its column means would switch every window on at once, so expand the
+    # means of data$x by the grid times instead. Such a phase is recognised
+    # by its columns, not by whether a formula was written: a phase formula
+    # the fit could not evaluate (no `data`) leaves the phase on data$x.
     time_windows <- object$spec$time_windows
+    window_cols <- if (!is.null(time_windows)) {
+      colnames(.hzr_expand_time_varying_design(
+        x = object$data$x[1, , drop = FALSE], time = 0,
+        time_windows = time_windows
+      ))
+    }
     x_bar <- function(m) {
       matrix(colMeans(m), nrow = length(time_grid), ncol = ncol(m),
              byrow = TRUE, dimnames = list(NULL, colnames(m)))
@@ -527,7 +548,7 @@ hzr_gof <- function(object, time_grid = NULL) {
       stats::setNames(nm = names(object$fit$x_list)), function(nm) {
         m <- object$fit$x_list[[nm]]
         if (is.null(m) || ncol(m) == 0) return(m)
-        if (!is.null(time_windows) && is.null(phases[[nm]]$formula)) {
+        if (!is.null(time_windows) && identical(colnames(m), window_cols)) {
           return(.hzr_expand_time_varying_design(
             x = x_bar(object$data$x), time = time_grid,
             time_windows = time_windows

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -338,6 +338,8 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' agree.  The means are those of the design-matrix columns, taken phase by
 #' phase when a multiphase fit's covariates enter through the phase
 #' formulas, so a factor enters as the proportion of patients in each level.
+#' With `time_windows`, the mean patient carries the covariate means in the
+#' window that contains each time.
 #'
 #' For a weighted fit both tallies carry the case weights: observed events
 #' are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
@@ -493,12 +495,31 @@ hzr_gof <- function(object, time_grid = NULL) {
     # puts every covariate at 0. Put each phase's design matrix at its column
     # means and the stored times at the grid; predict() without newdata then
     # evaluates that stored design.
-    curve_obj$data$time <- time_grid
-    curve_obj$fit$x_list <- lapply(object$fit$x_list, function(m) {
-      if (is.null(m) || ncol(m) == 0) return(m)
+    # With time_windows, a phase without a formula carries data$x expanded
+    # into one column per window, each on only in its own window. Its column
+    # means would switch every window on at once, so expand the means of
+    # data$x by the grid times instead.
+    phases <- object$fit$phases
+    if (is.null(phases)) phases <- object$spec$phases
+    time_windows <- object$spec$time_windows
+    x_bar <- function(m) {
       matrix(colMeans(m), nrow = length(time_grid), ncol = ncol(m),
              byrow = TRUE, dimnames = list(NULL, colnames(m)))
-    })
+    }
+    curve_obj$data$time <- time_grid
+    curve_obj$fit$x_list <- lapply(
+      stats::setNames(nm = names(object$fit$x_list)), function(nm) {
+        m <- object$fit$x_list[[nm]]
+        if (is.null(m) || ncol(m) == 0) return(m)
+        if (!is.null(time_windows) && is.null(phases[[nm]]$formula)) {
+          return(.hzr_expand_time_varying_design(
+            x = x_bar(object$data$x), time = time_grid,
+            time_windows = time_windows
+          ))
+        }
+        x_bar(m)
+      }
+    )
     nd <- NULL
   } else if (!is.null(object$data$x) && ncol(object$data$x) > 0) {
     # For covariate models, evaluate at covariate means (baseline patient)

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -486,17 +486,13 @@ hzr_gof <- function(object, time_grid = NULL) {
   ))
 
   curve_obj <- object
-  if (!is.null(object$data$x) && ncol(object$data$x) > 0) {
-    # For covariate models, evaluate at covariate means (baseline patient)
-    x_means <- colMeans(object$data$x)
-    nd <- as.data.frame(t(x_means))
-    nd <- nd[rep(1, length(time_grid)), , drop = FALSE]
-    nd$time <- time_grid
-  } else if (has_phase_x) {
-    # Covariates entered only through the phase formulas, so data$x is NULL
-    # and a time-only newdata would put them at 0. Put each phase's design
-    # matrix at its column means and the stored times at the grid; predict()
-    # without newdata then evaluates that stored design.
+  if (has_phase_x) {
+    # A multiphase fit stores each phase's own design matrix: the phase
+    # formula's columns, or data$x for a phase without one. A newdata built
+    # from data$x lacks the phase-formula variables, and a time-only newdata
+    # puts every covariate at 0. Put each phase's design matrix at its column
+    # means and the stored times at the grid; predict() without newdata then
+    # evaluates that stored design.
     curve_obj$data$time <- time_grid
     curve_obj$fit$x_list <- lapply(object$fit$x_list, function(m) {
       if (is.null(m) || ncol(m) == 0) return(m)
@@ -504,6 +500,12 @@ hzr_gof <- function(object, time_grid = NULL) {
              byrow = TRUE, dimnames = list(NULL, colnames(m)))
     })
     nd <- NULL
+  } else if (!is.null(object$data$x) && ncol(object$data$x) > 0) {
+    # For covariate models, evaluate at covariate means (baseline patient)
+    x_means <- colMeans(object$data$x)
+    nd <- as.data.frame(t(x_means))
+    nd <- nd[rep(1, length(time_grid)), , drop = FALSE]
+    nd$time <- time_grid
   } else {
     nd <- data.frame(time = time_grid)
   }
@@ -515,8 +517,10 @@ hzr_gof <- function(object, time_grid = NULL) {
   if (is_multiphase) {
     decomp <- predict(curve_obj, newdata = nd, type = "cumulative_hazard",
                       decompose = TRUE)
-    # decomp is a matrix; first column is "total", rest are phase names
-    phase_cols <- colnames(decomp)[colnames(decomp) != "total"]
+    # decomp is a data frame: time, total, then one column per phase. Select
+    # by phase name, as predict() does, not by excluding the other columns.
+    phase_cols <- names(object$fit$phases)
+    if (is.null(phase_cols)) phase_cols <- names(object$spec$phases)
     phase_cumhaz <- as.data.frame(decomp[, phase_cols, drop = FALSE])
   }
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -512,10 +512,10 @@ hzr_gof <- function(object, time_grid = NULL) {
   }, logical(1))
   if (is_multiphase && any(short)) {
     stop("hzr_gof() needs one design row per subject, but the fit dropped ",
-         "rows with missing covariates from phase ",
+         "the rows where a covariate was missing, so phase ",
          paste0("'", names(short)[short], "'", collapse = ", "),
-         ". Refit on complete cases, e.g. data = na.omit(data).",
-         call. = FALSE)
+         " has fewer rows than the data. Refit on complete cases, e.g. ",
+         "data = na.omit(data).", call. = FALSE)
   }
 
   curve_obj <- object

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -300,7 +300,10 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #'
 #' The diagnostic is for right-censored data: every stored status must be 0
 #' (censored) or 1 (event).  A fit with any left-censored (status -1) or
-#' interval-censored (status 2) row is refused with an error.
+#' interval-censored (status 2) row is refused with an error.  So is a
+#' multiphase fit that dropped the rows where a covariate was missing: its
+#' design matrices then hold fewer rows than there are patients, so no
+#' patient-by-patient tally can be formed.  Refit it on complete cases.
 #'
 #' At each time point the function computes:
 #' \itemize{
@@ -529,9 +532,11 @@ hzr_gof <- function(object, time_grid = NULL) {
   }, logical(1))
   if (is_multiphase && any(short)) {
     stop("hzr_gof() needs one design row per subject, but the fit dropped ",
-         "the rows where a covariate was missing, so phase ",
+         "the rows where any covariate was missing, from every phase: ",
+         ngettext(sum(short), "phase ", "phases "),
          paste0("'", names(short)[short], "'", collapse = ", "),
-         " has fewer rows than the data. Refit on complete cases, e.g. ",
+         ngettext(sum(short), " has", " have"),
+         " fewer rows than the data. Refit on complete cases, e.g. ",
          "data = na.omit(data).", call. = FALSE)
   }
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -344,8 +344,9 @@ print.hzr_deciles <- function(x, digits = 3, ...) {
 #' phase for a multiphase fit, whether its covariates enter globally, through
 #' the phase formulas or both, so a factor enters as the proportion of
 #' patients in each level.
-#' With `time_windows`, the mean patient carries the covariate means in the
-#' window that contains each time.
+#' With `time_windows`, a phase built on the global covariates carries their
+#' means in the window that contains each time; a phase formula's own columns
+#' keep their plain means.
 #'
 #' For a weighted fit both tallies carry the case weights: observed events
 #' are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the
@@ -536,8 +537,9 @@ hzr_gof <- function(object, time_grid = NULL) {
          ngettext(sum(short), "phase ", "phases "),
          paste0("'", names(short)[short], "'", collapse = ", "),
          ngettext(sum(short), " has", " have"),
-         " fewer rows than the data. Refit on complete cases, e.g. ",
-         "data = na.omit(data).", call. = FALSE)
+         " fewer rows than the data. Refit on complete cases, dropping ",
+         "those rows from every input (data, or time, status and x).",
+         call. = FALSE)
   }
 
   curve_obj <- object
@@ -551,15 +553,22 @@ hzr_gof <- function(object, time_grid = NULL) {
     # With time_windows, a phase that took the global x carries data$x
     # expanded into one column per window, each on only in its own window.
     # Its column means would switch every window on at once, so expand the
-    # means of data$x by the grid times instead. Such a phase is recognised
-    # by its columns, not by whether a formula was written: a phase formula
-    # the fit could not evaluate (no `data`) leaves the phase on data$x.
+    # means of data$x by the grid times instead. Such a phase is known by the
+    # fit's own record of which designs came from a phase formula, not by
+    # whether a formula was written (the fit ignores one it cannot evaluate,
+    # without `data`) nor by column names (a phase formula's columns can share
+    # the expanded names). A fit from before that record falls back to names.
     time_windows <- object$spec$time_windows
+    from_formula <- attr(object$fit$x_list, "from_formula")
     window_cols <- if (!is.null(time_windows)) {
       colnames(.hzr_expand_time_varying_design(
         x = object$data$x[1, , drop = FALSE], time = 0,
         time_windows = time_windows
       ))
+    }
+    inherits_global <- function(nm, m) {
+      if (is.null(from_formula)) return(identical(colnames(m), window_cols))
+      !isTRUE(from_formula[nm])
     }
     x_bar <- function(m) {
       matrix(colMeans(m), nrow = length(time_grid), ncol = ncol(m),
@@ -570,7 +579,7 @@ hzr_gof <- function(object, time_grid = NULL) {
       stats::setNames(nm = names(object$fit$x_list)), function(nm) {
         m <- object$fit$x_list[[nm]]
         if (is.null(m) || ncol(m) == 0) return(m)
-        if (!is.null(time_windows) && identical(colnames(m), window_cols)) {
+        if (!is.null(time_windows) && inherits_global(nm, m)) {
           return(.hzr_expand_time_varying_design(
             x = x_bar(object$data$x), time = time_grid,
             time_windows = time_windows

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1637,6 +1637,14 @@
     }
   }
 
+  # Record which phases' designs came from their own formula, evaluated in
+  # `data`, rather than the inherited global x, by the rule the loop above
+  # applied. hzr_gof() reads it: under time_windows a phase formula's columns
+  # can carry the same names as the window-expanded global x.
+  attr(x_list, "from_formula") <- vapply(names(x_list), function(nm) {
+    !is.null(phases[[nm]]$formula) && !is.null(data)
+  }, logical(1))
+
   # --- Assemble starting values if not provided ------------------------------
   if (is.null(theta_start)) {
     theta_start <- unlist(lapply(names(phases), function(nm) {

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -64,7 +64,10 @@ conservation-of-events diagnostic.
 \details{
 The diagnostic is for right-censored data: every stored status must be 0
 (censored) or 1 (event).  A fit with any left-censored (status -1) or
-interval-censored (status 2) row is refused with an error.
+interval-censored (status 2) row is refused with an error.  So is a
+multiphase fit that dropped the rows where a covariate was missing: its
+design matrices then hold fewer rows than there are patients, so no
+patient-by-patient tally can be formed.  Refit it on complete cases.
 
 At each time point the function computes:
 \itemize{

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -108,8 +108,9 @@ differ.  The means are those of the design-matrix columns, taken phase by
 phase for a multiphase fit, whether its covariates enter globally, through
 the phase formulas or both, so a factor enters as the proportion of
 patients in each level.
-With \code{time_windows}, the mean patient carries the covariate means in the
-window that contains each time.
+With \code{time_windows}, a phase built on the global covariates carries their
+means in the window that contains each time; a phase formula's own columns
+keep their plain means.
 
 For a weighted fit both tallies carry the case weights: observed events
 are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the

--- a/man/hzr_gof.Rd
+++ b/man/hzr_gof.Rd
@@ -96,6 +96,8 @@ For an intercept-only model every patient shares that curve and the two
 agree.  The means are those of the design-matrix columns, taken phase by
 phase when a multiphase fit's covariates enter through the phase
 formulas, so a factor enters as the proportion of patients in each level.
+With \code{time_windows}, the mean patient carries the covariate means in the
+window that contains each time.
 
 For a weighted fit both tallies carry the case weights: observed events
 are \eqn{\sum_i w_i d_i} and expected events \eqn{\sum_i w_i H_i}, the

--- a/tests/testthat/test-gof-phase-covariates.R
+++ b/tests/testthat/test-gof-phase-covariates.R
@@ -254,8 +254,10 @@ test_that("time_windows: a phase formula whose columns share the window names", 
 })
 
 test_that("#263: a phase literally named `time` keeps its column", {
-  # decompose = TRUE returns a `time` column of its own; selecting phases by
-  # excluding "time" would drop this real phase.
+  # predict(decompose = TRUE) names its grid column `time`, so a phase named
+  # `time` collides with it there (the phase's values currently overwrite
+  # the grid column). Selecting phases by excluding "time" would drop this
+  # real phase; hzr_gof() selects by phase name and keeps its own grid.
   d <- .gof_pc_avc
   fit <- hazard(
     survival::Surv(int_dead, dead) ~ 1,
@@ -275,8 +277,10 @@ test_that("#263: a phase literally named `time` keeps its column", {
   expect_equal(gof$par_cumhaz_time, gof$par_cumhaz - gof$par_cumhaz_early,
                tolerance = 1e-12)
   expect_gt(max(gof$par_cumhaz_time), 0.01)
-  # The grid column is still the grid.
-  expect_true(all(diff(gof$time) > 0))
+  # hzr_gof()'s time column is its Kaplan-Meier grid, not the collided
+  # column of decompose's output.
+  km <- survival::survfit(survival::Surv(d$int_dead, d$dead) ~ 1)
+  expect_equal(gof$time, km$time)
 })
 
 test_that("global and phase covariates together: curve at both sets of means", {

--- a/tests/testthat/test-gof-phase-covariates.R
+++ b/tests/testthat/test-gof-phase-covariates.R
@@ -45,6 +45,25 @@ test_that("phase-formula fit: par_cumhaz is at the covariate means, not at 0", {
   expect_equal(gof$par_cumhaz_constant, decomp$constant, tolerance = 1e-10)
 })
 
+test_that("multiphase fit: one par_cumhaz_<phase> column per phase, no others", {
+  d <- .gof_pc_avc
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    ),
+    fit    = TRUE
+  )
+  gof <- hzr_gof(fit)
+  # decompose = TRUE also returns `time` and `total`; neither is a phase.
+  expect_identical(grep("^par_cumhaz_", names(gof), value = TRUE),
+                   c("par_cumhaz_early", "par_cumhaz_constant"))
+})
+
 test_that("global-covariate fit: par_cumhaz is at the design-matrix means", {
   d <- .gof_pc_avc
   fit <- hazard(
@@ -86,4 +105,75 @@ test_that("intercept-only multiphase fit: par_cumhaz is the one shared curve", {
                   type = "cumulative_hazard")
   expect_equal(unname(gof$par_cumhaz), unname(at_t), tolerance = 1e-10)
   expect_gt(max(gof$par_cumhaz), 0.1)
+})
+
+test_that("multiphase fit with only global covariates: curve at their means", {
+  d <- .gof_pc_avc
+  fit <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ age,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    ),
+    fit    = TRUE
+  ))
+  expect_true(isTRUE(fit$fit$converged))
+
+  gof <- hzr_gof(fit)
+  nd_mean <- data.frame(time = gof$time, age = mean(d$age))
+  at_mean <- predict(fit, newdata = nd_mean, type = "cumulative_hazard")
+  at_zero <- predict(fit, newdata = data.frame(time = gof$time, age = 0),
+                     type = "cumulative_hazard")
+  expect_gt(max(abs(at_zero / at_mean - 1)), 0.5)
+  expect_equal(unname(gof$par_cumhaz), unname(at_mean), tolerance = 1e-10)
+})
+
+test_that("global and phase covariates together: curve at both sets of means", {
+  # age enters globally (so data$x is set and reaches the constant phase);
+  # mal enters only through the early phase's formula.  A newdata built from
+  # data$x alone has no mal column, and predict() needs it for that formula.
+  d <- .gof_pc_avc
+  fit <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ age,
+    data   = d,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes", formula = ~ mal),
+      constant = hzr_phase("constant")
+    ),
+    fit     = TRUE,
+    control = list(conserve = TRUE)
+  ))
+  expect_true(isTRUE(fit$fit$converged))
+  expect_true(isTRUE(fit$spec$control$conserve_applied))
+  expect_identical(colnames(fit$data$x), "age")
+  expect_identical(colnames(fit$fit$x_list$early), "mal")
+
+  gof <- hzr_gof(fit)
+  # The per-subject tally is reached, and conserves events.
+  s <- attr(gof, "summary")
+  expect_equal(s$total_observed, sum(d$dead))
+  expect_equal(s$total_expected / s$total_observed, 1, tolerance = 1e-6)
+
+  # predict() with a newdata cannot evaluate this fit, so build the reference
+  # from the model's structure instead: within a phase the covariates scale
+  # the baseline, H_j(t | x) = exp(x beta_j) H0_j(t). A time-only newdata
+  # gives each phase's baseline H0_j.
+  base <- predict(fit, newdata = data.frame(time = gof$time),
+                  type = "cumulative_hazard", decompose = TRUE)
+  th <- fit$fit$theta
+  early_ref <- base$early * exp(th[["early.mal"]] * mean(d$mal))
+  constant_ref <- base$constant * exp(th[["constant.age"]] * mean(d$age))
+  expect_gt(max(abs(base$total / (early_ref + constant_ref) - 1)), 0.1)
+
+  expect_equal(gof$par_cumhaz_early, early_ref, tolerance = 1e-10)
+  expect_equal(gof$par_cumhaz_constant, constant_ref, tolerance = 1e-10)
+  expect_equal(unname(gof$par_cumhaz), early_ref + constant_ref,
+               tolerance = 1e-10)
+  expect_identical(grep("^par_cumhaz_", names(gof), value = TRUE),
+                   c("par_cumhaz_early", "par_cumhaz_constant"))
 })

--- a/tests/testthat/test-gof-phase-covariates.R
+++ b/tests/testthat/test-gof-phase-covariates.R
@@ -217,6 +217,68 @@ test_that("a phase covariate with missing values is refused, not recycled", {
   }
 })
 
+test_that("time_windows: a phase formula whose columns share the window names", {
+  # The global age expands to age_w1, age_w2; this phase formula uses data
+  # columns of the same names. The fit evaluates the formula, so the phase
+  # sits at its own columns' means, not at the windowed global age.
+  d <- .gof_pc_avc
+  set.seed(1)
+  d$age_w1 <- stats::rnorm(nrow(d), 5, 1)
+  d$age_w2 <- stats::rnorm(nrow(d), 50, 5)
+  fit <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ age,
+    data = d, time_windows = 1, dist = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes", formula = ~ age_w1 + age_w2),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE
+  ))
+  # The collision: both phases' designs carry the same column names.
+  expect_identical(colnames(fit$fit$x_list$early),
+                   colnames(fit$fit$x_list$constant))
+
+  gof <- hzr_gof(fit)
+  base <- predict(fit, newdata = data.frame(time = gof$time),
+                  type = "cumulative_hazard", decompose = TRUE)
+  th <- fit$fit$theta
+  early_ref <- base$early * exp(th[["early.age_w1"]] * mean(d$age_w1) +
+                                  th[["early.age_w2"]] * mean(d$age_w2))
+  expect_equal(gof$par_cumhaz_early, early_ref, tolerance = 1e-10)
+  # The inherited phase still switches windows with time.
+  beta_c <- ifelse(gof$time <= 1, th[["constant.age_w1"]],
+                   th[["constant.age_w2"]])
+  expect_equal(gof$par_cumhaz_constant,
+               base$constant * exp(beta_c * mean(d$age)), tolerance = 1e-10)
+})
+
+test_that("#263: a phase literally named `time` keeps its column", {
+  # decompose = TRUE returns a `time` column of its own; selecting phases by
+  # excluding "time" would drop this real phase.
+  d <- .gof_pc_avc
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1,
+    data = d, dist = "multiphase",
+    phases = list(
+      early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                        fixed = "shapes"),
+      time  = hzr_phase("constant")
+    ),
+    fit = TRUE
+  )
+  gof <- hzr_gof(fit)
+  expect_identical(grep("^par_cumhaz_", names(gof), value = TRUE),
+                   c("par_cumhaz_early", "par_cumhaz_time"))
+  # The phases add up to the total, so the `time` phase's own contribution
+  # is the total less the early phase, independent of decompose's columns.
+  expect_equal(gof$par_cumhaz_time, gof$par_cumhaz - gof$par_cumhaz_early,
+               tolerance = 1e-12)
+  expect_gt(max(gof$par_cumhaz_time), 0.01)
+  # The grid column is still the grid.
+  expect_true(all(diff(gof$time) > 0))
+})
+
 test_that("global and phase covariates together: curve at both sets of means", {
   # age enters globally (so data$x is set and reaches the constant phase);
   # mal enters only through the early phase's formula.  A newdata built from

--- a/tests/testthat/test-gof-phase-covariates.R
+++ b/tests/testthat/test-gof-phase-covariates.R
@@ -131,6 +131,21 @@ test_that("multiphase fit with only global covariates: curve at their means", {
   expect_equal(unname(gof$par_cumhaz), unname(at_mean), tolerance = 1e-10)
 })
 
+# The mean patient's curve under time_windows = 1, built by hand: each phase's
+# baseline (a time-only newdata) times exp(beta * mean(age)), using the w1
+# coefficient up to time 1 and the w2 coefficient after it.
+.gof_pc_window_ref <- function(fit, gof, d) {
+  base <- predict(fit, newdata = data.frame(time = gof$time),
+                  type = "cumulative_hazard", decompose = TRUE)
+  th <- fit$fit$theta
+  beta <- function(ph) {
+    ifelse(gof$time <= 1, th[[paste0(ph, ".age_w1")]],
+           th[[paste0(ph, ".age_w2")]])
+  }
+  base$early * exp(beta("early") * mean(d$age)) +
+    base$constant * exp(beta("constant") * mean(d$age))
+}
+
 test_that("multiphase fit with time_windows: curve switches windows with time", {
   # time_windows expands the global x into one column per window, each on
   # only while the row's time is in that window. Column means of the
@@ -152,19 +167,54 @@ test_that("multiphase fit with time_windows: curve switches windows with time", 
   expect_identical(colnames(fit$fit$x_list$constant), c("age_w1", "age_w2"))
 
   gof <- hzr_gof(fit)
-  n <- length(gof$time)
-  x_mean <- .hzr_expand_time_varying_design(
-    x = matrix(mean(d$age), nrow = n, ncol = 1,
-               dimnames = list(NULL, "age")),
-    time = gof$time, time_windows = 1
-  )
   # Both windows are visited, so a wrong window would show.
   expect_true(any(gof$time <= 1) && any(gof$time > 1))
-  ref <- .hzr_multiphase_cumhaz(
-    gof$time, fit$fit$theta, fit$fit$phases, fit$fit$covariate_counts,
-    list(early = x_mean, constant = x_mean)
+  expect_equal(unname(gof$par_cumhaz), .gof_pc_window_ref(fit, gof, d),
+               tolerance = 1e-10)
+})
+
+test_that("time_windows: a phase formula ignored at fit time gets the windows", {
+  # Without `data`, the fit cannot evaluate a phase formula, so the phase
+  # takes the window-expanded global x like any other. The curve has to
+  # follow what the fit built, not whether a formula was written.
+  d <- .gof_pc_avc
+  fit <- suppressWarnings(hazard(
+    time = d$int_dead, status = d$dead, x = cbind(age = d$age),
+    time_windows = 1,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes", formula = ~ age),
+      constant = hzr_phase("constant")
+    ),
+    fit    = TRUE
+  ))
+  expect_identical(colnames(fit$fit$x_list$early), c("age_w1", "age_w2"))
+  expect_false(is.null(fit$fit$phases$early$formula))
+
+  gof <- hzr_gof(fit)
+  expect_equal(unname(gof$par_cumhaz), .gof_pc_window_ref(fit, gof, d),
+               tolerance = 1e-10)
+})
+
+test_that("a phase covariate with missing values is refused, not recycled", {
+  # The fit drops rows with a missing phase covariate from that phase's
+  # design matrix but keeps every row's time and status, so a per-subject
+  # prediction would recycle the shorter design across the longer data.
+  d <- .gof_pc_avc
+  d$mal[1:5] <- NA
+  phases <- list(
+    early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                         fixed = "shapes", formula = ~ mal),
+    constant = hzr_phase("constant")
   )
-  expect_equal(unname(gof$par_cumhaz), ref, tolerance = 1e-10)
+  for (f in list(survival::Surv(int_dead, dead) ~ age,
+                 survival::Surv(int_dead, dead) ~ 1)) {
+    fit <- suppressWarnings(hazard(f, data = d, dist = "multiphase",
+                                   phases = phases, fit = TRUE))
+    expect_identical(nrow(fit$fit$x_list$early), nrow(d) - 5L)
+    expect_error(hzr_gof(fit), "one design row per subject")
+  }
 })
 
 test_that("global and phase covariates together: curve at both sets of means", {

--- a/tests/testthat/test-gof-phase-covariates.R
+++ b/tests/testthat/test-gof-phase-covariates.R
@@ -131,6 +131,42 @@ test_that("multiphase fit with only global covariates: curve at their means", {
   expect_equal(unname(gof$par_cumhaz), unname(at_mean), tolerance = 1e-10)
 })
 
+test_that("multiphase fit with time_windows: curve switches windows with time", {
+  # time_windows expands the global x into one column per window, each on
+  # only while the row's time is in that window. Column means of the
+  # expanded matrix would switch every window on at once. The mean patient
+  # has mean(age) in the window active at each grid time.
+  d <- .gof_pc_avc
+  fit <- suppressWarnings(hazard(
+    time = d$int_dead, status = d$dead, x = cbind(age = d$age),
+    time_windows = 1,
+    dist   = "multiphase",
+    phases = list(
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
+    ),
+    fit    = TRUE
+  ))
+  expect_true(isTRUE(fit$fit$converged))
+  expect_identical(colnames(fit$fit$x_list$constant), c("age_w1", "age_w2"))
+
+  gof <- hzr_gof(fit)
+  n <- length(gof$time)
+  x_mean <- .hzr_expand_time_varying_design(
+    x = matrix(mean(d$age), nrow = n, ncol = 1,
+               dimnames = list(NULL, "age")),
+    time = gof$time, time_windows = 1
+  )
+  # Both windows are visited, so a wrong window would show.
+  expect_true(any(gof$time <= 1) && any(gof$time > 1))
+  ref <- .hzr_multiphase_cumhaz(
+    gof$time, fit$fit$theta, fit$fit$phases, fit$fit$covariate_counts,
+    list(early = x_mean, constant = x_mean)
+  )
+  expect_equal(unname(gof$par_cumhaz), ref, tolerance = 1e-10)
+})
+
 test_that("global and phase covariates together: curve at both sets of means", {
   # age enters globally (so data$x is set and reaches the constant phase);
   # mal enters only through the early phase's formula.  A newdata built from


### PR DESCRIPTION
This PR builds on #285, which rewrote `hzr_gof()` and is now on `main`. The branch took #285 by merge as it evolved: 6538323 in 70d7e46, e30237a in 6aea926, and finally `origin/main` (2daa3e1, which contains #285's last head, 614914e) in 601bdcb. After #287 (the #286 fix) merged, `origin/main` (36c92aa) was merged in as 47c9c3e; that merge had no conflicts. Nothing was rebased. Against `main` the diff is four files: `NEWS.md`, `R/diagnostics.R`, `man/hzr_gof.Rd` and `tests/testthat/test-gof-phase-covariates.R`.

Closes #263
Closes #264

Commits:
- d3fb49f: #263/#264.
- f07790a: `time_windows`, from the first r-reviewer pass.
- 70d7e46 and 6aea926: merges of #285.
- 601bdcb: merge of `origin/main`.
- 2f17735: the second r-reviewer pass's two fixes.
- 577c6e0: rewording of the refusal message, from a later review.
- 47c9c3e: merge of `origin/main` after #287.
- 726b6b8: documents the one-design-row refusal and fixes its message grammar. These three text items came from the final review, which found no silent wrong answer.
- 91eadd6: answers Copilot on #288. Picks the time-window path by provenance (a new record, set at fit time, of which designs came from a phase formula), not by column names. Also a narrower `time_windows` sentence, an interface-neutral refusal remedy, and a guard test for a phase named `time`.
- de86bc3: test only. The `time`-phase test now describes the mechanism correctly, and its assertion that could not fail is replaced by one that can.

#286, which #285 introduced, is fixed separately in #287. This branch doesn't touch that code.

## #263 and #264: what was wrong

**#264: `hzr_gof()` stopped on a mixed-covariate multiphase fit.** With `Surv(int_dead, dead) ~ age` and an early phase `formula = ~ mal`, the fit converges, but `hzr_gof()` stopped with `object 'mal' not found`. The global-x branch was tried first. It built the mean-patient `newdata` from `data$x` (only `age`), and `predict()` then evaluated the phase formula `~ mal` against it. The stop came before the per-subject expected-event tally, so no conservation-of-events check was produced.

**#263: junk `par_cumhaz_time` column.** `predict(..., decompose = TRUE)` returns a data frame of `time`, `total` and one column per phase. The filter `colnames(decomp) != "total"` let `time` through as a phase, so every multiphase `hzr_gof()` output carried `par_cumhaz_time`.

## The fix

- For a multiphase fit with any per-phase design matrix, the curve is built on the `has_phase_x` path from #285. Each phase's stored design matrix in `fit$x_list` is set to its column means. That matrix is the phase formula's columns, or `data$x` for a phase built on the global covariates, so global, phase-formula and mixed covariates share one path. The global-x `newdata` branch remains for single-distribution fits.
- `par_cumhaz_<phase>` columns are selected by phase name (`fit$phases`, falling back to `spec$phases`, which is `predict()`'s own lookup). Only `"total"` is a reserved phase name, so excluding `c("time", "total")` would have silently dropped a phase legitimately named `time`.

## Tests (`test-gof-phase-covariates.R`), written first and seen failing

| Test | Before | After |
|---|---|---|
| names are exactly `par_cumhaz_early`, `par_cumhaz_constant` | **fail**: extra `par_cumhaz_time` | pass |
| mixed `~ age` + phase `~ mal`, `conserve = TRUE` | **error**: `object 'mal' not found` | pass |
| global-only multiphase curve at the means (characterization: this path moved) | pass | pass |

For the mixed test, #264 asked for `par_cumhaz` "equal to `predict()` at the means". That reference is not available: `predict()` with a `newdata` **cannot evaluate a mixed fit at all**. It gives a formula-less phase every non-time `newdata` column (`age` and `mal`) against its one `age` coefficient and fails as non-conformable. That is a separate defect in `predict.hazard()` (`R/hazard_api.R:1388`), out of scope here and being worked on separately. The test instead builds its reference from the model's structure, `H_j(t | x) = exp(x beta_j) H0_j(t)`, with each phase's baseline taken from a time-only `newdata`. It checks each phase, the total, and E/O = 1 under conservation of events.

**Mutation check.** Each mutant was applied in a scratch copy, and the substitution was confirmed before the run. All three were caught:
- old `!= "total"` filter: 2 failures (both names assertions);
- old branch order, global x first: the mixed test errors on `mal` again;
- `colMeans` replaced by column medians: 8 failures across the phase-only, global-only and mixed tests, including the `constant.age` half of the mixed reference.

## First r-reviewer pass: `time_windows` (f07790a)

**Multiphase fits with `time_windows` got a curve with the right shape and wrong values.** With `time_windows`, the stored design of a phase built on the global covariates is `data$x` expanded into one column per window (`age_w1`, `age_w2`), each on only in its own window. Column means of that matrix switch every window on at once. On avc with `time_windows = 1`, `par_cumhaz` was **0.0039 to 0.596** times the mean patient's curve, while E/O was still exactly 1: a hollow result. On `main` the same fit is broken visibly instead, with 540 output rows for 270 grid times (measured at 2daa3e1).

f07790a expands the means of `data$x` by the grid times for those phases, as `predict()` already does for a single-distribution fit. Phase-formula designs are not window-expanded at fit time and keep plain column means. The new test failed before the fix, and a wrong-window mutant (expanding at `time = 0`) is caught. The roxygen now says what the mean patient is under `time_windows`.

## Second r-reviewer pass, after merging `origin/main` (2f17735)

The reviewer found two silent wrong answers in this branch. Both were reproduced before any change, and both are fixed test-first:

- **A missing phase covariate: the design was recycled, and the tally was wrong.** The fit drops rows with a missing covariate from `x_list`, but it keeps every row's time and status. The per-subject `predict()` then recycled the shorter design across the full data, and the length check on its result could not catch this, because recycling returns the full length. Take a mixed fit with `mal[1:5] <- NA`: `main` stops with an error, but this branch returned E/O 1.0073, and the only sign was a length warning. `main` already gave the same wrong answer for fits with phase-formula covariates only (E/O 1.0066). `hzr_gof()` now refuses whenever any phase's `x_list` doesn't have one row per subject, and says to refit on complete cases.
- **The `time_windows` curve followed the formula field, not the design the fit built.** A phase formula passed without `data` is ignored at fit time, so that phase runs on the window-expanded `data$x`. Its `formula` field is still set, though, and the curve took the plain column-means path. It came out up to 89% off, even though theta was identical to the same fit without the formula. The window path is now chosen by the columns of `x_list`.
- The `time_windows` test used to build its reference with the same helpers the code calls. The reference is now built by hand: the time-only baseline times `exp(beta_w * mean(age))`, with the window chosen from the grid time.

New tests: a phase covariate with missing values must be refused, for a mixed fit and for a fit with phase-formula covariates only; and a phase formula without `data`, under `time_windows`, is checked against the hand-built reference. On the code before the fix, both new tests failed and the rewritten `time_windows` test passed. The mutation checks were both caught:
- disabling the refusal makes the missing-value test fail for both fits;
- going back to choosing the window path by the `formula` field makes only the formula-without-`data` test fail.

A later pass verified both fixes and found no silent wrong answer. Its one low-severity finding was that the refusal named phases without a missing covariate, because the fit drops the rows from every phase. The message is reworded in 577c6e0.

Verified by running code that #285's five fixes survive next to this branch:
- a sorted, de-duplicated grid on the mixed-covariate path, matching the structural reference;
- the `time_windows` curve on a supplied grid;
- KM(0) = 1;
- `n_risk` counted with the relative tolerance, on a grid confirmed to sit a few ulps off the data times;
- the entry-time wording in the Rd.

#285's own test files pass.

## Definition of done

At de86bc3 (head):
- `devtools::document()`: two runs, with no changes to `man/` or `NAMESPACE`. The stale "#264" sentence is not in NEWS.md, `R/diagnostics.R` or the Rd, and NEWS.md carries this PR's bullet and #287's #286 bullet, with no conflict markers.
- `lintr::lint_package()`: 0.
- `spelling::spell_check_package()`: 0.
- The gof test files: all pass with 0 failed, 0 skipped and 0 warnings. #287's `test-gof-timefix.R` runs on the merged tree: 7 tests, 59 expectations. `test-gof-phase-covariates.R` 46 (11 tests, including the two added for Copilot's review), `test-gof-grid-and-windows.R` 23, `test-gof-per-subject.R` 27, `test-gof-entry-km.R` 9.
- `NOT_CRAN=true devtools::test()`: **0 failed, 0 errors, 6 skipped, 5098 passed**, with `/Volumes/qhsstudies` mounted. The maze parity tests ran: `repeated-events-parity` 66 passed and `repeated-events-renewal-parity` 60 passed, with none skipped. The 6 skips are the usual local ones: 3 for the `bh.dead` fixtures, 2 for the weighted-parity fixture and 1 for the C binary.
- `R CMD check --as-cran` with the manual, from `git archive` in a `mktemp -d` dir: **Status: OK**. Tarball 3.23 MB; `grep -iE 'CLAUDE|AGENTS'` over its listing: 0.

The same gates also passed at the earlier commits:
- 91eadd6 (the Copilot fixes): suite 0 failed, 6 skipped, 5098 passed, with both maze parity files run; check Status OK. The r-reviewer pass on it found no silent wrong answer in the change.
- 726b6b8: suite 0 failed, 6 skipped, 5091 passed, with both maze parity files run; check Status OK.
- 47c9c3e (merge of `origin/main` after #287): suite 0 failed, 6 skipped, 5091 passed, with both maze parity files run; check Status OK. The final r-reviewer pass on this tree found no silent wrong answer.
- 2f17735: suite 0 failed, 6 skipped, 5032 passed; check Status OK.
- 601bdcb (merge of `origin/main`): suite 0 failed, 6 skipped, 5025 passed, with both maze parity files run; check Status OK.
- 6aea926: suite 0 failed, 6 skipped, 5025 passed; check Status OK.
- 70d7e46: suite 0 failed, 6 skipped, 5002 passed; check Status OK.
- f07790a: suite 0 failed, 6 skipped, 4538 passed; check Status OK.
- d3fb49f: suite 0 failed, 6 skipped, 4534 passed; check Status OK.

Every check ran while a full suite was running on the same machine, so none of the check timings is a budget measurement.

NEWS: one bullet under 1.2.11 Bug fixes, covering #263, #264, `time_windows` and the missing-covariate refusal. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
