### PR TITLE
fix(stepwise): add to the covariates a phase inherits, and refuse what cannot be rebuilt

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,25 @@
   unchanged, as is a multiphase screen in which every phase has its own
   formula.
 
+* **`hzr_stepwise()` now refuses a vector-interface multiphase fit whose
+  phases inherit a design matrix passed directly as `x`** (#284). A phase
+  with no formula of its own uses that `x`, and a candidate refit had no
+  terms to rebuild it from, so every refit dropped its columns from every
+  such phase: on `avc`, entering `mal` into one phase took `age` out of
+  both, and the log-likelihood fell from -196.44 to -202.17 while the step
+  table reported a plain "enter". The only warning blamed a refit that "did
+  not converge". The screen now stops before printing anything. Give each
+  phase its covariates with `hzr_phase(formula = ~ ...)`, with the columns
+  in `data`; a fit whose phases all have their own formulas is unaffected.
+  It refuses the same way when a phase the screen can step inherits
+  time-varying coefficients (`time_windows`), which rebuilding the phase
+  from its terms would fit as one constant effect, or a term that expands
+  to more than one column, such as a factor with more than two levels or
+  `poly()`, which a step cannot add or drop as one coefficient. Both used
+  to change the phase's design without a word. A forward screen steps only
+  the phases its `scope` names, so an inheriting phase outside the scope
+  is left alone; a backward or two-way screen can drop from any phase.
+
 ## New features
 
 * **Every fit now says what it did not do** (#242, following #197). A
@@ -246,6 +265,31 @@
   is refused or flagged and never fitted (#181). The row is now
   `"planned"` with `r_parameter` "(not implemented)", so
   `hzr_argument_mapping(include_planned = FALSE)` no longer includes it.
+
+* **A multiphase stepwise step now adds to the covariates a phase inherits,
+  instead of replacing them** (#284). A phase with no formula of its own
+  uses the global formula's covariates. Entering a variable into such a
+  phase built a formula holding only the new variable, so `early.age`
+  became `early.mal`: the refitted model had lost a covariate, its
+  log-likelihood fell (-196.44 to -204.43 on `avc`, with the control the
+  tests use), and the step reported `mal` entering at p = 5.9e-05, a
+  p-value from that smaller model. The
+  model the step describes, `early ~ age + mal`, gives p = 5.4e-04. The
+  step now starts from the inherited terms, so it fits that model and
+  reports its p-value. Drops start from the inherited terms too, and the
+  inherited covariates are now drop candidates. The default score
+  criterion used to stop on this case, reporting that the candidate "could
+  not be added to the model"; it now scores it. Two related defects are
+  fixed with it. Dropping a phase's last covariate set its formula to
+  NULL, which made the phase inherit the global covariates again, so a
+  later "drop" could bring `age` back; it now leaves `~ 1`. And the score
+  test pinned a candidate in the phase's last slot, which is wrong after an
+  interaction: `model.matrix()` puts main effects first, so with
+  `age * mal` it scored `age:mal` in the candidate's place. It now finds
+  the candidate's column by name. That one affected phases with their own
+  formula too. **Selected models and p-values change** for any multiphase
+  screen that stepped a phase without a formula while the global formula
+  had covariates, or scored a candidate for a phase with an interaction.
 
 # TemporalHazard 1.2.10
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -1542,8 +1542,10 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
       },
       # A multiphase scope is refit through .hzr_phase_update_formula(): into
       # the phase's own formula, keeping its environment, or, for a phase
-      # without one, into a fresh formula whose lookups reach this package's
-      # namespace and the search path. Each phase's scope is checked there.
+      # without one, into the inherited global terms in the stored formula's
+      # environment (#284), or, with no global terms, into a fresh formula
+      # whose lookups reach this package's namespace and the search path.
+      # Each phase's scope is checked in every one of those places.
       if (is.list(scope)) {
         unlist(lapply(names(scope), function(p) {
           sc <- scope[[p]]
@@ -1554,6 +1556,7 @@ hzr_bootstrap <- function(object, n_boot = 200L, fraction = 1.0,
           } else {
             environment(pf)
           }),
+          if (is.null(pf)) outside_in(all.vars(sc), base_env %||% call_env),
           outside_in(all.vars(sc), environment(sc) %||% call_env))
         }))
       }

--- a/R/score-test.R
+++ b/R/score-test.R
@@ -346,8 +346,13 @@
   }
 
   new_phases <- phases
+  # As in .hzr_refit_with_scope(): a phase with no formula inherits the
+  # global terms, and the candidate is added to them (#284).
+  inherited <- if (is.null(new_phases[[phase]]$formula)) {
+    .hzr_inherited_rhs(current)
+  }
   new_phases[[phase]] <- .hzr_phase_update_formula(
-    new_phases[[phase]], action = "add", var = var
+    new_phases[[phase]], action = "add", var = var, inherited = inherited
   )
 
   d <- current$data
@@ -370,9 +375,13 @@
       x_j <- stats::model.matrix(ph$formula, data = mf_j)[, -1L, drop = FALSE]
       x_list[[nm]] <- x_j
       cov_counts[[nm]] <- ncol(x_j)
