### PR TITLE
docs(loglogistic): stop roxygen reading gradient math as a link

### DIFF
--- a/R/likelihood-loglogistic.R
+++ b/R/likelihood-loglogistic.R
@@ -272,7 +272,7 @@ NULL
 #' dL/d(log alpha) = sum(delta_i) - sum(w_i)
 #'
 #' dL/d(log beta) = sum(delta_i)
-#'                  + beta * [sum(delta_i * log(t_i)) - sum(w_i * log(t_i))]
+#'                  + beta * (sum(delta_i * log(t_i)) - sum(w_i * log(t_i)))
 #'
 #' dL/db_j = sum(delta_i * x_ij) - sum(w_i * x_ij) = t(X) %*% (delta - w)
 #'


### PR DESCRIPTION
`devtools::document()` on `main` (`a2ff8da`) warned:

```
✖ likelihood-loglogistic.R:264: @details Could not resolve link to topic
  "sum(delta_i * log(t_i)) - sum(w_i * log(t_i))"
```

The source is the `@noRd` gradient comment of `.hzr_gradient_loglogistic()`. With markdown on, `beta * [sum(...) - sum(...)]` was parsed as a link. This PR swaps the brackets for parentheses, which carry the same grouping.

**Scope checked:** that warning was the only link warning on `main`. The `[\log(...)]` two lines up sits inside `\eqn{}`, where roxygen does not parse markdown. The Weibull gradient comment (`R/likelihood-weibull.R` ~249) has no brackets.

**No `man/` or `NAMESPACE` change**, because the block is `@noRd`. There is no version bump and no NEWS entry: this is a comment-only change.

### Gates (run at `e0462c9`)
- `devtools::document()`: no warnings; tree clean apart from the one-line source edit
- `lintr::lint_package()`: 0 lints
- `devtools::test()` with `NOT_CRAN=true`: 0 FAIL, 0 ERROR, 6 SKIP, 5098 PASS

**Not run:** `R CMD check --as-cran` and the `r-reviewer` agent. The diff changes one character pair inside a roxygen comment that is never rendered, and touches no code or `Rd`. CI's R-CMD-check matrix covers the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
