### PR TITLE
fix(predict): multiphase predictions no longer carry a theta element's name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,18 @@
 
 ## Bug fixes
 
+* **`predict()` on a multiphase fit now returns an unnamed vector.** For
+  `type = "cumulative_hazard"`, `"survival"` and `"hazard"`, every element
+  was named after a parameter -- `"constant.log_mu"`, say, on each row --
+  because the phase parameters are named elements of `theta` and R carried
+  a name onto the prediction: from any phase without covariates, and, for a
+  single row of `newdata`, from almost any phase parameter. The values were
+  right; the names were meaningless, and they followed the result into
+  anything built from it. With one row, the `decompose = TRUE` and
+  `se.fit = TRUE` data frames also took such a name as their row name.
+  Single-distribution `predict()` already returned unnamed vectors, and now
+  both agree.
+
 * **The multiphase gradient and Hessian are now right when an early phase's
   `m` is near 0.** Both differentiate in `m` by finite differences, and
   their stencils straddled 0: the gradient's (half-width about 6e-6)

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -190,7 +190,10 @@
                                   m = pars$m, type = phases[[nm]]$type)
     }
 
-    contrib <- mu_j * phi_j
+    # unname(): the phase parameters are named elements of theta, and R
+    # carries such a name onto the product -- through rep() for every n, and
+    # through any length-1 operand when n == 1 -- and so into predict().
+    contrib <- unname(mu_j * phi_j)
     total <- total + contrib
 
     if (per_phase) phase_contributions[[i]] <- contrib
@@ -242,7 +245,7 @@
                                    m = pars$m, type = phases[[nm]]$type)
     }
 
-    total <- total + mu_j * dphi_j
+    total <- total + unname(mu_j * dphi_j)  # see .hzr_multiphase_cumhaz()
   }
 
   total

--- a/tests/testthat/test-predict-hazard-multiphase.R
+++ b/tests/testthat/test-predict-hazard-multiphase.R
@@ -79,6 +79,41 @@ test_that("multiphase hazard se.fit returns delta-method limits", {
   expect_true(all(out$lower >= 0))  # log-scale CL keeps hazard positive
 })
 