-    } else if (!is.null(d$x)) {
-      x_list[[nm]] <- d$x
-      cov_counts[[nm]] <- ncol(d$x)
+    } else if (!is.null(current$fit$x_list[[nm]]) || !is.null(d$x)) {
+      # A phase with no formula uses the design the fit used, which under
+      # `time_windows` is the window-expanded one; `d$x` is the plain global
+      # matrix and would change the phase's columns (#284).
+      xm <- current$fit$x_list[[nm]] %||% d$x
+      x_list[[nm]] <- xm
+      cov_counts[[nm]] <- ncol(xm)
     } else {
       x_list[[nm]] <- NULL
       cov_counts[[nm]] <- 0L
@@ -386,10 +395,36 @@
     # one-zero-per-add layout; the refit path guards this upstream too.
     return(NULL)
   }
+  unchanged <- setdiff(nms, phase)
+  if (any(cov_counts[unchanged] != old_counts[unchanged])) {
+    # Every phase the step does not touch must keep the design the fit used;
+    # a different column count means the expansion rebuilt it wrongly.
+    return(NULL)
+  }
   for (nm in nms) {
     xm <- x_list[[nm]]
     if (is.null(xm) || ncol(xm) == 0L) next
     if (nrow(xm) != n_time || anyNA(xm)) return(NULL)
+  }
+
+  # The candidate's column is not always the phase's last: model.matrix()
+  # puts main effects before interactions, so a phase with `age * mal`
+  # gains `opmos` before `age:mal`. Find it by name among the phase's
+  # columns. A phase with no columns yet takes the only slot; one whose
+  # columns cannot be matched by name declines (a score of NA) rather than
+  # pin the zero on whichever coefficient happens to be last.
+  old_cols <- colnames(current$fit$x_list[[phase]])
+  new_cols <- colnames(x_list[[phase]])
+  new_col_pos <- cov_counts[[phase]]
+  if (old_counts[[phase]] > 0L) {
+    hit <- if (!is.null(new_cols) &&
+                 length(old_cols) == old_counts[[phase]]) {
+      which(!new_cols %in% old_cols)
+    } else {
+      integer()
+    }
+    if (length(hit) != 1L) return(NULL)
+    new_col_pos <- hit
   }
 
   parts <- .hzr_split_theta(current$fit$theta, phases, old_counts)
@@ -400,15 +435,22 @@
   pos <- 0L
   for (nm in nms) {
     part <- parts[[nm]]
-    theta_new <- c(theta_new, part)
-    theta_idx <- c(theta_idx, pos + seq_along(part))
-    pos <- pos + length(part)
     if (identical(nm, phase)) {
-      # The new covariate is the phase's last term, so its coefficient is the
-      # last slot of that phase's sub-vector -- matching model.matrix ordering.
-      theta_new <- c(theta_new, 0)
-      pos <- pos + 1L
-      beta_idx <- pos
+      # Old entries before the new slot: log_mu, the shapes, and the betas
+      # whose columns precede the candidate's. The pinned zero goes there,
+      # so every other coefficient keeps its own column.
+      at <- length(part) - old_counts[[phase]] + new_col_pos - 1L
+      after <- length(part) - at
+      theta_new <- c(theta_new, part[seq_len(at)], 0,
+                     part[at + seq_len(after)])
+      theta_idx <- c(theta_idx, pos + seq_len(at),
+                     pos + at + 1L + seq_len(after))
+      beta_idx <- pos + at + 1L
+      pos <- pos + length(part) + 1L
+    } else {
+      theta_new <- c(theta_new, part)
+      theta_idx <- c(theta_idx, pos + seq_along(part))
+      pos <- pos + length(part)
     }
   }
 

--- a/R/stepwise-formula.R
+++ b/R/stepwise-formula.R
@@ -111,16 +111,21 @@
 #' Add or drop a variable from a phase's formula
 #'
 #' @param phase An `hzr_phase` object.  Its `formula` slot may be NULL
-#'   (no phase-specific covariates); in the add case a fresh
-#'   `~ var` formula is created.
+#'   (no phase-specific covariates), in which case the phase inherits the
+#'   global design: the step starts from `inherited` when that is given, and
+#'   otherwise the add case creates a fresh `~ var` formula.
 #' @param action Either `"add"` or `"drop"`.
 #' @param var Character scalar.
+#' @param inherited One-sided formula of the global terms a phase with no
+#'   formula inherits (see `.hzr_inherited_rhs()`), or `NULL` when there are
+#'   none. Ignored for a phase with a formula of its own.
 #'
 #' @return An updated `hzr_phase` object with the new formula.
 #'
 #' @keywords internal
 #' @noRd
