### PR TITLE
fix(phases): reserve "time" as a phase name, like "total"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,15 @@
     which `hzr_repeated_events()` can emit; read as "no entry", each would
     be charged its full cumulative hazard from time 0.
 
+* **`"time"` is now a reserved phase name, like `"total"`** (#224). The
+  decomposed output of `predict(decompose = TRUE)` starts with a `time`
+  column holding the prediction times, then adds one column per phase under
+  the phase's name. A phase called `time` therefore overwrote the requested
+  times with its own cumulative hazard, and the times were lost with no
+  error. `hazard()` and `hzr_theta_names()` now stop on a phase named
+  `time`, before any fitting, and ask for a different name. Rename the
+  phase; nothing else about the model changes.
+
 ## New features
 
 * **Every fit now says what it did not do** (#242, following #197). A

--- a/R/hazard_api.R
+++ b/R/hazard_api.R
@@ -207,9 +207,9 @@ NULL
 #'   each means and when to use it.
 #' @param phases Optional named list of [hzr_phase()] objects specifying the
 #'   phases for a multiphase model (`dist = "multiphase"`).  Names must be
-#'   unique, and `"total"` is reserved: it labels the summed column in the
-#'   decomposed output of [predict.hazard()], so a phase of that name is
-#'   rejected.  See Examples.
+#'   unique, and `"total"` and `"time"` are reserved: they label the summed
+#'   column and the column of prediction times in the decomposed output of
+#'   [predict.hazard()], so a phase of either name is rejected.  See Examples.
 #' @param fit Logical; if TRUE, fit the model via maximum likelihood (default FALSE).
 #' @param weights Optional numeric vector of observation weights (non-negative).
 #'   Each observation's log-likelihood contribution is multiplied by its weight.

--- a/R/phase-spec.R
+++ b/R/phase-spec.R
@@ -470,8 +470,9 @@ is_hzr_phase <- function(x) {
 #' @seealso [hzr_phase()] for building a specification, [hazard()] for the fit
 #'   whose `theta` this names.
 #' @export
-#' @details Phase names must be unique, and `"total"` is reserved; this applies
-#'   the same validation [hazard()] does, so both reject it identically.
+#' @details Phase names must be unique, and `"total"` and `"time"` are
+#'   reserved; this applies the same validation [hazard()] does, so both reject
+#'   them identically.
 hzr_theta_names <- function(phases, covariates = NULL) {
   # The same validation hazard() applies, so auto-named phases get the same
   # phase_1/phase_2 labels here as they will in the fit. Re-deriving them
@@ -707,6 +708,15 @@ hzr_theta_names <- function(phases, covariates = NULL) {
   if (any(nms == "total")) {
     stop("'total' is a reserved phase name. Rename the phase: it collides with ",
          "the accumulator holding the summed cumulative hazard.", call. = FALSE)
+  }
+
+  # 'time' is the first column of predict(decompose = TRUE)'s output, which then
+  # stores each phase's cumulative hazard under the phase's name, so a phase of
+  # that name overwrote the requested times with no error (#224).
+  if (any(nms == "time")) {
+    stop("'time' is a reserved phase name. Rename the phase: it collides with ",
+         "the column of prediction times in the decomposed output of ",
+         "predict().", call. = FALSE)
   }
 
   # Check for duplicate names

--- a/man/hazard.Rd
+++ b/man/hazard.Rd
@@ -110,9 +110,9 @@ each means and when to use it.}
 
 \item{phases}{Optional named list of \code{\link[=hzr_phase]{hzr_phase()}} objects specifying the
 phases for a multiphase model (\code{dist = "multiphase"}).  Names must be
-unique, and \code{"total"} is reserved: it labels the summed column in the
-decomposed output of \code{\link[=predict.hazard]{predict.hazard()}}, so a phase of that name is
-rejected.  See Examples.}
+unique, and \code{"total"} and \code{"time"} are reserved: they label the summed
+column and the column of prediction times in the decomposed output of
+\code{\link[=predict.hazard]{predict.hazard()}}, so a phase of either name is rejected.  See Examples.}
 
 \item{fit}{Logical; if TRUE, fit the model via maximum likelihood (default FALSE).}
 

--- a/man/hzr_theta_names.Rd
+++ b/man/hzr_theta_names.Rd
@@ -45,8 +45,9 @@ Phase names come from \code{names(phases)}; unnamed phases are labelled
 \code{phase_1}, \code{phase_2}, ... by the same validation \code{\link[=hazard]{hazard()}} applies, so the
 labels here are the labels a fit will use.
 
-Phase names must be unique, and \code{"total"} is reserved; this applies
-the same validation \code{\link[=hazard]{hazard()}} does, so both reject it identically.
+Phase names must be unique, and \code{"total"} and \code{"time"} are
+reserved; this applies the same validation \code{\link[=hazard]{hazard()}} does, so both reject
+them identically.
 }
 \examples{
 phases <- list(early = hzr_phase("cdf"), late = hzr_phase("g3"))

--- a/tests/testthat/test-gof-phase-covariates.R
+++ b/tests/testthat/test-gof-phase-covariates.R
@@ -253,32 +253,46 @@ test_that("time_windows: a phase formula whose columns share the window names", 
                base$constant * exp(beta_c * mean(d$age)), tolerance = 1e-10)
 })
 
-test_that("#263: a phase literally named `time` keeps its column", {
+test_that("#263/#224: a phase named `time` is refused; gof keeps its own grid", {
   # predict(decompose = TRUE) names its grid column `time`, so a phase named
-  # `time` collides with it there (the phase's values currently overwrite
-  # the grid column). Selecting phases by excluding "time" would drop this
-  # real phase; hzr_gof() selects by phase name and keeps its own grid.
+  # `time` collided with it there and overwrote the prediction times. #224
+  # reserves the name, so such a fit now stops before hzr_gof() can see it.
   d <- .gof_pc_avc
+  expect_error(
+    hazard(
+      survival::Surv(int_dead, dead) ~ 1,
+      data = d, dist = "multiphase",
+      phases = list(
+        early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                          fixed = "shapes"),
+        time  = hzr_phase("constant")
+      ),
+      fit = TRUE
+    ),
+    "'time' is a reserved phase name"
+  )
+
+  # With ordinary names, decompose's own `time` and `total` columns never
+  # become par_cumhaz_ columns, and every real phase gets exactly one.
   fit <- hazard(
     survival::Surv(int_dead, dead) ~ 1,
     data = d, dist = "multiphase",
     phases = list(
-      early = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
-                        fixed = "shapes"),
-      time  = hzr_phase("constant")
+      early    = hzr_phase("cdf", t_half = 0.5, nu = 1, m = 1,
+                           fixed = "shapes"),
+      constant = hzr_phase("constant")
     ),
     fit = TRUE
   )
   gof <- hzr_gof(fit)
   expect_identical(grep("^par_cumhaz_", names(gof), value = TRUE),
-                   c("par_cumhaz_early", "par_cumhaz_time"))
-  # The phases add up to the total, so the `time` phase's own contribution
-  # is the total less the early phase, independent of decompose's columns.
-  expect_equal(gof$par_cumhaz_time, gof$par_cumhaz - gof$par_cumhaz_early,
-               tolerance = 1e-12)
-  expect_gt(max(gof$par_cumhaz_time), 0.01)
-  # hzr_gof()'s time column is its Kaplan-Meier grid, not the collided
-  # column of decompose's output.
+                   c("par_cumhaz_early", "par_cumhaz_constant"))
+  expect_false(any(c("par_cumhaz_time", "par_cumhaz_total") %in% names(gof)))
+  # The phases add up to the total, so each column is a phase's own share.
+  expect_equal(gof$par_cumhaz_early + gof$par_cumhaz_constant,
+               gof$par_cumhaz, tolerance = 1e-12)
+  expect_gt(max(gof$par_cumhaz_constant), 0.01)
+  # hzr_gof()'s time column is its Kaplan-Meier grid.
   km <- survival::survfit(survival::Surv(d$int_dead, d$dead) ~ 1)
   expect_equal(gof$time, km$time)
 })