+test_that("multiphase predict returns unnamed vectors, like single-dist", {
+  # A phase without covariates builds its eta by rep()-ing the named log_mu
+  # element of theta, and that name leaked onto every prediction, e.g.
+  # c("constant.log_mu", "constant.log_mu").
+  d <- .ph_data()
+  nd <- data.frame(time = c(1, 2), x = c(-1, 1))
+  # .ph_fit()'s `formula` is the global one, so the phase formula that gives
+  # only `early` a covariate is spelt out here.
+  early_x <- hazard(survival::Surv(time, status) ~ 1, data = d,
+                    dist = "multiphase",
+                    phases = list(
+                      early    = hzr_phase("cdf", t_half = 0.3, nu = 1, m = 1,
+                                           fixed = "shapes", formula = ~ x),
+                      constant = hzr_phase("constant")),
+                    fit = TRUE,
+                    control = list(n_starts = 1, maxit = 500, conserve = TRUE))
+  fits <- list(no_covariates = .ph_fit(data = d), early_x = early_x)
+  # With one row every operand is length 1, so any named scalar -- t_half,
+  # the covariate branch's log_mu -- can name the result, not just rep().
+  nd1 <- nd[1, , drop = FALSE]
+  for (nm in names(fits)) {
+    for (ty in c("cumulative_hazard", "survival", "hazard")) {
+      p <- predict(fits[[nm]], newdata = nd, type = ty)
+      expect_length(p, 2L)
+      expect_null(names(p), label = paste(nm, ty))
+      p1 <- predict(fits[[nm]], newdata = nd1, type = ty)
+      expect_length(p1, 1L)
+      expect_null(names(p1), label = paste(nm, ty, "one row"))
+    }
+    dec <- predict(fits[[nm]], newdata = nd1, type = "cumulative_hazard",
+                   decompose = TRUE)
+    expect_identical(rownames(dec), "1", label = paste(nm, "decompose"))
+  }
+})
+
 test_that("multiphase hazard rejects decompose = TRUE", {
   d <- .ph_data()
   fit <- .ph_fit(data = d)


### PR DESCRIPTION
Closes #282.

The phase parameters are named elements of `theta`, and R carried such a name onto the prediction. It happened two ways:

- through `rep(log_mu, n)`, for any phase without covariates;
- through any length-1 operand, when `newdata` has one row.

So `predict()` returned, for example, `c("constant.log_mu", "constant.log_mu")`, and one-row `decompose` and `se.fit` data frames took the name as a row name.

The fix applies `unname()` to each phase's contribution in `.hzr_multiphase_cumhaz()` and `.hzr_multiphase_hazard()`. The output is now unnamed, as it already was for single-distribution fits. The values themselves were always right; only the names were wrong.

## Status

`origin/main` (`9ec83e7`, which includes #281, #290 and #292) is merged in at `041c918`. `NEWS.md` conflicted twice across the two merges, and every Bug fixes bullet is kept. `R/likelihood-multiphase.R` merged cleanly: against `origin/main` it differs only by the two `unname()` lines, and #292's `.hzr_phase_newdata_design()` is unchanged.

At `041c918`, the six parity tests that read the study volume were run on their own, and all six passed: 126 assertions, no failures, errors or skips. They cover the maze cardioversion `%repeat` job and the achalasia `ac.reintervention` job. An earlier run on this branch errored in one of them because the volume dropped part-way through; the same test passes here with every change merged.

Gates at `041c918`, with `/Volumes/qhsstudies` mounted:

| Gate | Result |
|---|---|
| `devtools::document()` | no `man/` or `NAMESPACE` diff |
| `lintr::lint_package()` | 0 lints |
| `spelling::spell_check_package(use_wordlist = TRUE)` | 0 |
| `NOT_CRAN=true devtools::test()` | 5550 passes, 655 warnings, 6 skips (testthat `passed`); 0 failures, 0 errors |
| `R CMD check --as-cran` with the manual, from a clean `git archive` of `3a91203` | Status: OK |

An earlier version of this description gave 5832 passes. That figure was the result frame's `nb - failed`, which counts warnings and skips as passes.

The 6 skips are the expected fixture and environment set: 3 bh.dead fixture, 1 C binary, 2 `weighted-avc-fractional.rds`. The maze and achalasia parity tests ran and passed. The cardioversion model fits in them go through both changed functions.

On the merged tree I re-checked the defect with a probe script, not the test file. It used two fits, one with no covariates and one with a numeric covariate on `early`, and one-row and two-row `newdata`, and checked all three types plus the `se.fit` and `decompose` row names. None of the 28 checks carried a `theta` element's name.

The new test in `tests/testthat/test-predict-hazard-multiphase.R` fails on the old code: 6 assertions for two rows, and 8 more for one row. Taking out either `unname()` makes it fail again, 10 assertions for the `cumhaz` line and 4 for the `hazard` line. Two `r-reviewer` passes ran on this change. The first found the one-row route, which is fixed here; the second, on `6ab5c73`, found no defects.

Copilot's review found that the one-row `se.fit` frame's row name was not asserted. A mutant that restored the name there alone passed the old test. `03478d5` adds that assertion, test only: it fails 6 times on that mutant and on `origin/main`'s code, and passes here.

## Out of scope, noted

On `origin/main` `4b68020`, with one row of `newdata`, a factor phase covariate given as a single label errored in `model.matrix()`: "contrasts can be applied only to factors with 2 or more levels". The error was loud, and this PR did not cause it. #290 fixed it and is now merged. At `041c918`, with #292's design rebuild also merged, that case runs, and the probe finds none of its 28 checks carrying a `theta` element's name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