-.hzr_phase_update_formula <- function(phase, action = c("add", "drop"), var) {
+.hzr_phase_update_formula <- function(phase, action = c("add", "drop"), var,
+                                      inherited = NULL) {
   action <- match.arg(action)
   if (!inherits(phase, "hzr_phase")) {
     stop("`phase` must be an `hzr_phase` object.", call. = FALSE)
@@ -130,6 +135,14 @@
   }
 
   f <- phase$formula
+  if (is.null(f) && !is.null(inherited)) {
+    # A phase with no formula of its own carries the global terms, so a step
+    # starts from them: adding `mal` to a phase inheriting `age` gives
+    # `~ age + mal`, not `~ mal` (#284). An emptied result stays `~ 1`
+    # rather than NULL, which would inherit the global terms again.
+    phase$formula <- .hzr_formula_update(inherited, action, var)
+    return(phase)
+  }
   if (is.null(f)) {
     if (action == "drop") {
       return(phase)   # nothing to drop
@@ -143,16 +156,37 @@
     return(phase)
   }
 
+  # A drop that empties the RHS leaves `~ 1`, never NULL: a NULL phase
+  # formula inherits the global design, so the phase would take back the
+  # global covariates the step table says it no longer has (#284).
   phase$formula <- .hzr_formula_update(f, action, var)
-
-  # If dropping emptied the RHS (`~ 1`), null the slot out for
-  # consistency with hzr_phase(formula = NULL) construction.
-  if (action == "drop" &&
-        identical(.hzr_formula_rhs_terms(phase$formula), character())) {
-    phase$formula <- NULL
-  }
-
   phase
+}
+
+
+#' The global terms a phase with no formula of its own inherits
+#'
+#' A multiphase phase whose `formula` is `NULL` uses the global design: the
+#' right-hand side of the fit's formula. A stepwise step on such a phase has
+#' to start from those terms (#284). A vector-interface fit has no formula,
+#' so nothing here can say what a directly passed `x` holds;
+#' `.hzr_refit_blocker()` refuses the case where a phase inherits one.
+#'
+#' @param fit A fitted `hazard` object.
+#' @return A one-sided formula in the stored formula's environment, or `NULL`
+#'   when the global design has no terms.
+#' @keywords internal
+#' @noRd
+.hzr_inherited_rhs <- function(fit) {
+  f <- .hzr_stored_formula(fit)
+  if (is.null(f) || length(f) < 3L) {
+    return(NULL)
+  }
+  rhs_terms <- .hzr_formula_rhs_terms(f)
+  if (length(rhs_terms) == 0L) {
+    return(NULL)
+  }
+  stats::reformulate(rhs_terms, env = environment(f))
 }
 
 
@@ -194,9 +228,18 @@
     return(.hzr_formula_rhs_terms(f))
   }
 
-  # Multiphase
+  # Multiphase. A phase with no formula of its own carries the global terms
+  # it inherits (#284); they are read only when some phase does inherit, so
+  # a global `.` beside phases that all have formulas is never parsed here.
+  inherits_global <- vapply(fit$spec$phases, function(ph) is.null(ph$formula),
+                            logical(1))
+  inherited_terms <- character()
+  if (any(inherits_global)) {
+    rhs <- .hzr_inherited_rhs(fit)
+    if (!is.null(rhs)) inherited_terms <- .hzr_formula_rhs_terms(rhs)
+  }
   per_phase <- lapply(fit$spec$phases, function(ph) {
-    if (is.null(ph$formula)) character() else .hzr_formula_rhs_terms(ph$formula)
+    if (is.null(ph$formula)) inherited_terms else .hzr_formula_rhs_terms(ph$formula)
   })
 
   if (is.null(phase)) return(per_phase)

--- a/R/stepwise-refit.R
+++ b/R/stepwise-refit.R
@@ -76,12 +76,18 @@
 #' records as having shipped a wrong-answer bug.
 #'
 #' @param fit A fitted `hazard` object.
+#' @param stepped Names of the multiphase phases a step can change, or
+#'   `NULL` for all of them; passed to `.hzr_inherit_blocker()`.
 #' @return `NULL` when the fit can be refit, otherwise a character scalar
 #'   naming the obstruction, phrased to follow "... because".
 #'
 #' @keywords internal
 #' @noRd
-.hzr_refit_blocker <- function(fit) {
+.hzr_refit_blocker <- function(fit, stepped = NULL) {
+  inherit_blocker <- .hzr_inherit_blocker(fit, stepped = stepped)
+  if (!is.null(inherit_blocker)) {
+    return(inherit_blocker)
+  }
   if (!is.null(fit$call$formula)) {
     return(NULL)
   }
@@ -108,6 +114,85 @@
   }
 
   NULL
+}
+
+
+#' Why a multiphase fit's inherited design cannot be stepped
+#'
+#' A phase with no formula of its own inherits the global design, and a
+#' stepwise step on it rebuilds that design as a phase formula from the
+#' global formula's terms (#284). The rebuild is exact only for plain
+#' one-column terms, so three cases are refused here, before any fitting:
+#' a design matrix passed directly as `x`, which has no terms at all;
+#' time-varying coefficients (`time_windows`), which a phase formula would
+#' fit as one constant effect; and a term that expands to more than one
+#' column, such as a factor, which a step cannot add or drop as one
+#' coefficient. Each silently changed the phase's design before.
+#'
+#' @param fit A fitted `hazard` object.
+#' @param stepped Names of the phases a step can change, or `NULL` for all
+#'   of them. The `time_windows` and multi-column checks apply only to these;
+#'   a direct `x` is refused for any inheriting phase.
+#' @return `NULL`, or a character scalar phrased to follow "... because",
+#'   carrying its own remedy.
+#' @keywords internal
+#' @noRd
+.hzr_inherit_blocker <- function(fit, stepped = NULL) {
+  if (!identical(fit$spec$dist, "multiphase")) {
+    return(NULL)
+  }
+  inherits <- vapply(fit$spec$phases, function(ph) is.null(ph$formula),
+                     logical(1))
+  if (!any(inherits)) {
+    return(NULL)
+  }
+  name_phases <- function(p) {
+    paste0(if (length(p) > 1L) "phases " else "phase ",
+           paste0("'", p, "'", collapse = ", "),
+           if (length(p) > 1L) " inherit" else " inherits")
+  }
+  inheriting <- names(fit$spec$phases)[inherits]
+  who <- name_phases(inheriting)
+  fix <- paste0(". Give each phase its covariates with ",
+                "hzr_phase(formula = ~ ...), with the columns in `data`")
+
+  if (is.null(fit$call$formula)) {
+    if (!is.null(fit$call$x)) {
+      return(paste0(who, " a design matrix passed directly as `x`, and a ",
+                    "refit has no terms to rebuild it from", fix))
+    }
+    return(NULL)
+  }
+
+  # A global `.` is left to hzr_stepwise()'s own refusal (#279).
+  tt <- tryCatch(stats::terms(.hzr_stored_formula(fit)),
+                 error = function(e) NULL)
+  labels <- if (is.null(tt)) character() else attr(tt, "term.labels")
+  if (length(labels) == 0L) {
+    return(NULL)
+  }
+  # A refit hands an inheriting phase that is not stepped the same global
+  # design back, so these two checks apply only to a phase being stepped.
+  # (A direct `x`, above, is lost by every inheriting phase, stepped or not.)
+  if (!is.null(stepped)) {
+    inheriting <- intersect(stepped, inheriting)
+    if (length(inheriting) == 0L) {
+      return(NULL)
+    }
+    who <- name_phases(inheriting)
+  }
+  reason <- if (!is.null(fit$spec$time_windows)) {
+    paste0("time-varying coefficients (`time_windows`), which a phase ",
+           "formula would fit as one constant effect")
+  } else if (!is.null(fit$data$x) && ncol(fit$data$x) != length(labels)) {
+    paste0("a term that expands to more than one column, such as a factor ",
+           "with more than two levels or `poly()`, which a step cannot add ",
+           "or drop as one coefficient")
+  }
+  if (is.null(reason)) {
+    return(NULL)
+  }
+  paste0(who, " a global design with ", reason, fix)
 }
 
 
@@ -187,7 +272,7 @@
   extra_args <- user_args[!names(user_args) %in%
                             c("weights", "time_windows", "objective")]
 
-  blocker <- .hzr_refit_blocker(current)
+  blocker <- .hzr_refit_blocker(current, stepped = phase)
   if (!is.null(blocker)) {
     stop("`current` cannot be refit because ", blocker, ".", call. = FALSE)
   }
@@ -213,8 +298,13 @@
     }
 
     new_phases <- current$spec$phases
