### PR TITLE
fix(predict): rebuild a multiphase phase formula at newdata with the fit's levels and contrasts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,9 +74,11 @@
   wrong cumulative hazard. The fit now stores each phase formula's terms,
   factor levels and contrasts (`fit$x_design`), and `predict()` rebuilds the
   phase's columns from them, matched by name. A level the fit never saw is an
-  error, as is a covariate the phase uses and `newdata` lacks. `newdata`
-  carrying the phase's design columns by name (`grpyoung`) is taken as it
-  is. A fit saved by an earlier version rebuilds as before.
+  error. So is a covariate the phase uses that `newdata` lacks, where it was
+  silently taken from a same-named object in the workspace; a `newdata` with
+  only a `time` column still evaluates the baseline, every covariate at 0.
+  `newdata` carrying the phase's design columns by name (`grpyoung`) is taken
+  as it is. A fit saved by an earlier version rebuilds as before.
 
 * **The multiphase gradient and Hessian are now right when an early phase's
   `m` is near 0.** Both differentiate in `m` by finite differences, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,19 @@
 
 ## Bug fixes
 
+* **`predict(newdata = )` on a multiphase fit now codes a phase formula's
+  factors as the fit did.** It rebuilt a phase's design with a bare
+  `model.matrix()` at `newdata`, with no stored levels or contrasts, so a
+  factor given as one label (`grp = "young"`) stopped with "contrasts can be
+  applied only to factors with 2 or more levels", and a factor whose levels
+  were in another order was coded against the wrong level with no error: a
+  wrong cumulative hazard. The fit now stores each phase formula's terms,
+  factor levels and contrasts (`fit$x_design`), and `predict()` rebuilds the
+  phase's columns from them, matched by name. A level the fit never saw is an
+  error, as is a covariate the phase uses and `newdata` lacks. `newdata`
+  carrying the phase's design columns by name (`grpyoung`) is taken as it
+  is. A fit saved by an earlier version rebuilds as before.
+
 * **The multiphase gradient and Hessian are now right when an early phase's
   `m` is near 0.** Both differentiate in `m` by finite differences, and
   their stencils straddled 0: the gradient's (half-width about 6e-6)

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -869,6 +869,7 @@ hazard <- function(formula = NULL,
     fit_state$phases <- optim_result$phases
     fit_state$covariate_counts <- optim_result$covariate_counts
     fit_state$x_list <- optim_result$x_list
+    fit_state$x_design <- optim_result$x_design
     fit_state$fixed_mask <- optim_result$fixed_mask
     fit_state$starts <- optim_result$starts
     # Applied CoE state, recorded next to the requested one in spec$control
@@ -1430,7 +1431,8 @@ predict.hazard <- function(object, newdata = NULL,
         for (nm in names(phases)) {
           ph <- phases[[nm]]
           if (!is.null(ph$formula) && ncol(nd_covs) > 0) {
-            x_list[[nm]] <- stats::model.matrix(ph$formula, data = newdata)[, -1L, drop = FALSE]
+            # The fit's levels, contrasts and columns, not newdata's.
+            x_list[[nm]] <- .hzr_phase_newdata_design(object, nm, ph, newdata)
           } else if (cov_counts[[nm]] > 0 && ncol(nd_covs) > 0) {
             x_list[[nm]] <- as.matrix(nd_covs)
           } else {

--- a/R/likelihood-multiphase.R
+++ b/R/likelihood-multiphase.R
@@ -1498,6 +1498,51 @@
 }
 
 
+#' Rebuild one phase's formula design matrix at new rows
+#'
+#' Used by `predict(newdata = )` for a multiphase phase with its own formula.
+#' Returns the fit's columns for that phase, in the fit's order, built with
+#' the factor levels and contrasts stored at fit time, so a factor given as a
+#' single label, or with its levels in another order, codes as it did in the
+#' fit.
+#'
+#' @param object A fitted multiphase `hazard` object.
+#' @param nm Phase name.
+#' @param ph The phase's `hzr_phase` object.
+#' @param newdata Data frame of new rows.
+#' @return Numeric matrix with `nrow(newdata)` rows.
+#' @keywords internal
+#' @noRd
+.hzr_phase_newdata_design <- function(object, nm, ph, newdata) {
+  cols <- colnames(object$fit$x_list[[nm]])
+  design <- object$fit$x_design[[nm]]
+
+  # newdata that already carries the phase's design columns by name (as
+  # hzr_gof() passes a design built from stored matrices) is taken as it is.
+  if (!is.null(cols) && all(cols %in% names(newdata))) {
+    return(as.matrix(newdata[, cols, drop = FALSE]))
+  }
+
+  # A fit made before the phase design was stored: rebuild as it did then.
+  if (is.null(design)) {
+    return(stats::model.matrix(ph$formula, data = newdata)[, -1L, drop = FALSE])
+  }
+
+  missing <- setdiff(design$data_vars, names(newdata))
+  if (length(missing) > 0L) {
+    stop("'newdata' lacks the covariate column(s) ",
+         paste0("'", missing, "'", collapse = ", "),
+         " that phase '", nm, "' uses. Columns are matched by name.",
+         call. = FALSE)
+  }
+  mf <- stats::model.frame(design$terms, data = newdata,
+                           xlev = design$xlevels, na.action = stats::na.pass)
+  mm <- stats::model.matrix(design$terms, data = mf,
+                            contrasts.arg = design$contrasts)
+  mm[, cols, drop = FALSE]
+}
+
+
 #' Fit a multiphase additive hazard model via maximum likelihood
 #'
 #' Assembles starting values from phase specifications, resolves per-phase
@@ -1548,6 +1593,8 @@
   x_list <- vector("list", length(phases))
   names(x_list) <- names(phases)
   covariate_counts <- setNames(integer(length(phases)), names(phases))
+  # Per-phase design metadata; stays NULL for a phase without a formula.
+  x_design <- setNames(vector("list", length(phases)), names(phases))
 
   for (nm in names(phases)) {
     ph <- phases[[nm]]
@@ -1559,10 +1606,20 @@
       # rows with NA covariates.
       mf_j <- stats::model.frame(ph$formula, data = data,
                                    na.action = stats::na.pass)
-      x_j <- stats::model.matrix(ph$formula, data = mf_j)[, -1L,
-                                                           drop = FALSE]
+      mm_j <- stats::model.matrix(ph$formula, data = mf_j)
+      x_j <- mm_j[, -1L, drop = FALSE]
       x_list[[nm]] <- x_j
       covariate_counts[[nm]] <- ncol(x_j)
+      # What predict(newdata = ) needs to rebuild x_j from new rows: the
+      # terms (carrying predvars), the factor levels and the contrasts seen
+      # here, and the formula's variables that were columns of `data`.
+      terms_j <- attr(mf_j, "terms")
+      x_design[[nm]] <- list(
+        terms = terms_j,
+        xlevels = stats::.getXlevels(terms_j, mf_j),
+        contrasts = attr(mm_j, "contrasts"),
+        data_vars = intersect(all.vars(terms_j), names(data))
+      )
     } else if (!is.null(x)) {
       # Inherit global design matrix
       x_list[[nm]] <- x
@@ -2238,6 +2295,7 @@
   best_result$phases <- phases
   best_result$covariate_counts <- covariate_counts
   best_result$x_list <- x_list
+  best_result$x_design <- x_design
 
   # Which starts survived, and which one the reported fit came from.
   best_result$starts <- starts

--- a/tests/testthat/test-predict-newdata-phase-formula.R
+++ b/tests/testthat/test-predict-newdata-phase-formula.R
@@ -1,0 +1,150 @@
+# predict(newdata = ) on a multiphase fit whose phase carries its own formula.
+#
+# The phase design at newdata must be the fit's design: the same factor
+# levels, contrasts and columns. Rebuilding it with a bare model.matrix()
+# failed on a factor given as one label, and silently recoded a factor whose
+# levels were a subset or in another order.
+#
+# Reference: the structural identity H_j(t | x) = exp(x beta_j) H0_j(t), with
+# the baseline H0_j from a time-only newdata and beta_j from the fit's theta
+# by name. It does not go through the design rebuild under test.
+
+phase_formula_fit <- function(sum_contrasts = FALSE) {
+  data(avc, package = "TemporalHazard", envir = environment())
+  d <- stats::na.omit(avc)
+  d$grp <- factor(ifelse(d$age > 100, "old", "young"))
+  if (sum_contrasts) stats::contrasts(d$grp) <- stats::contr.sum(2)
+  hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = d, dist = "multiphase",
+    phases = list(
+      early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                        fixed = "shapes", formula = ~ grp),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE
+  )
+}
+
+# Expected total cumulative hazard for rows with the given `young` indicator.
+reference_cumhaz <- function(fit, time, young) {
+  base <- predict(fit, newdata = data.frame(time = time),
+                  type = "cumulative_hazard", decompose = TRUE)
+  beta <- fit$fit$theta[["early.grpyoung"]]
+  exp(beta * young) * base$early + base$constant
+}
+
+test_that("the reference can fail: the grp effect is not negligible", {
+  fit <- phase_formula_fit()
+  expect_true(fit$fit$converged)
+  # A beta near 0 would let an ignored covariate pass every test below.
+  expect_gt(abs(fit$fit$theta[["early.grpyoung"]]), 0.5)
+  tt <- c(0.5, 2)
+  expect_gt(min(abs(reference_cumhaz(fit, tt, 1) /
+                      reference_cumhaz(fit, tt, 0) - 1)), 0.05)
+})
+
+test_that("a factor given as a single label codes to the fit's levels", {
+  fit <- phase_formula_fit()
+  tt <- c(0.5, 2, 6)
+  young <- predict(fit, newdata = data.frame(time = tt, grp = "young"),
+                   type = "cumulative_hazard")
+  old <- predict(fit, newdata = data.frame(time = tt, grp = "old"),
+                 type = "cumulative_hazard")
+  expect_equal(young / reference_cumhaz(fit, tt, 1), rep(1, 3),
+               tolerance = 1e-10, ignore_attr = TRUE)
+  expect_equal(old / reference_cumhaz(fit, tt, 0), rep(1, 3),
+               tolerance = 1e-10, ignore_attr = TRUE)
+})
+
+test_that("a full-level factor, in any level order, codes to the fit's levels", {
+  fit <- phase_formula_fit()
+  tt <- c(1, 1)
+  want <- reference_cumhaz(fit, tt, c(0, 1))
+  same <- data.frame(time = tt,
+                     grp = factor(c("old", "young"), levels = c("old", "young")))
+  reversed <- data.frame(time = tt,
+                         grp = factor(c("old", "young"),
+                                      levels = c("young", "old")))
+  subset <- data.frame(time = 1, grp = factor("young"))
+  expect_equal(predict(fit, newdata = same, type = "cumulative_hazard") / want,
+               c(1, 1), tolerance = 1e-10, ignore_attr = TRUE)
+  expect_equal(predict(fit, newdata = reversed, type = "cumulative_hazard") /
+                 want, c(1, 1), tolerance = 1e-10, ignore_attr = TRUE)
+  expect_equal(predict(fit, newdata = subset, type = "cumulative_hazard") /
+                 want[2], 1, tolerance = 1e-10, ignore_attr = TRUE)
+})
+
+test_that("extra and reordered newdata columns are ignored", {
+  fit <- phase_formula_fit()
+  tt <- c(0.5, 2)
+  nd <- data.frame(age = c(5, 500), grp = c("young", "old"),
+                   junk = c("a", "b"), time = tt)
+  expect_equal(predict(fit, newdata = nd, type = "cumulative_hazard") /
+                 reference_cumhaz(fit, tt, c(1, 0)),
+               c(1, 1), tolerance = 1e-10, ignore_attr = TRUE)
+  # decompose = TRUE and se.fit = TRUE read the same per-phase design.
+  dec <- predict(fit, newdata = nd, type = "cumulative_hazard",
+                 decompose = TRUE)
+  base <- predict(fit, newdata = data.frame(time = tt),
+                  type = "cumulative_hazard", decompose = TRUE)
+  beta <- fit$fit$theta[["early.grpyoung"]]
+  expect_equal(dec$early / (exp(beta * c(1, 0)) * base$early), c(1, 1),
+               tolerance = 1e-10, ignore_attr = TRUE)
+  se <- predict(fit, newdata = nd, type = "cumulative_hazard", se.fit = TRUE)
+  expect_equal(se$fit / reference_cumhaz(fit, tt, c(1, 0)), c(1, 1),
+               tolerance = 1e-10, ignore_attr = TRUE)
+})
+
+test_that("newdata carrying the fit's design columns by name is accepted", {
+  fit <- phase_formula_fit()
+  tt <- c(0.5, 2)
+  nd <- data.frame(time = tt, grpyoung = c(1, 0))
+  expect_equal(predict(fit, newdata = nd, type = "cumulative_hazard") /
+                 reference_cumhaz(fit, tt, c(1, 0)),
+               c(1, 1), tolerance = 1e-10, ignore_attr = TRUE)
+})
+
+test_that("an unseen level or a missing covariate is an error", {
+  fit <- phase_formula_fit()
+  expect_error(
+    predict(fit, newdata = data.frame(time = 1, grp = "middle"),
+            type = "cumulative_hazard"),
+    "new level"
+  )
+  expect_error(
+    predict(fit, newdata = data.frame(time = 1, age = 5),
+            type = "cumulative_hazard"),
+    "lacks the covariate column\\(s\\) 'grp'"
+  )
+})
+
+test_that("a factor's non-default contrasts are the fit's, not the default", {
+  # Under contr.sum the fit's column is grp1: old = +1, young = -1. Rebuilt
+  # with default contrasts, a single label would code grpyoung instead.
+  fit <- phase_formula_fit(sum_contrasts = TRUE)
+  expect_true(fit$fit$converged)
+  expect_identical(colnames(fit$fit$x_list$early), "grp1")
+  tt <- c(0.5, 2)
+  base <- predict(fit, newdata = data.frame(time = tt),
+                  type = "cumulative_hazard", decompose = TRUE)
+  beta <- fit$fit$theta[["early.grp1"]]
+  expect_gt(abs(beta), 0.5)
+  for (lab in c("old", "young")) {
+    x <- if (lab == "old") 1 else -1
+    got <- predict(fit, newdata = data.frame(time = tt, grp = lab),
+                   type = "cumulative_hazard")
+    expect_equal(got / (exp(beta * x) * base$early + base$constant),
+                 c(1, 1), tolerance = 1e-10, ignore_attr = TRUE)
+  }
+})
+
+test_that("a fit without the stored phase design still predicts", {
+  fit <- phase_formula_fit()
+  fit$fit$x_design <- NULL
+  tt <- c(1, 1)
+  nd <- data.frame(time = tt,
+                   grp = factor(c("old", "young"), levels = c("old", "young")))
+  expect_equal(predict(fit, newdata = nd, type = "cumulative_hazard") /
+                 reference_cumhaz(fit, tt, c(0, 1)),
+               c(1, 1), tolerance = 1e-10, ignore_attr = TRUE)
+})

--- a/tests/testthat/test-predict-newdata-phase-formula.R
+++ b/tests/testthat/test-predict-newdata-phase-formula.R
@@ -138,6 +138,30 @@ test_that("a factor's non-default contrasts are the fit's, not the default", {
   }
 })
 
+test_that("a missing phase covariate is not filled from the workspace (#268)", {
+  data(avc, package = "TemporalHazard", envir = environment())
+  d <- stats::na.omit(avc)
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ age, data = d, dist = "multiphase",
+    phases = list(
+      early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                        fixed = "shapes"),
+      constant = hzr_phase("constant", formula = ~ mal)
+    ),
+    fit = TRUE
+  )
+  # A same-named object where the formula's environment chain can see it.
+  assign("mal", 1, envir = globalenv())
+  tryCatch(
+    expect_error(
+      predict(fit, newdata = data.frame(time = 2, age = 60),
+              type = "cumulative_hazard"),
+      "lacks the covariate column\\(s\\) 'mal' that phase 'constant' uses"
+    ),
+    finally = rm("mal", envir = globalenv())
+  )
+})
+
 test_that("a fit without the stored phase design still predicts", {
   fit <- phase_formula_fit()
   fit$fit$x_design <- NULL

--- a/tests/testthat/test-predict-newdata-phase-formula.R
+++ b/tests/testthat/test-predict-newdata-phase-formula.R
@@ -141,6 +141,9 @@ test_that("a factor's non-default contrasts are the fit's, not the default", {
 test_that("a missing phase covariate is not filled from the workspace (#268)", {
   data(avc, package = "TemporalHazard", envir = environment())
   d <- stats::na.omit(avc)
+  # A same-named object in the phase formula's own environment, which is
+  # where a rebuild without the guard would look it up.
+  mal <- 1
   fit <- hazard(
     survival::Surv(int_dead, dead) ~ age, data = d, dist = "multiphase",
     phases = list(
@@ -150,16 +153,64 @@ test_that("a missing phase covariate is not filled from the workspace (#268)", {
     ),
     fit = TRUE
   )
-  # A same-named object where the formula's environment chain can see it.
-  assign("mal", 1, envir = globalenv())
-  tryCatch(
-    expect_error(
-      predict(fit, newdata = data.frame(time = 2, age = 60),
-              type = "cumulative_hazard"),
-      "lacks the covariate column\\(s\\) 'mal' that phase 'constant' uses"
-    ),
-    finally = rm("mal", envir = globalenv())
+  expect_error(
+    predict(fit, newdata = data.frame(time = 2, age = 60),
+            type = "cumulative_hazard"),
+    "lacks the covariate column\\(s\\) 'mal' that phase 'constant' uses"
   )
+})
+
+test_that("a phase formula's environment constant still reaches newdata", {
+  data(avc, package = "TemporalHazard", envir = environment())
+  d <- stats::na.omit(avc)
+  cutoff <- 100
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = d, dist = "multiphase",
+    phases = list(
+      early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                        fixed = "shapes", formula = ~ I(age > cutoff)),
+      constant = hzr_phase("constant")
+    ),
+    fit = TRUE
+  )
+  expect_true(fit$fit$converged)
+  tt <- c(0.5, 2)
+  base <- predict(fit, newdata = data.frame(time = tt),
+                  type = "cumulative_hazard", decompose = TRUE)
+  beta <- fit$fit$theta[["early.I(age > cutoff)TRUE"]]
+  expect_gt(abs(beta), 0.5)
+  got <- predict(fit, newdata = data.frame(time = tt, age = c(150, 50)),
+                 type = "cumulative_hazard")
+  expect_equal(got / (exp(beta * c(1, 0)) * base$early + base$constant),
+               c(1, 1), tolerance = 1e-10, ignore_attr = TRUE)
+})
+
+test_that("all columns present: predictions unchanged from main 8a26c0e", {
+  # Two numeric phase formulas, every covariate supplied: a case the old
+  # rebuild got right. Values computed on main at 8a26c0e, before this fix.
+  data(avc, package = "TemporalHazard", envir = environment())
+  d <- stats::na.omit(avc)
+  fit <- hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = d, dist = "multiphase",
+    phases = list(
+      early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                        fixed = "shapes", formula = ~ mal),
+      constant = hzr_phase("constant", formula = ~ age)
+    ),
+    fit = TRUE
+  )
+  expect_true(fit$fit$converged)
+  nd <- data.frame(time = c(0.5, 2, 6), mal = c(0, 1, 1), age = c(30, 60, 120))
+  # Optimizer results, so a tolerance well above the optimizer's noise.
+  expect_equal(predict(fit, newdata = nd, type = "cumulative_hazard"),
+               c(0.08822505274, 0.42642619050, 0.49399211094),
+               tolerance = 1e-6, ignore_attr = TRUE)
+  expect_equal(predict(fit, newdata = nd, type = "survival"),
+               c(0.9155548054, 0.6528380494, 0.6101855969),
+               tolerance = 1e-6, ignore_attr = TRUE)
+  expect_equal(predict(fit, newdata = nd, type = "hazard"),
+               c(0.088515938428, 0.043098312832, 0.006837292565),
+               tolerance = 1e-6, ignore_attr = TRUE)
 })
 
 test_that("a fit without the stored phase design still predicts", {


### PR DESCRIPTION
Closes #268.

`predict(newdata)` rebuilt phase-formula designs without the fit's factor levels or columns, so a factor label errored, and a covariate missing from `newdata` was **silently filled from the workspace**: a wrong answer with no error.

- Rebuild each phase formula at `newdata` with the fit's levels and contrasts (`0e4d1d7`).
- A missing phase covariate is refused, not looked up in the formula environment (`4d2b102`); the test puts the shadowing variable in the phase formula's own environment, not `globalenv`, so it can actually fail.
- A formula-environment constant (`I(age > cutoff)`) still resolves, and all-columns-present predictions are pinned to values computed on `main` `8a26c0e`, so the fix is shown not to move an answer that was already right (`fa5b9bc`).
- **Applies #272's rule to the phase-formula path** (`6b9baff`, `8989e58`, and the derived-column / legacy commit): a design-named column no longer overrides a contradicting phase variable. `grp = "old"` beside `grpyoung = 1` was the young value, silently. `.hzr_phase_newdata_design()` takes design columns only on the rule #292's `.hzr_uses_design_columns()` applies to the global design: every fitted column present, and then the caller marked them design-level (`hzr_design_columns`) or the formula's variables are absent. Some variables beside the design columns, with others missing, is an error; a variable another design column is built from (`age` in `age:grp`) counts as given, so a changed `age` beside a stale `age:grpyoung` is refused. Design-only `newdata` is unchanged: pinned to values computed on 7edcee6, before the change.
- **Copilot, fits saved before this PR:** such a fit still fell back to a bare `model.matrix(ph$formula, newdata)`, which took a missing phase covariate from the formula's environment (as `main` does for every fit). Its covariates are now recovered as the formula variables that were columns of its fitting data (`fit$data$frame`: `frame = data` in the return list of `hazard()` since v1.1.0, `R/hazard_api.R` line 599 there), so a missing one is refused while a formula-environment constant (`cutoff` in `I(age > cutoff)`) still resolves (`4b7da5a`). A fit saved by 1.0.3 or earlier kept no data frame, cannot tell the two apart, and keeps `main`'s behaviour exactly: the same object run through `main` 4b68020 and this branch gives identical values, now pinned (`7f13135`). Tests: the legacy workspace-fill case errors (fails on `812ab56`); a legacy `I(age > cutoff)` fit still matches the structural reference, with and without its frame (guards the naive refuse-every-`all.vars()` fix, and keeps the refusal off no-frame fits).
- One-row `newdata` giving the phase factor as a single character label (`data.frame(time = 1, grp = "old")`), which stopped with "contrasts can be applied only to factors with 2 or more levels" on `main` 4b68020, is pinned for both levels (`812ab56`).

## Deliberate difference from #292's global rule

For a fit saved before `x_design` existed (every previously saved fit, CRAN 1.1.0 included), #292's global rule takes the design columns. The phase path does not: it runs the same rule with the phase formula's own variables and term labels standing in for the stored design (`c82b449`, `812ab56`). All variables given rebuilds from `ph$formula`; some given beside the design columns is an error; none given takes the design columns. The reason is that `main`'s phase path always rebuilt from the formula, so taking the design columns would be a new silent swap, and a phase, unlike the global design, still carries its formula to rebuild from. Reproducer (phase `~ grp`, `fit$fit$x_design <- NULL`):

```r
nd <- data.frame(time = c(1, 1), grp = factor(c("old", "young")), grpyoung = c(1, 0))
predict(fit, newdata = nd, type = "cumulative_hazard")
#> main 4b68020:        0.04647389634149 0.23995615103791
#> global-rule mirror:  0.23995615103791 0.04647389634149   (swapped, no warning)
#> this PR:             0.04647389634149 0.23995615103791   (pinned to main's values)
```

With phase `~ grp + sx` and `newdata` `grp = "old", grpyoung = 1, sxM = 0` (no `sx`), `main` stopped with "object 'sx' not found"; the global-rule mirror silently returned 0.2130339278163 (the `grpyoung = 1` value); this PR refuses it, naming `grp` and `sx`.

**The legacy rule, stated:** for a phase fit without `x_design`, the three-way rule of the stored-design path runs with the phase formula's variables that were columns of its fitting data (`intersect(all.vars(ph$formula), names(fit$data$frame))`) and `terms(ph$formula)` in place of the stored `data_vars` and `terms`: all of the phase's variables given rebuilds from the formula; some given beside the design columns (counting a variable another design column is built from) is an error; none given takes the design columns; and a missing one is refused rather than taken from the workspace. It is loud exactly where `main` was loud, and it keeps the legacy and stored-design paths one rule. A formula constant is never one of those variables, so it is never refused. Without the frame (fits saved by 1.0.3 or earlier), every formula variable stands in for the route and `main`'s rebuild is kept.

**Why not #292's blanket refusal** (refuse any `newdata` column that is neither a design column nor `time`): multiphase `newdata` routinely carries other phases' and the global formula's variables, so that refusal would have broken every mixed multiphase prediction. Approved by the PR queue coordinator. #292 carries the global half and the markers at the `hzr_gof()` / `hzr_deciles()` call sites; on current `main` no phase path receives marked `newdata` (the multiphase branches of both set `x_list` or call `.hzr_multiphase_cumhaz()` directly).

## Status

Ready for review. `main` merged in twice, each with only the expected `NEWS.md` handling: `4b68020` as `7edcee6` (no conflicts at all), then `e6cf2dd` (#281, survival `se.fit`) as `c8cbe21` (one `NEWS.md` hunk, both bullets kept). The combined tree was checked live for both fixes, not trusted from the clean merge: survival `se.fit` equals S times se(H) (ratio 1, 1, on a multiphase fit), and `predict()` calls `.hzr_phase_newdata_design()`, whose legacy frame rule refuses a missing `mal` with a same-named local in scope.

Gates on the final head `7f13135`:

- `devtools::document()`: no `man/` or `NAMESPACE` diff. `lintr::lint_package()`: 0. `spelling::spell_check_package(use_wordlist = TRUE)`: 0.
- `NOT_CRAN=true devtools::test()`, run alone: **5275 passes, 647 warnings, 6 skips (testthat `passed`)**, 0 failures, 0 errors. This is the first run of #281's and this PR's code together. The six skips are the known ones: 3 × "bh.dead SAS fixture not available" (`test-bhdead-sas-parity.R`), 1 × "Legacy binary returned non-zero status 126" (`test-parity-c-binary.R`), 2 × "weighted-avc-fractional.rds not found" (`test-weights-sas-parity.R`). `/Volumes/qhsstudies` mounted.
- `R CMD check --as-cran` with the manual, from a clean `git archive` of `7f13135` in a fresh `mktemp -d` under the session scratchpad, run alone after the suite: **Status: OK**, PDF manual built. Tarball 3,248,553 bytes (3.1 MiB), no `CLAUDE`/`AGENTS` files. Tests under check: 4064 passes, 102 warnings, 212 skips, 0 failures (210 skips at `812ab56`; the +2 are #281's merged tests: `skip_on_cran()` calls went 190 to 192, both added by #281's own commits). Vignette rebuild 53 s. Other sessions' R jobs shared the machine, so the overall 331 s is not a timing measurement.
- `test-predict-newdata-phase-formula.R`: 18 tests, 51 expectations, 0 failures. Red runs: the #268 tests fail on `main` 8a26c0e / 4b68020; the one-row labels error on `main` 4b68020; the final test file fails 1 test against `812ab56` (the legacy workspace fill). Mutation, each killed by a named test: variables-never-win, no-partial-stop, ignore-marker, legacy-vars-empty, no-derived-count, count-bare-numeric, legacy-pure-mirror, no-legacy-missing-refusal, naive-all-vars, and refuse-without-frame.
- Copilot (one review, on `812ab56`): `.getXlevels` "not exported" is false (`".getXlevels" %in% getNamespaceExports("stats")` is `TRUE`; replied, no change); the legacy workspace fill is valid and fixed in `4b7da5a` / `7f13135`.
- `r-reviewer` on the #272 commit: its silent-wrong-answer finding (the legacy swap) is fixed above; its test gaps are filled; its one pre-existing loud error (global `~ age` + phase `~ grp` at `newdata`, the positional `as.matrix(nd_covs)` line) is left for #292, which replaces that line.

## Queue

Lands **before** #292 (#266/#267/#270/#272, global design). #292's #266 change makes the formula-less global phase work, which on its own exposes the bare `model.matrix(ph$formula, data = newdata)` line: a phase `~ grp` given reordered levels or a character label returns swapped values with no warning where `main` errors. This PR's `xlev` rebuild removes that line, so `main` is never silently wrong in between. #292 merges `main` after this lands and cross-checks that the global and phase rules agree; folding the two helpers into one is #271.

**No internal caller reaches the phase shortcut on current `main`**, counted rather than reasoned: with `.hzr_phase_newdata_design()` wrapped in a counter, a direct `predict(newdata = )` on a phase `~ grp` fit calls it once (the known positive), while `hzr_gof()` and `hzr_deciles()` call it 0 times on both a global `~ 1` and a global `~ age` fit with phase `~ grp`, and no `newdata` carrying `hzr_design_columns` ever reaches it. Nothing in `R/` sets that attribute on this branch; #292 adds it at the `hzr_gof()` / `hzr_deciles()` call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