--- a/tests/testthat/test-phase-spec.R
+++ b/tests/testthat/test-phase-spec.R
@@ -316,6 +316,63 @@ test_that("hzr_theta_names() rejects a phase named 'total'", {
   expect_error(hzr_theta_names(list(total = hzr_phase("cdf"))), "reserved")
 })
 
+# 'time' is reserved too (#224). predict(decompose = TRUE) builds its output as
+# data.frame(time = ...) and then stores each phase's cumulative hazard under
+# the phase's name, so a phase called `time` overwrote the requested times with
+# its own cumulative hazard, and the times vanished with no error.
+
+test_that("validate_phases rejects a phase named 'time'", {
+  phases <- list(time = hzr_phase("cdf"), late = hzr_phase("constant"))
+  expect_error(.hzr_validate_phases(phases),
+               "'time' is a reserved phase name")
+})
+
+test_that("hazard() rejects a phase named 'time' or 'total', naming it", {
+  dat <- data.frame(time = c(1, 2, 3, 4, 5), status = c(1, 1, 0, 1, 0))
+  for (nm in c("time", "total")) {
+    phases <- stats::setNames(list(hzr_phase("cdf"), hzr_phase("constant")),
+                              c(nm, "late"))
+    expect_error(
+      hazard(survival::Surv(time, status) ~ 1, data = dat,
+             dist = "multiphase", fit = TRUE, phases = phases),
+      paste0("'", nm, "' is a reserved phase name")
+    )
+  }
+})
+
+test_that("hzr_theta_names() rejects a phase named 'time'", {
+  expect_error(hzr_theta_names(list(time = hzr_phase("cdf"))),
+               "'time' is a reserved phase name")
+})
+
+test_that("an early/constant fit is unchanged, and its decomposition keeps time", {
+  d <- na.omit(avc[, c("int_dead", "dead")])
+  ph <- list(
+    early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1, fixed = "m"),
+    constant = hzr_phase("constant")
+  )
+  ctl <- list(n_starts = 1L, conserve = FALSE)
+  fit <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = d, dist = "multiphase",
+    phases = ph, fit = TRUE, control = ctl
+  ))
+  # The same model refitted from its own estimates lands on the same optimum,
+  # a comparison with the fit itself rather than a recorded number.
+  refit <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ 1, data = d, dist = "multiphase",
+    phases = ph, theta = fit$fit$theta, fit = TRUE, control = ctl
+  ))
+  expect_true(fit$fit$converged)
+  expect_equal(refit$fit$objective, fit$fit$objective, tolerance = 1e-8)
+
+  times <- c(1, 5, 10)
+  dec <- predict(fit, newdata = data.frame(time = times),
+                 type = "cumulative_hazard", decompose = TRUE)
+  expect_identical(names(dec), c("time", "total", "early", "constant"))
+  expect_identical(dec$time, times)
+  expect_equal(dec$total, dec$early + dec$constant, tolerance = 1e-12)
+})
+
 test_that("'total' is still the name the cumhaz accumulator is stored under", {
   # Cross-check for the guard above. Asserting only that "reserved" is thrown
   # restates the guard's own string: rename the accumulator and that test stays


### PR DESCRIPTION
Closes #224.

`predict(decompose = TRUE)` builds its output as `data.frame(time = ...)` and then stores each phase's cumulative hazard under the phase's name, so a phase literally named `time` **overwrote the requested prediction times with its own cumulative hazard**. The times vanished with no error.

## Change

`.hzr_validate_phases()` now refuses a phase named `"time"` beside `"total"`, with the same style of message: it names the reserved word and asks for a different name. `hazard()` and `hzr_theta_names()` both validate through it, so a phase named `time` stops before any fitting. The roxygen for `hazard(phases =)` and `hzr_theta_names()` lists both reserved names.

**Caller census:** `hzr_translate_sas()` emits only `early`/`constant`/`late`; stepwise and bootstrap refits reuse the fit's own phase names; no vignette, test, `inst/` file or `R/` code builds a phase named `"time"` (the `"time"` names in `R/sas-parse-job.R` are call-argument names).

## Interaction with #288

#288 landed first and added a test that fitted a phase literally named `time`. That fit now stops, so the test (`7423515`) asserts the refusal and keeps #288's point on an early/constant fit: decompose's own `time` and `total` columns never become `par_cumhaz_` columns, each real phase gets exactly one, the phase columns add up to `par_cumhaz`, and `hzr_gof()`'s `time` column is its Kaplan-Meier grid.

## Evidence

- Tests fail first on the pre-fix base: the validator, `hazard()` and `hzr_theta_names()` all accepted `"time"`. Disabling the new check fails the three `"time"` tests.
- A normal early/constant fit is unchanged, checked against the same model refitted from its own estimates, and its decomposition keeps the requested times.
- Local gates at `7423515` (up to date with `main` `a2ff8da`), with `/Volumes/qhsstudies` mounted so the private-dataset parity tests ran rather than skipped:
  - `devtools::document()`: no changes to `man/` or `NAMESPACE`
  - `lintr::lint_package()`: 0 lints
  - `devtools::test()` with `NOT_CRAN=true`: **0 failures, 5740 passes, 6 skips**; the six are the known unsatisfiable ones (three `bh.dead` fixture, the C binary, two weighted-parity fixture), and the maze and achalasia parity tests ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)