+    # A phase with no formula inherits the global terms, and the step starts
+    # from them (#284). Read only for such a phase.
+    inherited <- if (is.null(new_phases[[phase]]$formula)) {
+      .hzr_inherited_rhs(current)
+    }
     new_phases[[phase]] <- .hzr_phase_update_formula(
-      new_phases[[phase]], action = action, var = var
+      new_phases[[phase]], action = action, var = var, inherited = inherited
     )
 
     # The scope change above rewrote the PHASE formula; the global formula

--- a/R/stepwise.R
+++ b/R/stepwise.R
@@ -240,14 +240,25 @@ hzr_stepwise <- function(fit,
   # refit's own predicate once, up front: one message, naming the remedy,
   # before any fitting happens.  Sharing .hzr_refit_blocker() with the refit
   # is what stops the two answers drifting apart.
-  refit_blocker <- .hzr_refit_blocker(fit)
+  # A forward screen steps only the phases its scope names; a backward or
+  # two-way screen can drop from any phase, so it steps them all (#284).
+  stepped <- if (identical(fit$spec$dist, "multiphase") &&
+                   direction == "forward" && is.list(scope) &&
+                   !is.null(names(scope))) {
+    names(scope)
+  }
+  refit_blocker <- .hzr_refit_blocker(fit, stepped = stepped)
   if (!is.null(refit_blocker)) {
     # The remedy is distribution-specific. Telling a multiphase caller to
     # "rebuild with the formula interface" would be wrong twice over: it is
     # not what blocked them, and for a translated SAS job it would force the
     # -1/0/1/2 -> Surv() 0/1/2/3 status round-trip this package has already
     # shipped a wrong answer through.
-    remedy <- if (identical(fit$spec$dist, "multiphase")) {
+    remedy <- if (!is.null(.hzr_inherit_blocker(fit, stepped = stepped))) {
+      # An inherited-design refusal names its own remedy; the generic one
+      # below would ask for `time` and `status` the caller already gave.
+      ""
+    } else if (identical(fit$spec$dist, "multiphase")) {
       paste0("Refit the base model with hazard(), supplying `time` and ",
              "`status` (or a formula), and retry.")
     } else {
@@ -256,8 +267,9 @@ hzr_stepwise <- function(fit,
              "hazard(Surv(time, status) ~ 1, data = df, ...) -- and retry.")
     }
     stop("`fit` cannot be used as a stepwise base model because ",
-         refit_blocker, ". Every candidate would fail to refit, so the ",
-         "screen could never enter or drop anything. ", remedy,
+         refit_blocker, ". No candidate could be refit as the step ",
+         "describes, so the screen cannot run.",
+         if (nzchar(remedy)) paste0(" ", remedy),
          call. = FALSE)
   }
 

--- a/tests/testthat/test-stepwise-formula.R
+++ b/tests/testthat/test-stepwise-formula.R
@@ -93,10 +93,12 @@ test_that("phase_update_formula creates a formula when the phase had none", {
   expect_identical(.hzr_formula_rhs_terms(out$formula), "age")
 })
 
-test_that("phase_update_formula drops the only term, nulling the slot", {
+test_that("phase_update_formula drops the only term, leaving `~ 1`", {
+  # Not NULL: a NULL phase formula inherits the global design, so dropping a
+  # phase's last covariate would bring the global ones back (#284).
   ph <- hzr_phase("cdf", t_half = 1, nu = 1, m = 1, formula = ~ age)
   out <- .hzr_phase_update_formula(ph, "drop", "age")
-  expect_null(out$formula)
+  expect_identical(deparse(out$formula), "~1")
 })
 
 test_that("phase_update_formula on NULL-formula drop is a no-op", {

--- a/tests/testthat/test-stepwise-phase-inherits.R
+++ b/tests/testthat/test-stepwise-phase-inherits.R
@@ -1,0 +1,319 @@
+# tests/testthat/test-stepwise-phase-inherits.R
+# A multiphase phase with no formula of its own inherits the global design.
+# A stepwise step that entered a variable into such a phase built `~ var`
+# from scratch, so it REPLACED the inherited covariates: `early.age` became
+# `early.mal`, the log-likelihood fell, and the step's p-value belonged to
+# that smaller model (#284). Every refit here uses the same `control` as the
+# explicit reference fit, so the two are the same `hazard()` call.
+
+avc_284 <- na.omit(avc[, c("int_dead", "dead", "age", "mal")])
+ctl_284 <- list(n_starts = 1L, conserve = FALSE)
+
+ph_284 <- function(fe = NULL, fc = NULL) {
+  list(
+    early    = hzr_phase("cdf", t_half = 0.15, nu = 1.4, m = 1, fixed = "m",
+                         formula = fe),
+    constant = hzr_phase("constant", formula = fc)
+  )
+}
+
+fit_284 <- function(formula, phases) {
+  suppressWarnings(hazard(formula, data = avc_284, dist = "multiphase",
+                          phases = phases, fit = TRUE, control = ctl_284))
+}
+
+# The covariate coefficients of one phase, without its shape parameters.
+phase_covs <- function(fit, phase) {
+  nm <- names(coef(fit))
+  shapes <- paste0(phase, ".", c("log_mu", "log_t_half", "nu", "m"))
+  setdiff(grep(paste0("^", phase, "\\."), nm, value = TRUE), shapes)
+}
+
+wald_p <- function(fit, name) {
+  i <- which(names(coef(fit)) == name)
+  z <- coef(fit)[[i]] / sqrt(diag(fit$fit$vcov))[[i]]
+  2 * stats::pnorm(-abs(z))
+}
+
+step_284 <- function(base, scope, direction = "forward", ...) {
+  suppressWarnings(hzr_stepwise(base, data = avc_284, scope = scope,
+                                direction = direction, trace = FALSE,
+                                control = ctl_284, ...))
+}
+
+test_that("the phase update starts from the terms a phase inherits", {
+  inh <- ~ age
+  p0 <- hzr_phase("constant")
+  added <- .hzr_phase_update_formula(p0, "add", "mal", inherited = inh)
+  expect_identical(all.vars(added$formula), c("age", "mal"))
+  # Emptying an inheriting phase leaves `~ 1`: NULL would inherit again.
+  dropped <- .hzr_phase_update_formula(p0, "drop", "age", inherited = inh)
+  expect_identical(deparse(dropped$formula), "~1")
+  # A phase with its own formula ignores what it would inherit.
+  own <- hzr_phase("constant", formula = ~ zz)
+  kept <- .hzr_phase_update_formula(own, "add", "mal", inherited = inh)
+  expect_identical(all.vars(kept$formula), c("zz", "mal"))
+})
+
+test_that("a Wald step adds to the inherited terms and reports their p-value", {
+  base <- fit_284(survival::Surv(int_dead, dead) ~ age, ph_284())
+  expect_identical(phase_covs(base, "early"), "early.age")
+  sw <- step_284(base, list(early = ~ mal), criterion = "wald",
+                 slentry = 0.99)
+  explicit <- fit_284(survival::Surv(int_dead, dead) ~ age,
+                      ph_284(~ age + mal))
+
+  expect_identical(sw$steps$variable, "mal")
+  expect_identical(sw$steps$phase, "early")
+  expect_identical(phase_covs(sw, "early"), c("early.age", "early.mal"))
+  expect_identical(phase_covs(sw, "constant"), "constant.age")
+  expect_equal(sw$fit$objective, explicit$fit$objective, tolerance = 1e-8)
+  # The entered model contains the base one, so its log-likelihood cannot
+  # fall; under this control it did, from -196.44 to -204.43, when `age`
+  # was replaced.
+  expect_gt(sw$fit$objective, base$fit$objective)
+  expect_equal(sw$steps$p_value, wald_p(explicit, "early.mal"),
+               tolerance = 1e-6)
+})
+
+test_that("the score screen enters the variable instead of stopping", {
+  base <- fit_284(survival::Surv(int_dead, dead) ~ age, ph_284())
+  sw <- step_284(base, list(early = ~ mal), slentry = 0.99)
+  explicit <- fit_284(survival::Surv(int_dead, dead) ~ age,
+                      ph_284(~ age + mal))
+
+  entered <- sw$steps[sw$steps$action == "enter", ]
+  expect_identical(entered$variable, "mal")
+  expect_identical(entered$phase, "early")
+  expect_identical(phase_covs(sw, "early"), c("early.age", "early.mal"))
+  expect_equal(sw$fit$objective, explicit$fit$objective, tolerance = 1e-8)
+  # The same base model written with `early ~ age` as the phase's own formula
+  # goes through the path that already worked, so its score p-value is the
+  # reference. The old code could not score the inheriting candidate at all.
+  own <- step_284(fit_284(survival::Surv(int_dead, dead) ~ age,
+                          ph_284(~ age)),
+                  list(early = ~ mal), slentry = 0.99)
+  p_own <- own$steps$p_value[own$steps$action == "enter"]
+  expect_true(is.finite(entered$p_value))
+  expect_equal(entered$p_value, p_own, tolerance = 1e-8)
+})
+
+test_that("a drop starts from the terms the phase inherits", {
+  base <- fit_284(survival::Surv(int_dead, dead) ~ age + mal, ph_284())
+  pairs <- vapply(.hzr_stepwise_drop_candidates(base),
+                  function(c) paste0(c$var, "@", c$phase), character(1))
+  expect_setequal(pairs, c("age@early", "mal@early",
+                           "age@constant", "mal@constant"))
+
+  refit <- suppressWarnings(.hzr_refit_with_scope(
+    base, "drop", "mal", phase = "early", data = avc_284, control = ctl_284
+  ))
+  explicit <- fit_284(survival::Surv(int_dead, dead) ~ age + mal,
+                      ph_284(~ age))
+  expect_identical(phase_covs(refit, "early"), "early.age")
+  expect_identical(phase_covs(refit, "constant"),
+                   c("constant.age", "constant.mal"))
+  expect_equal(refit$fit$objective, explicit$fit$objective, tolerance = 1e-8)
+})
+
+test_that("a phase with its own formula is unchanged", {
+  base <- fit_284(survival::Surv(int_dead, dead) ~ 1, ph_284(~ age))
+  sw <- step_284(base, list(early = ~ mal), criterion = "wald",
+                 slentry = 0.99)
+  explicit <- fit_284(survival::Surv(int_dead, dead) ~ 1,
+                      ph_284(~ age + mal))
+  expect_identical(phase_covs(sw, "early"), c("early.age", "early.mal"))
+  expect_identical(phase_covs(sw, "constant"), character(0))
+  expect_equal(sw$fit$objective, explicit$fit$objective, tolerance = 1e-8)
+})
+
+test_that("a vector-interface fit whose phases inherit a direct `x` is refused", {
+  # A refit has no terms to rebuild `x` from, so candidate refits dropped it
+  # from every phase that inherited it.
+  mp <- suppressWarnings(hazard(
+    data = avc_284, time = int_dead, status = dead,
+    x = as.matrix(avc_284["age"]), dist = "multiphase", phases = ph_284(),
+    fit = TRUE, control = ctl_284
+  ))
+  expect_error(step_284(mp, list(early = ~ mal), criterion = "wald",
+                        slentry = 0.99),
+               "passed directly as `x`")
+
+  # When every phase has its own formula, no phase reads `x`, and the
+  # screen runs.
+  mp2 <- suppressWarnings(hazard(
+    data = avc_284, time = int_dead, status = dead,
+    x = as.matrix(avc_284["age"]), dist = "multiphase",
+    phases = ph_284(~ age, ~ age), fit = TRUE, control = ctl_284
+  ))
+  sw <- step_284(mp2, list(early = ~ mal), criterion = "wald",
+                 slentry = 0.99)
+  expect_identical(phase_covs(sw, "early"), c("early.age", "early.mal"))
+})
+
+test_that("an inherit refusal names its own remedy only", {
+  mp <- suppressWarnings(hazard(
+    data = avc_284, time = int_dead, status = dead,
+    x = as.matrix(avc_284["age"]), dist = "multiphase", phases = ph_284(),
+    fit = TRUE, control = ctl_284
+  ))
+  err <- tryCatch(step_284(mp, list(early = ~ mal), criterion = "wald",
+                           slentry = 0.99),
+                  error = conditionMessage)
+  expect_match(err, "hzr_phase(formula = ~ ...)", fixed = TRUE)
+  # The generic multiphase remedy asks for `time` and `status`, which this
+  # caller already supplied.
+  expect_false(grepl("supplying `time`", err, fixed = TRUE))
+})
+
+test_that("the score test pins the candidate where its column is", {
+  # model.matrix() puts main effects before interactions, so a phase with
+  # `age * mal` gains `opmos` BEFORE `age:mal`, not last. Pinning the zero in
+  # the last slot scored `age:mal` as if it were `opmos` (p = 0.433 against
+  # 0.251). The same model with a pre-built `age * mal` column is the check.
+  d5 <- na.omit(avc[, c("int_dead", "dead", "age", "mal", "opmos")])
+  d5$am <- d5$age * d5$mal
+  score_p <- function(formula, phases) {
+    base <- suppressWarnings(hazard(formula, data = d5, dist = "multiphase",
+                                    phases = phases, fit = TRUE,
+                                    control = ctl_284))
+    sw <- suppressWarnings(hzr_stepwise(base, data = d5,
+                                        scope = list(early = ~ opmos),
+                                        direction = "forward",
+                                        slentry = 0.99, trace = FALSE,
+                                        control = ctl_284))
+    sw$steps$p_value[sw$steps$action == "enter"]
+  }
+  # Inherited from the global formula.
+  expect_equal(score_p(survival::Surv(int_dead, dead) ~ age * mal, ph_284()),
+               score_p(survival::Surv(int_dead, dead) ~ age + mal + am,
+                       ph_284()),
+               tolerance = 1e-6)
+  # The phase's own formula.
+  expect_equal(score_p(survival::Surv(int_dead, dead) ~ 1,
+                       ph_284(~ age * mal)),
+               score_p(survival::Surv(int_dead, dead) ~ 1,
+                       ph_284(~ age + mal + am)),
+               tolerance = 1e-6)
+})
+
+test_that("an inherited time-varying design is refused", {
+  # Rebuilt from its term labels, the phase would lose its windows: `age_w1`
+  # and `age_w2` would become one constant `age` effect.
+  base <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ age, data = avc_284,
+    dist = "multiphase", phases = ph_284(), time_windows = 1, fit = TRUE,
+    control = ctl_284
+  ))
+  expect_error(step_284(base, list(early = ~ mal), criterion = "wald",
+                        slentry = 0.99),
+               "time_windows")
+})
+
+test_that("an inherited term with several columns is refused before output", {
+  d6 <- avc_284
+  d6$grp <- cut(d6$age, 3)
+  base <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ grp, data = d6, dist = "multiphase",
+    phases = ph_284(), fit = TRUE, control = ctl_284
+  ))
+  err <- NULL
+  out <- utils::capture.output(
+    err <- tryCatch(
+      hzr_stepwise(base, data = d6, scope = list(early = ~ mal),
+                   criterion = "wald", slentry = 0.99, trace = TRUE,
+                   control = ctl_284),
+      error = conditionMessage
+    )
+  )
+  expect_match(err, "more than one column")
+  expect_identical(out, character(0))
+})
+
+test_that("emptying a phase's own formula does not make it inherit again", {
+  base <- fit_284(survival::Surv(int_dead, dead) ~ age, ph_284())
+  refit <- function(fit, action, var) {
+    suppressWarnings(.hzr_refit_with_scope(fit, action, var, phase = "early",
+                                           data = avc_284,
+                                           control = ctl_284))
+  }
+  r1 <- refit(base, "drop", "age")
+  r2 <- refit(r1, "add", "mal")
+  r3 <- refit(r2, "drop", "mal")
+  expect_identical(deparse(r3$spec$phases$early$formula), "~1")
+  expect_identical(phase_covs(r3, "early"), character(0))
+  expect_identical(phase_covs(r3, "constant"), "constant.age")
+})
+
+test_that("a scope for an inheriting phase is checked where its refit reads it", {
+  # The refit builds the phase formula in the stored formula's environment,
+  # so `zz` here reaches it even though neither the scope's frame nor the
+  # search path can see it (#278's check, kept in step with #284).
+  local_base <- function() {
+    zz <- avc_284$age + sin(seq_len(nrow(avc_284))) # nolint: object_usage_linter.
+    fit_284(survival::Surv(int_dead, dead) ~ age, ph_284())
+  }
+  expect_error(
+    hzr_bootstrap(local_base(), n_boot = 2, seed = 1,
+                  scope = list(early = ~ zz), criterion = "wald",
+                  slentry = 0.99),
+    "uses 'zz', which is not a column"
+  )
+})
+
+test_that("a forward screen that never steps the inheriting phase still runs", {
+  # The refit hands the inheriting phase the same global design back, so the
+  # inherit refusals apply only to a phase the screen can step.
+  d7 <- avc_284
+  d7$grp <- cut(d7$age, 3)
+  run <- function(formula, ..., criterion = "wald") {
+    base <- suppressWarnings(hazard(
+      formula, data = d7, dist = "multiphase",
+      phases = ph_284(fc = ~ age), fit = TRUE, control = ctl_284, ...
+    ))
+    suppressWarnings(hzr_stepwise(base, data = d7,
+                                  scope = list(constant = ~ mal),
+                                  direction = "forward", criterion = criterion,
+                                  slentry = 0.99, trace = FALSE,
+                                  control = ctl_284))
+  }
+  sw <- run(survival::Surv(int_dead, dead) ~ grp)
+  expect_identical(sw$steps$variable, "mal")
+  expect_identical(phase_covs(sw, "constant"),
+                   c("constant.age", "constant.mal"))
+  expect_length(phase_covs(sw, "early"), 2L)
+
+  # The inheriting phase keeps its windowed design under either criterion.
+  # The score test rebuilt it from the plain global matrix instead, so the
+  # screen stopped, blaming the candidate.
+  for (crit in c("wald", "score")) {
+    tw <- run(survival::Surv(int_dead, dead) ~ age, time_windows = 1,
+              criterion = crit)
+    expect_identical(tw$steps$variable, "mal")
+    expect_true("constant.mal" %in% names(coef(tw)))
+    expect_true(all(c("early.age_w1", "early.age_w2") %in% names(coef(tw))))
+  }
+})
+
+test_that("the score expansion refuses rather than guess a column's slot", {
+  # With no column names to match, the candidate's slot cannot be found; the
+  # last slot is wrong after an interaction, so the expansion declines.
+  base <- fit_284(survival::Surv(int_dead, dead) ~ age, ph_284())
+  base$fit$x_list$early <- unname(base$fit$x_list$early)
+  expect_null(.hzr_score_expand(base, "mal", "early", avc_284))
+})
+
+test_that("the refit itself refuses to step an unrebuildable inheriting phase", {
+  # hzr_stepwise() refuses first, so this drives the refit's own check.
+  d8 <- avc_284
+  d8$grp <- cut(d8$age, 3)
+  base <- suppressWarnings(hazard(
+    survival::Surv(int_dead, dead) ~ grp, data = d8, dist = "multiphase",
+    phases = ph_284(), fit = TRUE, control = ctl_284
+  ))
+  expect_error(
+    .hzr_refit_with_scope(base, "add", "mal", phase = "early", data = d8,
+                          control = ctl_284),
+    "more than one column"
+  )
+})


### PR DESCRIPTION
Closes #284.

A multiphase phase with no formula of its own inherits the global design, and `hzr_stepwise()` steps on such a phase lost it. Entering a variable built `~ var` from scratch, replacing the inherited covariates. On `avc`, `early.age` became `early.mal`, the log-likelihood fell from -196.44 to -204.43, and the Wald step reported **p = 5.9e-05 for a model without `age`**. The default score screen could not score the candidate and stopped.

## Change

**(a) Add to what a phase inherits.** `.hzr_phase_update_formula()` now starts from the inherited terms (`.hzr_inherited_rhs()`), and the refit and the score test pass them, so an add or a drop on an inheriting phase starts from those terms. `.hzr_scope_current_vars()` reports them, so they are drop candidates and are not re-offered. The step now fits `early ~ age + mal` (logLik -190.85) and reports that model's Wald p, 5.4e-04. The score p equals the same model's p through the own-formula path.

Fixed with it, from three `r-reviewer` passes:
- A drop that empties a phase's own formula left it `NULL`, which **re-inherits** the global covariates, so a later drop brought `age` back. It now leaves `~ 1`.
- `.hzr_score_expand()` pinned the candidate in the phase's last slot, which is wrong after an interaction, so `age * mal` scored `age:mal` in the candidate's place. It now finds the column by name and declines (score `NA`) when it cannot match. This affected phases with their own formula too.
- An inheriting phase outside a forward scope lost its `time_windows` in the score expansion. It now takes that phase's design from the fit.
- `hzr_bootstrap()`'s per-phase scope check also looks in the stored formula's environment.

**(b) Refuse what a phase formula cannot rebuild.** A new check, `.hzr_inherit_blocker()`, refuses the following up front, and the refusal carries its own remedy:
- a vector-interface `x` on an inheriting phase, whose columns were dropped: logLik -196.44 to -202.17, `constant.age` gone;
- for a phase the screen can step, `time_windows`, or a term that expands to more than one column.

A forward screen steps only the phases its scope names, so an inheriting phase outside the scope is left alone.

## Evidence

- Tests fail first on `76d3e99`. Mutating any change above fails them, except a defensive column-count guard that no reachable case trips.
- `main` merged in twice: first at `50bfbc6` (`NEWS.md` conflict, both entries kept), then again at `a88cc51` after #291 (#224) landed, with no conflicts. The `NEWS.md` bullets this PR adds all have a blank line between them.
- Local gates on `a88cc51`, which is up to date with `main` `96aaf85`, with `/Volumes/qhsstudies` mounted:
  - `devtools::document()`: no changes to `man/` or `NAMESPACE`; `lintr::lint_package()`: 0 lints
  - `devtools::test()` with `NOT_CRAN=true`: **0 failures, 5788 passes, 6 skips** (the six known unsatisfiable ones: three `bh.dead` fixture, the C binary, two weighted-parity fixture)

## Copilot review

Copilot raised three items. Each was reproduced before acting on it.

- **An `x` bound to a `NULL` variable was refused** (`R/stepwise-refit.R`). The direct-`x` check read the call, not the design. It now asks `fit$data$x` for columns. **Fixed in `8bd5c31`.**
- **A `NULL` scope entry counted as a stepped phase** (`R/stepwise.R`), so `list(early = NULL, constant = ~ mal)` was refused for `early`, which is never refit. `stepped` now takes only the non-`NULL` entries. **Fixed in `8bd5c31`.**
- **Suppressed: the bootstrap scope check under a global `~ 1`** (`R/diagnostics.R:1796`). **Does not reproduce.** `hzr_bootstrap()` refuses the variable under `~ 1` exactly as under `~ age`. No change.

Both fixes were false refusals, not wrong answers. Each new test errors on `a88cc51` and fails again when its one line is reverted. Gates on `8bd5c31`:
  - `devtools::document()`: no changes; `lintr::lint_package()`: 0 lints; `devtools::test()` with `NOT_CRAN=true`: **0 failures, 5795 passes, 6 skips** (5788 before, plus the 7 expectations of the two new tests; the six skips are the known unsatisfiable ones)

## Status

**Ready for review.** #291 (#224) has landed and `main` is merged in. Next in the queue after this: #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
